### PR TITLE
fix(catalog): claim vouchers before rewards

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -711,17 +711,21 @@ public class CatalogManager {
             return;
         }
 
-        if (voucher.isExhausted()) {
-            client.sendResponse(new RedeemVoucherErrorComposer(Emulator.getGameEnvironment().getCatalogManager().deleteVoucher(voucher) ? RedeemVoucherErrorComposer.INVALID_CODE : RedeemVoucherErrorComposer.TECHNICAL_ERROR));
-            return;
+        Voucher.ClaimResult claimResult = voucher.claimForUser(habbo.getHabboInfo().getId());
+        switch (claimResult) {
+            case CLAIMED:
+                break;
+            case EXHAUSTED:
+                client.sendResponse(new RedeemVoucherErrorComposer(Emulator.getGameEnvironment().getCatalogManager().deleteVoucher(voucher) ? RedeemVoucherErrorComposer.INVALID_CODE : RedeemVoucherErrorComposer.TECHNICAL_ERROR));
+                return;
+            case USER_LIMIT:
+                client.sendResponse(new ModToolIssueHandledComposer("You have exceeded the limit for redeeming this voucher."));
+                return;
+            case FAILED:
+            default:
+                client.sendResponse(new RedeemVoucherErrorComposer(RedeemVoucherErrorComposer.TECHNICAL_ERROR));
+                return;
         }
-
-        if (voucher.hasUserExhausted(habbo.getHabboInfo().getId())) {
-            client.sendResponse(new ModToolIssueHandledComposer("You have exceeded the limit for redeeming this voucher."));
-            return;
-        }
-
-        voucher.addHistoryEntry(habbo.getHabboInfo().getId());
 
         if (voucher.points > 0) {
             client.getHabbo().givePoints(voucher.pointsType, voucher.points);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/Voucher.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/Voucher.java
@@ -14,6 +14,13 @@ import java.util.List;
 public class Voucher {
     private static final Logger LOGGER = LoggerFactory.getLogger(Voucher.class);
 
+    public enum ClaimResult {
+        CLAIMED,
+        EXHAUSTED,
+        USER_LIMIT,
+        FAILED
+    }
+
     public final int id;
     public final String code;
     public final int credits;
@@ -58,18 +65,34 @@ public class Voucher {
         return this.amount > 0 && this.history.size() >= this.amount;
     }
 
-    public void addHistoryEntry(int userId) {
-        int timestamp = Emulator.getIntUnixTimestamp();
-        this.history.add(new VoucherHistoryEntry(this.id, userId, timestamp));
+    public synchronized ClaimResult claimForUser(int userId) {
+        if (this.isExhausted()) {
+            return ClaimResult.EXHAUSTED;
+        }
 
+        if (this.hasUserExhausted(userId)) {
+            return ClaimResult.USER_LIMIT;
+        }
+
+        int timestamp = Emulator.getIntUnixTimestamp();
+        if (!this.insertHistoryEntry(userId, timestamp)) {
+            return ClaimResult.FAILED;
+        }
+
+        this.history.add(new VoucherHistoryEntry(this.id, userId, timestamp));
+        return ClaimResult.CLAIMED;
+    }
+
+    private boolean insertHistoryEntry(int userId, int timestamp) {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO voucher_history (`voucher_id`, `user_id`, `timestamp`) VALUES (?, ?, ?)")) {
             statement.setInt(1, this.id);
             statement.setInt(2, userId);
             statement.setInt(3, timestamp);
 
-            statement.execute();
+            return statement.executeUpdate() > 0;
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
+            return false;
         }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/VoucherClaimContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/VoucherClaimContractTest.java
@@ -1,0 +1,50 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class VoucherClaimContractTest {
+    private static String voucherSource() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/catalog/Voucher.java"));
+    }
+
+    private static String catalogManagerSource() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"));
+    }
+
+    @Test
+    void voucherClaimIsSynchronizedAndPersistsBeforeRewardEligibility() throws Exception {
+        String source = voucherSource();
+
+        assertTrue(source.contains("public synchronized ClaimResult claimForUser(int userId)"),
+                "voucher claim should check limits and persist history under a per-voucher lock");
+        assertTrue(source.contains("private boolean insertHistoryEntry"),
+                "history insert should report database failure to the caller");
+
+        int insertCall = source.indexOf("insertHistoryEntry(userId, timestamp)");
+        int memoryAppend = source.indexOf("this.history.add(new VoucherHistoryEntry(this.id, userId, timestamp))");
+
+        assertTrue(insertCall > -1, "claimForUser must persist the history row");
+        assertTrue(memoryAppend > insertCall,
+                "in-memory history must only be updated after the database insert succeeds");
+    }
+
+    @Test
+    void catalogRewardsOnlyAfterVoucherClaimSucceeds() throws Exception {
+        String source = catalogManagerSource();
+
+        int claim = source.indexOf("Voucher.ClaimResult claimResult = voucher.claimForUser");
+        int claimedGuard = source.indexOf("case CLAIMED", claim);
+        int pointsGrant = source.indexOf("client.getHabbo().givePoints", claim);
+        int creditsGrant = source.indexOf("client.getHabbo().giveCredits", claim);
+
+        assertTrue(claim > -1, "CatalogManager must claim the voucher before applying rewards");
+        assertTrue(claimedGuard > claim, "voucher rewards should only continue for a CLAIMED result");
+        assertTrue(pointsGrant > claimedGuard, "points must be granted only after CLAIMED");
+        assertTrue(creditsGrant > claimedGuard, "credits must be granted only after CLAIMED");
+    }
+}


### PR DESCRIPTION
## Summary
- Move voucher exhaustion and per-user limit checks into a synchronized per-voucher claim path
- Persist voucher history before granting credits, points, or catalog rewards
- Return a technical error when the history insert fails instead of granting an unclaimed reward
- Add a contract test covering claim ordering and reward gating

## Risk fixed
Voucher redemption previously checked limits and inserted history as separate steps, with rewards granted even though ddHistoryEntry could fail silently. Concurrent redeems or DB insert failures could therefore grant credits, points, or items without a reliable claim record.

## Tests
- mvn -Dtest=VoucherClaimContractTest test
- mvn -DskipTests package