### PR TITLE
fix(commands): quiet optional descriptions

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/core/TextsManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/TextsManager.java
@@ -52,6 +52,10 @@ public class TextsManager {
         return this.texts.getProperty(key, defaultValue);
     }
 
+    public String getValueQuietly(String key, String defaultValue) {
+        return this.texts.getProperty(key, defaultValue);
+    }
+
     public boolean getBoolean(String key) {
         return this.getBoolean(key, false);
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandsCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandsCommand.java
@@ -18,7 +18,7 @@ public class CommandsCommand extends Command {
 
         for (Command c : commands) {
             String textKey = "commands.description." + c.permission;
-            String commandText = Emulator.getTexts().getValue(textKey, "");
+            String commandText = Emulator.getTexts().getValueQuietly(textKey, "");
             String commandLine = ":" + c.keys[0];
             String description = "";
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/commands/AvailableCommandsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/commands/AvailableCommandsComposer.java
@@ -23,7 +23,7 @@ public class AvailableCommandsComposer extends MessageComposer {
         for (Command cmd : this.commands) {
             this.response.appendString(cmd.keys[0]);
             this.response.appendString(
-                    Emulator.getTexts().getValue("commands.description." + cmd.permission, cmd.permission)
+                    Emulator.getTexts().getValueQuietly("commands.description." + cmd.permission, cmd.permission)
             );
         }
 

--- a/Emulator/src/test/java/com/eu/habbo/core/CommandTextLookupContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/core/CommandTextLookupContractTest.java
@@ -1,0 +1,35 @@
+package com.eu.habbo.core;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class CommandTextLookupContractTest {
+    private static final Path TEXTS_MANAGER = Path.of("src/main/java/com/eu/habbo/core/TextsManager.java");
+    private static final Path COMMANDS_COMMAND = Path.of("src/main/java/com/eu/habbo/habbohotel/commands/CommandsCommand.java");
+    private static final Path AVAILABLE_COMMANDS_COMPOSER = Path.of(
+            "src/main/java/com/eu/habbo/messages/outgoing/commands/AvailableCommandsComposer.java");
+
+    @Test
+    void textsManagerExposesQuietFallbackLookupForOptionalTexts() throws IOException {
+        String source = Files.readString(TEXTS_MANAGER);
+
+        assertTrue(source.contains("public String getValueQuietly(String key, String defaultValue)"));
+        assertTrue(source.contains("return this.texts.getProperty(key, defaultValue);"));
+    }
+
+    @Test
+    void commandListsUseQuietDescriptionLookups() throws IOException {
+        String commandsCommand = Files.readString(COMMANDS_COMMAND);
+        String availableCommandsComposer = Files.readString(AVAILABLE_COMMANDS_COMPOSER);
+
+        assertTrue(commandsCommand.contains("getValueQuietly(textKey, \"\")"),
+                ":commands should not log an error when an optional command description is missing");
+        assertTrue(availableCommandsComposer.contains("getValueQuietly(\"commands.description.\" + cmd.permission, cmd.permission)"),
+                "available commands composer should not log an error when an optional command description is missing");
+    }
+}


### PR DESCRIPTION
## Summary
- Add a quiet text lookup for optional localization keys.
- Use it in :commands and AvailableCommandsComposer so missing optional command descriptions do not emit TextsManager ERROR logs.
- Preserve existing fallback behaviour for the UI/client command list.

## Validation
- mvn -Dtest=CommandTextLookupContractTest test

## Notes
- Required text lookups still use the normal noisy TextsManager path; this change is scoped to optional command descriptions.