### PR TITLE
🆙 Security Fix

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildAcceptMembershipEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildAcceptMembershipEvent.java
@@ -25,45 +25,55 @@ public class GuildAcceptMembershipEvent extends MessageHandler {
         int userId = this.packet.readInt();
 
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
+
+        if (guild == null) {
+            return;
+        }
+
+        GuildMember actorMember = Emulator.getGameEnvironment().getGuildManager().getGuildMember(guild, this.client.getHabbo());
+        boolean canAccept = guild.getOwnerId() == this.client.getHabbo().getHabboInfo().getId()
+                || this.client.getHabbo().hasPermission(Permission.ACC_GUILD_ADMIN)
+                || (actorMember != null && (actorMember.getRank().equals(GuildRank.ADMIN) || actorMember.getRank().equals(GuildRank.OWNER)));
+
+        if (!canAccept) {
+            return;
+        }
+
+        GuildMember targetMember = Emulator.getGameEnvironment().getGuildManager().getGuildMember(guildId, userId);
+
+        if (targetMember == null) {
+            this.client.sendResponse(new GuildAcceptMemberErrorComposer(guild.getId(), GuildAcceptMemberErrorComposer.NO_LONGER_MEMBER));
+            return;
+        }
+
+        if (targetMember.getRank().type != GuildRank.REQUESTED.type) {
+            this.client.sendResponse(new GuildAcceptMemberErrorComposer(guild.getId(), GuildAcceptMemberErrorComposer.ALREADY_ACCEPTED));
+            return;
+        }
+
         Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(userId);
 
-        if (guild != null) {
-            GuildMember groupMember = Emulator.getGameEnvironment().getGuildManager().getGuildMember(guild, this.client.getHabbo());
-            if (guild.getOwnerId() == this.client.getHabbo().getHabboInfo().getId()
-                || this.client.getHabbo().hasPermission(Permission.ACC_GUILD_ADMIN)
-                || (groupMember != null && (groupMember.getRank().equals(GuildRank.ADMIN) || groupMember.getRank().equals(GuildRank.OWNER)))) {
-                if (habbo != null) {
-                    if (habbo.getHabboStats().hasGuild(guild.getId())) {
-                        this.client.sendResponse(new GuildAcceptMemberErrorComposer(guild.getId(), GuildAcceptMemberErrorComposer.ALREADY_ACCEPTED));
-                        return;
-                    } else {
-                        //Check the user has requested
-                        GuildMember member = Emulator.getGameEnvironment().getGuildManager().getGuildMember(guild, habbo);
-                        if (member == null || member.getRank().type != GuildRank.REQUESTED.type) {
-                            this.client.sendResponse(new GuildAcceptMemberErrorComposer(guild.getId(), GuildAcceptMemberErrorComposer.NO_LONGER_MEMBER));
-                            return;
-                        } else {
-                            GuildAcceptedMembershipEvent event = new GuildAcceptedMembershipEvent(guild, userId, habbo);
-                            Emulator.getPluginManager().fireEvent(event);
-                            if (!event.isCancelled()) {
-                                habbo.getHabboStats().addGuild(guild.getId());
-                                Emulator.getGameEnvironment().getGuildManager().joinGuild(guild, this.client, habbo.getHabboInfo().getId(), true);
-                                guild.decreaseRequestCount();
-                                guild.increaseMemberCount();
-                                this.client.sendResponse(new GuildRefreshMembersListComposer(guild));
-                                Room room = habbo.getHabboInfo().getCurrentRoom();
-                                if (room != null) {
-                                    if (room.getGuildId() == guildId) {
-                                        habbo.getClient().sendResponse(new GuildInfoComposer(guild, habbo.getClient(), false, Emulator.getGameEnvironment().getGuildManager().getGuildMember(guildId, userId)));
-                                        room.refreshRightsForHabbo(habbo);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    Emulator.getGameEnvironment().getGuildManager().joinGuild(guild, this.client, userId, true);
-                }
+        GuildAcceptedMembershipEvent event = new GuildAcceptedMembershipEvent(guild, userId, habbo);
+        Emulator.getPluginManager().fireEvent(event);
+
+        if (event.isCancelled()) {
+            return;
+        }
+
+        if (habbo != null) {
+            habbo.getHabboStats().addGuild(guild.getId());
+        }
+
+        Emulator.getGameEnvironment().getGuildManager().joinGuild(guild, this.client, userId, true);
+        guild.decreaseRequestCount();
+        guild.increaseMemberCount();
+        this.client.sendResponse(new GuildRefreshMembersListComposer(guild));
+
+        if (habbo != null) {
+            Room room = habbo.getHabboInfo().getCurrentRoom();
+            if (room != null && room.getGuildId() == guildId) {
+                habbo.getClient().sendResponse(new GuildInfoComposer(guild, habbo.getClient(), false, Emulator.getGameEnvironment().getGuildManager().getGuildMember(guildId, userId)));
+                room.refreshRightsForHabbo(habbo);
             }
         }
     }


### PR DESCRIPTION
Thanks to @Bop:

There's a group bug where you can accept anyone into a group within MS. There's no packet validation for accepting members if the group is invite only. This is crucial because if you allow users to have rights who are group members, your rooms can be trashed. AKA YOUR EVENT ROOMS