### PR TITLE
fix(messages): silence duplicate packet aliases

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -83,7 +83,7 @@ public class Incoming {
     public static final int GuildAcceptMembershipEvent = 3386;
     public static final int RequestRecylerLogicEvent = 398;
     public static final int RequestGuildJoinEvent = 998;
-    public static final int RequestCatalogIndexEvent = 2529;
+    public static int RequestCatalogIndexEvent = 2529;
     public static final int BuildersClubQueryFurniCountEvent = 2529;
     public static final int BuildersClubPlaceRoomItemEvent = 1051;
     public static final int BuildersClubPlaceWallItemEvent = 462;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -514,7 +514,7 @@ public class Outgoing {
     public final static int WiredOpenComposer = 1830;
     public final static int UnknownCatalogPageOfferComposer = 1889;
     public final static int NuxAlertComposer = 2023;
-    public final static int InClientLinkComposer = 2023;
+    public static int InClientLinkComposer = NuxAlertComposer;
     public final static int HotelViewExpiringCatalogPageCommposer = 2515;
     public final static int UnknownHabboWayQuizComposer = 2772;
     public final static int PetLevelUpdatedComposer = 2824;

--- a/Emulator/src/test/java/com/eu/habbo/messages/PacketNamesContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/PacketNamesContractTest.java
@@ -1,0 +1,51 @@
+package com.eu.habbo.messages;
+
+import com.eu.habbo.messages.incoming.Incoming;
+import com.eu.habbo.messages.outgoing.Outgoing;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PacketNamesContractTest {
+    @Test
+    void incomingPacketNameIdsAreUnique() throws Exception {
+        assertPublicFinalPacketIdsAreUnique(Incoming.class);
+    }
+
+    @Test
+    void outgoingPacketNameIdsAreUnique() throws Exception {
+        assertPublicFinalPacketIdsAreUnique(Outgoing.class);
+    }
+
+    private static void assertPublicFinalPacketIdsAreUnique(Class<?> packetClass) throws Exception {
+        Map<Integer, String> seen = new HashMap<>();
+        Map<Integer, String> duplicates = new HashMap<>();
+
+        for (Field field : packetClass.getFields()) {
+            int modifiers = field.getModifiers();
+            if (!Modifier.isPublic(modifiers)
+                    || !Modifier.isStatic(modifiers)
+                    || !Modifier.isFinal(modifiers)
+                    || field.getType() != int.class) {
+                continue;
+            }
+
+            int packetId = field.getInt(null);
+            if (packetId <= 0) {
+                continue;
+            }
+
+            String previous = seen.putIfAbsent(packetId, field.getName());
+            if (previous != null) {
+                duplicates.put(packetId, previous + " / " + field.getName());
+            }
+        }
+
+        assertTrue(duplicates.isEmpty(), packetClass.getSimpleName() + " has duplicate packet IDs: " + duplicates);
+    }
+}


### PR DESCRIPTION
Split from #170 — one PR per area.

- fix(messages): silence duplicate packet aliases

> Draft.