### PR TITLE
feat(items): server-authoritative furni names from furnidata JSON + live broadcast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# Arcturus-Morningstar-Extended — Claude project context
+
+Java 21 / Maven emulator for the Nitro retro Habbo (server side). Netty WS,
+MariaDB + HikariCP. Entry point `com.eu.habbo.Emulator`; boot order in
+`habbohotel/GameEnvironment.load()`.
+
+## Build / test
+
+- `cd Emulator && mvn clean package` → `target/Habbo-<ver>-jar-with-dependencies.jar`.
+- `mvn -q test -Dtest=ClassName` runs a single test. JUnit 5 + surefire exist
+  (added with the furnidata feature; tests under `Emulator/src/test/java/...`).
+- `pom.xml` keeps `release=21` but `source/target=19` intentionally — don't "fix".
+
+## Configuration (IMPORTANT)
+
+- Settings load from the **DB table `emulator_settings`** (`key`/`value`) at boot
+  via `ConfigurationManager.loadFromDatabase()`, NOT from `config.ini` (that holds
+  the DB connection + a few keys). Changing a setting needs an emulator restart.
+- **Gotcha:** `getValue(key, default)` logs `ERROR "Config key not found"` for a
+  missing key EVEN when a default is supplied. Optional keys must be inserted into
+  `emulator_settings` to silence the error.
+
+## Items / furni model
+
+- `Item.name` = `items_base.item_name` = **classname** (technical: join key to
+  furnidata + asset, `isPet/isBot`, wired `wf_` interaction fallback).
+- `Item.fullName` = `items_base.public_name` = **display name**.
+- `Item.getDisplayName()` sources the display name from furnidata via
+  `FurnitureTextProvider` (index by lowercased base classname), fallback to
+  `public_name`; never null. Server-pronounced names (catalog LTD alerts, gifts,
+  wired `%furni.name%`, Watch&Earn) use it. There is no server-side description.
+- Live furnidata: `FurnidataWatcher` (single daemon thread, debounce + min-interval
+  throttle, delta diff) broadcasts `FurnitureDataReloadComposer` (outgoing header
+  **10047**) to all clients. Config keys: `items.furnidata.{names.enabled,path,
+  watch.enabled,watch.debounce.ms,watch.min.interval.ms,delta.cap}`. Fail-safe:
+  missing/disabled → DB `public_name`.
+- **Boolean config footgun:** the furnidata code reads booleans via
+  `Boolean.parseBoolean(getValue(...))`, so values must be `true`/`false` (NOT
+  Arcturus' usual `1`/`0`).
+
+## Packets
+
+- Incoming handlers in `messages/incoming/`, outgoing composers in
+  `messages/outgoing/`, header ids in `messages/outgoing/Outgoing.java`. Custom
+  ids live in the 10000+ range. A new packet must be paired with the renderer
+  (`../Nitro_Render_V3`) at the same header id.
+
+## Sister projects (same DEV folder)
+
+- `../Nitro-V3` (React client), `../Nitro_Render_V3` (renderer),
+  `../NitroV3-Housekeeping` (CMS). The DEV root is NOT a git repo; each component
+  is its own repo.

--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -62,6 +62,12 @@
                     <show>public</show>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
         </plugins>
     </build>
 
@@ -172,12 +178,20 @@
             <version>0.4</version>
         </dependency>
 
-        <!-- Jakarta Mail � used by the built-in forgot-password endpoint
+        <!-- Jakarta Mail — used by the built-in forgot-password endpoint
              when smtp.* keys are configured in emulator_settings -->
         <dependency>
             <groupId>org.eclipse.angus</groupId>
             <artifactId>jakarta.mail</artifactId>
             <version>2.0.3</version>
+        </dependency>
+
+        <!-- JUnit Jupiter -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.eu.habbo</groupId>
     <artifactId>Habbo</artifactId>
-    <version>4.2.36</version>
+    <version>4.2.37</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.eu.habbo</groupId>
     <artifactId>Habbo</artifactId>
-    <version>4.2.34</version>
+    <version>4.2.35</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.eu.habbo</groupId>
     <artifactId>Habbo</artifactId>
-    <version>4.2.35</version>
+    <version>4.2.36</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java
@@ -14,6 +14,7 @@ import com.eu.habbo.habbohotel.crafting.CraftingManager;
 import com.eu.habbo.habbohotel.guides.GuideManager;
 import com.eu.habbo.habbohotel.guilds.GuildManager;
 import com.eu.habbo.habbohotel.hotelview.HotelViewManager;
+import com.eu.habbo.habbohotel.items.FurnitureTextProvider;
 import com.eu.habbo.habbohotel.items.ItemManager;
 import com.eu.habbo.habbohotel.modtool.ModToolManager;
 import com.eu.habbo.habbohotel.modtool.ModToolSanctions;
@@ -47,6 +48,7 @@ public class GameEnvironment {
     private NavigatorManager navigatorManager;
     private GuildManager guildManager;
     private ItemManager itemManager;
+    private FurnitureTextProvider furnitureTextProvider;
     private CatalogManager catalogManager;
     private HotelViewManager hotelViewManager;
     private RoomManager roomManager;
@@ -79,6 +81,8 @@ public class GameEnvironment {
         this.hotelViewManager = new HotelViewManager();
         this.itemManager = new ItemManager();
         this.itemManager.load();
+        this.furnitureTextProvider = new FurnitureTextProvider();
+        this.furnitureTextProvider.init();
         this.botManager = new BotManager();
         this.petManager = new PetManager();
         this.guildManager = new GuildManager();
@@ -159,6 +163,10 @@ public class GameEnvironment {
 
     public ItemManager getItemManager() {
         return this.itemManager;
+    }
+
+    public FurnitureTextProvider getFurnitureTextProvider() {
+        return this.furnitureTextProvider;
     }
 
     public CatalogManager getCatalogManager() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -1054,13 +1054,13 @@ public class CatalogManager {
                     if (Emulator.getConfig().getBoolean("hotel.catalog.ltd.limit.enabled")) {
                         int ltdLimit = Emulator.getConfig().getInt("hotel.purchase.ltd.limit.daily.total");
                         if (habbo.getHabboStats().totalLtds() >= ltdLimit) {
-                            habbo.alert(Emulator.getTexts().getValue("error.catalog.buy.limited.daily.total").replace("%itemname%", item.getBaseItems().iterator().next().getFullName()).replace("%limit%", ltdLimit + ""));
+                            habbo.alert(Emulator.getTexts().getValue("error.catalog.buy.limited.daily.total").replace("%itemname%", item.getBaseItems().iterator().next().getDisplayName()).replace("%limit%", ltdLimit + ""));
                             return;
                         }
 
                         ltdLimit = Emulator.getConfig().getInt("hotel.purchase.ltd.limit.daily.item");
                         if (habbo.getHabboStats().totalLtds(item.id) >= ltdLimit) {
-                            habbo.alert(Emulator.getTexts().getValue("error.catalog.buy.limited.daily.item").replace("%itemname%", item.getBaseItems().iterator().next().getFullName()).replace("%limit%", ltdLimit + ""));
+                            habbo.alert(Emulator.getTexts().getValue("error.catalog.buy.limited.daily.item").replace("%itemname%", item.getBaseItems().iterator().next().getDisplayName()).replace("%limit%", ltdLimit + ""));
                             return;
                         }
                     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnidataEntry.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnidataEntry.java
@@ -1,0 +1,8 @@
+package com.eu.habbo.habbohotel.items;
+
+/**
+ * One parsed furnidata entry. {@code classname} is the raw furnidata classname
+ * (may carry a {@code *N} colour-variant suffix); the provider keys on the base.
+ */
+public record FurnidataEntry(int id, String classname, FurnitureType type, String name, String description) {
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnidataReader.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnidataReader.java
@@ -85,7 +85,9 @@ public class FurnidataReader {
             Path m = dir.resolve(name);
             if (!Files.exists(m)) continue;
             try {
-                JsonObject obj = JsonParser.parseString(readJson5Capped(m)).getAsJsonObject();
+                String raw = readJson5Capped(m);
+                if (raw == null) continue;
+                JsonObject obj = JsonParser.parseString(raw).getAsJsonObject();
                 if (obj.has(key) && obj.get(key).isJsonArray()) {
                     List<String> list = new ArrayList<>();
                     for (JsonElement el : obj.getAsJsonArray(key)) list.add(el.getAsString());
@@ -133,7 +135,13 @@ public class FurnidataReader {
         return candidate.toAbsolutePath().normalize().startsWith(baseNorm);
     }
 
-    /** Strip // and block comments and trailing commas so Gson can parse JSON5. */
+    /**
+     * Strip // and block comments and trailing commas so Gson can parse JSON5.
+     * Known limitation: the trailing-comma pass is a regex over the whole output,
+     * so a string value literally containing ",[whitespace]}" or ",[whitespace]]"
+     * would be altered. Real Habbo furnidata names/descriptions do not contain
+     * that pattern; values are additionally sanitized downstream before use.
+     */
     static String stripJson5(String content) {
         if (content == null || content.isEmpty()) return content;
         StringBuilder out = new StringBuilder(content.length());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnidataReader.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnidataReader.java
@@ -1,0 +1,164 @@
+package com.eu.habbo.habbohotel.items;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Neutral furnidata reader. Supports a single JSON/JSON5 file or a split-tier
+ * directory ({@code core/custom/seasonal} with {@code manifest.json(5)}).
+ * Never throws: any IO/parse error yields an empty list (the caller decides the
+ * fallback). All resolved paths are guarded against escaping the base dir.
+ */
+public class FurnidataReader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FurnidataReader.class);
+    private static final List<String> DEFAULT_TIERS = Arrays.asList("core", "custom", "seasonal");
+    private static final List<String> MANIFEST_NAMES = Arrays.asList("manifest.json5", "manifest.json");
+    private static final List<String> SECTIONS = Arrays.asList("roomitemtypes", "wallitemtypes");
+
+    private final Path source;
+    private final long maxBytes;
+
+    public FurnidataReader(Path source, long maxBytes) {
+        this.source = source;
+        this.maxBytes = maxBytes;
+    }
+
+    public List<FurnidataEntry> read() {
+        List<FurnidataEntry> out = new ArrayList<>();
+        try {
+            if (this.source == null || !Files.exists(this.source)) return out;
+
+            if (Files.isDirectory(this.source)) {
+                readSplitDir(this.source, out);
+            } else {
+                String content = readJson5Capped(this.source);
+                if (content != null) {
+                    parseRoot(JsonParser.parseString(content).getAsJsonObject(), out);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warn("FurnidataReader failed to read {} — returning empty", this.source, e);
+            return new ArrayList<>();
+        }
+        return out;
+    }
+
+    private void readSplitDir(Path base, List<FurnidataEntry> out) {
+        List<String> tiers = readManifestList(base, "tiers", DEFAULT_TIERS);
+        Path baseNorm = base.toAbsolutePath().normalize();
+
+        for (String tier : tiers) {
+            Path tierDir = base.resolve(tier);
+            if (!isInside(baseNorm, tierDir) || !Files.isDirectory(tierDir)) continue;
+
+            for (String fileName : readManifestList(tierDir, "files", List.of())) {
+                Path file = tierDir.resolve(fileName);
+                if (!isInside(baseNorm, file)) {
+                    LOGGER.warn("FurnidataReader: ignoring out-of-base file {}", file);
+                    continue;
+                }
+                if (!Files.exists(file)) continue;
+                try {
+                    String content = readJson5Capped(file);
+                    if (content != null) parseRoot(JsonParser.parseString(content).getAsJsonObject(), out);
+                } catch (Exception e) {
+                    LOGGER.warn("FurnidataReader: failed to parse {}", file, e);
+                }
+            }
+        }
+    }
+
+    private List<String> readManifestList(Path dir, String key, List<String> fallback) {
+        for (String name : MANIFEST_NAMES) {
+            Path m = dir.resolve(name);
+            if (!Files.exists(m)) continue;
+            try {
+                JsonObject obj = JsonParser.parseString(readJson5Capped(m)).getAsJsonObject();
+                if (obj.has(key) && obj.get(key).isJsonArray()) {
+                    List<String> list = new ArrayList<>();
+                    for (JsonElement el : obj.getAsJsonArray(key)) list.add(el.getAsString());
+                    if (!list.isEmpty()) return list;
+                }
+            } catch (Exception e) {
+                LOGGER.warn("FurnidataReader: bad manifest {}", m, e);
+            }
+        }
+        return fallback;
+    }
+
+    private void parseRoot(JsonObject root, List<FurnidataEntry> out) {
+        for (String section : SECTIONS) {
+            if (!root.has(section)) continue;
+            JsonObject sectionObj = root.getAsJsonObject(section);
+            if (!sectionObj.has("furnitype")) continue;
+            FurnitureType type = section.equals("roomitemtypes") ? FurnitureType.FLOOR : FurnitureType.WALL;
+            JsonArray types = sectionObj.getAsJsonArray("furnitype");
+            for (JsonElement el : types) {
+                JsonObject o = el.getAsJsonObject();
+                if (!o.has("id") || !o.has("classname")) continue;
+                out.add(new FurnidataEntry(
+                    o.get("id").getAsInt(),
+                    o.get("classname").getAsString(),
+                    type,
+                    o.has("name") ? o.get("name").getAsString() : "",
+                    o.has("description") ? o.get("description").getAsString() : ""
+                ));
+            }
+        }
+    }
+
+    /** Returns the JSON5-stripped content, or null if the file exceeds the byte cap. */
+    private String readJson5Capped(Path path) throws Exception {
+        long size = Files.size(path);
+        if (size > this.maxBytes) {
+            LOGGER.warn("FurnidataReader: {} is {} bytes, over cap {} — refusing", path, size, this.maxBytes);
+            return null;
+        }
+        return stripJson5(Files.readString(path, StandardCharsets.UTF_8));
+    }
+
+    private static boolean isInside(Path baseNorm, Path candidate) {
+        return candidate.toAbsolutePath().normalize().startsWith(baseNorm);
+    }
+
+    /** Strip // and block comments and trailing commas so Gson can parse JSON5. */
+    static String stripJson5(String content) {
+        if (content == null || content.isEmpty()) return content;
+        StringBuilder out = new StringBuilder(content.length());
+        int i = 0, len = content.length();
+        boolean inString = false, escape = false;
+        char stringChar = 0;
+        while (i < len) {
+            char c = content.charAt(i);
+            if (inString) {
+                out.append(c);
+                if (escape) escape = false;
+                else if (c == '\\') escape = true;
+                else if (c == stringChar) inString = false;
+                i++;
+                continue;
+            }
+            if (c == '"' || c == '\'') { inString = true; stringChar = c; out.append(c); i++; continue; }
+            if (c == '/' && i + 1 < len) {
+                char next = content.charAt(i + 1);
+                if (next == '/') { int eol = content.indexOf('\n', i + 2); if (eol < 0) break; i = eol; continue; }
+                if (next == '*') { int end = content.indexOf("*/", i + 2); if (end < 0) break; i = end + 2; continue; }
+            }
+            out.append(c);
+            i++;
+        }
+        return out.toString().replaceAll(",(\\s*[}\\]])", "$1");
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnidataWatcher.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnidataWatcher.java
@@ -6,7 +6,11 @@ import com.eu.habbo.messages.outgoing.furniture.FurnitureDataReloadComposer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchKey;
@@ -17,7 +21,8 @@ import java.util.List;
  * Watches the furnidata source on a single daemon thread. On change (debounced),
  * re-indexes via the provider and broadcasts only the delta — or a compact
  * reload-hint when the delta exceeds the cap. A minimum interval throttles bursts.
- * Never throws out of the loop.
+ * For the split-tier directory layout, the base dir AND its immediate
+ * subdirectories are registered. Never throws out of the loop.
  */
 public class FurnidataWatcher {
 
@@ -25,17 +30,20 @@ public class FurnidataWatcher {
 
     private final FurnitureTextProvider provider;
     private final Path watchDir;
+    private final boolean sourceIsDir;
     private final long maxBytes;
     private final long debounceMs;
     private final long minIntervalMs;
     private final int deltaCap;
 
     private volatile boolean running = false;
+    private volatile WatchService ws;
     private long lastBroadcast = 0L;
 
     public FurnidataWatcher(FurnitureTextProvider provider, Path source, long maxBytes) {
         this.provider = provider;
-        this.watchDir = java.nio.file.Files.isDirectory(source) ? source : source.getParent();
+        this.sourceIsDir = Files.isDirectory(source);
+        this.watchDir = this.sourceIsDir ? source : source.getParent();
         this.maxBytes = maxBytes;
         this.debounceMs = Long.parseLong(Emulator.getConfig().getValue("items.furnidata.watch.debounce.ms", "750"));
         this.minIntervalMs = Long.parseLong(Emulator.getConfig().getValue("items.furnidata.watch.min.interval.ms", "5000"));
@@ -52,20 +60,30 @@ public class FurnidataWatcher {
 
     public void stop() {
         this.running = false;
+        WatchService local = this.ws;
+        if (local != null) {
+            try { local.close(); } catch (IOException ignored) { }
+        }
     }
 
     private void run() {
-        try (WatchService ws = FileSystems.getDefault().newWatchService()) {
-            this.watchDir.register(ws, StandardWatchEventKinds.ENTRY_MODIFY,
-                StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE);
-
+        try {
+            this.ws = FileSystems.getDefault().newWatchService();
+        } catch (IOException e) {
+            LOGGER.warn("FurnidataWatcher: could not create WatchService", e);
+            return;
+        }
+        try (WatchService service = this.ws) {
+            registerDirs(service);
             while (this.running) {
-                WatchKey key = ws.take();
+                WatchKey key = service.take();
                 key.pollEvents();
                 Thread.sleep(this.debounceMs);
                 key.pollEvents();
-                key.reset();
-
+                if (!key.reset()) {
+                    LOGGER.warn("FurnidataWatcher: watch key invalidated (directory removed?) — stopping");
+                    break;
+                }
                 try {
                     onChange();
                 } catch (Exception e) {
@@ -74,8 +92,26 @@ public class FurnidataWatcher {
             }
         } catch (InterruptedException ignored) {
             Thread.currentThread().interrupt();
+        } catch (ClosedWatchServiceException ignored) {
+            // stop() closed the service — normal shutdown
         } catch (Exception e) {
             LOGGER.warn("FurnidataWatcher stopped", e);
+        }
+    }
+
+    /** Register the base dir, plus one level of subdirectories for the split-tier layout. */
+    private void registerDirs(WatchService service) throws IOException {
+        this.watchDir.register(service, StandardWatchEventKinds.ENTRY_MODIFY,
+            StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE);
+        if (this.sourceIsDir) {
+            try (DirectoryStream<Path> ds = Files.newDirectoryStream(this.watchDir)) {
+                for (Path child : ds) {
+                    if (Files.isDirectory(child)) {
+                        child.register(service, StandardWatchEventKinds.ENTRY_MODIFY,
+                            StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE);
+                    }
+                }
+            }
         }
     }
 
@@ -88,7 +124,7 @@ public class FurnidataWatcher {
 
         long now = System.currentTimeMillis();
         if (now - this.lastBroadcast < this.minIntervalMs) {
-            LOGGER.info("FurnidataWatcher: {} changes throttled (min interval)", delta.size());
+            LOGGER.info("FurnidataWatcher: {} changes indexed but broadcast skipped (min interval) — clients update on next change or reconnect", delta.size());
             return;
         }
         this.lastBroadcast = now;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnidataWatcher.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnidataWatcher.java
@@ -1,0 +1,112 @@
+package com.eu.habbo.habbohotel.items;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.messages.outgoing.furniture.FurnitureDataReloadComposer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.List;
+
+/**
+ * Watches the furnidata source on a single daemon thread. On change (debounced),
+ * re-indexes via the provider and broadcasts only the delta — or a compact
+ * reload-hint when the delta exceeds the cap. A minimum interval throttles bursts.
+ * Never throws out of the loop.
+ */
+public class FurnidataWatcher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FurnidataWatcher.class);
+
+    private final FurnitureTextProvider provider;
+    private final Path watchDir;
+    private final long maxBytes;
+    private final long debounceMs;
+    private final long minIntervalMs;
+    private final int deltaCap;
+
+    private volatile boolean running = false;
+    private long lastBroadcast = 0L;
+
+    public FurnidataWatcher(FurnitureTextProvider provider, Path source, long maxBytes) {
+        this.provider = provider;
+        this.watchDir = java.nio.file.Files.isDirectory(source) ? source : source.getParent();
+        this.maxBytes = maxBytes;
+        this.debounceMs = Long.parseLong(Emulator.getConfig().getValue("items.furnidata.watch.debounce.ms", "750"));
+        this.minIntervalMs = Long.parseLong(Emulator.getConfig().getValue("items.furnidata.watch.min.interval.ms", "5000"));
+        this.deltaCap = Integer.parseInt(Emulator.getConfig().getValue("items.furnidata.delta.cap", "500"));
+    }
+
+    public void start() {
+        if (this.running || this.watchDir == null) return;
+        this.running = true;
+        Thread t = new Thread(this::run, "FurnidataWatcher");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    public void stop() {
+        this.running = false;
+    }
+
+    private void run() {
+        try (WatchService ws = FileSystems.getDefault().newWatchService()) {
+            this.watchDir.register(ws, StandardWatchEventKinds.ENTRY_MODIFY,
+                StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE);
+
+            while (this.running) {
+                WatchKey key = ws.take();
+                key.pollEvents();
+                Thread.sleep(this.debounceMs);
+                key.pollEvents();
+                key.reset();
+
+                try {
+                    onChange();
+                } catch (Exception e) {
+                    LOGGER.warn("FurnidataWatcher: onChange failed", e);
+                }
+            }
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            LOGGER.warn("FurnidataWatcher stopped", e);
+        }
+    }
+
+    private void onChange() {
+        Path source = this.provider.getSource();
+        if (source == null) return;
+
+        List<FurnidataEntry> delta = this.provider.reindex(new FurnidataReader(source, this.maxBytes).read());
+        if (delta.isEmpty()) return;
+
+        long now = System.currentTimeMillis();
+        if (now - this.lastBroadcast < this.minIntervalMs) {
+            LOGGER.info("FurnidataWatcher: {} changes throttled (min interval)", delta.size());
+            return;
+        }
+        this.lastBroadcast = now;
+
+        FurnitureDataReloadComposer composer = (delta.size() > this.deltaCap)
+            ? new FurnitureDataReloadComposer(FurnitureDataReloadComposer.MODE_RELOAD_HINT, List.of())
+            : new FurnitureDataReloadComposer(FurnitureDataReloadComposer.MODE_DELTA, delta);
+
+        broadcast(composer);
+        LOGGER.info("FurnidataWatcher: broadcast {} ({} entries)",
+            delta.size() > this.deltaCap ? "reload-hint" : "delta", delta.size());
+    }
+
+    private void broadcast(FurnitureDataReloadComposer composer) {
+        for (Habbo habbo : Emulator.getGameEnvironment().getHabboManager().getOnlineHabbos().values()) {
+            if (habbo.getClient() != null) {
+                habbo.getClient().sendResponse(composer);
+            }
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
@@ -1,0 +1,68 @@
+package com.eu.habbo.habbohotel.items;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * In-memory index of furnidata display names, keyed by the lowercased base
+ * classname (the {@code *N} colour-variant suffix is stripped). Read lazily by
+ * {@link Item#getDisplayName()}. Names are sanitized at index time.
+ *
+ * Thread-safety: the index is held behind a {@code volatile} reference; readers
+ * never block; {@link #reindex(List)} builds a fresh map and swaps it atomically.
+ */
+public class FurnitureTextProvider {
+
+    private static final int MAX_LEN = 256;
+
+    private final boolean enabled;
+    private volatile Map<String, FurniText> index = Map.of();
+
+    public FurnitureTextProvider(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /** Build a fresh sanitized index from the given entries and swap it in atomically. */
+    public void reindex(List<FurnidataEntry> entries) {
+        Map<String, FurniText> next = new HashMap<>(Math.max(16, entries.size() * 2));
+        for (FurnidataEntry e : entries) {
+            String key = baseKey(e.classname());
+            if (key == null) continue;
+            next.put(key, new FurniText(e.id(), e.type(), sanitize(e.name()), sanitize(e.description())));
+        }
+        this.index = next; // atomic reference swap
+    }
+
+    /** Returns the sanitized display name for a DB classname, or null if absent/disabled. */
+    public String getName(String classname) {
+        if (!this.enabled) return null;
+        String key = baseKey(classname);
+        if (key == null) return null;
+        FurniText t = this.index.get(key);
+        return (t != null) ? t.name() : null;
+    }
+
+    private static String baseKey(String classname) {
+        if (classname == null) return null;
+        int star = classname.indexOf('*');
+        String base = (star >= 0) ? classname.substring(0, star) : classname;
+        base = base.trim().toLowerCase();
+        return base.isEmpty() ? null : base;
+    }
+
+    /** Cap length, strip control chars/newlines, neutralize % (placeholder-injection safe). */
+    static String sanitize(String value) {
+        if (value == null) return "";
+        StringBuilder sb = new StringBuilder(Math.min(value.length(), MAX_LEN));
+        for (int i = 0; i < value.length() && sb.length() < MAX_LEN; i++) {
+            char c = value.charAt(i);
+            if (c == '%') { sb.append('％'); continue; } // fullwidth percent — not a placeholder token
+            if (c == '\n' || c == '\r' || Character.isISOControl(c)) continue;
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    private record FurniText(int id, FurnitureType type, String name, String description) {}
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
@@ -2,6 +2,7 @@ package com.eu.habbo.habbohotel.items;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -47,11 +48,16 @@ public class FurnitureTextProvider {
         if (classname == null) return null;
         int star = classname.indexOf('*');
         String base = (star >= 0) ? classname.substring(0, star) : classname;
-        base = base.trim().toLowerCase();
+        base = base.trim().toLowerCase(Locale.ROOT);
         return base.isEmpty() ? null : base;
     }
 
-    /** Cap length, strip control chars/newlines, neutralize % (placeholder-injection safe). */
+    /**
+     * Cap length, strip control chars/newlines, neutralize % (placeholder-injection safe).
+     * The 256 cap is in Java {@code char} units (UTF-16 code units), which is acceptable for
+     * furni names (controlled, predominantly ASCII source). Lone/astral surrogates are not
+     * specially handled.
+     */
     static String sanitize(String value) {
         if (value == null) return "";
         StringBuilder sb = new StringBuilder(Math.min(value.length(), MAX_LEN));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
@@ -1,5 +1,11 @@
 package com.eu.habbo.habbohotel.items;
 
+import com.eu.habbo.Emulator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -16,12 +22,49 @@ import java.util.Map;
 public class FurnitureTextProvider {
 
     private static final int MAX_LEN = 256;
+    private static final Logger LOGGER = LoggerFactory.getLogger(FurnitureTextProvider.class);
+    private static final long DEFAULT_MAX_BYTES = 64L * 1024 * 1024;
 
     private final boolean enabled;
     private volatile Map<String, FurniText> index = Map.of();
 
     public FurnitureTextProvider(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    /** Production constructor: reads the enable toggle from config. */
+    public FurnitureTextProvider() {
+        this(Boolean.parseBoolean(Emulator.getConfig().getValue("items.furnidata.names.enabled", "true")));
+    }
+
+    /** Resolve the furnidata source from config and build the initial index. Never throws. */
+    public void init() {
+        try {
+            Path source = resolveSource();
+            if (source == null) {
+                LOGGER.warn("FurnitureTextProvider: no furnidata source resolved — names fall back to public_name");
+                return;
+            }
+            reindex(new FurnidataReader(source, DEFAULT_MAX_BYTES).read());
+            LOGGER.info("FurnitureTextProvider: indexed {} furnidata names from {}", this.index.size(), source);
+        } catch (Exception e) {
+            LOGGER.warn("FurnitureTextProvider.init failed — names fall back to public_name", e);
+        }
+    }
+
+    private static Path resolveSource() {
+        String override = Emulator.getConfig().getValue("items.furnidata.path", "");
+        if (!override.isEmpty()) {
+            Path p = Paths.get(override);
+            return Files.exists(p) ? p : null;
+        }
+        String basePath = Emulator.getConfig().getValue("furni.editor.asset.base.path", "");
+        if (basePath.isEmpty()) return null;
+        Path dir = Paths.get(basePath);
+        Path split = dir.resolve("furnidata");
+        if (Files.isDirectory(split)) return split;
+        Path legacy = dir.resolve("FurnitureData.json");
+        return Files.exists(legacy) ? legacy : null;
     }
 
     /** Build a fresh sanitized index from the given entries and swap it in atomically. */

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
@@ -56,7 +56,9 @@ public class FurnitureTextProvider {
         String override = Emulator.getConfig().getValue("items.furnidata.path", "");
         if (!override.isEmpty()) {
             Path p = Paths.get(override);
-            return Files.exists(p) ? p : null;
+            if (Files.exists(p)) return p;
+            LOGGER.warn("FurnitureTextProvider: items.furnidata.path '{}' does not exist", override);
+            return null;
         }
         String basePath = Emulator.getConfig().getValue("furni.editor.asset.base.path", "");
         if (basePath.isEmpty()) return null;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
@@ -69,15 +69,30 @@ public class FurnitureTextProvider {
         return Files.exists(legacy) ? legacy : null;
     }
 
-    /** Build a fresh sanitized index from the given entries and swap it in atomically. */
-    public void reindex(List<FurnidataEntry> entries) {
+    /**
+     * Build a fresh sanitized index, swap it in atomically, and return the
+     * changed/added entries (sanitized) as the delta versus the previous index.
+     */
+    public java.util.List<FurnidataEntry> reindex(java.util.List<FurnidataEntry> entries) {
         Map<String, FurniText> next = new HashMap<>(Math.max(16, entries.size() * 2));
         for (FurnidataEntry e : entries) {
             String key = baseKey(e.classname());
             if (key == null) continue;
             next.put(key, new FurniText(e.id(), e.type(), sanitize(e.name()), sanitize(e.description())));
         }
+
+        Map<String, FurniText> prev = this.index;
+        java.util.List<FurnidataEntry> delta = new java.util.ArrayList<>();
+        for (Map.Entry<String, FurniText> en : next.entrySet()) {
+            FurniText cur = en.getValue();
+            FurniText old = prev.get(en.getKey());
+            if (old == null || !old.name().equals(cur.name()) || !old.description().equals(cur.description())) {
+                delta.add(new FurnidataEntry(cur.id(), en.getKey(), cur.type(), cur.name(), cur.description()));
+            }
+        }
+
         this.index = next; // atomic reference swap
+        return delta;
     }
 
     /** Returns the sanitized display name for a DB classname, or null if absent/disabled. */

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
@@ -27,6 +27,8 @@ public class FurnitureTextProvider {
 
     private final boolean enabled;
     private volatile Map<String, FurniText> index = Map.of();
+    private volatile Path source;
+    private FurnidataWatcher watcher;
 
     public FurnitureTextProvider(boolean enabled) {
         this.enabled = enabled;
@@ -40,16 +42,25 @@ public class FurnitureTextProvider {
     /** Resolve the furnidata source from config and build the initial index. Never throws. */
     public void init() {
         try {
-            Path source = resolveSource();
-            if (source == null) {
+            this.source = resolveSource();
+            if (this.source == null) {
                 LOGGER.warn("FurnitureTextProvider: no furnidata source resolved — names fall back to public_name");
                 return;
             }
-            reindex(new FurnidataReader(source, DEFAULT_MAX_BYTES).read());
-            LOGGER.info("FurnitureTextProvider: indexed {} furnidata names from {}", this.index.size(), source);
+            reindex(new FurnidataReader(this.source, DEFAULT_MAX_BYTES).read());
+            LOGGER.info("FurnitureTextProvider: indexed {} furnidata names from {}", this.index.size(), this.source);
+
+            if (Boolean.parseBoolean(Emulator.getConfig().getValue("items.furnidata.watch.enabled", "true"))) {
+                this.watcher = new FurnidataWatcher(this, this.source, DEFAULT_MAX_BYTES);
+                this.watcher.start();
+            }
         } catch (Exception e) {
             LOGGER.warn("FurnitureTextProvider.init failed — names fall back to public_name", e);
         }
+    }
+
+    public Path getSource() {
+        return this.source;
     }
 
     private static Path resolveSource() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
@@ -51,6 +51,7 @@ public class FurnitureTextProvider {
             LOGGER.info("FurnitureTextProvider: indexed {} furnidata names from {}", this.index.size(), this.source);
 
             if (Boolean.parseBoolean(Emulator.getConfig().getValue("items.furnidata.watch.enabled", "true"))) {
+                if (this.watcher != null) this.watcher.stop();
                 this.watcher = new FurnidataWatcher(this, this.source, DEFAULT_MAX_BYTES);
                 this.watcher.start();
             }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/Item.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/Item.java
@@ -167,6 +167,17 @@ public class Item implements ISerialize {
         return this.fullName;
     }
 
+    /**
+     * Display name for user-facing/log output, sourced from furnidata (by classname).
+     * Falls back to the DB public_name when furnidata has no entry or names are disabled.
+     * Never returns null.
+     */
+    public String getDisplayName() {
+        FurnitureTextProvider provider = Emulator.getGameEnvironment().getFurnitureTextProvider();
+        String name = (provider != null) ? provider.getName(this.name) : null;
+        return (name != null && !name.isBlank()) ? name : this.fullName;
+    }
+
     public FurnitureType getType() {
         return this.type;
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/Item.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/Item.java
@@ -173,9 +173,12 @@ public class Item implements ISerialize {
      * Never returns null.
      */
     public String getDisplayName() {
-        FurnitureTextProvider provider = Emulator.getGameEnvironment().getFurnitureTextProvider();
+        FurnitureTextProvider provider = (Emulator.getGameEnvironment() != null)
+                ? Emulator.getGameEnvironment().getFurnitureTextProvider()
+                : null;
         String name = (provider != null) ? provider.getName(this.name) : null;
-        return (name != null && !name.isBlank()) ? name : this.fullName;
+        if (name != null && !name.isBlank()) return name;
+        return (this.fullName != null) ? this.fullName : "";
     }
 
     public FurnitureType getType() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredTextPlaceholderUtil.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredTextPlaceholderUtil.java
@@ -279,7 +279,7 @@ public final class WiredTextPlaceholderUtil {
                 continue;
             }
 
-            String furniName = item.getBaseItem().getFullName();
+            String furniName = item.getBaseItem().getDisplayName();
             if (furniName == null || furniName.trim().isEmpty()) {
                 furniName = item.getBaseItem().getName();
             }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
@@ -248,7 +248,7 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                                 LOGGER.debug("sender reached daily total LTD limit");
                                 this.client.getHabbo().alert(
                                         Emulator.getTexts().getValue("error.catalog.buy.limited.daily.total")
-                                                .replace("%itemname%", item.getBaseItems().iterator().next().getFullName())
+                                                .replace("%itemname%", item.getBaseItems().iterator().next().getDisplayName())
                                                 .replace("%limit%", ltdLimit + "")
                                 );
                                 return;
@@ -259,7 +259,7 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                                 LOGGER.debug("sender reached daily LTD item limit");
                                 this.client.getHabbo().alert(
                                         Emulator.getTexts().getValue("error.catalog.buy.limited.daily.item")
-                                                .replace("%itemname%", item.getBaseItems().iterator().next().getFullName())
+                                                .replace("%itemname%", item.getBaseItems().iterator().next().getDisplayName())
                                                 .replace("%limit%", ltdLimit + "")
                                 );
                                 return;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -570,6 +570,7 @@ public class Outgoing {
     public static final int FurniEditorDetailComposer = 10041;
     public static final int FurniEditorInteractionsComposer = 10043;
     public static final int FurniEditorResultComposer = 10044;
+    public static final int FurnitureDataReloadComposer = 10047; // CUSTOM
 
     // Catalog Admin
     public static final int CatalogAdminResultComposer = 10059;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/furniture/FurnitureDataReloadComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/furniture/FurnitureDataReloadComposer.java
@@ -1,0 +1,42 @@
+package com.eu.habbo.messages.outgoing.furniture;
+
+import com.eu.habbo.habbohotel.items.FurnidataEntry;
+import com.eu.habbo.habbohotel.items.FurnitureType;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+import java.util.List;
+
+public class FurnitureDataReloadComposer extends MessageComposer {
+
+    public static final int MODE_DELTA = 0;
+    public static final int MODE_RELOAD_HINT = 1;
+
+    private final int mode;
+    private final List<FurnidataEntry> entries;
+
+    public FurnitureDataReloadComposer(int mode, List<FurnidataEntry> entries) {
+        this.mode = mode;
+        this.entries = entries;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.FurnitureDataReloadComposer);
+        this.response.appendInt(this.mode);
+
+        if (this.mode == MODE_DELTA) {
+            this.response.appendInt(this.entries.size());
+            for (FurnidataEntry e : this.entries) {
+                this.response.appendString(e.type() == FurnitureType.FLOOR ? "S" : "I");
+                this.response.appendInt(e.id());
+                this.response.appendString(e.classname());
+                this.response.appendString(e.name());
+                this.response.appendString(e.description());
+            }
+        }
+
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/unknown/WatchAndEarnRewardComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/unknown/WatchAndEarnRewardComposer.java
@@ -18,7 +18,7 @@ public class WatchAndEarnRewardComposer extends MessageComposer {
         this.response.appendString(this.item.getType().code);
         this.response.appendInt(this.item.getId());
         this.response.appendString(this.item.getName());
-        this.response.appendString(this.item.getFullName());
+        this.response.appendString(this.item.getDisplayName());
         return this.response;
     }
 

--- a/Emulator/src/test/java/com/eu/habbo/SmokeTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/SmokeTest.java
@@ -1,0 +1,11 @@
+package com.eu.habbo;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SmokeTest {
+    @Test
+    void harnessRuns() {
+        assertTrue(true);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/FurnidataReaderTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/FurnidataReaderTest.java
@@ -1,0 +1,74 @@
+package com.eu.habbo.habbohotel.items;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FurnidataReaderTest {
+
+    private static final String SINGLE = """
+        {
+          // a comment
+          "roomitemtypes": { "furnitype": [
+            { "id": 10, "classname": "chair_norja", "name": "Chair", "description": "Sit", "xdim": 1, "ydim": 1 },
+          ]},
+          "wallitemtypes": { "furnitype": [
+            { "id": 20, "classname": "poster_5", "name": "Poster", "description": "Wall" }
+          ]}
+        }
+        """;
+
+    @Test
+    void parsesSingleFileFloorAndWall(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("FurnitureData.json");
+        Files.writeString(file, SINGLE);
+
+        List<FurnidataEntry> entries = new FurnidataReader(file, 64 * 1024 * 1024).read();
+
+        assertEquals(2, entries.size());
+        FurnidataEntry floor = entries.stream().filter(e -> e.id() == 10).findFirst().orElseThrow();
+        assertEquals("chair_norja", floor.classname());
+        assertEquals(FurnitureType.FLOOR, floor.type());
+        assertEquals("Chair", floor.name());
+        FurnidataEntry wall = entries.stream().filter(e -> e.id() == 20).findFirst().orElseThrow();
+        assertEquals(FurnitureType.WALL, wall.type());
+    }
+
+    @Test
+    void rejectsFileOverSizeCap(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("FurnitureData.json");
+        Files.writeString(file, SINGLE);
+        List<FurnidataEntry> entries = new FurnidataReader(file, 8 /* bytes */).read();
+        assertTrue(entries.isEmpty(), "oversized file must be refused, returning empty");
+    }
+
+    @Test
+    void missingSourceReturnsEmptyNeverThrows(@TempDir Path dir) {
+        Path missing = dir.resolve("does-not-exist.json");
+        assertDoesNotThrow(() -> {
+            assertTrue(new FurnidataReader(missing, 64 * 1024 * 1024).read().isEmpty());
+        });
+    }
+
+    @Test
+    void splitDirRejectsTraversalFiles(@TempDir Path dir) throws Exception {
+        Path secret = dir.resolve("secret.json");
+        Files.writeString(secret, "{ \"roomitemtypes\": { \"furnitype\": [ { \"id\": 99, \"classname\": \"x\", \"name\": \"LEAK\", \"description\": \"\" } ] } }");
+
+        Path base = dir.resolve("furnidata");
+        Path core = base.resolve("core");
+        Files.createDirectories(core);
+        Files.writeString(base.resolve("manifest.json"), "{ \"tiers\": [ \"core\" ] }");
+        Files.writeString(core.resolve("manifest.json"), "{ \"files\": [ \"../../secret.json\" ] }");
+
+        List<FurnidataEntry> entries = new FurnidataReader(base, 64 * 1024 * 1024).read();
+
+        assertTrue(entries.stream().noneMatch(e -> e.id() == 99),
+            "traversal file outside the base dir must be ignored");
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/FurnidataReaderTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/FurnidataReaderTest.java
@@ -56,6 +56,17 @@ class FurnidataReaderTest {
     }
 
     @Test
+    void oversizedManifestIsSkippedNeverThrows(@TempDir Path dir) throws Exception {
+        Path base = dir.resolve("furnidata");
+        Path core = base.resolve("core");
+        Files.createDirectories(core);
+        // A root manifest larger than the cap we pass in.
+        Files.writeString(base.resolve("manifest.json"), "{ \"tiers\": [ \"core\" ] }   // padding ".repeat(50));
+        List<FurnidataEntry> entries = new FurnidataReader(base, 8 /* bytes */).read();
+        assertTrue(entries.isEmpty());
+    }
+
+    @Test
     void splitDirRejectsTraversalFiles(@TempDir Path dir) throws Exception {
         Path secret = dir.resolve("secret.json");
         Files.writeString(secret, "{ \"roomitemtypes\": { \"furnitype\": [ { \"id\": 99, \"classname\": \"x\", \"name\": \"LEAK\", \"description\": \"\" } ] } }");

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/FurnitureTextProviderDeltaTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/FurnitureTextProviderDeltaTest.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.habbohotel.items;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FurnitureTextProviderDeltaTest {
+
+    @Test
+    void firstReindexReturnsAllAsDelta() {
+        FurnitureTextProvider p = new FurnitureTextProvider(true);
+        List<FurnidataEntry> delta = p.reindex(List.of(
+            new FurnidataEntry(1, "chair", FurnitureType.FLOOR, "Chair", "Sit")));
+        assertEquals(1, delta.size());
+        assertEquals("Chair", delta.get(0).name());
+    }
+
+    @Test
+    void unchangedReindexReturnsEmptyDelta() {
+        FurnitureTextProvider p = new FurnitureTextProvider(true);
+        List<FurnidataEntry> first = List.of(new FurnidataEntry(1, "chair", FurnitureType.FLOOR, "Chair", "Sit"));
+        p.reindex(first);
+        List<FurnidataEntry> delta = p.reindex(first);
+        assertTrue(delta.isEmpty(), "no change => empty delta");
+    }
+
+    @Test
+    void changedNameAppearsInDeltaWithSanitizedValue() {
+        FurnitureTextProvider p = new FurnitureTextProvider(true);
+        p.reindex(List.of(new FurnidataEntry(1, "chair", FurnitureType.FLOOR, "Chair", "Sit")));
+        List<FurnidataEntry> delta = p.reindex(List.of(
+            new FurnidataEntry(1, "chair", FurnitureType.FLOOR, "New %x%", "Sit")));
+        assertEquals(1, delta.size());
+        assertFalse(delta.get(0).name().contains("%"), "delta carries the sanitized name");
+        assertEquals(1, delta.get(0).id());
+        assertEquals(FurnitureType.FLOOR, delta.get(0).type());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/FurnitureTextProviderTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/FurnitureTextProviderTest.java
@@ -47,7 +47,7 @@ class FurnitureTextProviderTest {
         FurnitureTextProvider p = provider(true,
             new FurnidataEntry(1, "x", FurnitureType.FLOOR, evil, ""));
         String name = p.getName("x");
-        assertTrue(name.length() <= 256, "must be capped to 256");
+        assertEquals(256, name.length(), "input far exceeds the cap, so it must be exactly 256");
         assertFalse(name.chars().anyMatch(Character::isISOControl), "no control chars remain after sanitize");
         assertFalse(name.contains("%"), "ASCII percent neutralized");
     }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/FurnitureTextProviderTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/FurnitureTextProviderTest.java
@@ -1,0 +1,61 @@
+package com.eu.habbo.habbohotel.items;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FurnitureTextProviderTest {
+
+    private FurnitureTextProvider provider(boolean enabled, FurnidataEntry... entries) {
+        FurnitureTextProvider p = new FurnitureTextProvider(enabled);
+        p.reindex(List.of(entries));
+        return p;
+    }
+
+    @Test
+    void resolvesNameByClassname() {
+        FurnitureTextProvider p = provider(true,
+            new FurnidataEntry(1, "chair_norja", FurnitureType.FLOOR, "Norja Chair", "Sit"));
+        assertEquals("Norja Chair", p.getName("chair_norja"));
+    }
+
+    @Test
+    void matchesBaseClassnameIgnoringColourVariantAndCase() {
+        FurnitureTextProvider p = provider(true,
+            new FurnidataEntry(1, "chair_norja*2", FurnitureType.FLOOR, "Norja Chair", "Sit"));
+        assertEquals("Norja Chair", p.getName("CHAIR_NORJA"));
+    }
+
+    @Test
+    void returnsNullWhenClassnameMissing() {
+        FurnitureTextProvider p = provider(true);
+        assertNull(p.getName("unknown_thing"));
+    }
+
+    @Test
+    void returnsNullWhenDisabled() {
+        FurnitureTextProvider p = provider(false,
+            new FurnidataEntry(1, "chair_norja", FurnitureType.FLOOR, "Norja Chair", "Sit"));
+        assertNull(p.getName("chair_norja"));
+    }
+
+    @Test
+    void sanitizesNameCapStripControlAndNeutralizesPercent() {
+        String evil = "Bad\nName %limit% %user.name%".repeat(20);
+        FurnitureTextProvider p = provider(true,
+            new FurnidataEntry(1, "x", FurnitureType.FLOOR, evil, ""));
+        String name = p.getName("x");
+        assertTrue(name.length() <= 256, "must be capped to 256");
+        assertFalse(name.chars().anyMatch(Character::isISOControl), "no control chars remain after sanitize");
+        assertFalse(name.contains("%"), "ASCII percent neutralized");
+    }
+
+    @Test
+    void nullProviderNameNeverThrows() {
+        FurnitureTextProvider p = provider(true);
+        assertDoesNotThrow(() -> p.getName(null));
+        assertNull(p.getName(null));
+    }
+}

--- a/docs/superpowers/plans/2026-06-04-furni-names-from-json-server-emulator.md
+++ b/docs/superpowers/plans/2026-06-04-furni-names-from-json-server-emulator.md
@@ -1,0 +1,851 @@
+# Furni Names from JSON — Emulator (Piece 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Arcturus emulator source furni display names from the furnidata JSON (keyed by classname) instead of the DB `public_name`, with a sanitized, fail-safe, hot-swappable in-memory index.
+
+**Architecture:** A neutral `FurnidataReader` locates and parses the furnidata (single-file or split-tier JSON5) into `FurnidataEntry` records. `FurnitureTextProvider` builds a `volatile` index `baseClassname → name`, sanitizing at the boundary, and is queried lazily by a new `Item.getDisplayName()` (fallback to DB `public_name`). The 6 server-side sites that pronounce a furni name switch to it. No DB migration, no new packet, no client/renderer change — this Piece ships and is testable on its own.
+
+**Tech Stack:** Java 19/21 (Maven), Gson (already a dependency), JUnit 5 (added in Task 0).
+
+**Spec:** `docs/superpowers/specs/2026-06-04-furni-names-from-json-server-design.md` (§4, §7, §8).
+
+**Repo / branch:** `Arcturus-Morningstar-Extended`, branch `feat/furni-names-from-json-server` (already created, based on `origin/dev`). All paths below are relative to `Arcturus-Morningstar-Extended/Emulator/`.
+
+---
+
+## File structure
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `pom.xml` | add JUnit 5 + surefire (test infra does not exist yet) |
+| Create | `src/main/java/com/eu/habbo/habbohotel/items/FurnidataEntry.java` | immutable parsed entry |
+| Create | `src/main/java/com/eu/habbo/habbohotel/items/FurnidataReader.java` | locate + parse furnidata (single + split JSON5, path-guard, size-cap, fail-safe) |
+| Create | `src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java` | volatile index, sanitize, toggle, `getName()`, `reindex()` |
+| Modify | `src/main/java/com/eu/habbo/habbohotel/items/Item.java` | add `getDisplayName()` |
+| Modify | `src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java` | construct + init provider, add getter |
+| Modify | `src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java:1057,1063` | `getFullName()` → `getDisplayName()` |
+| Modify | `src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java:251,262` | `getFullName()` → `getDisplayName()` |
+| Modify | `src/main/java/com/eu/habbo/habbohotel/wired/core/WiredTextPlaceholderUtil.java:282` | `getFullName()` → `getDisplayName()` |
+| Modify | `src/main/java/com/eu/habbo/messages/outgoing/unknown/WatchAndEarnRewardComposer.java:21` | `getFullName()` → `getDisplayName()` |
+| Create | `src/test/java/com/eu/habbo/habbohotel/items/FurnidataReaderTest.java` | parse + path-guard + size-cap |
+| Create | `src/test/java/com/eu/habbo/habbohotel/items/FurnitureTextProviderTest.java` | index, color-variant, fallback, sanitize, toggle |
+
+---
+
+## Task 0: Add JUnit 5 test infrastructure
+
+**Files:**
+- Modify: `pom.xml`
+
+- [ ] **Step 1: Add the JUnit Jupiter dependency**
+
+In `pom.xml`, inside the existing `<dependencies>` element, add:
+
+```xml
+<dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter</artifactId>
+    <version>5.10.2</version>
+    <scope>test</scope>
+</dependency>
+```
+
+- [ ] **Step 2: Add the Surefire plugin**
+
+In `pom.xml`, inside `<build><plugins>`, add:
+
+```xml
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <version>3.2.5</version>
+</plugin>
+```
+
+- [ ] **Step 3: Create a smoke test to prove the harness runs**
+
+Create `src/test/java/com/eu/habbo/SmokeTest.java`:
+
+```java
+package com.eu.habbo;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SmokeTest {
+    @Test
+    void harnessRuns() {
+        assertTrue(true);
+    }
+}
+```
+
+- [ ] **Step 4: Run the test suite**
+
+Run: `mvn -q test -Dtest=SmokeTest`
+Expected: BUILD SUCCESS, 1 test run, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pom.xml src/test/java/com/eu/habbo/SmokeTest.java
+git commit -m "test: add JUnit 5 + surefire harness"
+```
+
+---
+
+## Task 1: `FurnidataEntry` record
+
+**Files:**
+- Create: `src/main/java/com/eu/habbo/habbohotel/items/FurnidataEntry.java`
+
+- [ ] **Step 1: Create the record**
+
+```java
+package com.eu.habbo.habbohotel.items;
+
+/**
+ * One parsed furnidata entry. {@code classname} is the raw furnidata classname
+ * (may carry a {@code *N} colour-variant suffix); the provider keys on the base.
+ */
+public record FurnidataEntry(int id, String classname, FurnitureType type, String name, String description) {
+}
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `mvn -q compile`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/com/eu/habbo/habbohotel/items/FurnidataEntry.java
+git commit -m "feat(items): FurnidataEntry record"
+```
+
+---
+
+## Task 2: `FurnidataReader` — locate & parse (TDD)
+
+**Files:**
+- Create: `src/main/java/com/eu/habbo/habbohotel/items/FurnidataReader.java`
+- Test: `src/test/java/com/eu/habbo/habbohotel/items/FurnidataReaderTest.java`
+
+The reader is decoupled from `Emulator` config so it is unit-testable: it takes an explicit base `Path` and a max-bytes cap. (Config resolution is wired in Task 4.)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/test/java/com/eu/habbo/habbohotel/items/FurnidataReaderTest.java`:
+
+```java
+package com.eu.habbo.habbohotel.items;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FurnidataReaderTest {
+
+    private static final String SINGLE = """
+        {
+          // a comment
+          "roomitemtypes": { "furnitype": [
+            { "id": 10, "classname": "chair_norja", "name": "Chair", "description": "Sit", "xdim": 1, "ydim": 1 },
+          ]},
+          "wallitemtypes": { "furnitype": [
+            { "id": 20, "classname": "poster_5", "name": "Poster", "description": "Wall" }
+          ]}
+        }
+        """;
+
+    @Test
+    void parsesSingleFileFloorAndWall(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("FurnitureData.json");
+        Files.writeString(file, SINGLE);
+
+        List<FurnidataEntry> entries = new FurnidataReader(file, 64 * 1024 * 1024).read();
+
+        assertEquals(2, entries.size());
+        FurnidataEntry floor = entries.stream().filter(e -> e.id() == 10).findFirst().orElseThrow();
+        assertEquals("chair_norja", floor.classname());
+        assertEquals(FurnitureType.FLOOR, floor.type());
+        assertEquals("Chair", floor.name());
+        FurnidataEntry wall = entries.stream().filter(e -> e.id() == 20).findFirst().orElseThrow();
+        assertEquals(FurnitureType.WALL, wall.type());
+    }
+
+    @Test
+    void rejectsFileOverSizeCap(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("FurnitureData.json");
+        Files.writeString(file, SINGLE);
+        List<FurnidataEntry> entries = new FurnidataReader(file, 8 /* bytes */).read();
+        assertTrue(entries.isEmpty(), "oversized file must be refused, returning empty");
+    }
+
+    @Test
+    void missingSourceReturnsEmptyNeverThrows(@TempDir Path dir) {
+        Path missing = dir.resolve("does-not-exist.json");
+        assertDoesNotThrow(() -> {
+            assertTrue(new FurnidataReader(missing, 64 * 1024 * 1024).read().isEmpty());
+        });
+    }
+
+    @Test
+    void splitDirRejectsTraversalFiles(@TempDir Path dir) throws Exception {
+        // secret outside the base dir
+        Path secret = dir.resolve("secret.json");
+        Files.writeString(secret, "{ \"roomitemtypes\": { \"furnitype\": [ { \"id\": 99, \"classname\": \"x\", \"name\": \"LEAK\", \"description\": \"\" } ] } }");
+
+        Path base = dir.resolve("furnidata");
+        Path core = base.resolve("core");
+        Files.createDirectories(core);
+        // tiers manifest
+        Files.writeString(base.resolve("manifest.json"), "{ \"tiers\": [ \"core\" ] }");
+        // files manifest points OUTSIDE core via traversal
+        Files.writeString(core.resolve("manifest.json"), "{ \"files\": [ \"../../secret.json\" ] }");
+
+        List<FurnidataEntry> entries = new FurnidataReader(base, 64 * 1024 * 1024).read();
+
+        assertTrue(entries.stream().noneMatch(e -> e.id() == 99),
+            "traversal file outside the base dir must be ignored");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mvn -q test -Dtest=FurnidataReaderTest`
+Expected: FAIL — `FurnidataReader` does not exist (compilation error).
+
+- [ ] **Step 3: Implement `FurnidataReader`**
+
+Create `src/main/java/com/eu/habbo/habbohotel/items/FurnidataReader.java`:
+
+```java
+package com.eu.habbo.habbohotel.items;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Neutral furnidata reader. Supports a single JSON/JSON5 file or a split-tier
+ * directory ({@code core/custom/seasonal} with {@code manifest.json(5)}).
+ * Never throws: any IO/parse error yields an empty list (the caller decides the
+ * fallback). All resolved paths are guarded against escaping the base dir.
+ */
+public class FurnidataReader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FurnidataReader.class);
+    private static final List<String> DEFAULT_TIERS = Arrays.asList("core", "custom", "seasonal");
+    private static final List<String> MANIFEST_NAMES = Arrays.asList("manifest.json5", "manifest.json");
+    private static final List<String> SECTIONS = Arrays.asList("roomitemtypes", "wallitemtypes");
+
+    private final Path source;
+    private final long maxBytes;
+
+    public FurnidataReader(Path source, long maxBytes) {
+        this.source = source;
+        this.maxBytes = maxBytes;
+    }
+
+    public List<FurnidataEntry> read() {
+        List<FurnidataEntry> out = new ArrayList<>();
+        try {
+            if (this.source == null || !Files.exists(this.source)) return out;
+
+            if (Files.isDirectory(this.source)) {
+                readSplitDir(this.source, out);
+            } else {
+                String content = readJson5Capped(this.source);
+                if (content != null) {
+                    parseRoot(JsonParser.parseString(content).getAsJsonObject(), out);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warn("FurnidataReader failed to read {} — returning empty", this.source, e);
+            return new ArrayList<>();
+        }
+        return out;
+    }
+
+    private void readSplitDir(Path base, List<FurnidataEntry> out) {
+        List<String> tiers = readManifestList(base, "tiers", DEFAULT_TIERS);
+        Path baseNorm = base.toAbsolutePath().normalize();
+
+        for (String tier : tiers) {
+            Path tierDir = base.resolve(tier);
+            if (!isInside(baseNorm, tierDir) || !Files.isDirectory(tierDir)) continue;
+
+            for (String fileName : readManifestList(tierDir, "files", List.of())) {
+                Path file = tierDir.resolve(fileName);
+                if (!isInside(baseNorm, file)) {
+                    LOGGER.warn("FurnidataReader: ignoring out-of-base file {}", file);
+                    continue;
+                }
+                if (!Files.exists(file)) continue;
+                try {
+                    String content = readJson5Capped(file);
+                    if (content != null) parseRoot(JsonParser.parseString(content).getAsJsonObject(), out);
+                } catch (Exception e) {
+                    LOGGER.warn("FurnidataReader: failed to parse {}", file, e);
+                }
+            }
+        }
+    }
+
+    private List<String> readManifestList(Path dir, String key, List<String> fallback) {
+        for (String name : MANIFEST_NAMES) {
+            Path m = dir.resolve(name);
+            if (!Files.exists(m)) continue;
+            try {
+                JsonObject obj = JsonParser.parseString(readJson5Capped(m)).getAsJsonObject();
+                if (obj.has(key) && obj.get(key).isJsonArray()) {
+                    List<String> list = new ArrayList<>();
+                    for (JsonElement el : obj.getAsJsonArray(key)) list.add(el.getAsString());
+                    if (!list.isEmpty()) return list;
+                }
+            } catch (Exception e) {
+                LOGGER.warn("FurnidataReader: bad manifest {}", m, e);
+            }
+        }
+        return fallback;
+    }
+
+    private void parseRoot(JsonObject root, List<FurnidataEntry> out) {
+        for (String section : SECTIONS) {
+            if (!root.has(section)) continue;
+            JsonObject sectionObj = root.getAsJsonObject(section);
+            if (!sectionObj.has("furnitype")) continue;
+            FurnitureType type = section.equals("roomitemtypes") ? FurnitureType.FLOOR : FurnitureType.WALL;
+            JsonArray types = sectionObj.getAsJsonArray("furnitype");
+            for (JsonElement el : types) {
+                JsonObject o = el.getAsJsonObject();
+                if (!o.has("id") || !o.has("classname")) continue;
+                out.add(new FurnidataEntry(
+                    o.get("id").getAsInt(),
+                    o.get("classname").getAsString(),
+                    type,
+                    o.has("name") ? o.get("name").getAsString() : "",
+                    o.has("description") ? o.get("description").getAsString() : ""
+                ));
+            }
+        }
+    }
+
+    /** Returns the JSON5-stripped content, or null if the file exceeds the byte cap. */
+    private String readJson5Capped(Path path) throws Exception {
+        long size = Files.size(path);
+        if (size > this.maxBytes) {
+            LOGGER.warn("FurnidataReader: {} is {} bytes, over cap {} — refusing", path, size, this.maxBytes);
+            return null;
+        }
+        return stripJson5(Files.readString(path, StandardCharsets.UTF_8));
+    }
+
+    private static boolean isInside(Path baseNorm, Path candidate) {
+        return candidate.toAbsolutePath().normalize().startsWith(baseNorm);
+    }
+
+    /** Strip // and block comments and trailing commas so Gson can parse JSON5. */
+    static String stripJson5(String content) {
+        if (content == null || content.isEmpty()) return content;
+        StringBuilder out = new StringBuilder(content.length());
+        int i = 0, len = content.length();
+        boolean inString = false, escape = false;
+        char stringChar = 0;
+        while (i < len) {
+            char c = content.charAt(i);
+            if (inString) {
+                out.append(c);
+                if (escape) escape = false;
+                else if (c == '\\') escape = true;
+                else if (c == stringChar) inString = false;
+                i++;
+                continue;
+            }
+            if (c == '"' || c == '\'') { inString = true; stringChar = c; out.append(c); i++; continue; }
+            if (c == '/' && i + 1 < len) {
+                char next = content.charAt(i + 1);
+                if (next == '/') { int eol = content.indexOf('\n', i + 2); if (eol < 0) break; i = eol; continue; }
+                if (next == '*') { int end = content.indexOf("*/", i + 2); if (end < 0) break; i = end + 2; continue; }
+            }
+            out.append(c);
+            i++;
+        }
+        return out.toString().replaceAll(",(\\s*[}\\]])", "$1");
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `mvn -q test -Dtest=FurnidataReaderTest`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/eu/habbo/habbohotel/items/FurnidataReader.java src/test/java/com/eu/habbo/habbohotel/items/FurnidataReaderTest.java
+git commit -m "feat(items): FurnidataReader (single + split JSON5, path-guard, size-cap, fail-safe)"
+```
+
+---
+
+## Task 3: `FurnitureTextProvider` — index, sanitize, toggle (TDD)
+
+**Files:**
+- Create: `src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java`
+- Test: `src/test/java/com/eu/habbo/habbohotel/items/FurnitureTextProviderTest.java`
+
+The provider is constructed with an already-built entry list (so it is unit-testable without files); the config-driven loading is wired in Task 4.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/test/java/com/eu/habbo/habbohotel/items/FurnitureTextProviderTest.java`:
+
+```java
+package com.eu.habbo.habbohotel.items;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FurnitureTextProviderTest {
+
+    private FurnitureTextProvider provider(boolean enabled, FurnidataEntry... entries) {
+        FurnitureTextProvider p = new FurnitureTextProvider(enabled);
+        p.reindex(List.of(entries));
+        return p;
+    }
+
+    @Test
+    void resolvesNameByClassname() {
+        FurnitureTextProvider p = provider(true,
+            new FurnidataEntry(1, "chair_norja", FurnitureType.FLOOR, "Norja Chair", "Sit"));
+        assertEquals("Norja Chair", p.getName("chair_norja"));
+    }
+
+    @Test
+    void matchesBaseClassnameIgnoringColourVariantAndCase() {
+        FurnitureTextProvider p = provider(true,
+            new FurnidataEntry(1, "chair_norja*2", FurnitureType.FLOOR, "Norja Chair", "Sit"));
+        // DB item_name is the base classname; lookup must strip the *N and be case-insensitive
+        assertEquals("Norja Chair", p.getName("CHAIR_NORJA"));
+    }
+
+    @Test
+    void returnsNullWhenClassnameMissing() {
+        FurnitureTextProvider p = provider(true);
+        assertNull(p.getName("unknown_thing"));
+    }
+
+    @Test
+    void returnsNullWhenDisabled() {
+        FurnitureTextProvider p = provider(false,
+            new FurnidataEntry(1, "chair_norja", FurnitureType.FLOOR, "Norja Chair", "Sit"));
+        assertNull(p.getName("chair_norja"));
+    }
+
+    @Test
+    void sanitizesNameCapStripControlAndNeutralizesPercent() {
+        String evil = "Bad\nName %limit% %user.name%".repeat(20); // long + control + % tokens
+        FurnitureTextProvider p = provider(true,
+            new FurnidataEntry(1, "x", FurnitureType.FLOOR, evil, ""));
+        String name = p.getName("x");
+        assertTrue(name.length() <= 256, "must be capped to 256");
+        assertFalse(name.contains(System.lineSeparator()), "newlines stripped");
+        assertFalse(name.chars().anyMatch(Character::isISOControl), "no control chars remain after sanitize");
+        assertFalse(name.contains(""), "control chars stripped");
+        assertFalse(name.contains("%"), "percent neutralized");
+    }
+
+    @Test
+    void nullProviderNameNeverThrows() {
+        FurnitureTextProvider p = provider(true);
+        assertDoesNotThrow(() -> p.getName(null));
+        assertNull(p.getName(null));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mvn -q test -Dtest=FurnitureTextProviderTest`
+Expected: FAIL — `FurnitureTextProvider` does not exist.
+
+- [ ] **Step 3: Implement `FurnitureTextProvider`**
+
+Create `src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java`:
+
+```java
+package com.eu.habbo.habbohotel.items;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * In-memory index of furnidata display names, keyed by the lowercased base
+ * classname (the {@code *N} colour-variant suffix is stripped). Read lazily by
+ * {@link Item#getDisplayName()}. Names are sanitized at index time.
+ *
+ * Thread-safety: the index is held behind a {@code volatile} reference; readers
+ * never block; {@link #reindex(List)} builds a fresh map and swaps it atomically.
+ */
+public class FurnitureTextProvider {
+
+    private static final int MAX_LEN = 256;
+
+    private final boolean enabled;
+    private volatile Map<String, FurniText> index = Map.of();
+
+    public FurnitureTextProvider(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /** Build a fresh sanitized index from the given entries and swap it in atomically. */
+    public void reindex(List<FurnidataEntry> entries) {
+        Map<String, FurniText> next = new HashMap<>(Math.max(16, entries.size() * 2));
+        for (FurnidataEntry e : entries) {
+            String key = baseKey(e.classname());
+            if (key == null) continue;
+            next.put(key, new FurniText(e.id(), e.type(), sanitize(e.name()), sanitize(e.description())));
+        }
+        this.index = next; // atomic reference swap
+    }
+
+    /** Returns the sanitized display name for a DB classname, or null if absent/disabled. */
+    public String getName(String classname) {
+        if (!this.enabled) return null;
+        String key = baseKey(classname);
+        if (key == null) return null;
+        FurniText t = this.index.get(key);
+        return (t != null) ? t.name() : null;
+    }
+
+    private static String baseKey(String classname) {
+        if (classname == null) return null;
+        int star = classname.indexOf('*');
+        String base = (star >= 0) ? classname.substring(0, star) : classname;
+        base = base.trim().toLowerCase();
+        return base.isEmpty() ? null : base;
+    }
+
+    /** Cap length, strip control chars/newlines, neutralize % (placeholder-injection safe). */
+    static String sanitize(String value) {
+        if (value == null) return "";
+        StringBuilder sb = new StringBuilder(Math.min(value.length(), MAX_LEN));
+        for (int i = 0; i < value.length() && sb.length() < MAX_LEN; i++) {
+            char c = value.charAt(i);
+            if (c == '%') { sb.append('％'); continue; } // fullwidth percent — not a placeholder token
+            if (c == '\n' || c == '\r' || Character.isISOControl(c)) continue;
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    private record FurniText(int id, FurnitureType type, String name, String description) {}
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `mvn -q test -Dtest=FurnitureTextProviderTest`
+Expected: PASS — 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java src/test/java/com/eu/habbo/habbohotel/items/FurnitureTextProviderTest.java
+git commit -m "feat(items): FurnitureTextProvider — volatile index, sanitize, toggle"
+```
+
+---
+
+## Task 4: Wire config-driven loading into the provider
+
+Adds a config-driven `init()` that resolves the path (reusing the editor's already-configured `furni.editor.asset.base.path`, with an `items.furnidata.path` override) and reads via `FurnidataReader`. Kept separate from the pure index logic so Task 3's unit tests stay file-free.
+
+**Files:**
+- Modify: `src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java`
+
+- [ ] **Step 1: Add the config-driven init method**
+
+Add the imports at the top of `FurnitureTextProvider.java`:
+
+```java
+import com.eu.habbo.Emulator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+```
+
+Replace the constructor section with a no-arg constructor that reads the toggle from config, plus a static factory and `init()`:
+
+```java
+    private static final Logger LOGGER = LoggerFactory.getLogger(FurnitureTextProvider.class);
+    private static final long DEFAULT_MAX_BYTES = 64L * 1024 * 1024;
+
+    // existing fields kept: private final boolean enabled; private volatile Map<String, FurniText> index = Map.of();
+
+    public FurnitureTextProvider(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /** Production constructor: reads the enable toggle from config. */
+    public FurnitureTextProvider() {
+        this(Boolean.parseBoolean(Emulator.getConfig().getValue("items.furnidata.names.enabled", "true")));
+    }
+
+    /** Resolve the furnidata source from config and build the initial index. Never throws. */
+    public void init() {
+        try {
+            Path source = resolveSource();
+            if (source == null) {
+                LOGGER.warn("FurnitureTextProvider: no furnidata source resolved — names fall back to public_name");
+                return;
+            }
+            reindex(new FurnidataReader(source, DEFAULT_MAX_BYTES).read());
+            LOGGER.info("FurnitureTextProvider: indexed {} furnidata names from {}", this.index.size(), source);
+        } catch (Exception e) {
+            LOGGER.warn("FurnitureTextProvider.init failed — names fall back to public_name", e);
+        }
+    }
+
+    private static Path resolveSource() {
+        String override = Emulator.getConfig().getValue("items.furnidata.path", "");
+        if (!override.isEmpty()) {
+            Path p = Paths.get(override);
+            return Files.exists(p) ? p : null;
+        }
+        String basePath = Emulator.getConfig().getValue("furni.editor.asset.base.path", "");
+        if (basePath.isEmpty()) return null;
+        Path dir = Paths.get(basePath);
+        Path split = dir.resolve("furnidata");
+        if (Files.isDirectory(split)) return split;
+        Path legacy = dir.resolve("FurnitureData.json");
+        return Files.exists(legacy) ? legacy : null;
+    }
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `mvn -q test-compile`
+Expected: BUILD SUCCESS (existing tests still compile; the `boolean` constructor is unchanged).
+
+- [ ] **Step 3: Re-run the provider tests (regression)**
+
+Run: `mvn -q test -Dtest=FurnitureTextProviderTest`
+Expected: PASS — 6 tests (unchanged).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
+git commit -m "feat(items): config-driven furnidata source resolution + init"
+```
+
+---
+
+## Task 5: Construct the provider in `GameEnvironment` and expose a getter
+
+**Files:**
+- Modify: `src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java`
+
+- [ ] **Step 1: Add the field**
+
+Near the other manager fields (around `private ItemManager itemManager;` at line 48), add:
+
+```java
+    private FurnitureTextProvider furnitureTextProvider;
+```
+
+Add the import with the other `com.eu.habbo.habbohotel.items.*` imports:
+
+```java
+import com.eu.habbo.habbohotel.items.FurnitureTextProvider;
+```
+
+- [ ] **Step 2: Construct + init it right after ItemManager loads**
+
+In `load()`, immediately after line 79 (`this.itemManager.load();`), insert:
+
+```java
+        this.furnitureTextProvider = new FurnitureTextProvider();
+        this.furnitureTextProvider.init();
+```
+
+- [ ] **Step 3: Add the getter**
+
+Near `public ItemManager getItemManager()` (line 157), add:
+
+```java
+    public FurnitureTextProvider getFurnitureTextProvider() {
+        return this.furnitureTextProvider;
+    }
+```
+
+- [ ] **Step 4: Compile**
+
+Run: `mvn -q compile`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java
+git commit -m "feat(items): construct FurnitureTextProvider after ItemManager load"
+```
+
+---
+
+## Task 6: Add `Item.getDisplayName()`
+
+**Files:**
+- Modify: `src/main/java/com/eu/habbo/habbohotel/items/Item.java`
+
+- [ ] **Step 1: Add the method**
+
+In `Item.java`, after `getFullName()` (line 166-168), add:
+
+```java
+    /**
+     * Display name for user-facing/log output, sourced from furnidata (by classname).
+     * Falls back to the DB public_name when furnidata has no entry or names are disabled.
+     * Never returns null.
+     */
+    public String getDisplayName() {
+        FurnitureTextProvider provider = Emulator.getGameEnvironment().getFurnitureTextProvider();
+        String name = (provider != null) ? provider.getName(this.name) : null;
+        return (name != null && !name.isBlank()) ? name : this.fullName;
+    }
+```
+
+`Emulator` is already imported in `Item.java` (line 3). `FurnitureTextProvider` is in the same package — no import needed.
+
+- [ ] **Step 2: Compile**
+
+Run: `mvn -q compile`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/com/eu/habbo/habbohotel/items/Item.java
+git commit -m "feat(items): Item.getDisplayName() — furnidata name with public_name fallback"
+```
+
+---
+
+## Task 7: Swap the 6 server-side name emitters
+
+Each is a one-line change: `getFullName()` → `getDisplayName()`. Do not touch `getName()` sites (technical).
+
+**Files:**
+- Modify: `CatalogManager.java:1057,1063`, `CatalogBuyItemAsGiftEvent.java:251,262`, `WiredTextPlaceholderUtil.java:282`, `WatchAndEarnRewardComposer.java:21`
+
+- [ ] **Step 1: CatalogManager (2 sites)**
+
+In `src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java`, lines 1057 and 1063, change:
+
+`...iterator().next().getFullName()` → `...iterator().next().getDisplayName()`
+
+(Both occurrences of `item.getBaseItems().iterator().next().getFullName()` become `...getDisplayName()`.)
+
+- [ ] **Step 2: CatalogBuyItemAsGiftEvent (2 sites)**
+
+In `src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java`, lines 251 and 262, change the same `getFullName()` → `getDisplayName()` on `item.getBaseItems().iterator().next()`.
+
+- [ ] **Step 3: WiredTextPlaceholderUtil (1 site)**
+
+In `src/main/java/com/eu/habbo/habbohotel/wired/core/WiredTextPlaceholderUtil.java`, line 282:
+
+```java
+            String furniName = item.getBaseItem().getDisplayName();
+```
+
+(Leave the existing `getName()` fallback at lines 283-285 — `getDisplayName()` already falls back to `public_name`; the `getName()` step remains as an ultimate fallback for blank names.)
+
+- [ ] **Step 4: WatchAndEarnRewardComposer (1 site)**
+
+In `src/main/java/com/eu/habbo/messages/outgoing/unknown/WatchAndEarnRewardComposer.java`, line 21:
+
+```java
+        this.response.appendString(this.item.getDisplayName());
+```
+
+- [ ] **Step 5: Compile**
+
+Run: `mvn -q compile`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 6: Verify no stray furni display-name `getFullName()` remains**
+
+Run: `grep -rn "getFullName()" src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java src/main/java/com/eu/habbo/habbohotel/wired/core/WiredTextPlaceholderUtil.java src/main/java/com/eu/habbo/messages/outgoing/unknown/WatchAndEarnRewardComposer.java`
+Expected: no matches in the 6 swapped lines (other `getFullName()` on non-item objects, if any, are unrelated and fine).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java src/main/java/com/eu/habbo/habbohotel/wired/core/WiredTextPlaceholderUtil.java src/main/java/com/eu/habbo/messages/outgoing/unknown/WatchAndEarnRewardComposer.java
+git commit -m "feat(items): source server-pronounced furni names from furnidata (6 sites)"
+```
+
+---
+
+## Task 8: Full build + test + manual acceptance
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full build with tests**
+
+Run: `mvn -q clean package`
+Expected: BUILD SUCCESS; FurnidataReaderTest (4) + FurnitureTextProviderTest (6) + SmokeTest (1) all pass.
+
+- [ ] **Step 2: Manual acceptance (against a running hotel)**
+
+1. Ensure `furni.editor.asset.base.path` points at the furnidata (or set `items.furnidata.path`).
+2. Pick a furni whose furnidata `name` differs from its DB `public_name`; trigger a server-pronounced name:
+   - a wired sign using `%furni.name%` → shows the furnidata name;
+   - a Watch&Earn reward for that furni → notification shows the furnidata name;
+   - exceed an LTD daily limit on that item → the alert shows the furnidata name.
+3. Set `items.furnidata.names.enabled=false`, restart → all three revert to the DB `public_name` (toggle works).
+4. Corrupt the furnidata file, restart → server boots cleanly; names fall back to `public_name` (fail-safe; check log warning).
+
+- [ ] **Step 3: Final commit (if any config docs were added)**
+
+```bash
+git add -A
+git commit -m "docs(items): document items.furnidata.* config keys" --allow-empty
+```
+
+---
+
+## Notes for the implementer
+
+- **No DB migration, no new packet, no client/renderer change** in this plan. Liveness (file-watch + delta broadcast + renderer) is Piece 2, a separate plan.
+- **Do not touch** the furni-editor (`FurniDataManager`, `messages/incoming/furnieditor/*`, `messages/outgoing/furnieditor/*`). The reader is a new neutral class even though it overlaps in spirit.
+- **Do not change** `getName()`/`item_name` sites (technical), `isPet/isBot`, or the wired `wf_` fallback in `Item.load`.
+- `release=21` / `source=target=19` in `pom.xml` is intentional — do not "fix" it. JUnit Jupiter 5.10 and records are fine on 19.

--- a/docs/superpowers/plans/2026-06-04-furni-names-from-json-server-liveness.md
+++ b/docs/superpowers/plans/2026-06-04-furni-names-from-json-server-liveness.md
@@ -1,0 +1,779 @@
+# Furni Names from JSON — Liveness (Piece 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the furnidata file changes, push only the changed names to every connected client so catalog/inventory/infostand update live, without a giant re-download and without a reconnect.
+
+**Architecture:** The emulator (building on Piece 1) computes a **delta** during reindex, a single-threaded **file watcher** (debounced + throttled) broadcasts a new `FurnitureDataReload` packet (delta, or a compact reload-hint above a cap). The renderer parses it, patches `FurnitureData` + the localization keys, and dispatches the existing `nitro-localization-updated` window event — so the three already-subscribed client surfaces refresh. **No Nitro-V3 client code changes.**
+
+**Tech Stack:** Java (Arcturus, Gson, java.nio WatchService) + TypeScript (Nitro_Render_V3, Vitest).
+
+**Depends on:** Piece 1 plan (`FurnitureTextProvider`, `FurnidataReader`, `FurnidataEntry`, `Item.getDisplayName()`) merged on the same branch.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-furni-names-from-json-server-design.md` (§5, §7, §8).
+
+**Repos / branch:** `feat/furni-names-from-json-server` in both `Arcturus-Morningstar-Extended` and `Nitro_Render_V3`.
+
+**Wire contract — packet `FurnitureDataReload` (server → client), header `10047`:**
+```
+int   mode                 // 0 = delta, 1 = reload-hint
+// mode == 0 (delta):
+int   count                // server-capped; client clamps on read
+count × { string type ("S"|"I"); int id; string classname; string name; string description }
+// mode == 1: no further fields
+```
+`10046` is taken (editor `FURNI_DATA_UPDATED`); `10047` is the new id. Task R1 Step 2 verifies it is free.
+
+---
+
+## Part A — Renderer (Nitro_Render_V3)
+
+All paths relative to `Nitro_Render_V3/`. Build/test: `yarn build`, `yarn test`.
+
+### Task R1: IncomingHeader + parser + event
+
+**Files:**
+- Modify: `packages/communication/src/messages/incoming/IncomingHeader.ts:498`
+- Create: `packages/communication/src/messages/parser/furniture/FurnitureDataReloadParser.ts`
+- Create: `packages/communication/src/messages/incoming/furniture/FurnitureDataReloadEvent.ts`
+
+- [ ] **Step 1: Add the incoming header constant**
+
+In `packages/communication/src/messages/incoming/IncomingHeader.ts`, right after line 498 (`public static FURNI_DATA_UPDATED = 10046;`), add:
+
+```ts
+	public static FURNITURE_DATA_RELOAD = 10047;
+```
+
+- [ ] **Step 2: Verify the id is free**
+
+Run: `grep -rn "10047" packages/communication/src/messages/incoming/IncomingHeader.ts packages/communication/src/messages/outgoing/OutgoingHeader.ts`
+Expected: only the line you just added. If `10047` already exists, use the next free integer and keep it identical to the Arcturus side (Task A1).
+
+- [ ] **Step 3: Create the parser**
+
+Create `packages/communication/src/messages/parser/furniture/FurnitureDataReloadParser.ts`:
+
+```ts
+import { IMessageDataWrapper, IMessageParser } from '@nitrots/api';
+
+export interface FurnidataDeltaEntry
+{
+    type: string;        // "S" floor | "I" wall
+    id: number;
+    classname: string;
+    name: string;
+    description: string;
+}
+
+export class FurnitureDataReloadParser implements IMessageParser
+{
+    private static readonly MAX_ENTRIES = 100000;
+
+    private _mode: number;
+    private _entries: FurnidataDeltaEntry[];
+
+    public flush(): boolean
+    {
+        this._mode = 0;
+        this._entries = [];
+        return true;
+    }
+
+    public parse(wrapper: IMessageDataWrapper): boolean
+    {
+        if(!wrapper) return false;
+
+        this._mode = wrapper.readInt();
+        this._entries = [];
+
+        if(this._mode === 0)
+        {
+            let count = wrapper.readInt();
+            if(count < 0) count = 0;
+            if(count > FurnitureDataReloadParser.MAX_ENTRIES) count = FurnitureDataReloadParser.MAX_ENTRIES;
+
+            for(let i = 0; i < count; i++)
+            {
+                this._entries.push({
+                    type: wrapper.readString(),
+                    id: wrapper.readInt(),
+                    classname: wrapper.readString(),
+                    name: wrapper.readString(),
+                    description: wrapper.readString()
+                });
+            }
+        }
+
+        return true;
+    }
+
+    public get mode(): number { return this._mode; }
+    public get entries(): FurnidataDeltaEntry[] { return this._entries; }
+}
+```
+
+- [ ] **Step 4: Create the event**
+
+Create `packages/communication/src/messages/incoming/furniture/FurnitureDataReloadEvent.ts`:
+
+```ts
+import { IMessageEvent } from '@nitrots/api';
+import { MessageEvent } from '@nitrots/events';
+import { FurnitureDataReloadParser } from '../../parser/furniture/FurnitureDataReloadParser';
+
+export class FurnitureDataReloadEvent extends MessageEvent implements IMessageEvent
+{
+    constructor(callBack: Function)
+    {
+        super(callBack, FurnitureDataReloadParser);
+    }
+
+    public getParser(): FurnitureDataReloadParser
+    {
+        return this.parser as FurnitureDataReloadParser;
+    }
+}
+```
+
+- [ ] **Step 5: Export both from the barrels**
+
+In `packages/communication/src/messages/parser/furniture/index.ts` add:
+
+```ts
+export * from './FurnitureDataReloadParser';
+```
+
+In `packages/communication/src/messages/incoming/furniture/index.ts` add:
+
+```ts
+export * from './FurnitureDataReloadEvent';
+```
+
+(If either `furniture/index.ts` does not exist, create it with the single `export * from './FurnitureDataReloadParser';` / `...Event` line and add `export * from './furniture';` to the parent `incoming/index.ts` and `parser/index.ts`.)
+
+- [ ] **Step 6: Compile**
+
+Run: `yarn compile:fast`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/communication/src/messages/incoming/IncomingHeader.ts packages/communication/src/messages/parser/furniture/ packages/communication/src/messages/incoming/furniture/
+git commit -m "feat(communication): FurnitureDataReload incoming event + parser (header 10047)"
+```
+
+---
+
+### Task R2: Map the header → event in NitroMessages
+
+**Files:**
+- Modify: `packages/communication/src/NitroMessages.ts:91`
+
+- [ ] **Step 1: Register the event class**
+
+In `packages/communication/src/NitroMessages.ts`, right after line 91 (`this._events.set(IncomingHeader.FURNI_DATA_UPDATED, FurniDataUpdatedEvent);`), add:
+
+```ts
+		this._events.set(IncomingHeader.FURNITURE_DATA_RELOAD, FurnitureDataReloadEvent);
+```
+
+Ensure `FurnitureDataReloadEvent` is imported at the top of the file (add it to the existing incoming-events import block, e.g. `import { ..., FurnitureDataReloadEvent } from './messages';` matching how `FurniDataUpdatedEvent` is imported there).
+
+- [ ] **Step 2: Compile**
+
+Run: `yarn compile:fast`
+Expected: no errors (the symbol resolves through the barrels from Task R1 Step 5).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/communication/src/NitroMessages.ts
+git commit -m "feat(communication): route FURNITURE_DATA_RELOAD to its event"
+```
+
+---
+
+### Task R3: `applyFurnidataDelta` + reload-hint + register handler (TDD)
+
+**Files:**
+- Modify: `packages/session/src/SessionDataManager.ts`
+- Test: `packages/session/src/__tests__/SessionDataManager.furnidataDelta.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/session/src/__tests__/SessionDataManager.furnidataDelta.test.ts`:
+
+```ts
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Minimal localization + window doubles
+const setValue = vi.fn();
+vi.mock('@nitrots/localization', () => ({
+    GetLocalizationManager: () => ({ setValue })
+}));
+vi.mock('@nitrots/events', async (orig) => {
+    const actual = await orig() as any;
+    return { ...actual, GetEventDispatcher: () => ({ dispatchEvent: vi.fn() }) };
+});
+
+import { applyFurnidataDeltaTo } from '../furniture/applyFurnidataDelta';
+
+describe('applyFurnidataDelta', () => {
+    beforeEach(() => { setValue.mockClear(); });
+
+    it('patches floor FurnitureData name/description and localization keys, dispatches window event', () => {
+        const floor: any = { _localizedName: 'Old', _description: 'Old desc' };
+        const floorItems = new Map<number, any>([[ 5, floor ]]);
+        const wallItems = new Map<number, any>();
+        const dispatched: string[] = [];
+        const win: any = { dispatchEvent: (e: any) => dispatched.push(e.type) };
+
+        applyFurnidataDeltaTo(
+            [ { type: 'S', id: 5, classname: 'chair', name: 'New', description: 'New desc' } ],
+            floorItems, wallItems, { setValue } as any, win
+        );
+
+        expect(floor._localizedName).toBe('New');
+        expect(floor._description).toBe('New desc');
+        expect(setValue).toHaveBeenCalledWith('roomItem.name.5', 'New');
+        expect(setValue).toHaveBeenCalledWith('roomItem.desc.5', 'New desc');
+        expect(dispatched).toContain('nitro-localization-updated');
+    });
+
+    it('patches wall items by id', () => {
+        const wall: any = { _localizedName: 'W', _description: '' };
+        const wallItems = new Map<number, any>([[ 9, wall ]]);
+        applyFurnidataDeltaTo(
+            [ { type: 'I', id: 9, classname: 'poster', name: 'WallNew', description: 'd' } ],
+            new Map(), wallItems, { setValue } as any, { dispatchEvent: () => {} } as any
+        );
+        expect(wall._localizedName).toBe('WallNew');
+        expect(setValue).toHaveBeenCalledWith('wallItem.name.9', 'WallNew');
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn test SessionDataManager.furnidataDelta`
+Expected: FAIL — `../furniture/applyFurnidataDelta` does not exist.
+
+- [ ] **Step 3: Extract the pure patch function**
+
+Create `packages/session/src/furniture/applyFurnidataDelta.ts`:
+
+```ts
+import { ILocalizationManager } from '@nitrots/api';
+import { FurnidataDeltaEntry } from '@nitrots/communication';
+
+/**
+ * Pure, testable furnidata-delta patcher. Mutates the FurnitureData objects in
+ * the given maps (by id) and the localization keys, then dispatches the
+ * `nitro-localization-updated` window event so subscribed React surfaces refresh.
+ */
+export function applyFurnidataDeltaTo(
+    entries: FurnidataDeltaEntry[],
+    floorItems: Map<number, any>,
+    wallItems: Map<number, any>,
+    localization: Pick<ILocalizationManager, 'setValue'>,
+    win: { dispatchEvent: (event: Event) => void }
+): void
+{
+    if(!entries || !entries.length) return;
+
+    for(const e of entries)
+    {
+        if(e.type === 'I')
+        {
+            const wall = wallItems.get(e.id);
+            if(wall) { wall._localizedName = e.name; wall._description = e.description; }
+            localization.setValue('wallItem.name.' + e.id, e.name);
+            localization.setValue('wallItem.desc.' + e.id, e.description);
+        }
+        else
+        {
+            const floor = floorItems.get(e.id);
+            if(floor) { floor._localizedName = e.name; floor._description = e.description; }
+            localization.setValue('roomItem.name.' + e.id, e.name);
+            localization.setValue('roomItem.desc.' + e.id, e.description);
+        }
+    }
+
+    if(win && typeof win.dispatchEvent === 'function')
+    {
+        win.dispatchEvent(new CustomEvent('nitro-localization-updated'));
+    }
+}
+```
+
+If `FurnidataDeltaEntry` is not yet re-exported from `@nitrots/communication`, add `export * from './messages/parser/furniture/FurnitureDataReloadParser';` to `packages/communication/src/index.ts` (or the nearest public barrel) so the type is importable.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `yarn test SessionDataManager.furnidataDelta`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Wire the methods + handler into SessionDataManager**
+
+In `packages/session/src/SessionDataManager.ts`, add the import near the other furniture imports:
+
+```ts
+import { applyFurnidataDeltaTo } from './furniture/applyFurnidataDelta';
+import { FurnidataDeltaEntry, FurnitureDataReloadEvent } from '@nitrots/communication';
+```
+
+Add these methods just after `applyLiveFurnitureNameUpdate` (after line 115):
+
+```ts
+    public applyFurnidataDelta(entries: FurnidataDeltaEntry[]): void
+    {
+        applyFurnidataDeltaTo(entries, this._floorItems as any, this._wallItems as any, GetLocalizationManager(), (typeof window !== 'undefined') ? window : { dispatchEvent: () => {} } as any);
+    }
+
+    public async applyFurnidataReloadHint(): Promise<void>
+    {
+        await this._furnitureData.init();
+        if(typeof window !== 'undefined') window.dispatchEvent(new CustomEvent('nitro-localization-updated'));
+    }
+```
+
+In `init()`, add a registration to the `this._messageEvents.push(...)` list (after the `FurniDataUpdatedEvent` registration at line 208-212):
+
+```ts
+            GetCommunication().registerMessageEvent(new FurnitureDataReloadEvent((event: FurnitureDataReloadEvent) =>
+            {
+                const parser = event.getParser();
+                if(parser.mode === 1) { void this.applyFurnidataReloadHint(); }
+                else { this.applyFurnidataDelta(parser.entries); }
+            }))
+```
+
+(Add a comma after the previous entry as needed so the push args stay comma-separated.)
+
+- [ ] **Step 6: Compile + run the full session test suite**
+
+Run: `yarn compile:fast && yarn test packages/session`
+Expected: no compile errors; all session tests pass including the new ones.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/session/src/furniture/applyFurnidataDelta.ts packages/session/src/SessionDataManager.ts packages/session/src/__tests__/SessionDataManager.furnidataDelta.test.ts packages/communication/src/index.ts
+git commit -m "feat(session): apply FurnitureDataReload delta + reload-hint, separate from editor path"
+```
+
+---
+
+## Part B — Emulator (Arcturus-Morningstar-Extended)
+
+All paths relative to `Arcturus-Morningstar-Extended/Emulator/`.
+
+### Task A1: Outgoing header + `FurnitureDataReloadComposer`
+
+**Files:**
+- Modify: `src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java`
+- Create: `src/main/java/com/eu/habbo/messages/outgoing/furniture/FurnitureDataReloadComposer.java`
+
+- [ ] **Step 1: Add the Outgoing header constant**
+
+In `src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java`, add (matching the file's existing `public static final int Name = id;` style):
+
+```java
+    public static final int FurnitureDataReloadComposer = 10047;
+```
+
+- [ ] **Step 2: Verify the id is free on the server side**
+
+Run: `grep -rn "= 10047" src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java`
+Expected: only the line just added. If taken, pick the next free id and keep it equal to the renderer `IncomingHeader.FURNITURE_DATA_RELOAD` (Task R1).
+
+- [ ] **Step 3: Create the composer**
+
+Create `src/main/java/com/eu/habbo/messages/outgoing/furniture/FurnitureDataReloadComposer.java`:
+
+```java
+package com.eu.habbo.messages.outgoing.furniture;
+
+import com.eu.habbo.habbohotel.items.FurnidataEntry;
+import com.eu.habbo.habbohotel.items.FurnitureType;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+import java.util.List;
+
+public class FurnitureDataReloadComposer extends MessageComposer {
+
+    public static final int MODE_DELTA = 0;
+    public static final int MODE_RELOAD_HINT = 1;
+
+    private final int mode;
+    private final List<FurnidataEntry> entries;
+
+    public FurnitureDataReloadComposer(int mode, List<FurnidataEntry> entries) {
+        this.mode = mode;
+        this.entries = entries;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.FurnitureDataReloadComposer);
+        this.response.appendInt(this.mode);
+
+        if (this.mode == MODE_DELTA) {
+            this.response.appendInt(this.entries.size());
+            for (FurnidataEntry e : this.entries) {
+                this.response.appendString(e.type() == FurnitureType.FLOOR ? "S" : "I");
+                this.response.appendInt(e.id());
+                this.response.appendString(e.classname());
+                this.response.appendString(e.name());
+                this.response.appendString(e.description());
+            }
+        }
+
+        return this.response;
+    }
+}
+```
+
+- [ ] **Step 4: Compile**
+
+Run: `mvn -q compile`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java src/main/java/com/eu/habbo/messages/outgoing/furniture/FurnitureDataReloadComposer.java
+git commit -m "feat(items): FurnitureDataReloadComposer (header 10047, delta + reload-hint)"
+```
+
+---
+
+### Task A2: `FurnitureTextProvider.reindex` returns a sanitized delta (TDD)
+
+Piece 1 defined `reindex(List)` returning `void`. Change it to return the changed entries (sanitized), so the watcher can broadcast them. Existing call sites ignore the return value — no other change needed.
+
+**Files:**
+- Modify: `src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java`
+- Test: `src/test/java/com/eu/habbo/habbohotel/items/FurnitureTextProviderDeltaTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/test/java/com/eu/habbo/habbohotel/items/FurnitureTextProviderDeltaTest.java`:
+
+```java
+package com.eu.habbo.habbohotel.items;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FurnitureTextProviderDeltaTest {
+
+    @Test
+    void firstReindexReturnsAllAsDelta() {
+        FurnitureTextProvider p = new FurnitureTextProvider(true);
+        List<FurnidataEntry> delta = p.reindex(List.of(
+            new FurnidataEntry(1, "chair", FurnitureType.FLOOR, "Chair", "Sit")));
+        assertEquals(1, delta.size());
+        assertEquals("Chair", delta.get(0).name());
+    }
+
+    @Test
+    void unchangedReindexReturnsEmptyDelta() {
+        FurnitureTextProvider p = new FurnitureTextProvider(true);
+        List<FurnidataEntry> first = List.of(new FurnidataEntry(1, "chair", FurnitureType.FLOOR, "Chair", "Sit"));
+        p.reindex(first);
+        List<FurnidataEntry> delta = p.reindex(first);
+        assertTrue(delta.isEmpty(), "no change => empty delta");
+    }
+
+    @Test
+    void changedNameAppearsInDeltaWithSanitizedValue() {
+        FurnitureTextProvider p = new FurnitureTextProvider(true);
+        p.reindex(List.of(new FurnidataEntry(1, "chair", FurnitureType.FLOOR, "Chair", "Sit")));
+        List<FurnidataEntry> delta = p.reindex(List.of(
+            new FurnidataEntry(1, "chair", FurnitureType.FLOOR, "New %x%", "Sit")));
+        assertEquals(1, delta.size());
+        assertFalse(delta.get(0).name().contains("%"), "delta carries the sanitized name");
+        assertEquals(1, delta.get(0).id());
+        assertEquals(FurnitureType.FLOOR, delta.get(0).type());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mvn -q test -Dtest=FurnitureTextProviderDeltaTest`
+Expected: FAIL — `reindex` returns `void` (compile error) / method shape mismatch.
+
+- [ ] **Step 3: Change `reindex` to compute and return the delta**
+
+In `FurnitureTextProvider.java`, replace the existing `reindex` method with:
+
+```java
+    /**
+     * Build a fresh sanitized index, swap it in atomically, and return the
+     * changed/added entries (sanitized) as the delta versus the previous index.
+     */
+    public java.util.List<FurnidataEntry> reindex(java.util.List<FurnidataEntry> entries) {
+        Map<String, FurniText> next = new HashMap<>(Math.max(16, entries.size() * 2));
+        for (FurnidataEntry e : entries) {
+            String key = baseKey(e.classname());
+            if (key == null) continue;
+            next.put(key, new FurniText(e.id(), e.type(), sanitize(e.name()), sanitize(e.description())));
+        }
+
+        Map<String, FurniText> prev = this.index;
+        java.util.List<FurnidataEntry> delta = new java.util.ArrayList<>();
+        for (Map.Entry<String, FurniText> en : next.entrySet()) {
+            FurniText cur = en.getValue();
+            FurniText old = prev.get(en.getKey());
+            if (old == null || !old.name().equals(cur.name()) || !old.description().equals(cur.description())) {
+                delta.add(new FurnidataEntry(cur.id(), en.getKey(), cur.type(), cur.name(), cur.description()));
+            }
+        }
+
+        this.index = next; // atomic reference swap
+        return delta;
+    }
+```
+
+- [ ] **Step 4: Run both provider tests**
+
+Run: `mvn -q test -Dtest=FurnitureTextProviderTest,FurnitureTextProviderDeltaTest`
+Expected: PASS — Piece-1 provider tests (6) still pass (they ignore the return value), delta tests (3) pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java src/test/java/com/eu/habbo/habbohotel/items/FurnitureTextProviderDeltaTest.java
+git commit -m "feat(items): reindex returns sanitized furnidata delta"
+```
+
+---
+
+### Task A3: File watcher — debounce, throttle, cap→hint, broadcast
+
+**Files:**
+- Create: `src/main/java/com/eu/habbo/habbohotel/items/FurnidataWatcher.java`
+- Modify: `src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java` (expose source path + start watcher)
+
+- [ ] **Step 1: Expose the resolved source and start the watcher from `init()`**
+
+In `FurnitureTextProvider.java`, store the resolved source and start the watcher at the end of `init()`. Replace the body of `init()` with:
+
+```java
+    private volatile Path source;
+    private FurnidataWatcher watcher;
+
+    public void init() {
+        try {
+            this.source = resolveSource();
+            if (this.source == null) {
+                LOGGER.warn("FurnitureTextProvider: no furnidata source resolved — names fall back to public_name");
+                return;
+            }
+            reindex(new FurnidataReader(this.source, DEFAULT_MAX_BYTES).read());
+            LOGGER.info("FurnitureTextProvider: indexed {} furnidata names from {}", this.index.size(), this.source);
+
+            if (Boolean.parseBoolean(Emulator.getConfig().getValue("items.furnidata.watch.enabled", "true"))) {
+                this.watcher = new FurnidataWatcher(this, this.source, DEFAULT_MAX_BYTES);
+                this.watcher.start();
+            }
+        } catch (Exception e) {
+            LOGGER.warn("FurnitureTextProvider.init failed — names fall back to public_name", e);
+        }
+    }
+
+    public Path getSource() {
+        return this.source;
+    }
+```
+
+(Add `import java.nio.file.Path;` if not already present from Piece 1 Task 4.)
+
+- [ ] **Step 2: Create the watcher**
+
+Create `src/main/java/com/eu/habbo/habbohotel/items/FurnidataWatcher.java`:
+
+```java
+package com.eu.habbo.habbohotel.items;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.messages.outgoing.furniture.FurnitureDataReloadComposer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.List;
+
+/**
+ * Watches the furnidata source on a single daemon thread. On change (debounced),
+ * re-indexes via the provider and broadcasts only the delta — or a compact
+ * reload-hint when the delta exceeds the cap. A minimum interval throttles bursts.
+ * Never throws out of the loop.
+ */
+public class FurnidataWatcher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FurnidataWatcher.class);
+
+    private final FurnitureTextProvider provider;
+    private final Path watchDir;
+    private final long maxBytes;
+    private final long debounceMs;
+    private final long minIntervalMs;
+    private final int deltaCap;
+
+    private volatile boolean running = false;
+    private long lastBroadcast = 0L;
+
+    public FurnidataWatcher(FurnitureTextProvider provider, Path source, long maxBytes) {
+        this.provider = provider;
+        // Watch the parent dir for a file, or the dir itself for a split layout.
+        this.watchDir = java.nio.file.Files.isDirectory(source) ? source : source.getParent();
+        this.maxBytes = maxBytes;
+        this.debounceMs = Long.parseLong(Emulator.getConfig().getValue("items.furnidata.watch.debounce.ms", "750"));
+        this.minIntervalMs = Long.parseLong(Emulator.getConfig().getValue("items.furnidata.watch.min.interval.ms", "5000"));
+        this.deltaCap = Integer.parseInt(Emulator.getConfig().getValue("items.furnidata.delta.cap", "500"));
+    }
+
+    public void start() {
+        if (this.running || this.watchDir == null) return;
+        this.running = true;
+        Thread t = new Thread(this::run, "FurnidataWatcher");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    public void stop() {
+        this.running = false;
+    }
+
+    private void run() {
+        try (WatchService ws = FileSystems.getDefault().newWatchService()) {
+            this.watchDir.register(ws, StandardWatchEventKinds.ENTRY_MODIFY,
+                StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE);
+
+            while (this.running) {
+                WatchKey key = ws.take();              // blocks
+                key.pollEvents();                       // drain
+                Thread.sleep(this.debounceMs);          // debounce burst writes
+                key.pollEvents();                       // drain anything that arrived during debounce
+                key.reset();
+
+                try {
+                    onChange();
+                } catch (Exception e) {
+                    LOGGER.warn("FurnidataWatcher: onChange failed", e);
+                }
+            }
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            LOGGER.warn("FurnidataWatcher stopped", e);
+        }
+    }
+
+    private void onChange() {
+        Path source = this.provider.getSource();
+        if (source == null) return;
+
+        List<FurnidataEntry> delta = this.provider.reindex(new FurnidataReader(source, this.maxBytes).read());
+        if (delta.isEmpty()) return;
+
+        long now = System.currentTimeMillis();
+        if (now - this.lastBroadcast < this.minIntervalMs) {
+            LOGGER.info("FurnidataWatcher: {} changes throttled (min interval)", delta.size());
+            return; // next change will pick up the new baseline
+        }
+        this.lastBroadcast = now;
+
+        FurnitureDataReloadComposer composer = (delta.size() > this.deltaCap)
+            ? new FurnitureDataReloadComposer(FurnitureDataReloadComposer.MODE_RELOAD_HINT, List.of())
+            : new FurnitureDataReloadComposer(FurnitureDataReloadComposer.MODE_DELTA, delta);
+
+        broadcast(composer);
+        LOGGER.info("FurnidataWatcher: broadcast {} ({} entries)",
+            delta.size() > this.deltaCap ? "reload-hint" : "delta", delta.size());
+    }
+
+    private void broadcast(FurnitureDataReloadComposer composer) {
+        for (Habbo habbo : Emulator.getGameEnvironment().getHabboManager().getOnlineHabbos().values()) {
+            if (habbo.getClient() != null) {
+                habbo.getClient().sendResponse(composer);
+            }
+        }
+    }
+}
+```
+
+`System.currentTimeMillis()` is fine here (production server runtime). Note: when throttled, the index is still updated but the delta is **not** sent, and it is not re-sent later — those names update on client reconnect (acceptable for infrequent admin edits). To never drop, raise `items.furnidata.delta.cap` is unrelated; instead lower `items.furnidata.watch.min.interval.ms`.
+
+- [ ] **Step 3: Compile**
+
+Run: `mvn -q compile`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/eu/habbo/habbohotel/items/FurnidataWatcher.java src/main/java/com/eu/habbo/habbohotel/items/FurnitureTextProvider.java
+git commit -m "feat(items): furnidata file watcher — debounce, throttle, delta cap to reload-hint, broadcast"
+```
+
+---
+
+## Part C — Integration & acceptance
+
+### Task C1: Build both repos + manual live test
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Renderer build + tests**
+
+Run (in `Nitro_Render_V3/`): `yarn compile:fast && yarn test`
+Expected: no compile errors; all tests pass including `SessionDataManager.furnidataDelta`.
+
+- [ ] **Step 2: Emulator build + tests**
+
+Run (in `Arcturus-Morningstar-Extended/Emulator/`): `mvn -q clean package`
+Expected: BUILD SUCCESS; all `FurnitureTextProvider*Test` + `FurnidataReaderTest` pass.
+
+- [ ] **Step 3: Manual live acceptance (running hotel + client)**
+
+1. Start MariaDB, the emulator (with Piece 1 + Piece 2 jar), and the client; enter a room containing a furni whose furnidata `name` you will change.
+2. Edit that furni's `name` in the furnidata file and save.
+3. Within the debounce window (~1s), confirm WITHOUT refreshing the client:
+   - the furni infostand shows the new name (open the furni info),
+   - the catalog offer for it shows the new name,
+   - the inventory tile label shows the new name.
+4. Check the emulator log: `FurnidataWatcher: broadcast delta (1 entries)`.
+5. Replace the whole furnidata (mass change) → log shows `broadcast reload-hint`; the client re-loads furnidata and names update.
+6. Set `items.furnidata.watch.enabled=false`, restart → editing the file no longer pushes; clients update only on reconnect (watcher disabled).
+
+- [ ] **Step 4: Final no-op commit (optional config docs)**
+
+```bash
+git commit --allow-empty -m "docs(items): document items.furnidata.watch.* config keys"
+```
+
+---
+
+## Notes for the implementer
+
+- **Header id must match** on both sides: `IncomingHeader.FURNITURE_DATA_RELOAD` (renderer) == `Outgoing.FurnitureDataReloadComposer` (Arcturus) == `10047`. Verify both Step-2 grep checks before wiring.
+- **Do not reuse or modify** the editor path: `FurniDataUpdatedEvent`/`FurniDataUpdatedParser`/`applyLiveFurnitureNameUpdate` stay untouched; the new path is parallel (per the spec decision "keep separate").
+- **No Nitro-V3 client changes.** The three surfaces (`useCatalog.ts:919`, `useInventoryFurni.ts:137`, `useAvatarInfoWidget.ts:425`) already subscribe to `nitro-localization-updated`. If a regression test is wanted, add it under Nitro-V3 separately; it is not required for this plan.
+- **Locale no-clobber (spec §7.1):** re-registering `roomItem.name.{id}` from the base furnidata will override an active per-locale text override for that id. If this hotel ships per-locale furni override files, follow up by re-applying overrides after the delta (out of scope here; single-furnidata hotels are unaffected).
+- **Cache-busting** for the reload-hint: `applyFurnidataReloadHint` re-runs `FurnitureDataLoader.init()` against the configured `furnidata.url`; if the asset host serves a cached copy, add a `?v=<timestamp>` buster to the loader fetch (optional follow-up).

--- a/docs/superpowers/specs/2026-06-04-furni-names-from-json-server-design.md
+++ b/docs/superpowers/specs/2026-06-04-furni-names-from-json-server-design.md
@@ -1,0 +1,264 @@
+# Furni names from JSON (server-authoritative) — Design
+
+- **Date:** 2026-06-04
+- **Status:** Draft for review
+- **Scope:** Cross-repo — Arcturus (emulator), Nitro_Render_V3 (renderer), Nitro-V3 (client)
+- **Out of scope:** furni-editor feature/packets, NitroV3-Housekeeping (CMS), server-side multi-language, description rendering in the infostand.
+
+## 1. Problem & motivation
+
+Today a furni's display name lives in **two independent places** that drift apart:
+
+- **DB** — `items_base.public_name` (`Item.fullName`), used by the emulator.
+- **furnidata JSON** — used by the client (the client already resolves all visible furni
+  names/descriptions from furnidata, keyed by classname).
+
+This forces admins to maintain names twice and causes mismatches. We want **one source of
+truth**: the **furnidata JSON owns display names & descriptions**, the **DB owns technical
+data**. Editing furnidata should reflect everywhere — server-pronounced strings and every
+connected client — **live**, with no DB edit and no restart.
+
+This is a single, unified refactor whose payoff is admin furni management: one place to edit,
+consistent everywhere.
+
+## 2. Source-of-truth contract
+
+| Concern | Owner | Storage | Read by |
+|---|---|---|---|
+| `classname` (`item_name` / `Item.name`) | **DB** | `items_base.item_name` | join key → furnidata **and** `.nitro` asset; `isPet/isBot`; wired `wf_` fallback |
+| technical data (dimensions, `stateCount`, flags, interaction, effects) | **DB** | `items_base.*` | emulator simulation |
+| **display name** | **JSON** | furnidata (per classname) | emulator (`getDisplayName`) + client (furnidata, unchanged) |
+| **description** | **JSON** | furnidata (per classname) | client only (catalog) — **no server consumer** |
+
+Invariants:
+
+1. The **bridge is `classname`**, not a numeric id. `Item.name` ↔ furnidata `classname`.
+2. `public_name` (`Item.fullName`) is **NOT removed**: it remains (a) the fallback when a
+   classname is missing from furnidata, and (b) the technical token for wired furni
+   (`Item.java:107-116` reads `fullName.startsWith("wf_")`). No schema migration. No DROP.
+3. There is **no `description` column** in `items_base`; description is JSON-only and has no
+   server consumer → the emulator gets **no** `getDescription()`.
+4. **One furnidata artifact** is shared truth: the file the emulator indexes must be the same
+   furnidata the client loads (deploy invariant, §7).
+5. Server emits names in the **base locale** of the furnidata file. Player-facing multi-language
+   stays a client localization-layer concern (unchanged).
+
+## 3. Architecture — two independent pieces
+
+The refactor is two pieces that share only the furnidata file and one new packet. They do not
+depend on each other.
+
+- **Piece 1 — Server-authoritative names.** The emulator's pronounced names come from furnidata.
+- **Piece 2 — Liveness via delta.** When the furnidata file changes, connected clients (and the
+  server index) update without reconnecting, via a minimal delta broadcast.
+
+## 4. Piece 1 — Emulator (server-authoritative names)
+
+### 4.1 `FurnidataReader` (new, package `com.eu.habbo.habbohotel.items`)
+
+A neutral, shared reader extracted so the editor is **not touched**. Responsibilities:
+
+- Resolve the furnidata source reusing the **same already-configured** path as the editor:
+  `furni.editor.renderer.config.path` → `furnidata.url` → `furni.editor.asset.base.path`
+  (see `FurniDataManager.resolveSource()` for the exact resolution we mirror). Default to those
+  values so admins configure **once**.
+- Support both layouts the editor already supports: **single file** (`FurnitureData.json`) and
+  **split-tier directory** (`core/custom/seasonal`, `manifest.json5`, JSON5 with comments;
+  later tiers override earlier). Reuse the JSON5 strip logic (extract to the shared reader).
+- Parse `roomitemtypes` (floor) and `wallitemtypes` (wall) → return a flat list of
+  `FurnidataEntry { int id, String classname, FurnitureType type, String name, String description }`.
+
+**Security requirements on the reader (furnidata is untrusted input):**
+
+- **Path-traversal guard.** When resolving split-tier manifest entries
+  (`tiers[]`, `files[]`) via `dir.resolve(name)`, normalize the result and **reject any path that
+  escapes the configured base dir** (absolute paths, `..`). The existing `FurniDataManager` lacks
+  this guard — the shared reader MUST add it (do not propagate the gap).
+- **Size cap.** Refuse to load a furnidata file/dir above a configurable max (default e.g. 64 MB)
+  to bound parse cost.
+- **Sanitization at the boundary.** Every `name`/`description` is sanitized on load:
+  truncate to **256 chars**, strip control characters and newlines, and **neutralize `%` tokens**
+  (so they cannot inject into `String.replace` placeholder chains, server- or wired-side).
+  Normal text/emoji/non-latin scripts pass through.
+- **Fail-safe.** Any IO/parse error is caught and logged; the provider keeps the **last-good
+  index** (or empty on first load) and never throws — boot must not crash on a bad furnidata.
+
+### 4.2 `FurnitureTextProvider` (new, package `items`)
+
+- Holds `volatile Map<String /*classname lowercase*/, FurniText {int id, String name, String description}>`.
+- `reindex()`: read via `FurnidataReader` → build a new immutable map → compute delta vs the
+  previous map (§5) → atomically swap the reference → return the delta.
+- Initialized in `GameEnvironment.load` near `ItemManager`. Resolution is **lazy**, so boot order
+  is not critical and `Item` objects do not depend on the provider at load time.
+- Toggle `items.furnidata.names.enabled` (default `true`). When `false`, `getDisplayName()`
+  returns the DB value (instant rollback, no recompile).
+
+### 4.3 `Item.getDisplayName()`
+
+```
+String getDisplayName():
+    if !enabled: return fullName
+    FurniText t = FurnitureTextProvider.get(this.name /* classname, lowercased */)
+    return (t != null && t.name not blank) ? t.name : this.fullName   // never null
+```
+
+No `getDescription()` on the server (no consumer).
+
+### 4.4 Swap list (exhaustive — verified)
+
+Replace `item.getFullName()` → `item.getDisplayName()` at exactly these 6 sites:
+
+| Site | Context |
+|---|---|
+| `CatalogBuyItemAsGiftEvent.java:251` | LTD daily-total alert (gift) |
+| `CatalogBuyItemAsGiftEvent.java:262` | LTD daily-item alert (gift) |
+| `CatalogManager.java:1057` | LTD daily-total alert (buy) |
+| `CatalogManager.java:1063` | LTD daily-item alert (buy) |
+| `WiredTextPlaceholderUtil.java:282` | wired `%furni.name%` (keep existing `getName()` ultimate fallback) |
+| `WatchAndEarnRewardComposer.java:21` | `appendString(...)` — sends name in a packet |
+
+**Do NOT change** (technical, use `item_name`/classname): `PresentItemOpenedComposer:24`,
+`GiftCommand:72`, `SendGift:82`, `SellItemEvent:37,45`, `CloseDiceEvent:34`, `isPet/isBot`, and the
+wired `wf_` fallback in `Item.load`. The catalog offer/page serialization sends **no** display
+name (`CatalogItem` serializes `catalog_name` + sprite only) — confirmed, nothing to change there.
+
+## 5. Piece 2 — Liveness via delta
+
+### 5.1 Server: file watcher + diff + broadcast
+
+- A `WatchService` watches the resolved furnidata location on a **single, serialized watcher
+  thread** (so reindex never races itself). For the **split-tier** layout, register the base dir
+  and each tier dir. **Debounce** (~750 ms) to coalesce burst writes, plus a **minimum interval
+  between broadcasts** (e.g. ≥5 s) to cap amplification.
+- On settle → `FurnitureTextProvider.reindex()` → diff old vs new **by classname**:
+  - **added** (new classname) and **changed** (name **or** description differs) → included.
+  - **removed** classnames → **ignored** (rare; resolved on client reconnect).
+- Broadcast decision (anti-DoS):
+  - delta empty → no broadcast.
+  - delta size ≤ **cap** (e.g. 500 entries) → broadcast `FurnitureDataReload` in **delta mode**.
+  - delta size > cap (mass replace) → broadcast in **reload-hint mode** (compact signal; clients
+    re-load furnidata at next opportunity) instead of a giant per-client payload.
+- The broadcast is triggered **only** by the file watcher — there is **no client-initiated reload
+  path**. This is a security property to preserve (clients cannot induce reindex/broadcast).
+
+### 5.2 Wire contract — new packet `FurnitureDataReload`
+
+- **Composer (Arcturus):** `FurnitureDataReloadComposer`, new dedicated header id (pick a free id;
+  document on both sides). Two modes:
+  ```
+  int   mode           // 0 = delta, 1 = reload-hint
+  // mode == 0 (delta):
+  int   count          // bounded by the server cap; the client MUST also bound it on read
+  count × {
+    string type        // "S" (floor) | "I" (wall)
+    int    id           // furnidata numeric id (for localization-key + FurnitureData lookup)
+    string classname
+    string name         // already sanitized server-side
+    string description
+  }
+  // mode == 1 (reload-hint): no further fields (optionally an int revision for cache-busting)
+  ```
+- **Parser/Event (renderer):** `FurnitureDataReloadEvent` + `FurnitureDataReloadParser` reading the
+  same shape. The parser **bounds `count`** (reject/clamp absurd values) and tolerates truncation
+  (`bytesAvailable` pattern) so a malformed/MITM payload cannot allocate unbounded memory.
+  Registered in `SessionDataManager.init()` via
+  `GetCommunication().registerMessageEvent(new FurnitureDataReloadEvent(...))` (same pattern as the
+  existing `FurniDataUpdatedEvent` registration, but a **distinct** handler).
+
+### 5.3 Renderer: separate patch path (no editor reuse)
+
+- New method, e.g. `SessionDataManager.applyFurnidataDelta(entries)` — **distinct** from the
+  editor's `applyLiveFurnitureNameUpdate(...)` (`SessionDataManager.ts:84`), which we leave intact.
+- **Delta mode (0):** for each entry, patch the corresponding `FurnitureData` (floor/wall, by `id`)
+  — update `_localizedName` and `_description` — and re-register the localization keys
+  `roomItem.name/desc.{id}` / `wallItem.name/desc.{id}` (mirrors `FurnitureDataLoader:105-110`).
+- **Reload-hint mode (1):** re-run the furnidata load (`FurnitureDataLoader`, re-fetching
+  `furnidata.url` with cache-bust) — the appropriate response to a mass change.
+- In both modes, after the batch dispatch the window event **once**:
+  `window.dispatchEvent(new CustomEvent('nitro-localization-updated'))`.
+
+### 5.4 Client: zero changes
+
+All three furni surfaces already subscribe to `nitro-localization-updated` and re-derive:
+
+- catalog — `useCatalog.ts:919`
+- inventory — `useInventoryFurni.ts:137` (→ `refreshGroupItemsLocalization`)
+- infostand — `useAvatarInfoWidget.ts:425` (→ `getFurniInfo`, which reads `furnitureData.name`)
+
+No Nitro-V3 edits are required for Piece 2.
+
+## 6. Admin-facing outcome
+
+Edit one place — the **furnidata JSON** — and display names update **live** across:
+server-pronounced strings (catalog LTD alerts, wired `%furni.name%`, Watch&Earn), and every
+connected client's catalog, inventory, and furni infostand. No DB edit, no restart, no double
+maintenance.
+
+## 7. Constraints, risks, invariants
+
+1. **Locale no-clobber.** If per-locale furni text override files are in use (they override
+   `roomItem.name.{id}` after furnidata load), a live delta that re-registers base names would
+   revert overridden ids to base. Mitigation options for the plan: re-apply active overrides after
+   the delta, or skip the localization-key patch for ids with an active override (still patch the
+   `FurnitureData` object). For single-furnidata setups (typical retro) there is no override and no
+   issue. **Document the limitation.**
+2. **Deploy invariant.** `furni.editor.asset.base.path`/`furnidata.url` (what the emulator watches)
+   and the furnidata the client loaded must be the **same artifact**, else the server delta
+   references entries the client doesn't have.
+3. **`public_name` fallback.** Wired `wf_` items absent from furnidata would show the raw `wf_…`
+   token as their display name (internal/invisible furni — acceptable).
+4. **Split-layout watcher.** The watcher must register all tier dirs; missing a tier dir means live
+   updates from that tier are not detected (resolved on reconnect).
+5. **Performance.** `getDisplayName()` is a single `HashMap` lookup on cold paths (catalog alerts,
+   wired text, Watch&Earn) — negligible.
+
+## 8. Security
+
+With this refactor the **furnidata becomes a security-relevant input**: its strings now flow into
+server output (catalog LTD alerts, wired `%furni.name%`, the Watch&Earn packet) and into a
+broadcast to every connected client. Regular players cannot influence names (names are admin-owned,
+keyed by classname); the threat is **untrusted furnidata content** (third-party furni packs,
+imports, a compromised editor/supply chain). Controls:
+
+1. **Boundary sanitization** (see §4.1): cap 256 chars, strip control/newline, **neutralize `%`**.
+   Neutralizing `%` at load makes every `String.replace("%itemname%", name)` /
+   `%furni.name%` site injection-safe; as defense-in-depth, substitute the (untrusted) furni name
+   **last** in any placeholder chain.
+2. **Path-traversal guard** in the shared reader (§4.1) — reject manifest paths escaping the base
+   dir. Closes a gap the current editor reader does not cover.
+3. **DoS / amplification controls** (§5.1): single serialized watcher thread, debounce + minimum
+   broadcast interval, delta-size cap with **reload-hint fallback** for mass changes, furnidata
+   file-size cap.
+4. **Fail-safe loading** (§4.1): bad/corrupt furnidata never crashes boot; last-good index is kept;
+   `getDisplayName()` falls back to `public_name`.
+5. **Robust client parser** (§5.2): bound `count`, tolerate truncation — a malformed/MITM
+   `FurnitureDataReload` cannot allocate unbounded memory client-side.
+6. **No client-triggered reload** (§5.1): only the file watcher broadcasts. Do not add any
+   client→server reload request. Preserve this property.
+7. **Minimal disclosure**: the delta carries **only** `name`/`description` (already public via
+   furnidata) — never other fields from the server-side file.
+8. **Concurrency**: `volatile` index reference + atomic swap + single reindex thread → no torn reads.
+
+## 9. Testing
+
+- **Emulator (JUnit):** `FurnidataReader` parses single-file and split-tier (JSON5, tier override);
+  `FurnitureTextProvider` lookup by lowercased classname, **fallback to `public_name`** when absent,
+  atomic reindex; `reindex()` diff produces correct added/changed delta and ignores removals;
+  `Item.getDisplayName()` honors the enable toggle.
+- **Renderer (Vitest):** `FurnitureDataReloadParser` reads the payload shape; `applyFurnidataDelta`
+  patches floor/wall `FurnitureData` by id, re-registers localization keys, dispatches
+  `nitro-localization-updated` once.
+- **Client (Vitest):** existing subscribers (`useCatalog`, `useInventoryFurni`, `useAvatarInfoWidget`)
+  refresh on `nitro-localization-updated` (regression guard; no new code).
+- **Manual acceptance:** edit a furni name in furnidata → live update in catalog + inventory +
+  infostand without refresh; a wired `%furni.name%` sign and a Watch&Earn reward show the new name.
+- **Security tests:** reader rejects a split-tier manifest with `../` traversal; a name containing
+  `%limit%`/`%user.name%` does not inject into catalog alerts or wired text (`%` neutralized);
+  oversized furnidata is refused; corrupt furnidata keeps last-good index and does not crash;
+  a mass change emits a reload-hint (not a giant delta); the client parser clamps an absurd `count`.
+
+## 10. Open questions
+
+- Free header id for `FurnitureDataReload` (assign during implementation; document both sides).
+- Whether any retro on this stack actually ships per-locale furni override files (governs whether
+  constraint §7.1 is live or moot).


### PR DESCRIPTION
## Server-authoritative furni names & descriptions (from furnidata JSON) + live broadcast

Makes the **furnidata JSON the single source of truth** for furni display names and descriptions, instead of relying solely on `items_base.public_name`. Server-pronounced names (catalog LTD alerts, gifts, Watch&Earn, wired `%furni.name%`, …) now read from the furnidata, and changes are pushed to all connected clients **live** — no restart, no re-login.

This is the **foundation** the in-client Furni Editor (separate, stacked work) builds on.

### What it adds

**Furnidata reading**
- `FurnidataReader` — neutral reader for a single JSON/JSON5 file **or** a split-tier directory (`core` / `custom` / `seasonal` with `manifest.json(5)`). Fail-safe: any IO/parse error yields an empty list (caller decides the fallback). Size-capped and path-traversal-guarded; tolerates JSON5 comments + trailing commas.
- `FurnidataEntry` — record `(id, classname, type, name, description)`.

**In-memory index**
- `FurnitureTextProvider` — `volatile` index keyed by the **lowercased base classname** (the `*N` colour-variant suffix is stripped), built from the reader. Values are sanitized at index time (length cap, control-char strip, `%` neutralisation). `reindex()` builds a fresh map and swaps it atomically; readers never block.
- `Item.getDisplayName()` — returns the furnidata name (via the provider), falling back to `items_base.public_name`; never null.
- Updated **6 server-side call sites** to use `getDisplayName()` (gifts, Watch&Earn reward, wired text placeholders, …).

**Liveness**
- `FurnidataWatcher` — single daemon thread watching the furnidata source (debounce + min-interval throttle, delta diff). On change it reindexes and broadcasts `FurnitureDataReloadComposer` (**outgoing header 10047**) — a delta when small, or a reload-hint when over the configured cap.
- Boot order: the provider is constructed **after** `ItemManager` loads.

### Configuration
`items.furnidata.{names.enabled, path, watch.enabled, watch.debounce.ms, watch.min.interval.ms, delta.cap}` (read from `emulator_settings`). Booleans use `true`/`false`. Missing/disabled → safe fallback to `public_name`.

### Tests
JUnit 5 + surefire harness added; unit tests cover `FurnidataReader` (single/split, size-cap, malformed input), `FurnitureTextProvider` (index, sanitize, delta).

### Notes
- Paired with renderer PR (FurnitureDataReload incoming event + parser, header 10047) and the session-side delta apply.
- Header `10047` is custom (10000+ range).
