### PR TITLE
Allow manual emulator release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,6 +3,7 @@ name: Build & Release JAR
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds workflow_dispatch to the existing release workflow so emulator releases can also be triggered manually from GitHub Actions.