### PR TITLE
🆙 Fix in habbomanager

### DIFF
--- a/Database Updates/006_HabboManager_fix.sql
+++ b/Database Updates/006_HabboManager_fix.sql
@@ -1,0 +1,35 @@
+ALTER TABLE `users`
+  DROP KEY IF EXISTS `auth_ticket`,
+  MODIFY `auth_ticket` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  ADD KEY IF NOT EXISTS `idx_users_auth_ticket` (`auth_ticket`);
+
+  ADD KEY IF NOT EXISTS `idx_rel_user_room` (`user_id`, `room_id`);
+
+ALTER TABLE `logs_hc_payday`
+  ADD KEY IF NOT EXISTS `idx_lhcp_user_claimed` (`user_id`, `claimed`);
+
+ALTER TABLE `room_votes`
+  DROP KEY IF EXISTS `user_id`,
+  ADD UNIQUE KEY IF NOT EXISTS `uniq_room_votes_user_room` (`user_id`, `room_id`);
+
+ALTER TABLE `room_game_scores`
+  ADD KEY IF NOT EXISTS `idx_rgs_room_ts` (`room_id`, `game_start_timestamp`),
+  ADD KEY IF NOT EXISTS `idx_rgs_user`    (`user_id`);
+
+ALTER TABLE `calendar_rewards_claimed`
+  DROP KEY IF EXISTS `idx_cal_claimed_user_id`,
+  ADD UNIQUE KEY IF NOT EXISTS `uniq_crc_user_campaign_reward` (`user_id`, `campaign_id`, `reward_id`);
+
+ALTER TABLE `emulator_settings`
+  ENGINE = InnoDB,
+  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `gift_wrappers`     ENGINE = InnoDB;
+ALTER TABLE `pet_actions`       ENGINE = InnoDB;
+ALTER TABLE `pet_commands_data` ENGINE = InnoDB;
+
+ALTER TABLE `calendar_rewards`
+  MODIFY `product_name`      VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  MODIFY `custom_image`      VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  MODIFY `badge`             VARCHAR(25)  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  MODIFY `subscription_type` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci          DEFAULT '';

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboManager.java
@@ -198,7 +198,7 @@ public class HabboManager {
     public ArrayList<HabboInfo> getCloneAccounts(Habbo habbo, int limit) {
         ArrayList<HabboInfo> habboInfo = new ArrayList<>();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM users WHERE ip_register = ? OR ip_current = ? AND id != ? ORDER BY id DESC LIMIT ?")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM users WHERE (ip_register = ? OR ip_current = ?) AND id != ? ORDER BY id DESC LIMIT ?")) {
             statement.setString(1, habbo.getHabboInfo().getIpRegister());
             statement.setString(2, habbo.getHabboInfo().getIpLogin());
             statement.setInt(3, habbo.getHabboInfo().getId());


### PR DESCRIPTION
The getCloneAccounts query had an operator-precedence bug:

WHERE ip_register = ? OR ip_current = ? AND id != ? -- parsed as:
WHERE ip_register = ? OR (ip_current = ? AND id != ?)

So a user whose ip_register matched themselves would show up in their own clone list. Added parentheses:

WHERE (ip_register = ? OR ip_current = ?) AND id != ?

So please run the 006_HabboManager_fix before you run the update Emulator !