### PR TITLE
fix(guilds): only accept pending memberships

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/guilds/GuildManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/guilds/GuildManager.java
@@ -291,11 +291,12 @@ public class GuildManager {
                         }
                     }
                 } else if (!error) {
-                    try (PreparedStatement statement = connection.prepareStatement("UPDATE guilds_members SET level_id = ?, member_since = ? WHERE user_id = ? AND guild_id = ?")) {
+                    try (PreparedStatement statement = connection.prepareStatement("UPDATE guilds_members SET level_id = ?, member_since = ? WHERE user_id = ? AND guild_id = ? AND level_id = ?")) {
                         statement.setInt(1, GuildRank.MEMBER.type);
                         statement.setInt(2, Emulator.getIntUnixTimestamp());
                         statement.setInt(3, userId);
                         statement.setInt(4, guild.getId());
+                        statement.setInt(5, GuildRank.REQUESTED.type);
                         statement.execute();
                     }
                 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/guilds/GuildManagerMembershipContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/guilds/GuildManagerMembershipContractTest.java
@@ -1,0 +1,24 @@
+package com.eu.habbo.habbohotel.guilds;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class GuildManagerMembershipContractTest {
+    private static String guildManagerSource() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/guilds/GuildManager.java"));
+    }
+
+    @Test
+    void acceptRequestOnlyPromotesPendingMembershipRows() throws Exception {
+        String source = guildManagerSource();
+
+        assertTrue(source.contains("UPDATE guilds_members SET level_id = ?, member_since = ? WHERE user_id = ? AND guild_id = ? AND level_id = ?"),
+                "accepting a guild request must only promote rows still in REQUESTED state");
+        assertTrue(source.contains("statement.setInt(5, GuildRank.REQUESTED.type);"),
+                "the accept-request update must bind the expected REQUESTED rank guard");
+    }
+}


### PR DESCRIPTION
## Summary
- Guard guild request acceptance with level_id = REQUESTED
- Prevent stale or concurrent acceptance from promoting a membership row that has already changed state
- Add a contract test documenting the pending-only transition

## Risk fixed
The handler checked that a target membership was REQUESTED before calling the manager, but the manager update did not enforce that state in SQL. A stale or concurrent accept path could therefore promote a row that was no longer pending.

## Tests
- mvn '-Dtest=GuildManagerMembershipContractTest,GuildMembershipManagementContractTest,GuildMembershipRequestContractTest' test
- mvn -DskipTests package