### PR TITLE
fix(wired): bound reward amounts

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredNumericInputGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredNumericInputGuard.java
@@ -1,0 +1,38 @@
+package com.eu.habbo.habbohotel.items.interactions.wired;
+
+import com.eu.habbo.Emulator;
+
+public final class WiredNumericInputGuard {
+    public static final int DEFAULT_MAX_REWARD_AMOUNT = 1000;
+    public static final int DEFAULT_MAX_RESPECT_AMOUNT = 100;
+    public static final int MAX_ABSOLUTE_AMOUNT = 100000;
+
+    private WiredNumericInputGuard() {
+    }
+
+    public static int parsePositiveAmount(String value, int maxAmount) {
+        try {
+            int parsed = Integer.parseInt(value == null ? "" : value.trim());
+            if (parsed <= 0) {
+                return 0;
+            }
+
+            return Math.min(parsed, Math.max(1, Math.min(maxAmount, MAX_ABSOLUTE_AMOUNT)));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    public static int maxRewardAmount() {
+        return configuredMax("hotel.wired.reward.max_amount", DEFAULT_MAX_REWARD_AMOUNT);
+    }
+
+    public static int maxRespectAmount() {
+        return configuredMax("hotel.wired.respect.max_amount", DEFAULT_MAX_RESPECT_AMOUNT);
+    }
+
+    private static int configuredMax(String key, int fallback) {
+        int configured = Emulator.getConfig() != null ? Emulator.getConfig().getInt(key, fallback) : fallback;
+        return Math.max(1, Math.min(configured, MAX_ABSOLUTE_AMOUNT));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewBonusRarePoints.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewBonusRarePoints.java
@@ -5,6 +5,7 @@ import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
@@ -72,11 +73,11 @@ public class WiredEffectGiveHotelviewBonusRarePoints extends InteractionWiredEff
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) {
-        try {
-            this.amount = Integer.parseInt(settings.getStringParam());
-        } catch (Exception e) {
+        int nextAmount = WiredNumericInputGuard.parsePositiveAmount(settings.getStringParam(), WiredNumericInputGuard.maxRewardAmount());
+        if (nextAmount <= 0) {
             return false;
         }
+        this.amount = nextAmount;
 
         int[] params = settings.getIntParams();
         this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewHofPoints.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewHofPoints.java
@@ -5,6 +5,7 @@ import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
@@ -71,11 +72,11 @@ public class WiredEffectGiveHotelviewHofPoints extends InteractionWiredEffect {
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) {
-        try {
-            this.amount = Integer.parseInt(settings.getStringParam());
-        } catch (Exception e) {
+        int nextAmount = WiredNumericInputGuard.parsePositiveAmount(settings.getStringParam(), WiredNumericInputGuard.maxRewardAmount());
+        if (nextAmount <= 0) {
             return false;
         }
+        this.amount = nextAmount;
 
         int[] params = settings.getIntParams();
         this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveRespect.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveRespect.java
@@ -6,6 +6,7 @@ import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
@@ -72,11 +73,11 @@ public class WiredEffectGiveRespect extends InteractionWiredEffect {
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) {
-        try {
-            this.respects = Integer.parseInt(settings.getStringParam());
-        } catch (Exception e) {
+        int nextRespects = WiredNumericInputGuard.parsePositiveAmount(settings.getStringParam(), WiredNumericInputGuard.maxRespectAmount());
+        if (nextRespects <= 0) {
             return false;
         }
+        this.respects = nextRespects;
 
         int[] params = settings.getIntParams();
         this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredNumericInputGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredNumericInputGuardTest.java
@@ -1,0 +1,28 @@
+package com.eu.habbo.habbohotel.items.interactions.wired;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WiredNumericInputGuardTest {
+
+    @Test
+    void rejectsInvalidOrNonPositiveAmounts() {
+        assertEquals(0, WiredNumericInputGuard.parsePositiveAmount(null, 100));
+        assertEquals(0, WiredNumericInputGuard.parsePositiveAmount("nope", 100));
+        assertEquals(0, WiredNumericInputGuard.parsePositiveAmount("0", 100));
+        assertEquals(0, WiredNumericInputGuard.parsePositiveAmount("-5", 100));
+    }
+
+    @Test
+    void clampsAmountsToConfiguredMaximum() {
+        assertEquals(50, WiredNumericInputGuard.parsePositiveAmount("50", 100));
+        assertEquals(100, WiredNumericInputGuard.parsePositiveAmount("500", 100));
+    }
+
+    @Test
+    void appliesAbsoluteMaximumEvenWhenConfiguredTooHigh() {
+        assertEquals(WiredNumericInputGuard.MAX_ABSOLUTE_AMOUNT,
+                WiredNumericInputGuard.parsePositiveAmount("999999999", Integer.MAX_VALUE));
+    }
+}


### PR DESCRIPTION
## Summary
- bound wired hotelview reward and respect amounts during save
- reject non-positive or malformed numeric reward payloads
- add configurable maximums with an absolute safety cap

## Tests
- mvn -Dtest=WiredNumericInputGuardTest test