### PR TITLE
fix(modtool): bound staff supplied targets

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolAlertEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolAlertEvent.java
@@ -14,7 +14,7 @@ public class ModToolAlertEvent extends MessageHandler {
             int userId = this.packet.readInt();
             String message = ModToolInputGuard.normalize(this.packet.readString());
 
-            if (!ModToolInputGuard.isSafeMessage(message)) {
+            if (!ModToolTicketGuard.isPositiveId(userId) || !ModToolInputGuard.isSafeMessage(message)) {
                 return;
             }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolChangeRoomSettingsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolChangeRoomSettingsEvent.java
@@ -10,7 +10,13 @@ public class ModToolChangeRoomSettingsEvent extends MessageHandler {
     @Override
     public void handle() throws Exception {
         if (this.client.getHabbo().hasPermission(Permission.ACC_SUPPORTTOOL)) {
-            Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.packet.readInt());
+            int roomId = this.packet.readInt();
+
+            if (!ModToolTicketGuard.isPositiveId(roomId)) {
+                return;
+            }
+
+            Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(roomId);
 
             if (room != null) {
                 final boolean lockDoor = this.packet.readInt() == 1;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolIssueDefaultSanctionEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolIssueDefaultSanctionEvent.java
@@ -19,6 +19,10 @@ public class ModToolIssueDefaultSanctionEvent extends MessageHandler {
             this.packet.readInt();
             int category = this.packet.readInt();
 
+            if (!ModToolTicketGuard.isPositiveId(issueId) || !ModToolTicketGuard.isPositiveId(category)) {
+                return;
+            }
+
             ModToolIssue issue = Emulator.getGameEnvironment().getModToolManager().getTicket(issueId);
 
             if (issue == null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolKickEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolKickEvent.java
@@ -21,7 +21,7 @@ public class ModToolKickEvent extends MessageHandler {
         int userId = this.packet.readInt();
         String message = ModToolInputGuard.normalize(this.packet.readString());
 
-        if (!ModToolInputGuard.isSafeMessage(message)) {
+        if (!ModToolTicketGuard.isPositiveId(userId) || !ModToolInputGuard.isSafeMessage(message)) {
             return;
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolRequestRoomInfoEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolRequestRoomInfoEvent.java
@@ -13,6 +13,10 @@ public class ModToolRequestRoomInfoEvent extends MessageHandler {
         if (this.client.getHabbo().hasPermission(Permission.ACC_SUPPORTTOOL)) {
             int roomId = this.packet.readInt();
 
+            if (!ModToolTicketGuard.isPositiveId(roomId)) {
+                return;
+            }
+
             Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(roomId);
 
             if (room != null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolRequestRoomVisitsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolRequestRoomVisitsEvent.java
@@ -12,6 +12,10 @@ public class ModToolRequestRoomVisitsEvent extends MessageHandler {
         if (this.client.getHabbo().hasPermission(Permission.ACC_SUPPORTTOOL)) {
             int userId = this.packet.readInt();
 
+            if (!ModToolTicketGuard.isPositiveId(userId)) {
+                return;
+            }
+
             HabboInfo habboInfo = Emulator.getGameEnvironment().getHabboManager().getHabboInfo(userId);
 
             if (habboInfo != null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionAlertEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionAlertEvent.java
@@ -24,7 +24,7 @@ public class ModToolSanctionAlertEvent extends MessageHandler {
         String message = ModToolInputGuard.normalize(this.packet.readString());
         int cfhTopic = this.packet.readInt();
 
-        if (!ModToolInputGuard.isSafeMessage(message)) {
+        if (!ModToolTicketGuard.isPositiveId(userId) || !ModToolTicketGuard.isPositiveId(cfhTopic) || !ModToolInputGuard.isSafeMessage(message)) {
             return;
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionBanEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionBanEvent.java
@@ -37,7 +37,7 @@ public class ModToolSanctionBanEvent extends MessageHandler {
 
         int duration = 0;
 
-        if (!ModToolInputGuard.isSafeMessage(message)) {
+        if (!ModToolTicketGuard.isPositiveId(userId) || !ModToolTicketGuard.isPositiveId(cfhTopic) || !ModToolInputGuard.isSafeMessage(message)) {
             return;
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionMuteEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionMuteEvent.java
@@ -26,7 +26,7 @@ public class ModToolSanctionMuteEvent extends MessageHandler {
         String message = ModToolInputGuard.normalize(this.packet.readString());
         int cfhTopic = this.packet.readInt();
 
-        if (!ModToolInputGuard.isSafeMessage(message)) {
+        if (!ModToolTicketGuard.isPositiveId(userId) || !ModToolTicketGuard.isPositiveId(cfhTopic) || !ModToolInputGuard.isSafeMessage(message)) {
             return;
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionTradeLockEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionTradeLockEvent.java
@@ -25,7 +25,7 @@ public class ModToolSanctionTradeLockEvent extends MessageHandler {
         int duration = this.packet.readInt();
         int cfhTopic = this.packet.readInt();
 
-        if (!ModToolInputGuard.isSafeMessage(message)) {
+        if (!ModToolTicketGuard.isPositiveId(userId) || !ModToolTicketGuard.isPositiveId(cfhTopic) || !ModToolInputGuard.isSafeMessage(message)) {
             return;
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolWarnEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolWarnEvent.java
@@ -19,7 +19,7 @@ public class ModToolWarnEvent extends MessageHandler {
             int userId = this.packet.readInt();
             String message = ModToolInputGuard.normalize(this.packet.readString());
 
-            if (!ModToolInputGuard.isSafeMessage(message)) {
+            if (!ModToolTicketGuard.isPositiveId(userId) || !ModToolInputGuard.isSafeMessage(message)) {
                 return;
             }
 

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/modtool/ModToolPermissionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/modtool/ModToolPermissionContractTest.java
@@ -109,4 +109,28 @@ class ModToolPermissionContractTest {
                     handler + " must reject empty or oversized staff-supplied text");
         }
     }
+
+    @Test
+    void staffSuppliedModToolTargetsArePositiveBeforeLookupOrMutation() throws Exception {
+        Path base = Path.of("src/main/java/com/eu/habbo/messages/incoming/modtool");
+
+        for (String handler : List.of(
+                "ModToolAlertEvent.java",
+                "ModToolWarnEvent.java",
+                "ModToolKickEvent.java",
+                "ModToolChangeRoomSettingsEvent.java",
+                "ModToolRequestRoomInfoEvent.java",
+                "ModToolRequestRoomVisitsEvent.java",
+                "ModToolIssueDefaultSanctionEvent.java",
+                "ModToolSanctionAlertEvent.java",
+                "ModToolSanctionBanEvent.java",
+                "ModToolSanctionMuteEvent.java",
+                "ModToolSanctionTradeLockEvent.java"
+        )) {
+            String source = Files.readString(base.resolve(handler));
+
+            assertTrue(source.contains("ModToolTicketGuard.isPositiveId"),
+                    handler + " must reject zero or negative client-provided ids before manager/database lookups");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- reject zero or negative staff-supplied user, room, ticket, and CFH topic ids before modtool lookups or mutations
- harden room settings, room info, room visits, alert/warn/kick, default sanction, and sanction packet handlers
- add a modtool permission contract covering positive-id validation for staff-driven targets

## Tests
- mvn -Dtest=ModToolInputGuardTest,ModToolTicketGuardTest,ModToolPermissionContractTest,ModToolTicketLifecycleContractTest,ModToolReportInputGuardTest,ModToolReportInputContractTest test