### PR TITLE
Feat/full box background

### DIFF
--- a/Emulator/sqlupdates/add_users_background_card_id.sql
+++ b/Emulator/sqlupdates/add_users_background_card_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD COLUMN IF NOT EXISTS `background_card_id` INT(11) NOT NULL DEFAULT 0 AFTER `background_overlay_id`;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInfo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInfo.java
@@ -45,6 +45,7 @@ public class HabboInfo implements Runnable {
     private int InfostandBg;
     private int InfostandStand;
     private int InfostandOverlay;
+    private int InfostandCardBg;
     private int loadingRoom;
     private Room currentRoom;
     private String roomEntryMethod = "door";
@@ -91,6 +92,7 @@ public class HabboInfo implements Runnable {
             this.InfostandBg = set.getInt("background_id");
             this.InfostandStand = set.getInt("background_stand_id");
             this.InfostandOverlay = set.getInt("background_overlay_id");
+            this.InfostandCardBg = set.getInt("background_card_id");
             this.currentRoom = null;
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
@@ -289,6 +291,14 @@ public class HabboInfo implements Runnable {
 
     public void setInfostandOverlay(int infostandOverlay) {
         InfostandOverlay = infostandOverlay;
+    }
+
+    public int getInfostandCardBg() {
+        return InfostandCardBg;
+    }
+
+    public void setInfostandCardBg(int infostandCardBg) {
+        InfostandCardBg = infostandCardBg;
     }
     public Rank getRank() {
         return this.rank;
@@ -577,7 +587,7 @@ public class HabboInfo implements Runnable {
 
         try {
             SqlQueries.update(
-                    "UPDATE users SET motto = ?, online = ?, look = ?, gender = ?, credits = ?, last_login = ?, last_online = ?, home_room = ?, ip_current = ?, `rank` = ?, machine_id = ?, username = ?, background_id = ?, background_stand_id = ?, background_overlay_id = ? WHERE id = ?",
+                    "UPDATE users SET motto = ?, online = ?, look = ?, gender = ?, credits = ?, last_login = ?, last_online = ?, home_room = ?, ip_current = ?, `rank` = ?, machine_id = ?, username = ?, background_id = ?, background_stand_id = ?, background_overlay_id = ?, background_card_id = ? WHERE id = ?",
                     this.motto,
                     this.online ? "1" : "0",
                     this.look,
@@ -593,6 +603,7 @@ public class HabboInfo implements Runnable {
                     this.InfostandBg,
                     this.InfostandStand,
                     this.InfostandOverlay,
+                    this.InfostandCardBg,
                     this.id);
         } catch (SqlQueries.DataAccessException e) {
             LOGGER.error("Caught SQL exception", e);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/users/ChangeInfostandBgEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/users/ChangeInfostandBgEvent.java
@@ -9,10 +9,12 @@ public class ChangeInfostandBgEvent extends MessageHandler {
         int backgroundImage = this.packet.readInt();
         int backgroundStand = this.packet.readInt();
         int backgroundOverlay = this.packet.readInt();
+        int backgroundCard = this.packet.bytesAvailable() >= 4 ? this.packet.readInt() : 0;
 
         this.client.getHabbo().getHabboInfo().setInfostandBg(backgroundImage);
         this.client.getHabbo().getHabboInfo().setInfostandStand(backgroundStand);
         this.client.getHabbo().getHabboInfo().setInfostandOverlay(backgroundOverlay);
+        this.client.getHabbo().getHabboInfo().setInfostandCardBg(backgroundCard);
         this.client.getHabbo().getHabboInfo().run();
 
         if (this.client.getHabbo().getHabboInfo().getCurrentRoom() != null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/users/RoomUserDataComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/users/RoomUserDataComposer.java
@@ -23,6 +23,7 @@ public class RoomUserDataComposer extends MessageComposer {
         this.response.appendInt(this.habbo.getHabboInfo().getInfostandBg());
         this.response.appendInt(this.habbo.getHabboInfo().getInfostandStand());
         this.response.appendInt(this.habbo.getHabboInfo().getInfostandOverlay());
+        this.response.appendInt(this.habbo.getHabboInfo().getInfostandCardBg());
         return this.response;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/users/RoomUsersComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/users/RoomUsersComposer.java
@@ -43,6 +43,7 @@ public class RoomUsersComposer extends MessageComposer {
             this.response.appendInt(this.habbo.getHabboInfo().getInfostandBg());
             this.response.appendInt(this.habbo.getHabboInfo().getInfostandStand());
             this.response.appendInt(this.habbo.getHabboInfo().getInfostandOverlay());
+            this.response.appendInt(this.habbo.getHabboInfo().getInfostandCardBg());
             this.response.appendString(this.habbo.getHabboInfo().getLook());
             this.response.appendInt(this.habbo.getRoomUnit().getId()); //Room Unit ID
             this.response.appendInt(this.habbo.getRoomUnit().getX());
@@ -78,6 +79,7 @@ public class RoomUsersComposer extends MessageComposer {
 					this.response.appendInt(habbo.getHabboInfo().getInfostandBg());
                     this.response.appendInt(habbo.getHabboInfo().getInfostandStand());
                     this.response.appendInt(habbo.getHabboInfo().getInfostandOverlay());
+                    this.response.appendInt(habbo.getHabboInfo().getInfostandCardBg());
                     this.response.appendString(habbo.getHabboInfo().getLook());
                     this.response.appendInt(habbo.getRoomUnit().getId()); //Room Unit ID
                     this.response.appendInt(habbo.getRoomUnit().getX());
@@ -111,6 +113,7 @@ public class RoomUsersComposer extends MessageComposer {
 			this.response.appendInt(0);
             this.response.appendInt(0);
             this.response.appendInt(0);
+            this.response.appendInt(0);
             this.response.appendString(this.bot.getFigure());
             this.response.appendInt(this.bot.getRoomUnit().getId());
             this.response.appendInt(this.bot.getRoomUnit().getX());
@@ -140,6 +143,7 @@ public class RoomUsersComposer extends MessageComposer {
                 this.response.appendInt(0 - bot.getId());
                 this.response.appendString(bot.getName());
                 this.response.appendString(bot.getMotto());
+				this.response.appendInt(0);
 				this.response.appendInt(0);
 				this.response.appendInt(0);
 				this.response.appendInt(0);

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/UserProfileComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/UserProfileComposer.java
@@ -115,6 +115,7 @@ public class UserProfileComposer extends MessageComposer {
         this.response.appendInt(this.habboInfo.getInfostandBg());
         this.response.appendInt(this.habboInfo.getInfostandStand());
         this.response.appendInt(this.habboInfo.getInfostandOverlay());
+        this.response.appendInt(this.habboInfo.getInfostandCardBg());
 
         return this.response;
     }


### PR DESCRIPTION
Introduces a 4th profile-style id (cardBg) alongside the existing background/stand/overlay triplet. The new id is meant to render a background that fills the entire user info card on the client.

- HabboInfo: new InfostandCardBg field, loaded/saved with the existing background ids; users.background_card_id column added via sqlupdates/add_users_background_card_id.sql.
- ChangeInfostandBgEvent: reads a 4th int with bytesAvailable guard to remain compatible with older clients.
- RoomUserDataComposer, RoomUsersComposer, UserProfileComposer: append the cardBg int after the existing trio. Bot sections in RoomUsersComposer pad an extra zero to keep field count consistent.