### PR TITLE
Add UI Settings persistence handlers (10047-10048)

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -28,6 +28,7 @@ import com.eu.habbo.messages.incoming.guardians.GuardianNoUpdatesWantedEvent;
 import com.eu.habbo.messages.incoming.guardians.GuardianVoteEvent;
 import com.eu.habbo.messages.incoming.guides.*;
 import com.eu.habbo.messages.incoming.guilds.*;
+import com.eu.habbo.messages.incoming.uisettings.*;
 import com.eu.habbo.messages.incoming.guilds.forums.*;
 import com.eu.habbo.messages.incoming.handshake.*;
 import com.eu.habbo.messages.incoming.helper.MySanctionStatusEvent;
@@ -115,6 +116,7 @@ public class PacketManager {
         this.registerCrafting();
         this.registerCamera();
         this.registerGameCenter();
+        this.registerUiSettings();
     }
 
     public PacketNames getNames() {
@@ -655,5 +657,11 @@ public class PacketManager {
         this.registerHandler(Incoming.GameCenterLeaveGameEvent, GameCenterLeaveGameEvent.class);
         this.registerHandler(Incoming.GameCenterEvent, GameCenterEvent.class);
         this.registerHandler(Incoming.GameCenterRequestGameStatusEvent, GameCenterRequestGameStatusEvent.class);
+    }
+
+    // UI Settings
+    void registerUiSettings() throws Exception {
+        this.registerHandler(Incoming.UiSettingsSaveEvent, UiSettingsSaveEvent.class);
+        this.registerHandler(Incoming.UiSettingsLoadEvent, UiSettingsLoadEvent.class);
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -412,6 +412,10 @@ public class Incoming {
     public static final int RequestInventoryPetDelete = 10030;
     public static final int RequestInventoryBadgeDelete  = 10031;
 
+    // UI Settings
+    public static final int UiSettingsSaveEvent = 10047;
+    public static final int UiSettingsLoadEvent = 10048;
+
     // Custom Prefixes
     public static final int RequestUserPrefixesEvent = 7011;
     public static final int SetActivePrefixEvent = 7012;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/uisettings/UiSettingsLoadEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/uisettings/UiSettingsLoadEvent.java
@@ -1,0 +1,35 @@
+package com.eu.habbo.messages.incoming.uisettings;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.uisettings.UiSettingsDataComposer;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+public class UiSettingsLoadEvent extends MessageHandler {
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(UiSettingsLoadEvent.class);
+
+    @Override
+    public void handle() throws Exception {
+        int userId = this.client.getHabbo().getHabboInfo().getId();
+
+        LOGGER.info("[UiSettingsLoad] Loading settings for user {} (id: {})", this.client.getHabbo().getHabboInfo().getUsername(), userId);
+
+        String settingsJson = "{}";
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            try (PreparedStatement stmt = connection.prepareStatement("SELECT settings_json FROM users_ui_settings WHERE user_id = ?")) {
+                stmt.setInt(1, userId);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    if (rs.next()) {
+                        settingsJson = rs.getString("settings_json");
+                    }
+                }
+            }
+        }
+
+        this.client.sendResponse(new UiSettingsDataComposer(settingsJson));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/uisettings/UiSettingsSaveEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/uisettings/UiSettingsSaveEvent.java
@@ -1,0 +1,29 @@
+package com.eu.habbo.messages.incoming.uisettings;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.messages.incoming.MessageHandler;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+public class UiSettingsSaveEvent extends MessageHandler {
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(UiSettingsSaveEvent.class);
+
+    @Override
+    public void handle() throws Exception {
+        String settingsJson = this.packet.readString();
+        int userId = this.client.getHabbo().getHabboInfo().getId();
+
+        LOGGER.info("[UiSettingsSave] Saving settings for user {} (id: {})", this.client.getHabbo().getHabboInfo().getUsername(), userId);
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            try (PreparedStatement stmt = connection.prepareStatement(
+                    "INSERT INTO users_ui_settings (user_id, settings_json) VALUES (?, ?) ON DUPLICATE KEY UPDATE settings_json = ?")) {
+                stmt.setInt(1, userId);
+                stmt.setString(2, settingsJson);
+                stmt.setString(3, settingsJson);
+                stmt.executeUpdate();
+            }
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -556,6 +556,9 @@ public class Outgoing {
     public static final int SnowStormUserRematchedComposer = 5029;
 
 
+    // UI Settings
+    public static final int UiSettingsDataComposer = 10047;
+
     // Custom Prefixes
     public static final int UserPrefixesComposer = 7001;
     public static final int PrefixReceivedComposer = 7002;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/uisettings/UiSettingsDataComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/uisettings/UiSettingsDataComposer.java
@@ -1,0 +1,20 @@
+package com.eu.habbo.messages.outgoing.uisettings;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+public class UiSettingsDataComposer extends MessageComposer {
+    private final String settingsJson;
+
+    public UiSettingsDataComposer(String settingsJson) {
+        this.settingsJson = settingsJson;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.UiSettingsDataComposer);
+        this.response.appendString(this.settingsJson);
+        return this.response;
+    }
+}


### PR DESCRIPTION
## Summary
- Server-side persistence for UI color theming settings
- Companion PR to [Nitro-V3#45](https://github.com/duckietm/Nitro-V3/pull/45), extends [#16](https://github.com/duckietm/Nitro-V3/pull/16)

## Handlers
| Packet | Handler | Description |
|---|---|---|
| 10047 (in) | `UiSettingsSaveEvent` | Saves user UI settings JSON to DB (upsert) |
| 10048 (in) | `UiSettingsLoadEvent` | Loads user UI settings from DB |
| 10047 (out) | `UiSettingsDataComposer` | Sends settings JSON string to client |

## DB Migration
```sql
CREATE TABLE IF NOT EXISTS `users_ui_settings` (
  `user_id` INT NOT NULL,
  `settings_json` TEXT NOT NULL,
  PRIMARY KEY (`user_id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
```

## Files
- `messages/incoming/uisettings/UiSettingsSaveEvent.java`
- `messages/incoming/uisettings/UiSettingsLoadEvent.java`
- `messages/outgoing/uisettings/UiSettingsDataComposer.java`
- `Incoming.java`, `Outgoing.java`, `PacketManager.java` (registrations only)

## Test plan
- [ ] Build emulator without errors
- [ ] Run SQL migration
- [ ] Save color in client → verify row in `users_ui_settings`
- [ ] Reload client → verify settings loaded from server