### PR TITLE
feat(messages): extend UserPermissionsComposer with rank metadata + resolved permission map

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/UserPermissionsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/UserPermissionsComposer.java
@@ -1,11 +1,57 @@
 package com.eu.habbo.messages.outgoing.users;
 
+import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.habbohotel.permissions.PermissionSetting;
+import com.eu.habbo.habbohotel.permissions.Rank;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
+import com.eu.habbo.plugin.HabboPlugin;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Sends the full per-user permission state to the connected client.
+ *
+ * Wire layout (each trailing block is guarded by `bytesAvailable` on
+ * the client so older Nitro builds keep parsing the prefix and stop):
+ *
+ *   int     clubLevel
+ *   int     rank.level                           // mapped to securityLevel on the client
+ *   bool    isAmbassador                         // legacy ACC_AMBASSADOR flag
+ *   --- rank metadata (Arcturus ≥ 4.2.10) ---
+ *   int     rank.id
+ *   string  rank.name                            // permission_ranks.rank_name
+ *   string  rank.badge
+ *   string  rank.prefix
+ *   string  rank.prefixColor
+ *   --- resolved permission map (Arcturus ≥ 4.2.10) ---
+ *   int     count
+ *   loop:   string permission_key + int value   // 1 = ALLOWED, 2 = ROOM_OWNER
+ *
+ * The map is the union of:
+ *   • rank entries with `PermissionSetting != DISALLOWED` — same data
+ *     `Rank.hasPermission(key, isRoomOwner)` reads server-side.
+ *   • plugin grants — for each key the rank doesn't allow, every
+ *     installed `HabboPlugin.hasPermission(habbo, key)` is consulted;
+ *     if any plugin grants it, the key lands on the wire with value 1
+ *     (plugins don't have a ROOM_OWNER concept).
+ *
+ * The React-side `useHasPermission(key)` / `useUserPermissions()`
+ * consumers read the map directly so UI gates follow the same
+ * semantics as `PermissionsManager.hasPermission(habbo, key)`
+ * server-side — including plugin-granted permissions, which were
+ * invisible to the client before this commit.
+ *
+ * Two send points:
+ *   1. End of `SecureLoginEvent` — client receives the full state once.
+ *   2. Inside `HabboManager.setRank` — runtime promote/demote refresh.
+ *   3. Inside `UpdatePermissionsCommand` — broadcast after
+ *      `:update_permissions` reloads the tables at runtime.
+ */
 public class UserPermissionsComposer extends MessageComposer {
     private final int clubLevel;
 
@@ -20,9 +66,68 @@ public class UserPermissionsComposer extends MessageComposer {
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.UserPermissionsComposer);
         this.response.appendInt(this.clubLevel);
-        this.response.appendInt(this.habbo.getHabboInfo().getRank().getLevel());
+
+        Rank rank = this.habbo.getHabboInfo().getRank();
+
+        this.response.appendInt(rank.getLevel());
         this.response.appendBoolean(this.habbo.hasPermission(Permission.ACC_AMBASSADOR));
+
+        // Rank metadata
+        this.response.appendInt(rank.getId());
+        this.response.appendString(rank.getName());
+        this.response.appendString(rank.getBadge());
+        this.response.appendString(rank.getPrefix());
+        this.response.appendString(rank.getPrefixColor());
+
+        // Build the resolved permission map. Walk rank.getPermissions()
+        // (Rank.permissions has every row from permission_definitions
+        // because PermissionsManager.loadPermissionsNormalized() calls
+        // rank.setPermission(key, …) for every key, including DISALLOWED
+        // ones) and emit the final value per key:
+        //   ALLOWED                 → 1
+        //   ROOM_OWNER              → 2
+        //   DISALLOWED + plugin yes → 1
+        //   DISALLOWED + plugin no  → omit
+        //
+        // LinkedHashMap preserves the alphabetical order that the rank
+        // table was populated with, which is helpful for snapshotting
+        // and grep'ing wire dumps.
+        Map<String, Permission> rankPermissions = rank.getPermissions();
+        Map<String, Integer> resolved = new LinkedHashMap<>(rankPermissions.size());
+
+        for (Map.Entry<String, Permission> entry : rankPermissions.entrySet()) {
+            String key = entry.getKey();
+            Permission rankPerm = entry.getValue();
+
+            if (rankPerm.setting == PermissionSetting.ALLOWED) {
+                resolved.put(key, 1);
+            } else if (rankPerm.setting == PermissionSetting.ROOM_OWNER) {
+                resolved.put(key, 2);
+            } else if (this.anyPluginGrants(key)) {
+                resolved.put(key, 1);
+            }
+        }
+
+        // Plugins may also grant CUSTOM keys that aren't in
+        // permission_definitions — rare but legal. There's no enumeration
+        // API on HabboPlugin to discover them, so they stay invisible
+        // here. Document the limitation rather than over-engineer.
+
+        this.response.appendInt(resolved.size());
+
+        for (Map.Entry<String, Integer> entry : resolved.entrySet()) {
+            this.response.appendString(entry.getKey());
+            this.response.appendInt(entry.getValue());
+        }
+
         return this.response;
+    }
+
+    private boolean anyPluginGrants(String key) {
+        for (HabboPlugin plugin : Emulator.getPluginManager().getPlugins()) {
+            if (plugin.hasPermission(this.habbo, key)) return true;
+        }
+        return false;
     }
 
     public int getClubLevel() {


### PR DESCRIPTION
## Summary

Backward-compatible extension of `UserPermissionsComposer` (header `411`) that ships two new trailing blocks so Nitro clients can:

1. **Display per-deployment rank info** (badge, prefix, prefix color) instead of hardcoding the renderer-side `SecurityLevel` constants which don't line up with the operator's actual `permission_ranks.rank_name` values.
2. **Drive UI gates against `permission_definitions` keys** instead of rank levels — a new rank in `permission_ranks` or a re-shuffling of permission-to-rank assignments propagates through the React UI automatically, without recompiling the client.

## Wire layout (after this PR)

Each trailing block is guarded on the parser side by `bytesAvailable`, so older Nitro clients keep parsing the prefix and stop:

```
int     clubLevel
int     rank.level                          // mapped to securityLevel on the client
bool    isAmbassador                        // existing ACC_AMBASSADOR flag

--- NEW: rank metadata ---
int     rank.id
string  rank.name                           // permission_ranks.rank_name
string  rank.badge
string  rank.prefix
string  rank.prefixColor

--- NEW: resolved permission map ---
int     count
loop:   string permission_key + int value   // 1 = ALLOWED, 2 = ROOM_OWNER
```

## Permission map semantics

The map is the union of:

* Rank entries whose `PermissionSetting != DISALLOWED` (value `1` for ALLOWED, `2` for ROOM_OWNER).
* For every rank-DISALLOWED key, each installed `HabboPlugin.hasPermission(habbo, key)` is consulted; if any plugin grants the permission, the key lands on the wire with value `1` (plugins don't have a ROOM_OWNER concept).

Iterating `rank.getPermissions().keySet()` covers every key in `permission_definitions` because `PermissionsManager.loadPermissionsNormalized()` calls `rank.setPermission(key, …)` for every row of the table — including DISALLOWED ones.

The end-state semantics match exactly what `PermissionsManager.hasPermission(habbo, key)` returns server-side — **including plugin-granted permissions, which were invisible to the client before this PR**.

### Known limitation (documented in Javadoc)

If a plugin invents a permission key that isn't in `permission_definitions`, it stays invisible on the wire — there's no enumeration API on `HabboPlugin` to discover such custom keys. Rare case; out of scope for this PR.

## Backward compatibility

* **Older Nitro clients** keep parsing only the prefix `[clubLevel, securityLevel, isAmbassador]` and ignore the trailing bytes. No error, no behavior change.
* **New Nitro clients** with the matching parser extension expose the extra data via `IUserDataSnapshot` snapshot getters and React-side hooks (`useUserRank()`, `useHasPermission(key)`, `useUserPermissions()`).

## Performance

At login the loop is `O(N keys × P plugins)`:
* `N` ≈ 200 (size of `permission_definitions` in the default seed)
* `P` typically 1-5
* `HabboPlugin.hasPermission` is O(1) hashset lookups in realistic implementations

Sub-millisecond at login. The composer is only sent at three points: end of `SecureLoginEvent`, inside `HabboManager.setRank`, and the new `:update_permissions` broadcast (see companion PR).

## Companion PRs

* `duckietm/Nitro_Render_V3` — `UserPermissionsParser` extension + `SessionDataManager.getPermissionsSnapshot()` + `NitroEventType.USER_PERMISSIONS_UPDATED`.
* `duckietm/Nitro-V3` — React `useHasPermission(key)` / `useUserPermissions()` / `useUserRank()` hooks + 11 consumer migrations from hardcoded `SecurityLevel` gates to `permission_definitions` key gates.

A follow-up PR on this repo extends the `:update_permissions` console command to broadcast the new composer to every online client so runtime DB edits propagate without a server restart.

## Test plan

- [ ] `mvn -f Emulator/pom.xml clean package -DskipTests` builds cleanly.
- [ ] Connect a legacy Nitro client (without the parser extension) and verify login still works (trailing bytes ignored).
- [ ] Connect a new Nitro client (with parser extension) and verify `useUserRank()` returns the rank metadata and `useHasPermission('acc_supporttool')` matches the user's rank in `permission_definitions`.
- [ ] Grant a permission via a custom `HabboPlugin.hasPermission` override and verify it appears in the client's permission map (value 1).
- [ ] Use `:give_rank user 5` (or RCON `SetRank`) and verify the client's `useUserRank()` and `useHasPermission(...)` re-render with the new rank's data.