### PR TITLE
feat(furni-editor): add server-side packet handlers for furniture editor

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -128,6 +128,8 @@ public final class Emulator {
             Emulator.getPluginManager().fireEvent(new EmulatorConfigUpdatedEvent());
             Emulator.texts = new TextsManager();
 
+            Emulator.config.register("furni.editor.renderer.config.path", "");
+            Emulator.config.register("furni.editor.asset.base.path", "");
             Emulator.config.register("camera.url", "http://localhost/camera/");
             Emulator.config.register("imager.location.output.camera", "/public/camera/");
             Emulator.config.register("imager.location.output.thumbnail", "/public/camera/thumbnails/");

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java
@@ -11,6 +11,7 @@ import com.eu.habbo.habbohotel.crafting.CraftingManager;
 import com.eu.habbo.habbohotel.guides.GuideManager;
 import com.eu.habbo.habbohotel.guilds.GuildManager;
 import com.eu.habbo.habbohotel.hotelview.HotelViewManager;
+import com.eu.habbo.habbohotel.items.FurniDataManager;
 import com.eu.habbo.habbohotel.items.ItemManager;
 import com.eu.habbo.habbohotel.modtool.ModToolManager;
 import com.eu.habbo.habbohotel.modtool.ModToolSanctions;
@@ -58,6 +59,7 @@ public class GameEnvironment {
     private SubscriptionManager subscriptionManager;
     private CalendarManager calendarManager;
     private RoomChatBubbleManager roomChatBubbleManager;
+    private FurniDataManager furniDataManager;
 
     public void load() throws Exception {
         LOGGER.info("GameEnvironment -> Loading...");
@@ -84,6 +86,7 @@ public class GameEnvironment {
         this.pollManager = new PollManager();
         this.calendarManager = new CalendarManager();
         this.roomChatBubbleManager = new RoomChatBubbleManager();
+        this.furniDataManager = new FurniDataManager();
 
         this.roomManager.loadPublicRooms();
         this.navigatorManager.loadNavigator();
@@ -218,5 +221,9 @@ public class GameEnvironment {
 
     public RoomChatBubbleManager getRoomChatBubbleManager() {
         return roomChatBubbleManager;
+    }
+
+    public FurniDataManager getFurniDataManager() {
+        return furniDataManager;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurniDataManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurniDataManager.java
@@ -1,0 +1,290 @@
+package com.eu.habbo.habbohotel.items;
+
+import com.eu.habbo.Emulator;
+import com.google.gson.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class FurniDataManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FurniDataManager.class);
+    private static final Pattern VAR_PATTERN = Pattern.compile("\\$\\{([^}]+)}");
+
+    private String furniDataPath;
+    private final Object lock = new Object();
+
+    public FurniDataManager() {
+        this.resolveFurniDataPath();
+    }
+
+    private void resolveFurniDataPath() {
+        String rendererConfigPath = Emulator.getConfig().getValue("furni.editor.renderer.config.path", "");
+        String assetBasePath = Emulator.getConfig().getValue("furni.editor.asset.base.path", "");
+
+        if (rendererConfigPath.isEmpty() || assetBasePath.isEmpty()) {
+            LOGGER.warn("FurniDataManager: furni.editor.renderer.config.path or furni.editor.asset.base.path not configured");
+            return;
+        }
+
+        try {
+            Path configFile = Paths.get(rendererConfigPath);
+            if (!Files.exists(configFile)) {
+                LOGGER.error("FurniDataManager: renderer-config.json not found at {}", rendererConfigPath);
+                return;
+            }
+
+            String content = new String(Files.readAllBytes(configFile), StandardCharsets.UTF_8);
+            JsonObject config = JsonParser.parseString(content).getAsJsonObject();
+
+            // Build variable map from config
+            Properties vars = new Properties();
+            for (String key : config.keySet()) {
+                JsonElement el = config.get(key);
+                if (el.isJsonPrimitive() && el.getAsJsonPrimitive().isString()) {
+                    vars.setProperty(key, el.getAsString());
+                }
+            }
+
+            // Resolve variables in furnidata.url
+            String furniDataUrl = resolveVars(vars.getProperty("furnidata.url", ""), vars);
+
+            if (furniDataUrl.isEmpty()) {
+                LOGGER.error("FurniDataManager: could not resolve furnidata.url from renderer-config.json");
+                return;
+            }
+
+            // Convert URL to filesystem path using asset.base.path
+            String assetUrl = resolveVars(vars.getProperty("asset.url", ""), vars);
+            if (!assetUrl.isEmpty() && furniDataUrl.startsWith(assetUrl)) {
+                String relativePath = furniDataUrl.substring(assetUrl.length());
+                this.furniDataPath = assetBasePath + relativePath;
+            } else {
+                // Fallback: try to extract path from URL
+                this.furniDataPath = assetBasePath + "/gamedata/FurnitureData.json";
+            }
+
+            // Normalize path separators
+            this.furniDataPath = this.furniDataPath.replace("/", File.separator).replace("\\", File.separator);
+
+            if (Files.exists(Paths.get(this.furniDataPath))) {
+                LOGGER.info("FurniDataManager: FurnitureData.json found at {}", this.furniDataPath);
+            } else {
+                LOGGER.warn("FurniDataManager: FurnitureData.json NOT found at {}", this.furniDataPath);
+            }
+        } catch (Exception e) {
+            LOGGER.error("FurniDataManager: failed to resolve FurnitureData path", e);
+        }
+    }
+
+    private String resolveVars(String value, Properties vars) {
+        if (value == null) return "";
+        String result = value;
+        int maxIterations = 10;
+        while (maxIterations-- > 0) {
+            Matcher m = VAR_PATTERN.matcher(result);
+            if (!m.find()) break;
+            StringBuffer sb = new StringBuffer();
+            m.reset();
+            while (m.find()) {
+                String varName = m.group(1);
+                // Map dot notation: "gamedata.url" -> key in config
+                String replacement = vars.getProperty(varName, "");
+                m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+            }
+            m.appendTail(sb);
+            result = sb.toString();
+        }
+        return result;
+    }
+
+    public boolean isAvailable() {
+        return this.furniDataPath != null && !this.furniDataPath.isEmpty();
+    }
+
+    public JsonObject readFurniData() {
+        if (!isAvailable()) return null;
+
+        synchronized (this.lock) {
+            try {
+                String content = new String(Files.readAllBytes(Paths.get(this.furniDataPath)), StandardCharsets.UTF_8);
+                return JsonParser.parseString(content).getAsJsonObject();
+            } catch (Exception e) {
+                LOGGER.error("FurniDataManager: failed to read FurnitureData.json", e);
+                return null;
+            }
+        }
+    }
+
+    public boolean writeFurniData(JsonObject data) {
+        if (!isAvailable()) return false;
+
+        synchronized (this.lock) {
+            try {
+                Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+                String json = gson.toJson(data);
+                Files.write(Paths.get(this.furniDataPath), json.getBytes(StandardCharsets.UTF_8));
+                return true;
+            } catch (Exception e) {
+                LOGGER.error("FurniDataManager: failed to write FurnitureData.json", e);
+                return false;
+            }
+        }
+    }
+
+    public JsonObject findEntry(String classname) {
+        JsonObject data = readFurniData();
+        if (data == null) return null;
+
+        // Search in roomitemtypes
+        JsonObject entry = findInSection(data, "roomitemtypes", classname);
+        if (entry != null) return entry;
+
+        // Search in wallitemtypes
+        return findInSection(data, "wallitemtypes", classname);
+    }
+
+    private JsonObject findInSection(JsonObject data, String section, String classname) {
+        try {
+            JsonObject sectionObj = data.getAsJsonObject(section);
+            if (sectionObj == null) return null;
+
+            JsonArray items = sectionObj.getAsJsonArray("furnitype");
+            if (items == null) return null;
+
+            for (JsonElement el : items) {
+                JsonObject item = el.getAsJsonObject();
+                if (classname.equals(item.get("classname").getAsString())) {
+                    return item;
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("FurniDataManager: error searching section {}", section, e);
+        }
+        return null;
+    }
+
+    public boolean updateEntry(String classname, String publicName) {
+        if (!isAvailable()) return false;
+
+        synchronized (this.lock) {
+            try {
+                JsonObject data = readUnsafe();
+                if (data == null) return false;
+
+                boolean updated = updateInSection(data, "roomitemtypes", classname, publicName);
+                if (!updated) {
+                    updated = updateInSection(data, "wallitemtypes", classname, publicName);
+                }
+
+                if (updated) {
+                    return writeUnsafe(data);
+                }
+                return false;
+            } catch (Exception e) {
+                LOGGER.error("FurniDataManager: failed to update entry {}", classname, e);
+                return false;
+            }
+        }
+    }
+
+    private boolean updateInSection(JsonObject data, String section, String classname, String publicName) {
+        try {
+            JsonObject sectionObj = data.getAsJsonObject(section);
+            if (sectionObj == null) return false;
+
+            JsonArray items = sectionObj.getAsJsonArray("furnitype");
+            if (items == null) return false;
+
+            for (JsonElement el : items) {
+                JsonObject item = el.getAsJsonObject();
+                if (classname.equals(item.get("classname").getAsString())) {
+                    item.addProperty("name", publicName);
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("FurniDataManager: error updating section {}", section, e);
+        }
+        return false;
+    }
+
+    public boolean removeEntry(String classname) {
+        if (!isAvailable()) return false;
+
+        synchronized (this.lock) {
+            try {
+                JsonObject data = readUnsafe();
+                if (data == null) return false;
+
+                boolean removed = removeFromSection(data, "roomitemtypes", classname);
+                if (!removed) {
+                    removed = removeFromSection(data, "wallitemtypes", classname);
+                }
+
+                if (removed) {
+                    return writeUnsafe(data);
+                }
+                return false;
+            } catch (Exception e) {
+                LOGGER.error("FurniDataManager: failed to remove entry {}", classname, e);
+                return false;
+            }
+        }
+    }
+
+    private boolean removeFromSection(JsonObject data, String section, String classname) {
+        try {
+            JsonObject sectionObj = data.getAsJsonObject(section);
+            if (sectionObj == null) return false;
+
+            JsonArray items = sectionObj.getAsJsonArray("furnitype");
+            if (items == null) return false;
+
+            for (int i = 0; i < items.size(); i++) {
+                JsonObject item = items.get(i).getAsJsonObject();
+                if (classname.equals(item.get("classname").getAsString())) {
+                    items.remove(i);
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("FurniDataManager: error removing from section {}", section, e);
+        }
+        return false;
+    }
+
+    // Internal methods that don't acquire the lock (caller must hold it)
+    private JsonObject readUnsafe() {
+        try {
+            String content = new String(Files.readAllBytes(Paths.get(this.furniDataPath)), StandardCharsets.UTF_8);
+            return JsonParser.parseString(content).getAsJsonObject();
+        } catch (Exception e) {
+            LOGGER.error("FurniDataManager: failed to read FurnitureData.json", e);
+            return null;
+        }
+    }
+
+    private boolean writeUnsafe(JsonObject data) {
+        try {
+            Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+            String json = gson.toJson(data);
+            Files.write(Paths.get(this.furniDataPath), json.getBytes(StandardCharsets.UTF_8));
+            return true;
+        } catch (Exception e) {
+            LOGGER.error("FurniDataManager: failed to write FurnitureData.json", e);
+            return false;
+        }
+    }
+
+    public String getFurniDataPath() {
+        return this.furniDataPath;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -10,6 +10,8 @@ import com.eu.habbo.messages.incoming.ambassadors.AmbassadorAlertCommandEvent;
 import com.eu.habbo.messages.incoming.ambassadors.AmbassadorVisitCommandEvent;
 import com.eu.habbo.messages.incoming.camera.*;
 import com.eu.habbo.messages.incoming.catalog.*;
+import com.eu.habbo.messages.incoming.catalog.catalogadmin.*;
+import com.eu.habbo.messages.incoming.furnieditor.*;
 import com.eu.habbo.messages.incoming.catalog.marketplace.*;
 import com.eu.habbo.messages.incoming.catalog.recycler.OpenRecycleBoxEvent;
 import com.eu.habbo.messages.incoming.catalog.recycler.RecycleEvent;
@@ -258,6 +260,26 @@ public class PacketManager {
         this.registerHandler(Incoming.RequestClubCenterEvent, RequestClubCenterEvent.class);
         this.registerHandler(Incoming.CatalogRequestClubDiscountEvent, CatalogRequestClubDiscountEvent.class);
         this.registerHandler(Incoming.CatalogBuyClubDiscountEvent, CatalogBuyClubDiscountEvent.class);
+
+        // Catalog Admin
+        this.registerHandler(Incoming.CatalogAdminSavePageEvent, CatalogAdminSavePageEvent.class);
+        this.registerHandler(Incoming.CatalogAdminCreatePageEvent, CatalogAdminCreatePageEvent.class);
+        this.registerHandler(Incoming.CatalogAdminDeletePageEvent, CatalogAdminDeletePageEvent.class);
+        this.registerHandler(Incoming.CatalogAdminSaveOfferEvent, CatalogAdminSaveOfferEvent.class);
+        this.registerHandler(Incoming.CatalogAdminCreateOfferEvent, CatalogAdminCreateOfferEvent.class);
+        this.registerHandler(Incoming.CatalogAdminDeleteOfferEvent, CatalogAdminDeleteOfferEvent.class);
+        this.registerHandler(Incoming.CatalogAdminMoveOfferEvent, CatalogAdminMoveOfferEvent.class);
+        this.registerHandler(Incoming.CatalogAdminMovePageEvent, CatalogAdminMovePageEvent.class);
+        this.registerHandler(Incoming.CatalogAdminPublishEvent, CatalogAdminPublishEvent.class);
+
+        // Furni Editor
+        this.registerHandler(Incoming.FurniEditorSearchEvent, FurniEditorSearchEvent.class);
+        this.registerHandler(Incoming.FurniEditorDetailEvent, FurniEditorDetailEvent.class);
+        this.registerHandler(Incoming.FurniEditorBySpriteEvent, FurniEditorBySpriteEvent.class);
+        this.registerHandler(Incoming.FurniEditorInteractionsEvent, FurniEditorInteractionsEvent.class);
+        this.registerHandler(Incoming.FurniEditorUpdateEvent, FurniEditorUpdateEvent.class);
+        this.registerHandler(Incoming.FurniEditorCreateEvent, FurniEditorCreateEvent.class);
+        this.registerHandler(Incoming.FurniEditorDeleteEvent, FurniEditorDeleteEvent.class);
     }
 
     private void registerEvent() throws Exception {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -412,6 +412,26 @@ public class Incoming {
     public static final int RequestInventoryPetDelete = 10030;
     public static final int RequestInventoryBadgeDelete  = 10031;
 
+    // Catalog Admin
+    public static final int CatalogAdminSavePageEvent = 10050;
+    public static final int CatalogAdminCreatePageEvent = 10051;
+    public static final int CatalogAdminDeletePageEvent = 10052;
+    public static final int CatalogAdminSaveOfferEvent = 10053;
+    public static final int CatalogAdminCreateOfferEvent = 10054;
+    public static final int CatalogAdminDeleteOfferEvent = 10055;
+    public static final int CatalogAdminMoveOfferEvent = 10056;
+    public static final int CatalogAdminMovePageEvent = 10057;
+    public static final int CatalogAdminPublishEvent = 10058;
+
+    // Furni Editor
+    public static final int FurniEditorSearchEvent = 10040;
+    public static final int FurniEditorDetailEvent = 10041;
+    public static final int FurniEditorBySpriteEvent = 10042;
+    public static final int FurniEditorInteractionsEvent = 10043;
+    public static final int FurniEditorUpdateEvent = 10044;
+    public static final int FurniEditorCreateEvent = 10045;
+    public static final int FurniEditorDeleteEvent = 10046;
+
     // Custom Prefixes
     public static final int RequestUserPrefixesEvent = 7011;
     public static final int SetActivePrefixEvent = 7012;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorBySpriteEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorBySpriteEvent.java
@@ -1,0 +1,98 @@
+package com.eu.habbo.messages.incoming.furnieditor;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.furnieditor.FurniEditorDetailComposer;
+import com.eu.habbo.messages.outgoing.furnieditor.FurniEditorResultComposer;
+import com.google.gson.JsonObject;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class FurniEditorBySpriteEvent extends MessageHandler {
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(FurniEditorBySpriteEvent.class);
+
+    @Override
+    public void handle() throws Exception {
+        try {
+            LOGGER.info("[FurniEditorBySprite] Received packet from user {}", this.client.getHabbo().getHabboInfo().getUsername());
+
+            if (!this.client.getHabbo().hasPermission(Permission.ACC_CATALOGFURNI)) {
+                LOGGER.warn("[FurniEditorBySprite] No permission");
+                this.client.sendResponse(new FurniEditorResultComposer(false, "No permission"));
+                return;
+            }
+
+            int spriteId = this.packet.readInt();
+            LOGGER.info("[FurniEditorBySprite] spriteId={}", spriteId);
+
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+                Map<String, Object> item = null;
+                int itemId = -1;
+
+                try (PreparedStatement stmt = connection.prepareStatement("SELECT * FROM items_base WHERE sprite_id = ? LIMIT 1")) {
+                    stmt.setInt(1, spriteId);
+                    try (ResultSet rs = stmt.executeQuery()) {
+                        if (rs.next()) {
+                            item = FurniEditorHelper.readDetailItem(rs);
+                            itemId = rs.getInt("id");
+                            LOGGER.info("[FurniEditorBySprite] Found item id={} name={}", itemId, item.get("item_name"));
+                        }
+                    }
+                }
+
+                if (item == null) {
+                    LOGGER.warn("[FurniEditorBySprite] No item found for sprite {}", spriteId);
+                    this.client.sendResponse(new FurniEditorResultComposer(false, "Item not found for sprite " + spriteId));
+                    return;
+                }
+
+                // Usage count
+                int usageCount = 0;
+                try (PreparedStatement stmt = connection.prepareStatement("SELECT COUNT(*) as cnt FROM items WHERE item_id = ?")) {
+                    stmt.setInt(1, itemId);
+                    try (ResultSet rs = stmt.executeQuery()) {
+                        if (rs.next()) usageCount = rs.getInt("cnt");
+                    }
+                }
+
+                // Catalog references
+                List<Map<String, Object>> catalogItems = new ArrayList<>();
+                try (PreparedStatement stmt = connection.prepareStatement(
+                        "SELECT ci.id as ci_id, ci.catalog_name, ci.cost_credits, ci.cost_points, ci.points_type, ci.page_id, cp.caption as page_caption " +
+                        "FROM catalog_items ci LEFT JOIN catalog_pages cp ON ci.page_id = cp.id " +
+                        "WHERE ci.item_ids = ?")) {
+                    stmt.setString(1, String.valueOf(itemId));
+                    try (ResultSet rs = stmt.executeQuery()) {
+                        while (rs.next()) {
+                            catalogItems.add(FurniEditorHelper.readCatalogRef(rs));
+                        }
+                    }
+                }
+                LOGGER.info("[FurniEditorBySprite] catalogItems={}", catalogItems.size());
+
+                // FurniData entry
+                String furniDataJson = "";
+                String classname = (String) item.get("item_name");
+                if (classname != null && !classname.isEmpty()) {
+                    JsonObject entry = Emulator.getGameEnvironment().getFurniDataManager().findEntry(classname);
+                    if (entry != null) {
+                        furniDataJson = entry.toString();
+                    }
+                }
+
+                LOGGER.info("[FurniEditorBySprite] Sending detail response for item {}", itemId);
+                this.client.sendResponse(new FurniEditorDetailComposer(item, usageCount, catalogItems, furniDataJson));
+                LOGGER.info("[FurniEditorBySprite] Response sent OK");
+            }
+        } catch (Exception e) {
+            LOGGER.error("[FurniEditorBySprite] ERROR: {}", e.getMessage(), e);
+            this.client.sendResponse(new FurniEditorResultComposer(false, "Server error: " + e.getMessage()));
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorCreateEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorCreateEvent.java
@@ -1,0 +1,94 @@
+package com.eu.habbo.messages.incoming.furnieditor;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.furnieditor.FurniEditorResultComposer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+public class FurniEditorCreateEvent extends MessageHandler {
+
+    @Override
+    public void handle() throws Exception {
+        if (!this.client.getHabbo().hasPermission(Permission.ACC_CATALOGFURNI)) {
+            this.client.sendResponse(new FurniEditorResultComposer(false, "No permission"));
+            return;
+        }
+
+        String fieldsJson = this.packet.readString();
+
+        JsonObject fields;
+        try {
+            fields = JsonParser.parseString(fieldsJson).getAsJsonObject();
+        } catch (Exception e) {
+            this.client.sendResponse(new FurniEditorResultComposer(false, "Invalid JSON"));
+            return;
+        }
+
+        String itemName = fields.has("itemName") ? fields.get("itemName").getAsString() : "";
+        String publicName = fields.has("publicName") ? fields.get("publicName").getAsString() : "";
+        int spriteId = fields.has("spriteId") ? fields.get("spriteId").getAsInt() : 0;
+        String type = fields.has("type") ? fields.get("type").getAsString() : "s";
+        int width = fields.has("width") ? fields.get("width").getAsInt() : 1;
+        int length = fields.has("length") ? fields.get("length").getAsInt() : 1;
+        double stackHeight = fields.has("stackHeight") ? fields.get("stackHeight").getAsDouble() : 0.0;
+
+        if (itemName.isEmpty() || publicName.isEmpty()) {
+            this.client.sendResponse(new FurniEditorResultComposer(false, "itemName and publicName are required"));
+            return;
+        }
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            // Get next ID
+            int newId = 1;
+            try (PreparedStatement stmt = connection.prepareStatement("SELECT MAX(id) as max_id FROM items_base");
+                 ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) newId = rs.getInt("max_id") + 1;
+            }
+
+            // Insert
+            try (PreparedStatement stmt = connection.prepareStatement(
+                    "INSERT INTO items_base (id, sprite_id, item_name, public_name, type, width, `length`, stack_height, " +
+                    "allow_stack, allow_walk, allow_sit, allow_lay, allow_gift, allow_trade, allow_recycle, " +
+                    "allow_marketplace_sell, allow_inventory_stack, interaction_type, interaction_modes_count, customparams) " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+                stmt.setInt(1, newId);
+                stmt.setInt(2, spriteId);
+                stmt.setString(3, itemName);
+                stmt.setString(4, publicName);
+                stmt.setString(5, type);
+                stmt.setInt(6, width);
+                stmt.setInt(7, length);
+                stmt.setDouble(8, stackHeight);
+                stmt.setString(9, boolField(fields, "allowStack", "1"));
+                stmt.setString(10, boolField(fields, "allowWalk", "0"));
+                stmt.setString(11, boolField(fields, "allowSit", "0"));
+                stmt.setString(12, boolField(fields, "allowLay", "0"));
+                stmt.setString(13, boolField(fields, "allowGift", "1"));
+                stmt.setString(14, boolField(fields, "allowTrade", "1"));
+                stmt.setString(15, boolField(fields, "allowRecycle", "1"));
+                stmt.setString(16, boolField(fields, "allowMarketplaceSell", "1"));
+                stmt.setString(17, boolField(fields, "allowInventoryStack", "1"));
+                stmt.setString(18, fields.has("interactionType") ? fields.get("interactionType").getAsString() : "default");
+                stmt.setInt(19, fields.has("interactionModesCount") ? fields.get("interactionModesCount").getAsInt() : 1);
+                stmt.setString(20, fields.has("customparams") ? fields.get("customparams").getAsString() : "");
+                stmt.execute();
+            }
+
+            // Refresh item cache
+            Emulator.getGameEnvironment().getItemManager().loadItems();
+
+            this.client.sendResponse(new FurniEditorResultComposer(true, "Item created", newId));
+        }
+    }
+
+    private String boolField(JsonObject fields, String key, String defaultVal) {
+        if (!fields.has(key)) return defaultVal;
+        return fields.get(key).getAsBoolean() ? "1" : "0";
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorDeleteEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorDeleteEvent.java
@@ -1,0 +1,73 @@
+package com.eu.habbo.messages.incoming.furnieditor;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.furnieditor.FurniEditorResultComposer;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+public class FurniEditorDeleteEvent extends MessageHandler {
+
+    @Override
+    public void handle() throws Exception {
+        if (!this.client.getHabbo().hasPermission(Permission.ACC_CATALOGFURNI)) {
+            this.client.sendResponse(new FurniEditorResultComposer(false, "No permission"));
+            return;
+        }
+
+        int id = this.packet.readInt();
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            // Check usage
+            int usageCount = 0;
+            try (PreparedStatement stmt = connection.prepareStatement("SELECT COUNT(*) as cnt FROM items WHERE item_id = ?")) {
+                stmt.setInt(1, id);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    if (rs.next()) usageCount = rs.getInt("cnt");
+                }
+            }
+
+            if (usageCount > 0) {
+                this.client.sendResponse(new FurniEditorResultComposer(false, "Item is in use (" + usageCount + " instances)"));
+                return;
+            }
+
+            // Get item_name for FurniData removal
+            String itemName = null;
+            try (PreparedStatement stmt = connection.prepareStatement("SELECT item_name FROM items_base WHERE id = ?")) {
+                stmt.setInt(1, id);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    if (rs.next()) itemName = rs.getString("item_name");
+                }
+            }
+
+            if (itemName == null) {
+                this.client.sendResponse(new FurniEditorResultComposer(false, "Item not found"));
+                return;
+            }
+
+            // Delete catalog items referencing this item
+            try (PreparedStatement stmt = connection.prepareStatement("DELETE FROM catalog_items WHERE item_ids = ?")) {
+                stmt.setString(1, String.valueOf(id));
+                stmt.execute();
+            }
+
+            // Delete from items_base
+            try (PreparedStatement stmt = connection.prepareStatement("DELETE FROM items_base WHERE id = ?")) {
+                stmt.setInt(1, id);
+                stmt.execute();
+            }
+
+            // Remove from FurnitureData.json
+            Emulator.getGameEnvironment().getFurniDataManager().removeEntry(itemName);
+
+            // Refresh item cache
+            Emulator.getGameEnvironment().getItemManager().loadItems();
+
+            this.client.sendResponse(new FurniEditorResultComposer(true, "Item deleted"));
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorDetailEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorDetailEvent.java
@@ -1,0 +1,81 @@
+package com.eu.habbo.messages.incoming.furnieditor;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.furnieditor.FurniEditorDetailComposer;
+import com.eu.habbo.messages.outgoing.furnieditor.FurniEditorResultComposer;
+import com.google.gson.JsonObject;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class FurniEditorDetailEvent extends MessageHandler {
+
+    @Override
+    public void handle() throws Exception {
+        if (!this.client.getHabbo().hasPermission(Permission.ACC_CATALOGFURNI)) {
+            this.client.sendResponse(new FurniEditorResultComposer(false, "No permission"));
+            return;
+        }
+
+        int id = this.packet.readInt();
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            Map<String, Object> item = null;
+
+            try (PreparedStatement stmt = connection.prepareStatement("SELECT * FROM items_base WHERE id = ?")) {
+                stmt.setInt(1, id);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    if (rs.next()) {
+                        item = FurniEditorHelper.readDetailItem(rs);
+                    }
+                }
+            }
+
+            if (item == null) {
+                this.client.sendResponse(new FurniEditorResultComposer(false, "Item not found"));
+                return;
+            }
+
+            // Usage count
+            int usageCount = 0;
+            try (PreparedStatement stmt = connection.prepareStatement("SELECT COUNT(*) as cnt FROM items WHERE item_id = ?")) {
+                stmt.setInt(1, id);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    if (rs.next()) usageCount = rs.getInt("cnt");
+                }
+            }
+
+            // Catalog references
+            List<Map<String, Object>> catalogItems = new ArrayList<>();
+            try (PreparedStatement stmt = connection.prepareStatement(
+                    "SELECT ci.id as ci_id, ci.catalog_name, ci.cost_credits, ci.cost_points, ci.points_type, ci.page_id, cp.caption as page_caption " +
+                    "FROM catalog_items ci LEFT JOIN catalog_pages cp ON ci.page_id = cp.id " +
+                    "WHERE ci.item_ids = ?")) {
+                stmt.setString(1, String.valueOf(id));
+                try (ResultSet rs = stmt.executeQuery()) {
+                    while (rs.next()) {
+                        catalogItems.add(FurniEditorHelper.readCatalogRef(rs));
+                    }
+                }
+            }
+
+            // FurniData entry
+            String furniDataJson = "";
+            String classname = (String) item.get("item_name");
+            if (classname != null && !classname.isEmpty()) {
+                JsonObject entry = Emulator.getGameEnvironment().getFurniDataManager().findEntry(classname);
+                if (entry != null) {
+                    furniDataJson = entry.toString();
+                }
+            }
+
+            this.client.sendResponse(new FurniEditorDetailComposer(item, usageCount, catalogItems, furniDataJson));
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorHelper.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorHelper.java
@@ -1,0 +1,57 @@
+package com.eu.habbo.messages.incoming.furnieditor;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FurniEditorHelper {
+
+    public static Map<String, Object> readBasicItem(ResultSet rs) throws SQLException {
+        Map<String, Object> item = new HashMap<>();
+        item.put("id", rs.getInt("id"));
+        item.put("sprite_id", rs.getInt("sprite_id"));
+        item.put("item_name", rs.getString("item_name") != null ? rs.getString("item_name") : "");
+        item.put("public_name", rs.getString("public_name") != null ? rs.getString("public_name") : "");
+        item.put("type", rs.getString("type") != null ? rs.getString("type") : "s");
+        item.put("width", rs.getInt("width"));
+        item.put("length", rs.getInt("length"));
+        item.put("stack_height", rs.getDouble("stack_height"));
+        item.put("allow_stack", "1".equals(rs.getString("allow_stack")));
+        item.put("allow_walk", "1".equals(rs.getString("allow_walk")));
+        item.put("allow_sit", "1".equals(rs.getString("allow_sit")));
+        item.put("allow_lay", "1".equals(rs.getString("allow_lay")));
+        item.put("interaction_type", rs.getString("interaction_type") != null ? rs.getString("interaction_type") : "default");
+        item.put("interaction_modes_count", rs.getInt("interaction_modes_count"));
+        return item;
+    }
+
+    public static Map<String, Object> readDetailItem(ResultSet rs) throws SQLException {
+        Map<String, Object> item = readBasicItem(rs);
+        item.put("allow_gift", "1".equals(rs.getString("allow_gift")));
+        item.put("allow_trade", "1".equals(rs.getString("allow_trade")));
+        item.put("allow_recycle", "1".equals(rs.getString("allow_recycle")));
+        item.put("allow_marketplace_sell", "1".equals(rs.getString("allow_marketplace_sell")));
+        item.put("allow_inventory_stack", "1".equals(rs.getString("allow_inventory_stack")));
+        item.put("vending_ids", rs.getString("vending_ids") != null ? rs.getString("vending_ids") : "");
+        item.put("customparams", rs.getString("customparams") != null ? rs.getString("customparams") : "");
+        item.put("effect_id_male", rs.getInt("effect_id_male"));
+        item.put("effect_id_female", rs.getInt("effect_id_female"));
+        item.put("clothing_on_walk", rs.getString("clothing_on_walk") != null ? rs.getString("clothing_on_walk") : "");
+        item.put("multiheight", rs.getString("multiheight") != null ? rs.getString("multiheight") : "");
+        item.put("description", rs.getString("description") != null ? rs.getString("description") : "");
+        return item;
+    }
+
+    public static Map<String, Object> readCatalogRef(ResultSet rs) throws SQLException {
+        Map<String, Object> ref = new HashMap<>();
+        ref.put("id", rs.getInt("ci_id"));
+        ref.put("catalog_name", rs.getString("catalog_name") != null ? rs.getString("catalog_name") : "");
+        ref.put("cost_credits", rs.getInt("cost_credits"));
+        ref.put("cost_points", rs.getInt("cost_points"));
+        ref.put("points_type", rs.getInt("points_type"));
+        ref.put("page_id", rs.getInt("page_id"));
+        ref.put("page_caption", rs.getString("page_caption") != null ? rs.getString("page_caption") : "");
+        return ref;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorInteractionsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorInteractionsEvent.java
@@ -1,0 +1,36 @@
+package com.eu.habbo.messages.incoming.furnieditor;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.furnieditor.FurniEditorInteractionsComposer;
+import com.eu.habbo.messages.outgoing.furnieditor.FurniEditorResultComposer;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FurniEditorInteractionsEvent extends MessageHandler {
+
+    @Override
+    public void handle() throws Exception {
+        if (!this.client.getHabbo().hasPermission(Permission.ACC_CATALOGFURNI)) {
+            this.client.sendResponse(new FurniEditorResultComposer(false, "No permission"));
+            return;
+        }
+
+        List<String> interactions = new ArrayList<>();
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+             PreparedStatement stmt = connection.prepareStatement("SELECT DISTINCT interaction_type FROM items_base WHERE interaction_type != '' ORDER BY interaction_type");
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                interactions.add(rs.getString("interaction_type"));
+            }
+        }
+
+        this.client.sendResponse(new FurniEditorInteractionsComposer(interactions));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorSearchEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorSearchEvent.java
@@ -1,0 +1,96 @@
+package com.eu.habbo.messages.incoming.furnieditor;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.furnieditor.FurniEditorResultComposer;
+import com.eu.habbo.messages.outgoing.furnieditor.FurniEditorSearchComposer;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class FurniEditorSearchEvent extends MessageHandler {
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(FurniEditorSearchEvent.class);
+
+    @Override
+    public void handle() throws Exception {
+        LOGGER.info("[FurniEditorSearch] Received packet from user {}", this.client.getHabbo().getHabboInfo().getUsername());
+
+        if (!this.client.getHabbo().hasPermission(Permission.ACC_CATALOGFURNI)) {
+            LOGGER.warn("[FurniEditorSearch] No permission for user {}", this.client.getHabbo().getHabboInfo().getUsername());
+            this.client.sendResponse(new FurniEditorResultComposer(false, "No permission"));
+            return;
+        }
+
+        String query = this.packet.readString();
+        String type = this.packet.readString();
+        int page = this.packet.readInt();
+        int limit = 20;
+        int offset = (page - 1) * limit;
+
+        List<Object> params = new ArrayList<>();
+        List<Object> countParams = new ArrayList<>();
+        StringBuilder where = new StringBuilder(" WHERE 1=1");
+
+        if (!query.isEmpty()) {
+            try {
+                int numericQuery = Integer.parseInt(query);
+                where.append(" AND (id = ? OR sprite_id = ?)");
+                params.add(numericQuery);
+                params.add(numericQuery);
+                countParams.add(numericQuery);
+                countParams.add(numericQuery);
+            } catch (NumberFormatException e) {
+                where.append(" AND (item_name LIKE ? OR public_name LIKE ?)");
+                String like = "%" + query + "%";
+                params.add(like);
+                params.add(like);
+                countParams.add(like);
+                countParams.add(like);
+            }
+        }
+
+        if (!type.isEmpty()) {
+            where.append(" AND type = ?");
+            params.add(type);
+            countParams.add(type);
+        }
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            int total = 0;
+            try (PreparedStatement stmt = connection.prepareStatement("SELECT COUNT(*) as cnt FROM items_base" + where)) {
+                setParams(stmt, countParams);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    if (rs.next()) total = rs.getInt("cnt");
+                }
+            }
+
+            List<Map<String, Object>> items = new ArrayList<>();
+            try (PreparedStatement stmt = connection.prepareStatement("SELECT * FROM items_base" + where + " ORDER BY id DESC LIMIT ? OFFSET ?")) {
+                List<Object> allParams = new ArrayList<>(params);
+                allParams.add(limit);
+                allParams.add(offset);
+                setParams(stmt, allParams);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    while (rs.next()) {
+                        items.add(FurniEditorHelper.readBasicItem(rs));
+                    }
+                }
+            }
+
+            this.client.sendResponse(new FurniEditorSearchComposer(items, total, page));
+        }
+    }
+
+    private void setParams(PreparedStatement stmt, List<Object> params) throws Exception {
+        for (int i = 0; i < params.size(); i++) {
+            Object p = params.get(i);
+            if (p instanceof Integer) stmt.setInt(i + 1, (Integer) p);
+            else stmt.setString(i + 1, (String) p);
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorUpdateEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorUpdateEvent.java
@@ -1,0 +1,142 @@
+package com.eu.habbo.messages.incoming.furnieditor;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.furnieditor.FurniEditorResultComposer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FurniEditorUpdateEvent extends MessageHandler {
+
+    private static final Map<String, String> COL_MAP = new HashMap<>();
+
+    static {
+        COL_MAP.put("itemName", "item_name");
+        COL_MAP.put("publicName", "public_name");
+        COL_MAP.put("spriteId", "sprite_id");
+        COL_MAP.put("type", "type");
+        COL_MAP.put("width", "width");
+        COL_MAP.put("length", "length");
+        COL_MAP.put("stackHeight", "stack_height");
+        COL_MAP.put("allowStack", "allow_stack");
+        COL_MAP.put("allowWalk", "allow_walk");
+        COL_MAP.put("allowSit", "allow_sit");
+        COL_MAP.put("allowLay", "allow_lay");
+        COL_MAP.put("allowGift", "allow_gift");
+        COL_MAP.put("allowTrade", "allow_trade");
+        COL_MAP.put("allowRecycle", "allow_recycle");
+        COL_MAP.put("allowMarketplaceSell", "allow_marketplace_sell");
+        COL_MAP.put("allowInventoryStack", "allow_inventory_stack");
+        COL_MAP.put("interactionType", "interaction_type");
+        COL_MAP.put("interactionModesCount", "interaction_modes_count");
+        COL_MAP.put("vendingIds", "vending_ids");
+        COL_MAP.put("customparams", "customparams");
+        COL_MAP.put("effectIdMale", "effect_id_male");
+        COL_MAP.put("effectIdFemale", "effect_id_female");
+        COL_MAP.put("clothingOnWalk", "clothing_on_walk");
+        COL_MAP.put("multiheight", "multiheight");
+        COL_MAP.put("description", "description");
+    }
+
+    private static final List<String> BOOL_COLS = List.of(
+            "allow_stack", "allow_walk", "allow_sit", "allow_lay",
+            "allow_gift", "allow_trade", "allow_recycle",
+            "allow_marketplace_sell", "allow_inventory_stack"
+    );
+
+    @Override
+    public void handle() throws Exception {
+        if (!this.client.getHabbo().hasPermission(Permission.ACC_CATALOGFURNI)) {
+            this.client.sendResponse(new FurniEditorResultComposer(false, "No permission"));
+            return;
+        }
+
+        int id = this.packet.readInt();
+        String fieldsJson = this.packet.readString();
+
+        JsonObject fields;
+        try {
+            fields = JsonParser.parseString(fieldsJson).getAsJsonObject();
+        } catch (Exception e) {
+            this.client.sendResponse(new FurniEditorResultComposer(false, "Invalid JSON"));
+            return;
+        }
+
+        // Build SET clause
+        List<String> setClauses = new ArrayList<>();
+        List<Object> params = new ArrayList<>();
+
+        for (Map.Entry<String, String> entry : COL_MAP.entrySet()) {
+            String jsKey = entry.getKey();
+            String dbCol = entry.getValue();
+
+            if (!fields.has(jsKey)) continue;
+
+            setClauses.add(dbCol + " = ?");
+
+            if (BOOL_COLS.contains(dbCol)) {
+                params.add(fields.get(jsKey).getAsBoolean() ? "1" : "0");
+            } else if (dbCol.equals("stack_height")) {
+                params.add(fields.get(jsKey).getAsDouble());
+            } else if (dbCol.equals("width") || dbCol.equals("length") || dbCol.equals("interaction_modes_count")
+                    || dbCol.equals("sprite_id") || dbCol.equals("effect_id_male") || dbCol.equals("effect_id_female")) {
+                params.add(fields.get(jsKey).getAsInt());
+            } else {
+                params.add(fields.get(jsKey).getAsString());
+            }
+        }
+
+        if (setClauses.isEmpty()) {
+            this.client.sendResponse(new FurniEditorResultComposer(false, "No fields to update"));
+            return;
+        }
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            // Get current item_name for FurniData update
+            String currentItemName = null;
+            try (PreparedStatement stmt = connection.prepareStatement("SELECT item_name FROM items_base WHERE id = ?")) {
+                stmt.setInt(1, id);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    if (rs.next()) currentItemName = rs.getString("item_name");
+                }
+            }
+
+            if (currentItemName == null) {
+                this.client.sendResponse(new FurniEditorResultComposer(false, "Item not found"));
+                return;
+            }
+
+            // Execute update
+            String sql = "UPDATE items_base SET " + String.join(", ", setClauses) + " WHERE id = ?";
+            try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+                for (int i = 0; i < params.size(); i++) {
+                    Object p = params.get(i);
+                    if (p instanceof Integer) stmt.setInt(i + 1, (Integer) p);
+                    else if (p instanceof Double) stmt.setDouble(i + 1, (Double) p);
+                    else stmt.setString(i + 1, (String) p);
+                }
+                stmt.setInt(params.size() + 1, id);
+                stmt.execute();
+            }
+
+            // Update FurnitureData.json if publicName changed
+            if (fields.has("publicName")) {
+                Emulator.getGameEnvironment().getFurniDataManager().updateEntry(currentItemName, fields.get("publicName").getAsString());
+            }
+
+            // Refresh item cache
+            Emulator.getGameEnvironment().getItemManager().loadItems();
+
+            this.client.sendResponse(new FurniEditorResultComposer(true, "Item updated"));
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -555,6 +555,15 @@ public class Outgoing {
     public static final int SnowStormUserRematchedComposer = 5029;
 
 
+    // Catalog Admin
+    public static final int CatalogAdminResultComposer = 10059;
+
+    // Furni Editor
+    public static final int FurniEditorSearchComposer = 10040;
+    public static final int FurniEditorDetailComposer = 10041;
+    public static final int FurniEditorInteractionsComposer = 10043;
+    public static final int FurniEditorResultComposer = 10044;
+
     // Custom Prefixes
     public static final int UserPrefixesComposer = 7001;
     public static final int PrefixReceivedComposer = 7002;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/furnieditor/FurniEditorDetailComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/furnieditor/FurniEditorDetailComposer.java
@@ -1,0 +1,74 @@
+package com.eu.habbo.messages.outgoing.furnieditor;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+import java.util.List;
+import java.util.Map;
+
+public class FurniEditorDetailComposer extends MessageComposer {
+    private final Map<String, Object> item;
+    private final int usageCount;
+    private final List<Map<String, Object>> catalogItems;
+    private final String furniDataJson;
+
+    public FurniEditorDetailComposer(Map<String, Object> item, int usageCount, List<Map<String, Object>> catalogItems, String furniDataJson) {
+        this.item = item;
+        this.usageCount = usageCount;
+        this.catalogItems = catalogItems;
+        this.furniDataJson = furniDataJson;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.FurniEditorDetailComposer);
+
+        this.response.appendInt((int) this.item.get("id"));
+        this.response.appendInt((int) this.item.get("sprite_id"));
+        this.response.appendString((String) this.item.get("item_name"));
+        this.response.appendString((String) this.item.get("public_name"));
+        this.response.appendString((String) this.item.get("type"));
+        this.response.appendInt((int) this.item.get("width"));
+        this.response.appendInt((int) this.item.get("length"));
+        this.response.appendDouble((double) this.item.get("stack_height"));
+        this.response.appendBoolean((boolean) this.item.get("allow_stack"));
+        this.response.appendBoolean((boolean) this.item.get("allow_walk"));
+        this.response.appendBoolean((boolean) this.item.get("allow_sit"));
+        this.response.appendBoolean((boolean) this.item.get("allow_lay"));
+        this.response.appendString((String) this.item.get("interaction_type"));
+        this.response.appendInt((int) this.item.get("interaction_modes_count"));
+
+        // Extended fields
+        this.response.appendBoolean((boolean) this.item.get("allow_gift"));
+        this.response.appendBoolean((boolean) this.item.get("allow_trade"));
+        this.response.appendBoolean((boolean) this.item.get("allow_recycle"));
+        this.response.appendBoolean((boolean) this.item.get("allow_marketplace_sell"));
+        this.response.appendBoolean((boolean) this.item.get("allow_inventory_stack"));
+        this.response.appendString((String) this.item.getOrDefault("vending_ids", ""));
+        this.response.appendString((String) this.item.getOrDefault("customparams", ""));
+        this.response.appendInt((int) this.item.getOrDefault("effect_id_male", 0));
+        this.response.appendInt((int) this.item.getOrDefault("effect_id_female", 0));
+        this.response.appendString((String) this.item.getOrDefault("clothing_on_walk", ""));
+        this.response.appendString((String) this.item.getOrDefault("multiheight", ""));
+        this.response.appendString((String) this.item.getOrDefault("description", ""));
+        this.response.appendInt(this.usageCount);
+
+        // Catalog items
+        this.response.appendInt(this.catalogItems.size());
+        for (Map<String, Object> cat : this.catalogItems) {
+            this.response.appendInt((int) cat.get("id"));
+            this.response.appendString((String) cat.get("catalog_name"));
+            this.response.appendInt((int) cat.get("cost_credits"));
+            this.response.appendInt((int) cat.get("cost_points"));
+            this.response.appendInt((int) cat.get("points_type"));
+            this.response.appendInt((int) cat.get("page_id"));
+            this.response.appendString((String) cat.getOrDefault("page_caption", ""));
+        }
+
+        // FurniData JSON
+        this.response.appendString(this.furniDataJson != null ? this.furniDataJson : "");
+
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/furnieditor/FurniEditorInteractionsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/furnieditor/FurniEditorInteractionsComposer.java
@@ -1,0 +1,27 @@
+package com.eu.habbo.messages.outgoing.furnieditor;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+import java.util.List;
+
+public class FurniEditorInteractionsComposer extends MessageComposer {
+    private final List<String> interactions;
+
+    public FurniEditorInteractionsComposer(List<String> interactions) {
+        this.interactions = interactions;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.FurniEditorInteractionsComposer);
+        this.response.appendInt(this.interactions.size());
+
+        for (String interaction : this.interactions) {
+            this.response.appendString(interaction);
+        }
+
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/furnieditor/FurniEditorResultComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/furnieditor/FurniEditorResultComposer.java
@@ -1,0 +1,32 @@
+package com.eu.habbo.messages.outgoing.furnieditor;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+public class FurniEditorResultComposer extends MessageComposer {
+    private final boolean success;
+    private final String message;
+    private final int id;
+
+    public FurniEditorResultComposer(boolean success, String message) {
+        this.success = success;
+        this.message = message;
+        this.id = -1;
+    }
+
+    public FurniEditorResultComposer(boolean success, String message, int id) {
+        this.success = success;
+        this.message = message;
+        this.id = id;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.FurniEditorResultComposer);
+        this.response.appendBoolean(this.success);
+        this.response.appendString(this.message);
+        this.response.appendInt(this.id);
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/furnieditor/FurniEditorSearchComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/furnieditor/FurniEditorSearchComposer.java
@@ -1,0 +1,47 @@
+package com.eu.habbo.messages.outgoing.furnieditor;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+import java.util.List;
+import java.util.Map;
+
+public class FurniEditorSearchComposer extends MessageComposer {
+    private final List<Map<String, Object>> items;
+    private final int total;
+    private final int page;
+
+    public FurniEditorSearchComposer(List<Map<String, Object>> items, int total, int page) {
+        this.items = items;
+        this.total = total;
+        this.page = page;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.FurniEditorSearchComposer);
+        this.response.appendInt(this.items.size());
+
+        for (Map<String, Object> item : this.items) {
+            this.response.appendInt((int) item.get("id"));
+            this.response.appendInt((int) item.get("sprite_id"));
+            this.response.appendString((String) item.get("item_name"));
+            this.response.appendString((String) item.get("public_name"));
+            this.response.appendString((String) item.get("type"));
+            this.response.appendInt((int) item.get("width"));
+            this.response.appendInt((int) item.get("length"));
+            this.response.appendDouble((double) item.get("stack_height"));
+            this.response.appendBoolean((boolean) item.get("allow_stack"));
+            this.response.appendBoolean((boolean) item.get("allow_walk"));
+            this.response.appendBoolean((boolean) item.get("allow_sit"));
+            this.response.appendBoolean((boolean) item.get("allow_lay"));
+            this.response.appendString((String) item.get("interaction_type"));
+            this.response.appendInt((int) item.get("interaction_modes_count"));
+        }
+
+        this.response.appendInt(this.total);
+        this.response.appendInt(this.page);
+        return this.response;
+    }
+}


### PR DESCRIPTION
## Summary
- Add complete server-side implementation for the Furni Editor admin tool
- WebSocket-based CRUD operations on furniture items (`items_base` table)
- FurniDataManager for reading/writing `furnituredata.json` with automatic backup
- All handlers secured with `ACC_CATALOGFURNI` permission check

## New files
| File | Purpose |
|------|---------|
| `FurniDataManager.java` | Manages furnituredata.json read/write/backup |
| `FurniEditorSearchEvent.java` | Search items_base by name, ID, sprite, type (paginated) |
| `FurniEditorBySpriteEvent.java` | Lookup item by sprite_id with full detail |
| `FurniEditorDetailEvent.java` | Get item detail by ID |
| `FurniEditorUpdateEvent.java` | Update item properties in DB + furnituredata.json |
| `FurniEditorCreateEvent.java` | Create new furniture item |
| `FurniEditorDeleteEvent.java` | Delete furniture from DB + furnituredata.json |
| `FurniEditorInteractionsEvent.java` | List all available interaction types |
| `FurniEditorHelper.java` | Shared utility for building detail responses |
| `FurniEditorSearchComposer.java` | Paginated search results response |
| `FurniEditorDetailComposer.java` | Full item detail response |
| `FurniEditorInteractionsComposer.java` | Interaction type list response |
| `FurniEditorResultComposer.java` | Operation result confirmation |

## Modified files
| File | Changes |
|------|---------|
| `Emulator.java` | Register furni editor config keys |
| `GameEnvironment.java` | Initialize FurniDataManager |
| `PacketManager.java` | Register all furni editor packet handlers |
| `Incoming.java` | Add incoming packet header constants |
| `Outgoing.java` | Add outgoing packet header constants |

## Packet IDs (10040-10049)
| ID | Direction | Handler | Purpose |
|----|-----------|---------|---------|
| 10040 | In | FurniEditorSearchEvent | Search furniture |
| 10041 | Out | FurniEditorSearchComposer | Search results |
| 10042 | In | FurniEditorBySpriteEvent | Get by sprite ID |
| 10043 | Out | FurniEditorDetailComposer | Item detail |
| 10044 | In | FurniEditorUpdateEvent | Save changes |
| 10045 | In | FurniEditorCreateEvent | Create item |
| 10046 | In | FurniEditorDeleteEvent | Delete item |
| 10047 | In | FurniEditorInteractionsEvent | List interactions |
| 10048 | Out | FurniEditorInteractionsComposer | Interactions list |
| 10049 | Out | FurniEditorResultComposer | Operation result |

## Security
All handlers check `ACC_CATALOGFURNI` permission before processing.

## Related PRs
- **Nitro-V3**: duckietm/Nitro-V3#41 (client UI)
- **Renderer**: duckietm/Nitro_Render_V3#pending (WebSocket packets)

