### PR TITLE
Handle '.' in vending_ids parsing

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/Item.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/Item.java
@@ -123,7 +123,7 @@ public class Item implements ISerialize {
 
         if (!set.getString("vending_ids").isEmpty()) {
             this.vendingItems = new TIntArrayList();
-            String[] vendingIds = set.getString("vending_ids").replace(";", ",").split(",");
+            String[] vendingIds = set.getString("vending_ids").replace(";", ",").replace(".", ",").split(",");
             for (String s : vendingIds) {
                 this.vendingItems.add(Integer.parseInt(s.replace(" ", "")));
             }


### PR DESCRIPTION
Normalize vending_ids by replacing semicolons and dots with commas before splitting. This ensures values separated by '.' are treated like other delimiters and parsed correctly as integers, avoiding parsing errors from unexpected separators.