### PR TITLE
fix(items): persist clothing grants before redeem

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemClothingEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemClothingEvent.java
@@ -36,6 +36,10 @@ public class RedeemClothingEvent extends MessageHandler {
 
                     if (clothing != null) {
                         if (!this.client.getHabbo().getInventory().getWardrobeComponent().getClothing().contains(clothing.id)) {
+                            if (!this.grantClothing(clothing.id)) {
+                                return;
+                            }
+
                             item.setRoomId(0);
                             RoomTile tile = this.client.getHabbo().getHabboInfo().getCurrentRoom().getLayout().getTile(item.getX(), item.getY());
                             this.client.getHabbo().getHabboInfo().getCurrentRoom().removeHabboItem(item);
@@ -43,14 +47,6 @@ public class RedeemClothingEvent extends MessageHandler {
                             this.client.getHabbo().getHabboInfo().getCurrentRoom().sendComposer(new UpdateStackHeightComposer(tile.x, tile.y, tile.z, tile.relativeHeight()).compose());
                             this.client.getHabbo().getHabboInfo().getCurrentRoom().sendComposer(new RemoveFloorItemComposer(item, true).compose());
                             Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
-
-                            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO users_clothing (user_id, clothing_id) VALUES (?, ?)")) {
-                                statement.setInt(1, this.client.getHabbo().getHabboInfo().getId());
-                                statement.setInt(2, clothing.id);
-                                statement.execute();
-                            } catch (SQLException e) {
-                                LOGGER.error("Caught SQL exception", e);
-                            }
 
                             this.client.getHabbo().getInventory().getWardrobeComponent().getClothing().add(clothing.id);
                             this.client.getHabbo().getInventory().getWardrobeComponent().getClothingSets().addAll(clothing.setId);
@@ -65,6 +61,17 @@ public class RedeemClothingEvent extends MessageHandler {
                     }
                 }
             }
+        }
+    }
+
+    private boolean grantClothing(int clothingId) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO users_clothing (user_id, clothing_id) VALUES (?, ?)")) {
+            statement.setInt(1, this.client.getHabbo().getHabboInfo().getId());
+            statement.setInt(2, clothingId);
+            return statement.executeUpdate() > 0;
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+            return false;
         }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/RedeemClothingContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/RedeemClothingContractTest.java
@@ -1,0 +1,29 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class RedeemClothingContractTest {
+    private static String source() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemClothingEvent.java"));
+    }
+
+    @Test
+    void clothingIsGrantedBeforeVoucherFurnitureIsConsumed() throws Exception {
+        String source = source();
+
+        int grantCall = source.indexOf("grantClothing(");
+        int roomRemoval = source.indexOf("removeHabboItem(item)");
+        int deleteItem = source.indexOf("new QueryDeleteHabboItem(item.getId())");
+
+        assertTrue(source.contains("private boolean grantClothing(int clothingId)"),
+                "clothing DB insert should report whether the grant succeeded");
+        assertTrue(grantCall > -1, "redeem path should call grantClothing before consuming the item");
+        assertTrue(grantCall < roomRemoval, "room item must not be removed before the clothing grant succeeds");
+        assertTrue(grantCall < deleteItem, "voucher furniture must not be deleted before the clothing grant succeeds");
+    }
+}


### PR DESCRIPTION
## Summary
- Persist the users_clothing grant before consuming clothing voucher furniture
- Abort the redeem if the DB insert fails, leaving the item intact
- Update in-memory wardrobe only after the grant succeeds
- Add a contract test for grant-before-delete ordering

## Risk fixed
The old flow removed/deleted the room item before confirming the clothing grant. A DB failure could consume the voucher furniture while leaving the wardrobe grant unpersisted, creating item loss and inconsistent account state.

## Tests
- mvn -Dtest=RedeemClothingContractTest test
- mvn -DskipTests package