### PR TITLE
fix(catalog): align CatalogItem serialize order with Nitro client parser

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogItem.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogItem.java
@@ -335,10 +335,11 @@ public class CatalogItem implements ISerialize, Runnable, Comparable<CatalogItem
         }
 
         message.appendInt(this.clubOnly);
-        message.appendBoolean(haveOffer(this));
-        message.appendBoolean(false); //unknown
+        message.appendBoolean(false); //bundlePurchaseAllowed
+        message.appendBoolean(false); //isPet
         message.appendString(this.name + ".png");
         message.appendString(this.itemId == null ? "" : this.itemId);
+        message.appendBoolean(haveOffer(this));
     }
 
     @Override


### PR DESCRIPTION
## Summary

- Fixes `RangeError: offset is outside the bounds of the DataView` thrown by the Nitro client when opening catalog pages / browsing categories.
- The client parser `CatalogPageMessageOfferData` reads **six** trailing fields after the products loop: `clubLevel`, `bundlePurchaseAllowed`, `isPet`, `previewImage`, `itemIds`, `haveOffer`.
- `CatalogItem.serialize()` only wrote **five** and put `haveOffer` in the `bundlePurchaseAllowed` slot, so the final `readBoolean()` on the client overran the buffer.

## Change

In `Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogItem.java`:

```java
message.appendInt(this.clubOnly);
message.appendBoolean(false); //bundlePurchaseAllowed
message.appendBoolean(false); //isPet
message.appendString(this.name + ".png");
message.appendString(this.itemId == null ? "" : this.itemId);
message.appendBoolean(haveOffer(this));
```

`haveOffer` is now written last, matching the parser order. The two leading booleans fall back to `false` (as before the recent `have_offer` work).

## Test plan

- [ ] Build emulator (`mvn clean package -DskipTests`) — verified locally.
- [ ] Open the catalog in the Nitro client and browse categories — no more DataView range errors in the browser console.