### PR TITLE
fix(wired): bound date range inputs

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionDateRangeActive.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionDateRangeActive.java
@@ -53,8 +53,7 @@ public class WiredConditionDateRangeActive extends InteractionWiredCondition {
     @Override
     public boolean saveData(WiredSettings settings) {
         if(settings.getIntParams().length < 2) return false;
-        this.startDate = settings.getIntParams()[0];
-        this.endDate = settings.getIntParams()[1];
+        this.applyRange(settings.getIntParams()[0], settings.getIntParams()[1]);
         return true;
     }
 
@@ -81,19 +80,26 @@ public class WiredConditionDateRangeActive extends InteractionWiredCondition {
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
         String wiredData = set.getString("wired_data");
+        if (wiredData == null || wiredData.isEmpty()) {
+            this.applyRange(0, 0);
+            return;
+        }
 
         if (wiredData.startsWith("{")) {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
-            this.startDate = data.startDate;
-            this.endDate = data.endDate;
+            if (data == null) {
+                this.applyRange(0, 0);
+                return;
+            }
+            this.applyRange(data.startDate, data.endDate);
         } else {
             String[] data = wiredData.split("\t");
 
             if (data.length == 2) {
                 try {
-                    this.startDate = Integer.parseInt(data[0]);
-                    this.endDate = Integer.parseInt(data[1]);
+                    this.applyRange(Integer.parseInt(data[0]), Integer.parseInt(data[1]));
                 } catch (Exception e) {
+                    this.applyRange(0, 0);
                 }
             }
         }
@@ -103,6 +109,12 @@ public class WiredConditionDateRangeActive extends InteractionWiredCondition {
     public void onPickUp() {
         this.startDate = 0;
         this.endDate = 0;
+    }
+
+    private void applyRange(int startDate, int endDate) {
+        int[] range = WiredDateRangeInputGuard.normalizeRange(startDate, endDate);
+        this.startDate = range[0];
+        this.endDate = range[1];
     }
 
     static class JsonData {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredDateRangeInputGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredDateRangeInputGuard.java
@@ -1,0 +1,21 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+public final class WiredDateRangeInputGuard {
+    private WiredDateRangeInputGuard() {
+    }
+
+    public static int[] normalizeRange(int startDate, int endDate) {
+        int start = normalizeTimestamp(startDate);
+        int end = normalizeTimestamp(endDate);
+
+        if (start > end) {
+            return new int[]{0, 0};
+        }
+
+        return new int[]{start, end};
+    }
+
+    public static int normalizeTimestamp(int value) {
+        return Math.max(0, value);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredDateRangeInputGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredDateRangeInputGuardTest.java
@@ -1,0 +1,26 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WiredDateRangeInputGuardTest {
+
+    @Test
+    void timestampsAreNonNegative() {
+        assertEquals(0, WiredDateRangeInputGuard.normalizeTimestamp(-1));
+        assertEquals(42, WiredDateRangeInputGuard.normalizeTimestamp(42));
+    }
+
+    @Test
+    void validRangesArePreserved() {
+        assertArrayEquals(new int[]{100, 200}, WiredDateRangeInputGuard.normalizeRange(100, 200));
+    }
+
+    @Test
+    void negativeAndInvertedRangesBecomeInactive() {
+        assertArrayEquals(new int[]{0, 0}, WiredDateRangeInputGuard.normalizeRange(-10, -1));
+        assertArrayEquals(new int[]{0, 0}, WiredDateRangeInputGuard.normalizeRange(200, 100));
+    }
+}


### PR DESCRIPTION
## Summary
- add a small guard for wired date-range timestamps
- normalize client-provided and persisted date-range values
- make null, empty, malformed, negative, or inverted ranges safely inactive

## Risk fixed
- prevents corrupt wired_data from leaving stale or nonsensical date ranges loaded
- prevents negative timestamps and inverted ranges from creating surprising always-active or impossible conditions
- keeps the condition behavior explicit by resetting invalid ranges to 0..0

## Tests
- mvn -Dtest=WiredDateRangeInputGuardTest test