### PR TITLE
fix(wired): bound user action inputs

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionUserPerformsAction.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionUserPerformsAction.java
@@ -87,7 +87,13 @@ public class WiredConditionUserPerformsAction extends InteractionWiredCondition 
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data;
+        try {
+            data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (RuntimeException ignored) {
+            this.resetSettings();
+            return;
+        }
 
         if (data == null) {
             return;
@@ -253,7 +259,7 @@ public class WiredConditionUserPerformsAction extends InteractionWiredCondition 
         }
 
         long timestamp = (Long) timestampValue;
-        if ((System.currentTimeMillis() - timestamp) > TRANSIENT_ACTION_WINDOW_MS) {
+        if (!WiredUserActionInputGuard.isRecentTimestamp(timestamp, System.currentTimeMillis(), TRANSIENT_ACTION_WINDOW_MS)) {
             return false;
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredUserActionInputGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredUserActionInputGuard.java
@@ -1,0 +1,14 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+public final class WiredUserActionInputGuard {
+    private WiredUserActionInputGuard() {
+    }
+
+    public static boolean isRecentTimestamp(long timestamp, long now, long windowMs) {
+        if (timestamp < 1 || timestamp > now || windowMs < 1) {
+            return false;
+        }
+
+        return (now - timestamp) <= windowMs;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredUserActionInputGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredUserActionInputGuardTest.java
@@ -1,0 +1,22 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WiredUserActionInputGuardTest {
+
+    @Test
+    void rejectsInvalidOrFutureTimestamps() {
+        assertFalse(WiredUserActionInputGuard.isRecentTimestamp(0, 1000, 5000));
+        assertFalse(WiredUserActionInputGuard.isRecentTimestamp(1500, 1000, 5000));
+        assertFalse(WiredUserActionInputGuard.isRecentTimestamp(900, 1000, 0));
+    }
+
+    @Test
+    void acceptsTimestampsInsideWindowOnly() {
+        assertTrue(WiredUserActionInputGuard.isRecentTimestamp(900, 1000, 5000));
+        assertFalse(WiredUserActionInputGuard.isRecentTimestamp(100, 1000, 500));
+    }
+}


### PR DESCRIPTION
## Summary
- add a small guard for wired user-action transient timestamps
- reject invalid or future cached action timestamps when matching recent actions
- tolerate malformed JSON wired_data by resetting UserPerformsAction settings to defaults

## Risk fixed
- prevents corrupt persisted JSON from throwing during wired condition load
- prevents future timestamps from keeping a user action valid longer than the configured transient window
- keeps NOT user-action conditions covered through the shared parent logic

## Tests
- mvn -Dtest=WiredUserActionInputGuardTest test