### PR TITLE
fix(messenger): send friend look for offline friends in friend list

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/FriendsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/FriendsComposer.java
@@ -40,7 +40,7 @@ public class FriendsComposer extends MessageComposer {
                 this.response.appendInt(row.getGender().equals(HabboGender.M) ? 0 : 1);
                 this.response.appendBoolean(row.getOnline() == 1);
                 this.response.appendBoolean(row.inRoom()); //IN ROOM
-                this.response.appendString(row.getOnline() == 1 ? row.getLook() : "");
+                this.response.appendString(row.getLook()); // send look for offline friends too (loaded from DB)
                 this.response.appendInt(row.getCategoryId()); //Friends category
                 this.response.appendString(row.getMotto());
                 this.response.appendString(""); //Last seen as DATETIMESTRING


### PR DESCRIPTION
## Problem

Offline friends render with the anonymous/standard avatar in the friend list and messenger, even though their look is set. Their **profile** (fetched via a separate packet) shows the correct figure, which makes the inconsistency obvious.

## Cause

`FriendsComposer` (the initial friend-list payload) serialized the look **only when the friend is online**, sending an empty string otherwise:

```java
this.response.appendString(row.getOnline() == 1 ? row.getLook() : "");
```

The look is already loaded from the DB for **every** friend in `Messenger.loadFriends` (`SELECT users.look ...`), so the gate just threw valid data away.

## Fix

Always serialize `row.getLook()`.

- `StaffChatBuddy` keeps a non-null look (`"ADM"`) → no NPE risk.
- `UpdateFriendComposer` already sent the look unconditionally, so this only brings the **initial** friend list in line with subsequent updates.

## Notes

Client side, the friend list / messenger already feed the figure through the renderer; once the real look arrives, offline friends show their actual avatar. No protocol/field-order change — only the value of the existing look string.