### PR TITLE
fix(modtool): bump users_settings counters on every sanction

### DIFF
--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.eu.habbo</groupId>
     <artifactId>Habbo</artifactId>
-    <version>4.2.11</version>
+    <version>4.2.12</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.eu.habbo</groupId>
     <artifactId>Habbo</artifactId>
-    <version>4.2.10</version>
+    <version>4.2.11</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolManager.java
@@ -651,6 +651,10 @@ public class ModToolManager {
             sender.getClient().sendResponse(new ModToolIssueHandledComposer(ModToolIssueHandledComposer.ABUSIVE));
         }
 
+        // Reporter (the user who opened the CFH) gets their abusive
+        // counter bumped — the legacy stat shown in the User Info table.
+        bumpUserSettingCounter(issue.senderId, "cfh_abusive");
+
         this.updateTicketToMods(issue);
 
         this.removeTicket(issue);
@@ -736,5 +740,39 @@ public class ModToolManager {
         }
 
         return issues;
+    }
+
+    /**
+     * Increments a single integer counter on `users_settings` for the
+     * given user. Used by the moderation sanction handlers to bump the
+     * legacy counters that `ModToolUserInfoComposer` surfaces (cfh_warnings,
+     * cfh_bans, cfh_abusive, tradelock_amount) — historically these were
+     * only ever incremented by the CFH submission path, so a user could
+     * accumulate any number of bans/mutes without the User Info table
+     * reflecting it.
+     *
+     * Restricted to a whitelisted column name to keep the dynamic SQL
+     * safe; the caller passes a Permission-style constant.
+     */
+    public static void bumpUserSettingCounter(int userId, String column) {
+        switch (column) {
+            case "cfh_warnings":
+            case "cfh_bans":
+            case "cfh_abusive":
+            case "tradelock_amount":
+                break;
+            default:
+                LOGGER.warn("Refusing to bump unrecognized user_settings column: {}", column);
+                return;
+        }
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+             PreparedStatement statement = connection.prepareStatement(
+                 "UPDATE users_settings SET " + column + " = " + column + " + 1 WHERE user_id = ?")) {
+            statement.setInt(1, userId);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception bumping {} for user {}", column, userId, e);
+        }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionAlertEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionAlertEvent.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.messages.incoming.modtool;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.modtool.ModToolManager;
 import com.eu.habbo.habbohotel.modtool.ModToolSanctionItem;
 import com.eu.habbo.habbohotel.modtool.ModToolSanctions;
 import com.eu.habbo.habbohotel.permissions.Permission;
@@ -47,6 +48,8 @@ public class ModToolSanctionAlertEvent extends MessageHandler {
                 } else {
                     habbo.alert(message);
                 }
+
+                ModToolManager.bumpUserSettingCounter(userId, "cfh_warnings");
             } else {
                 this.client.sendResponse(new ModToolIssueHandledComposer(Emulator.getTexts().getValue("generic.user.not_found").replace("%user%", Emulator.getConfig().getValue("hotel.player.name"))));
             }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionBanEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionBanEvent.java
@@ -2,6 +2,7 @@ package com.eu.habbo.messages.incoming.modtool;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.modtool.ModToolBanType;
+import com.eu.habbo.habbohotel.modtool.ModToolManager;
 import com.eu.habbo.habbohotel.modtool.ModToolSanctionItem;
 import com.eu.habbo.habbohotel.modtool.ModToolSanctions;
 import com.eu.habbo.habbohotel.modtool.ScripterManager;
@@ -73,6 +74,7 @@ public class ModToolSanctionBanEvent extends MessageHandler {
                 Emulator.getGameEnvironment().getModToolManager().ban(userId, this.client.getHabbo(), message, duration, ModToolBanType.ACCOUNT, cfhTopic);
             }
 
+            ModToolManager.bumpUserSettingCounter(userId, "cfh_bans");
         } else {
             ScripterManager.scripterDetected(this.client, Emulator.getTexts().getValue("scripter.warning.modtools.ban").replace("%username%", this.client.getHabbo().getHabboInfo().getUsername()));
         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionMuteEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionMuteEvent.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.messages.incoming.modtool;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.modtool.ModToolManager;
 import com.eu.habbo.habbohotel.modtool.ModToolSanctionItem;
 import com.eu.habbo.habbohotel.modtool.ModToolSanctionLevelItem;
 import com.eu.habbo.habbohotel.modtool.ModToolSanctions;
@@ -59,6 +60,8 @@ public class ModToolSanctionMuteEvent extends MessageHandler {
                     habbo.alert(message);
                     this.client.getHabbo().whisper(Emulator.getTexts().getValue("commands.succes.cmd_mute.muted").replace("%user%", habbo.getHabboInfo().getUsername()));
                 }
+
+                ModToolManager.bumpUserSettingCounter(userId, "cfh_warnings");
             } else {
                 this.client.sendResponse(new ModToolIssueHandledComposer(Emulator.getTexts().getValue("generic.user.not_found").replace("%user%", Emulator.getConfig().getValue("hotel.player.name"))));
             }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionTradeLockEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionTradeLockEvent.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.messages.incoming.modtool;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.modtool.ModToolManager;
 import com.eu.habbo.habbohotel.modtool.ModToolSanctionItem;
 import com.eu.habbo.habbohotel.modtool.ModToolSanctions;
 import com.eu.habbo.habbohotel.permissions.Permission;
@@ -49,6 +50,8 @@ public class ModToolSanctionTradeLockEvent extends MessageHandler {
                     habbo.getHabboStats().setAllowTrade(false);
                     habbo.alert(message);
                 }
+
+                ModToolManager.bumpUserSettingCounter(userId, "tradelock_amount");
             } else {
                 this.client.sendResponse(new ModToolIssueHandledComposer(Emulator.getTexts().getValue("generic.user.not_found").replace("%user%", Emulator.getConfig().getValue("hotel.player.name"))));
             }


### PR DESCRIPTION
## Summary

The ModTools **User Info** panel reads its 4 stat counters (CFH / Cautions / Bans / Trade locks) from `users_settings.cfh_send` / `cfh_warnings` / `cfh_bans` / `tradelock_amount`. Historically only `cfh_send` was ever incremented (by `InsertModToolIssue` on CFH submit), so a user could accumulate any number of Alert / Mute / Ban / TradeLock sanctions without the stats reflecting it — every panel showed all zeros even on accounts with a long sanction history visible in the modern `sanctions` table.

The two systems aren't going away. `ModToolSanctions` tracks individual sanction events with probation timestamps; the legacy `users_settings.cfh_*` columns are flat counters the ModTool UI displays. Both need to stay in sync.

## Changes

### `ModToolManager.bumpUserSettingCounter(userId, column)` (new)

Static helper, **column-whitelisted** (`cfh_warnings` / `cfh_bans` / `cfh_abusive` / `tradelock_amount`) to keep the dynamic SQL safe. Single UPDATE per call; SQL exceptions logged, never thrown.

### Sanction handlers — increment on every action

| Handler | Bumps |
|---|---|
| `ModToolSanctionAlertEvent` | `cfh_warnings` |
| `ModToolSanctionMuteEvent` | `cfh_warnings` (mute = warning-tier in the legacy counter) |
| `ModToolSanctionBanEvent` | `cfh_bans` |
| `ModToolSanctionTradeLockEvent` | `tradelock_amount` |

`totalBans` (the wire field already counts entries in the `bans` table directly), but the `users_settings.cfh_bans` bump is a defensive duplicate so any code reading the column directly (plugins, CMS dashboards) stays in sync.

`tradelock_amount` mirrors what `AllowTradingCommand` already does for the command-line path.

### `closeTicketAsAbusive` — bump reporter's `cfh_abusive`

When a mod closes a CFH ticket as abusive, the user who **opened** the CFH (`issue.senderId`) gets `cfh_abusive` incremented. The counter measures false reports filed by the user, so it belongs on the reporter — not the reported user.

## Client compatibility

No client-side changes — counter columns are unchanged, only the write paths are. `ModToolUserInfoComposer` keeps reading the same columns.

## Test plan

- [ ] Pick a clean test account, open Mod Action → Alert → submit. Re-open User Info: **Cautions** should now read `1`.
- [ ] Same account, Mod Action → Mute. User Info **Cautions** → `2`.
- [ ] Same account, Mod Action → Ban 18h. User Info **Bans** → `1`.
- [ ] Same account, Mod Action → Lock trade 1 week. User Info **Trade locks** → `1`.
- [ ] As another test account, submit a CFH. Have a mod close it as abusive. Open User Info on the CFH submitter: **Abusive CFHs** should now read `1`.
- [ ] Bumps survive a server restart — they're persisted in `users_settings`.