### PR TITLE
feat(commands): :update_permissions broadcasts refreshed permissions to every online client

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/UpdatePermissionsCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/UpdatePermissionsCommand.java
@@ -2,7 +2,12 @@ package com.eu.habbo.habbohotel.commands;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.permissions.PermissionsManager;
+import com.eu.habbo.habbohotel.permissions.Rank;
 import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboManager;
+import com.eu.habbo.messages.outgoing.users.UserPermissionsComposer;
 
 public class UpdatePermissionsCommand extends Command {
     public UpdatePermissionsCommand() {
@@ -13,7 +18,41 @@ public class UpdatePermissionsCommand extends Command {
     public boolean handle(GameClient gameClient, String[] params) throws Exception {
         Emulator.getGameEnvironment().getPermissionsManager().reload();
 
-        gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.succes.cmd_update_permissions"), RoomChatMessageBubbles.ALERT);
+        // PermissionsManager.reload() rebuilt the rank table — each online
+        // Habbo's HabboInfo still references the OLD Rank object, so
+        // server-side hasPermission() / wire composers would keep
+        // reporting stale data until relogin. Re-bind every connected
+        // user to the freshly-loaded Rank by id, then ship the new
+        // UserPermissionsComposer (which carries clubLevel,
+        // securityLevel, isAmbassador, rank metadata and the resolved
+        // permission_definitions map) so Nitro clients' React-side
+        // useHasPermission(key) / useUserRank() / useUserPermissions()
+        // consumers re-render against the updated tables without an F5.
+        HabboManager habboManager = Emulator.getGameEnvironment().getHabboManager();
+        PermissionsManager permissions = Emulator.getGameEnvironment().getPermissionsManager();
+
+        int refreshed = 0;
+
+        for (Habbo habbo : habboManager.getOnlineHabbos().values()) {
+            if (habbo == null || habbo.getHabboInfo() == null || habbo.getClient() == null) continue;
+
+            int currentRankId = habbo.getHabboInfo().getRank().getId();
+            // Defensive fallback: if the admin deleted the rank from the
+            // permission_ranks table between sessions, fall back to rank 1
+            // (Member) so the user isn't stranded with a null Rank.
+            Rank freshRank = permissions.rankExists(currentRankId)
+                    ? permissions.getRank(currentRankId)
+                    : permissions.getRank(1);
+
+            habbo.getHabboInfo().setRank(freshRank);
+            habbo.getClient().sendResponse(new UserPermissionsComposer(habbo));
+            refreshed++;
+        }
+
+        gameClient.getHabbo().whisper(
+                Emulator.getTexts().getValue("commands.succes.cmd_update_permissions") + " (" + refreshed + " online refreshed)",
+                RoomChatMessageBubbles.ALERT
+        );
 
         return true;
     }


### PR DESCRIPTION
## Summary

Closes the runtime-dynamism gap on the `:update_permissions` console command.

`PermissionsManager.reload()` rebuilds the rank table from `permission_ranks` + `permission_definitions`, but every Habbo currently online still holds a reference to the OLD `Rank` object on `HabboInfo.rank`. Server-side `hasPermission()` therefore keeps returning stale results, and any Nitro client that reads permission state from the wire keeps gating UI on the map shipped at login — until a relogin or `:give_rank` forces a per-user refresh.

After this PR the command:

1. Iterates the online Habbos via `HabboManager.getOnlineHabbos()`.
2. Re-binds each one's `HabboInfo.rank` to the FRESH `Rank` object returned by `PermissionsManager.getRank(currentRankId)`. Falls back to rank `1` if the admin deleted the rank from `permission_ranks` between sessions, so the user is never left with a null `Rank` reference.
3. Sends a fresh `UserPermissionsComposer` to each client.

The whisper feedback now reports how many connected users were refreshed — useful for ops feedback after a large `permission_ranks` edit.

## Pairs naturally with the composer extension PR

This PR is independent and safe to merge first, but it gets dramatically more useful once the composer extension PR (`#109` on this repo) is merged: at that point, the broadcast pushes the full rank metadata + resolved permission map runtime, and the Nitro React-side `useHasPermission(key)` / `useUserRank()` consumers re-render against the freshly-loaded tables without requiring an F5.

## Runtime flow after merging both PRs

```
admin edits permission_definitions in DB (phpMyAdmin / Housekeeping CMS / any tool)
  ↓
:update_permissions in console/chat
  ↓
PermissionsManager.reload() → rebuilds rank table
  ↓
For every online Habbo:
    setRank(freshRank)  +  sendResponse(UserPermissionsComposer)
  ↓
Renderer UserPermissionsParser → SessionDataManager
  ↓
React useHasPermission(key) re-renders affected widgets for every connected user
```

Closes the "dynamic-from-DB" gap completely — no more server restart needed when tuning permission_definitions.

## Backward compatibility

* No wire format change in THIS PR; only invokes the existing composer per online user.
* If the composer extension PR is NOT merged, this still works — it just broadcasts the legacy `[clubLevel, securityLevel, isAmbassador]` triple to refresh those fields.

## Defensive checks

Null guards on `habbo` / `habboInfo` / `client` survive transient state during the broadcast (e.g. a user disconnecting mid-iteration). The rank fallback uses `permissionsManager.rankExists(id)` before calling `getRank(id)` to avoid NPE if a rank was deleted between sessions.

## Test plan

- [ ] `mvn -f Emulator/pom.xml clean package -DskipTests` builds cleanly.
- [ ] Run the server, connect a user, edit `permission_definitions.acc_supporttool.rank_5 = 0` in DB.
- [ ] Run `:update_permissions` from an admin account.
- [ ] Verify the whisper reports the right count of refreshed users.
- [ ] Verify the connected user's `hasPermission('acc_supporttool')` returns `false` on the server (was `true` before the reload), without relogin.
- [ ] (With composer extension PR merged) Verify the Nitro client's mod-only UI elements gated on `useHasPermission('acc_supporttool')` disappear live.