### PR TITLE
fix(forums): bound guild forum view inputs

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumDataEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumDataEvent.java
@@ -8,6 +8,7 @@ import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.guilds.forums.GuildForumDataComposer;
+import com.eu.habbo.messages.outgoing.handshake.ConnectionErrorComposer;
 
 public class GuildForumDataEvent extends MessageHandler {
     @Override
@@ -18,6 +19,11 @@ public class GuildForumDataEvent extends MessageHandler {
     @Override
     public void handle() throws Exception {
         int guildId = packet.readInt();
+
+        if (!GuildForumInputGuard.isPositiveId(guildId)) {
+            this.client.sendResponse(new ConnectionErrorComposer(400));
+            return;
+        }
 
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumInputGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumInputGuard.java
@@ -2,6 +2,7 @@ package com.eu.habbo.messages.incoming.guilds.forums;
 
 final class GuildForumInputGuard {
     static final int MAX_PAGE_LIMIT = 50;
+    static final int MAX_THREAD_INDEX = 1000;
     static final int MAX_MARK_READ_BATCH = 50;
 
     private GuildForumInputGuard() {
@@ -17,6 +18,10 @@ final class GuildForumInputGuard {
 
     static boolean isValidPage(int index, int limit) {
         return index >= 0 && limit > 0 && limit <= MAX_PAGE_LIMIT;
+    }
+
+    static boolean isValidThreadIndex(int index) {
+        return index >= 0 && index <= MAX_THREAD_INDEX;
     }
 
     static boolean isValidMarkReadBatch(int count) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumMarkAsReadEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumMarkAsReadEvent.java
@@ -1,6 +1,9 @@
 package com.eu.habbo.messages.incoming.guilds.forums;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.guilds.Guild;
+import com.eu.habbo.habbohotel.guilds.GuildMember;
+import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.guilds.forums.GuildForumDataComposer;
 import org.slf4j.Logger;
@@ -34,6 +37,17 @@ public class GuildForumMarkAsReadEvent extends MessageHandler {
             this.packet.readBoolean(); // isRead
 
             if (!GuildForumInputGuard.isPositiveId(guildId)) {
+                continue;
+            }
+
+            Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
+            if (guild == null || !guild.hasForum()) {
+                continue;
+            }
+
+            GuildMember member = Emulator.getGameEnvironment().getGuildManager().getGuildMember(guildId, userId);
+            boolean staff = this.client.getHabbo().hasPermission(Permission.ACC_MODTOOL_TICKET_Q);
+            if (!guild.canHabboReadForum(userId, member, staff)) {
                 continue;
             }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumThreadsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumThreadsEvent.java
@@ -22,7 +22,7 @@ public class GuildForumThreadsEvent extends MessageHandler {
         int guildId = packet.readInt();
         int index = packet.readInt();
 
-        if (!GuildForumInputGuard.isPositiveId(guildId) || index < 0) {
+        if (!GuildForumInputGuard.isPositiveId(guildId) || !GuildForumInputGuard.isValidThreadIndex(index)) {
             this.client.sendResponse(new ConnectionErrorComposer(400));
             return;
         }

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumInputGuardContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumInputGuardContractTest.java
@@ -15,6 +15,7 @@ class GuildForumInputGuardContractTest {
 
         for (String handler : List.of(
                 "GuildForumPostThreadEvent.java",
+                "GuildForumDataEvent.java",
                 "GuildForumModerateMessageEvent.java",
                 "GuildForumModerateThreadEvent.java",
                 "GuildForumThreadUpdateEvent.java",
@@ -39,9 +40,12 @@ class GuildForumInputGuardContractTest {
         String settings = Files.readString(base.resolve("GuildForumUpdateSettingsEvent.java"));
         String moderateThread = Files.readString(base.resolve("GuildForumModerateThreadEvent.java"));
         String moderateMessage = Files.readString(base.resolve("GuildForumModerateMessageEvent.java"));
+        String threads = Files.readString(base.resolve("GuildForumThreadsEvent.java"));
 
         assertTrue(messages.contains("GuildForumInputGuard.isValidPage(index, limit)"),
                 "thread message reads must bound index/limit before fetching comments");
+        assertTrue(threads.contains("GuildForumInputGuard.isValidThreadIndex(index)"),
+                "thread list reads must bound the client-provided index before composing results");
         assertTrue(markRead.contains("GuildForumInputGuard.isValidMarkReadBatch(count)"),
                 "mark-as-read must bound the client-provided batch count before DB writes");
         assertTrue(settings.contains("GuildForumInputGuard.isSettingsState"),
@@ -58,5 +62,17 @@ class GuildForumInputGuardContractTest {
 
         assertTrue(source.contains("GuildForumInputGuard.normalize(this.packet.readString())"),
                 "forum post subject and body should be normalized before word filtering and length checks");
+    }
+
+    @Test
+    void markAsReadRequiresForumReadAccessBeforeWritingViews() throws Exception {
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumMarkAsReadEvent.java"));
+
+        int guildLookup = source.indexOf("Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId)");
+        int readGuard = source.indexOf("guild.canHabboReadForum(userId, member, staff)");
+        int insert = source.indexOf("INSERT INTO `guild_forum_views`");
+
+        assertTrue(guildLookup > -1 && readGuard > guildLookup && readGuard < insert,
+                "mark-as-read should confirm the user can read the forum before inserting view rows");
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumInputGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumInputGuardTest.java
@@ -21,6 +21,8 @@ class GuildForumInputGuardTest {
         assertFalse(GuildForumInputGuard.isValidPage(0, 0));
         assertTrue(GuildForumInputGuard.isValidPage(0, GuildForumInputGuard.MAX_PAGE_LIMIT));
         assertFalse(GuildForumInputGuard.isValidPage(0, GuildForumInputGuard.MAX_PAGE_LIMIT + 1));
+        assertTrue(GuildForumInputGuard.isValidThreadIndex(GuildForumInputGuard.MAX_THREAD_INDEX));
+        assertFalse(GuildForumInputGuard.isValidThreadIndex(GuildForumInputGuard.MAX_THREAD_INDEX + 1));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- rejects invalid guild forum data ids before loading guild/forum state
- bounds guild forum thread list indexes with the existing forum input guard
- requires mark-as-read requests to target an existing readable forum before writing view rows

## Tests
- `mvn "-Dtest=GuildForumInputGuardTest,GuildForumInputGuardContractTest" test`
