### PR TITLE
feat(furni-editor): read-only resolver preview in detail packet

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorDetailEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorDetailEvent.java
@@ -74,8 +74,8 @@ public class FurniEditorDetailEvent extends MessageHandler {
                     "ci.page_id AS ci_page_id, COALESCE(cp.caption, '') AS page_caption " +
                     "FROM catalog_items ci " +
                     "LEFT JOIN catalog_pages cp ON ci.page_id = cp.id " +
-                    "WHERE ci.item_ids LIKE ?")) {
-                stmt.setString(1, "%" + itemId + "%");
+                    "WHERE FIND_IN_SET(?, REPLACE(REPLACE(ci.item_ids, ';', ','), ' ', '')) > 0")) {
+                stmt.setString(1, String.valueOf(itemId));
                 try (ResultSet rs = stmt.executeQuery()) {
                     while (rs.next()) {
                         catalogItems.add(FurniEditorHelper.readCatalogRef(rs));
@@ -90,7 +90,8 @@ public class FurniEditorDetailEvent extends MessageHandler {
         } catch (Exception e) {
             furniDataJson = "{}";
         }
+        String resolverPreviewJson = FurniEditorResolverPreview.build(item, furniDataJson);
 
-        client.sendResponse(new FurniEditorDetailComposer(item, usageCount, catalogItems, furniDataJson));
+        client.sendResponse(new FurniEditorDetailComposer(item, usageCount, catalogItems, furniDataJson, resolverPreviewJson));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorResolverPreview.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/furnieditor/FurniEditorResolverPreview.java
@@ -1,0 +1,113 @@
+package com.eu.habbo.messages.incoming.furnieditor;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.util.Map;
+
+public class FurniEditorResolverPreview {
+
+    public static String build(Map<String, Object> item, String furniDataJson) {
+        JsonObject root = new JsonObject();
+        com.google.gson.JsonArray fields = new com.google.gson.JsonArray();
+
+        JsonObject furniData = parseObject(furniDataJson);
+
+        addField(fields, "name", "Name",
+            getString(furniData, "name"),
+            stringValue(item.get("public_name")),
+            firstNonBlank(stringValue(item.get("public_name")), getString(furniData, "name"), stringValue(item.get("item_name"))));
+
+        addField(fields, "description", "Description",
+            getString(furniData, "description"),
+            stringValue(item.get("description")),
+            firstNonBlank(stringValue(item.get("description")), getString(furniData, "description"), ""));
+
+        addField(fields, "classname", "Classname",
+            getString(furniData, "classname"),
+            stringValue(item.get("item_name")),
+            firstNonBlank(stringValue(item.get("item_name")), getString(furniData, "classname"), ""));
+
+        addField(fields, "width", "Width",
+            getString(furniData, "xdim"),
+            stringValue(item.get("width")),
+            firstNonBlank(stringValue(item.get("width")), getString(furniData, "xdim"), "1"));
+
+        addField(fields, "length", "Length",
+            getString(furniData, "ydim"),
+            stringValue(item.get("length")),
+            firstNonBlank(stringValue(item.get("length")), getString(furniData, "ydim"), "1"));
+
+        String furniDataStackHeight = getFirstString(furniData,
+            "stackHeight", "stack_height", "stackheight", "height", "z");
+        String dbStackHeight = stringValue(item.get("stack_height"));
+        addField(fields, "stackHeight", "Stack Height",
+            furniDataStackHeight,
+            dbStackHeight,
+            firstNonBlank(dbStackHeight, furniDataStackHeight, "0"));
+
+        String furniDataInteractionType = getFirstString(furniData,
+            "interactionType", "interaction_type", "interactiontype", "logic");
+        String dbInteractionType = stringValue(item.get("interaction_type"));
+        addField(fields, "interactionType", "Interaction",
+            furniDataInteractionType,
+            dbInteractionType,
+            firstNonBlank(dbInteractionType, furniDataInteractionType, "default"));
+
+        root.add("fields", fields);
+        return root.toString();
+    }
+
+    private static JsonObject parseObject(String json) {
+        if (json == null || json.isBlank() || "{}".equals(json)) return new JsonObject();
+
+        try {
+            JsonElement element = JsonParser.parseString(json);
+            return element != null && element.isJsonObject() ? element.getAsJsonObject() : new JsonObject();
+        } catch (Exception e) {
+            return new JsonObject();
+        }
+    }
+
+    private static void addField(com.google.gson.JsonArray fields, String key, String label, String jsonValue, String dbValue, String resolvedValue) {
+        JsonObject field = new JsonObject();
+        String normalizedJson = jsonValue == null ? "" : jsonValue;
+        String normalizedDb = dbValue == null ? "" : dbValue;
+        String normalizedResolved = resolvedValue == null ? "" : resolvedValue;
+
+        field.addProperty("key", key);
+        field.addProperty("label", label);
+        field.addProperty("jsonValue", normalizedJson);
+        field.addProperty("dbValue", normalizedDb);
+        field.addProperty("resolvedValue", normalizedResolved);
+        field.addProperty("source", !normalizedDb.isBlank() ? "items_base" : (!normalizedJson.isBlank() ? "json" : "fallback"));
+        field.addProperty("different", !normalizedJson.isBlank() && !normalizedDb.isBlank() && !normalizedJson.equals(normalizedDb));
+        fields.add(field);
+    }
+
+    private static String getString(JsonObject object, String key) {
+        if (object == null || !object.has(key) || object.get(key).isJsonNull()) return "";
+        JsonElement value = object.get(key);
+        return value.isJsonPrimitive() ? value.getAsString() : value.toString();
+    }
+
+    private static String getFirstString(JsonObject object, String... keys) {
+        for (String key : keys) {
+            String value = getString(object, key);
+            if (value != null && !value.isBlank()) return value;
+        }
+        return "";
+    }
+
+    private static String stringValue(Object value) {
+        return value == null ? "" : String.valueOf(value);
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) return value;
+        }
+        return "";
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/furnieditor/FurniEditorDetailComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/furnieditor/FurniEditorDetailComposer.java
@@ -12,12 +12,14 @@ public class FurniEditorDetailComposer extends MessageComposer {
     private final int usageCount;
     private final List<Map<String, Object>> catalogItems;
     private final String furniDataJson;
+    private final String resolverPreviewJson;
 
-    public FurniEditorDetailComposer(Map<String, Object> item, int usageCount, List<Map<String, Object>> catalogItems, String furniDataJson) {
+    public FurniEditorDetailComposer(Map<String, Object> item, int usageCount, List<Map<String, Object>> catalogItems, String furniDataJson, String resolverPreviewJson) {
         this.item = item;
         this.usageCount = usageCount;
         this.catalogItems = catalogItems;
         this.furniDataJson = furniDataJson;
+        this.resolverPreviewJson = resolverPreviewJson;
     }
 
     @Override
@@ -71,6 +73,7 @@ public class FurniEditorDetailComposer extends MessageComposer {
 
         // furnidata JSON string
         this.response.appendString(this.furniDataJson != null ? this.furniDataJson : "{}");
+        this.response.appendString(this.resolverPreviewJson != null ? this.resolverPreviewJson : "{\"fields\":[]}");
 
         return this.response;
     }


### PR DESCRIPTION
@
## What

Adds a **read-only resolver preview** to the existing Furni Editor detail response so staff can see, side by side, the furnidata (JSON/JSON5) value, the `items_base` (DB) value, and the final resolved value for each core field — before any override schema is introduced.

## How

- New `FurniEditorResolverPreview` builder: normalizes furnidata from either JSON or JSON5 and compares it against `items_base`, producing a strict-JSON shape:
  ```json
  { "fields": [ { "key", "label", "jsonValue", "dbValue", "resolvedValue", "source", "different" } ] }
  ```
  Covered fields: name, description, classname, width, length, stackHeight, interactionType. `source` is one of `items_base` / `json` / `fallback`.
- `FurniEditorDetailEvent` builds the preview and passes it to the composer.
- `FurniEditorDetailComposer` appends it as **one extra string after `furniDataJson`**, defaulting to `{"fields":[]}` — the packet stays backward compatible, so older clients simply ignore the trailing string.

## Scope

Read-only first slice: **no DB schema changes**, no write-path changes, no chat commands. Paired client/renderer PRs expose and render the preview.
@