### PR TITLE
feat(commands): add wired tools launcher

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandHandler.java
@@ -297,6 +297,7 @@ public class CommandHandler {
         addCommand(new SoftKickCommand());
         addCommand(new SubscriptionCommand());
         addCommand(new UpdateChatBubblesCommand());
+        addCommand(new WiredCommand());
 
         addCommand(new TestCommand());
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/WiredCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/WiredCommand.java
@@ -1,0 +1,35 @@
+package com.eu.habbo.habbohotel.commands;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
+import com.eu.habbo.messages.outgoing.users.InClientLinkComposer;
+
+public class WiredCommand extends Command {
+    public WiredCommand() {
+        super(Permission.ACC_PLACEFURNI, new String[]{"wired"});
+    }
+
+    @Override
+    public boolean handle(GameClient gameClient, String[] params) throws Exception {
+        Room room = gameClient.getHabbo().getHabboInfo().getCurrentRoom();
+
+        if (room == null) {
+            gameClient.getHabbo().whisper("You need to be inside a room to use :wired.", RoomChatMessageBubbles.ALERT);
+            return true;
+        }
+
+        boolean hasRights = room.hasRights(gameClient.getHabbo())
+                || room.isOwner(gameClient.getHabbo())
+                || gameClient.getHabbo().hasPermission(Permission.ACC_ANYROOMOWNER);
+
+        if (!hasRights) {
+            gameClient.getHabbo().whisper("You need room rights to open the Wired Creator Tools.", RoomChatMessageBubbles.ALERT);
+            return true;
+        }
+
+        gameClient.sendResponse(new InClientLinkComposer("wired-tools/show"));
+        return true;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -504,6 +504,7 @@ public class Outgoing {
     public final static int WiredOpenComposer = 1830;
     public final static int UnknownCatalogPageOfferComposer = 1889;
     public final static int NuxAlertComposer = 2023;
+    public final static int InClientLinkComposer = 2023;
     public final static int HotelViewExpiringCatalogPageCommposer = 2515;
     public final static int UnknownHabboWayQuizComposer = 2772;
     public final static int PetLevelUpdatedComposer = 2824;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/InClientLinkComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/InClientLinkComposer.java
@@ -1,0 +1,20 @@
+package com.eu.habbo.messages.outgoing.users;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+public class InClientLinkComposer extends MessageComposer {
+    private final String link;
+
+    public InClientLinkComposer(String link) {
+        this.link = link;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.InClientLinkComposer);
+        this.response.appendString(this.link);
+        return this.response;
+    }
+}


### PR DESCRIPTION
## Summary
- add a new :wired command for room owners and users with placement rights
- send an in-client link packet that opens the new Wired Creator Tools panel
- register a dedicated composer alias for the existing in-client link packet id

## Notes
- this PR only adds the launcher flow on the emulator side
- the matching Nitro UI shell is opened in a separate PR