### PR TITLE
fix(rcon): offline grants, buffer release & edge cases

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/GiveBadge.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/GiveBadge.java
@@ -3,6 +3,8 @@ package com.eu.habbo.messages.rcon;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboBadge;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.messages.outgoing.users.AddUserBadgeComposer;
 import com.google.gson.Gson;
 import org.slf4j.Logger;
@@ -53,11 +55,18 @@ public class GiveBadge extends RCONMessage<GiveBadge.GiveBadgeJSON> {
                 this.message = Emulator.getTexts().getValue("commands.succes.cmd_badge.given").replace("%user%", username).replace("%badge%", badgeCode);
             }
         } else {
+            HabboInfo habboInfo = HabboManager.getOfflineHabboInfo(json.user_id);
+            if (habboInfo == null) {
+                this.status = RCONMessage.HABBO_NOT_FOUND;
+                return;
+            }
+
+            username = habboInfo.getUsername();
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
                 for (String badgeCode : json.badge.split(";")) {
                     int numberOfRows = 0;
-                    try (PreparedStatement statement = connection.prepareStatement("SELECT COUNT(slot_id) FROM users_badges INNER JOIN users ON users.id = user_id WHERE users.id = ? AND badge_code = ? LIMIT 1")) {
-                        statement.setInt(1, json.user_id);
+                    try (PreparedStatement statement = connection.prepareStatement("SELECT COUNT(slot_id) FROM users_badges WHERE user_id = ? AND badge_code = ? LIMIT 1")) {
+                        statement.setInt(1, habboInfo.getId());
                         statement.setString(2, badgeCode);
                         try (ResultSet set = statement.executeQuery()) {
                             if (set.next()){
@@ -70,8 +79,8 @@ public class GiveBadge extends RCONMessage<GiveBadge.GiveBadgeJSON> {
                         this.status = RCONMessage.STATUS_ERROR;
                         this.message += Emulator.getTexts().getValue("commands.error.cmd_badge.already_owns").replace("%user%", username).replace("%badge%", badgeCode) + "\r";
                     } else {
-                        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO users_badges VALUES (null, (SELECT id FROM users WHERE users.id = ? LIMIT 1), 0, ?)", Statement.RETURN_GENERATED_KEYS)) {
-                            statement.setInt(1, json.user_id);
+                        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO users_badges (`id`, `user_id`, `slot_id`, `badge_code`) VALUES (null, ?, 0, ?)", Statement.RETURN_GENERATED_KEYS)) {
+                            statement.setInt(1, habboInfo.getId());
                             statement.setString(2, badgeCode);
                             statement.execute();
                         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/GiveCredits.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/GiveCredits.java
@@ -28,10 +28,14 @@ public class GiveCredits extends RCONMessage<GiveCredits.JSONGiveCredits> {
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE users SET credits = credits + ? WHERE id = ? LIMIT 1")) {
                 statement.setInt(1, object.credits);
                 statement.setInt(2, object.user_id);
-                statement.execute();
+                if (statement.executeUpdate() == 0) {
+                    this.status = RCONMessage.HABBO_NOT_FOUND;
+                    return;
+                }
             } catch (SQLException e) {
                 this.status = RCONMessage.SYSTEM_ERROR;
                 LOGGER.error("Caught SQL exception", e);
+                return;
             }
 
             this.message = "offline";

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/GivePixels.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/GivePixels.java
@@ -25,10 +25,11 @@ public class GivePixels extends RCONMessage<GivePixels.JSONGivePixels> {
         if (habbo != null) {
             habbo.givePixels(object.pixels);
         } else {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE users_currency SET users_currency.amount = users_currency.amount + ? WHERE users_currency.user_id = ? AND users_currency.type = 0")) {
-                statement.setInt(1, object.pixels);
-                statement.setInt(2, object.user_id);
-                statement.execute();
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO users_currency (`user_id`, `type`, `amount`) VALUES (?, 0, ?) ON DUPLICATE KEY UPDATE amount = amount + ?")) {
+                statement.setInt(1, object.user_id);
+                statement.setInt(2, object.pixels);
+                statement.setInt(3, object.pixels);
+                statement.executeUpdate();
             } catch (SQLException e) {
                 this.status = RCONMessage.SYSTEM_ERROR;
                 LOGGER.error("Caught SQL exception", e);

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/GiveRespect.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/GiveRespect.java
@@ -30,8 +30,8 @@ public class GiveRespect extends RCONMessage<GiveRespect.JSONGiveRespect> {
             habbo.getClient().sendResponse(new UserDataComposer(habbo));
         } else {
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE users_settings SET respects_given = respects_given + ?, respects_received = respects_received + ?, daily_respect_points = daily_respect_points + ? WHERE user_id = ? LIMIT 1")) {
-                statement.setInt(1, object.respect_received);
-                statement.setInt(2, object.respect_given);
+                statement.setInt(1, object.respect_given);
+                statement.setInt(2, object.respect_received);
                 statement.setInt(3, object.daily_respects);
                 statement.setInt(4, object.user_id);
                 statement.execute();

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/SetMotto.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/SetMotto.java
@@ -24,7 +24,9 @@ public class SetMotto extends RCONMessage<SetMotto.SetMottoJSON> {
 
         if (habbo != null) {
             habbo.getHabboInfo().setMotto(json.motto);
-            habbo.getHabboInfo().getCurrentRoom().sendComposer(new RoomUserDataComposer(habbo).compose());
+            if (habbo.getHabboInfo().getCurrentRoom() != null) {
+                habbo.getHabboInfo().getCurrentRoom().sendComposer(new RoomUserDataComposer(habbo).compose());
+            }
         } else {
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
                 try (PreparedStatement statement = connection.prepareStatement("UPDATE users SET motto = ? WHERE id = ? LIMIT 1")) {

--- a/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
@@ -37,29 +37,35 @@ public class RCONServerHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        ByteBuf data = (ByteBuf) msg;
-
-        byte[] d = new byte[data.readableBytes()];
-        data.getBytes(0, d);
-        String message = new String(d, java.nio.charset.StandardCharsets.UTF_8);
-        Gson gson = GSON;
-        String response = "ERROR";
-        String key = "";
-        try {
-            JsonObject object = gson.fromJson(message, JsonObject.class);
-            key = object.get("key").getAsString();
-            response = Emulator.getRconServer().handle(ctx, key, object.get("data").toString());
-        } catch (ArrayIndexOutOfBoundsException e) {
-            LOGGER.error("Unknown RCON Message: {}", key);
-        } catch (Exception e) {
-            LOGGER.error("Invalid RCON Message: {}", message);
-            e.printStackTrace();
+        if (!(msg instanceof ByteBuf data)) {
+            ctx.fireChannelRead(msg);
+            return;
         }
 
-        ChannelFuture f = ctx.channel().write(Unpooled.copiedBuffer(response.getBytes(java.nio.charset.StandardCharsets.UTF_8)), ctx.channel().voidPromise());
-        ctx.channel().flush();
-        ctx.flush();
-        f.channel().close();
-        data.release();
+        try {
+            byte[] d = new byte[data.readableBytes()];
+            data.getBytes(0, d);
+            String message = new String(d, java.nio.charset.StandardCharsets.UTF_8);
+            Gson gson = GSON;
+            String response = "ERROR";
+            String key = "";
+            try {
+                JsonObject object = gson.fromJson(message, JsonObject.class);
+                key = object.get("key").getAsString();
+                response = Emulator.getRconServer().handle(ctx, key, object.get("data").toString());
+            } catch (ArrayIndexOutOfBoundsException e) {
+                LOGGER.error("Unknown RCON Message: {}", key);
+            } catch (Exception e) {
+                LOGGER.error("Invalid RCON Message: {}", message);
+                e.printStackTrace();
+            }
+
+            ChannelFuture f = ctx.channel().write(Unpooled.copiedBuffer(response.getBytes(java.nio.charset.StandardCharsets.UTF_8)), ctx.channel().voidPromise());
+            ctx.channel().flush();
+            ctx.flush();
+            f.channel().close();
+        } finally {
+            data.release();
+        }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/messages/rcon/GiveBadgeContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/rcon/GiveBadgeContractTest.java
@@ -1,0 +1,27 @@
+package com.eu.habbo.messages.rcon;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GiveBadgeContractTest {
+    private static String giveBadgeSource() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/messages/rcon/GiveBadge.java"));
+    }
+
+    @Test
+    void offlineBadgeGrantRequiresExistingUserBeforeInsert() throws Exception {
+        String source = giveBadgeSource();
+
+        assertTrue(source.contains("HabboManager.getOfflineHabboInfo(json.user_id)"),
+                "Offline RCON badge grants must verify the target user exists");
+        assertTrue(source.contains("RCONMessage.HABBO_NOT_FOUND"),
+                "Offline RCON badge grants must report missing users");
+        assertFalse(source.contains("(SELECT id FROM users WHERE users.id = ? LIMIT 1)"),
+                "Offline RCON badge grants must not insert through a nullable user subquery");
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/rcon/GiveCreditsContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/rcon/GiveCreditsContractTest.java
@@ -1,0 +1,24 @@
+package com.eu.habbo.messages.rcon;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GiveCreditsContractTest {
+    private static String giveCreditsSource() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/messages/rcon/GiveCredits.java"));
+    }
+
+    @Test
+    void offlineCreditGrantReportsMissingUsersWhenNoRowsChange() throws Exception {
+        String source = giveCreditsSource();
+
+        assertTrue(source.contains("executeUpdate()"),
+                "Offline RCON credit grants must inspect the affected row count");
+        assertTrue(source.contains("HABBO_NOT_FOUND"),
+                "Offline RCON credit grants must report missing users when the UPDATE changes no rows");
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/rcon/GivePixelsContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/rcon/GivePixelsContractTest.java
@@ -1,0 +1,24 @@
+package com.eu.habbo.messages.rcon;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GivePixelsContractTest {
+    private static String givePixelsSource() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/messages/rcon/GivePixels.java"));
+    }
+
+    @Test
+    void offlinePixelGrantCreatesMissingCurrencyRow() throws Exception {
+        String source = givePixelsSource();
+
+        assertTrue(source.contains("INSERT INTO users_currency"),
+                "Offline RCON pixel grants must create the users_currency type 0 row when it is missing");
+        assertTrue(source.contains("ON DUPLICATE KEY UPDATE"),
+                "Offline RCON pixel grants should increment existing rows with an upsert");
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/rcon/GiveRespectContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/rcon/GiveRespectContractTest.java
@@ -1,0 +1,24 @@
+package com.eu.habbo.messages.rcon;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GiveRespectContractTest {
+    private static String giveRespectSource() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/messages/rcon/GiveRespect.java"));
+    }
+
+    @Test
+    void offlineRespectGrantBindsGivenAndReceivedToMatchingColumns() throws Exception {
+        String source = giveRespectSource();
+
+        assertTrue(source.contains("statement.setInt(1, object.respect_given);"),
+                "respects_given must be incremented with respect_given");
+        assertTrue(source.contains("statement.setInt(2, object.respect_received);"),
+                "respects_received must be incremented with respect_received");
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/rcon/SetMottoContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/rcon/SetMottoContractTest.java
@@ -1,0 +1,22 @@
+package com.eu.habbo.messages.rcon;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SetMottoContractTest {
+    private static String setMottoSource() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/messages/rcon/SetMotto.java"));
+    }
+
+    @Test
+    void onlineMottoUpdateDoesNotRequireCurrentRoom() throws Exception {
+        String source = setMottoSource();
+
+        assertTrue(source.contains("getCurrentRoom() != null"),
+                "RCON SetMotto must not fail for online users outside a room");
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerContractTest.java
@@ -1,0 +1,24 @@
+package com.eu.habbo.networking.rconserver;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RCONServerHandlerContractTest {
+    private static String handlerSource() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java"));
+    }
+
+    @Test
+    void inboundByteBufIsReleasedFromFinallyBlock() throws Exception {
+        String source = handlerSource();
+        int finallyIndex = source.indexOf("finally");
+        int releaseIndex = source.indexOf("data.release()");
+
+        assertTrue(finallyIndex >= 0, "RCON channelRead must release inbound ByteBufs from a finally block");
+        assertTrue(releaseIndex > finallyIndex, "RCON channelRead must release the inbound ByteBuf after finally starts");
+    }
+}


### PR DESCRIPTION
Split from #170 — one PR per area.

- fix(rcon): upsert offline pixel grants
- fix(rcon): always release inbound buffers
- fix(rcon): report missing offline credit targets
- fix(rcon): bind offline respect counters correctly
- fix(rcon): allow online motto updates outside rooms
- fix(rcon): validate offline badge targets

> Draft.