### PR TITLE
fix(wired): bound team condition inputs

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTeamGameBase.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTeamGameBase.java
@@ -29,6 +29,7 @@ abstract class WiredConditionTeamGameBase extends InteractionWiredCondition {
     protected static final int COMPARISON_EQUAL = 1;
     protected static final int COMPARISON_HIGHER = 2;
     protected static final int TEAM_TRIGGERER = 0;
+    protected static final int MAX_SCORE = 1_000_000;
 
     private static final GameTeamColors[] SUPPORTED_TEAM_COLORS = new GameTeamColors[] {
             GameTeamColors.RED,
@@ -96,7 +97,11 @@ abstract class WiredConditionTeamGameBase extends InteractionWiredCondition {
     }
 
     protected int normalizeScore(int value) {
-        return Math.max(0, value);
+        if (value < 0) {
+            return 0;
+        }
+
+        return Math.min(value, MAX_SCORE);
     }
 
     protected int normalizeExplicitTeamType(int value) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTeamHasRank.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTeamHasRank.java
@@ -65,7 +65,13 @@ public class WiredConditionTeamHasRank extends WiredConditionTeamGameBase {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data;
+        try {
+            data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (RuntimeException ignored) {
+            this.resetSettings();
+            return;
+        }
         if (data == null) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTeamHasScore.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTeamHasScore.java
@@ -66,7 +66,13 @@ public class WiredConditionTeamHasScore extends WiredConditionTeamGameBase {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data;
+        try {
+            data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (RuntimeException ignored) {
+            this.resetSettings();
+            return;
+        }
         if (data == null) {
             return;
         }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTeamGameBaseTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTeamGameBaseTest.java
@@ -1,0 +1,91 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WiredConditionTeamGameBaseTest {
+
+    private final ExposedTeamGameBase guard = new ExposedTeamGameBase();
+
+    @Test
+    void scoresAreNonNegativeAndCapped() {
+        assertEquals(0, this.guard.score(-1));
+        assertEquals(42, this.guard.score(42));
+        assertEquals(WiredConditionTeamGameBase.MAX_SCORE, this.guard.score(Integer.MAX_VALUE));
+    }
+
+    @Test
+    void userSourcesFallBackToTriggerWhenUnknown() {
+        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, this.guard.userSource(-1));
+        assertEquals(WiredSourceUtil.SOURCE_SELECTOR, this.guard.userSource(WiredSourceUtil.SOURCE_SELECTOR));
+    }
+
+    @Test
+    void teamTypesAndPlacementsStayInSupportedRange() {
+        assertEquals(1, this.guard.placement(-1));
+        assertEquals(4, this.guard.placement(4));
+        assertEquals(1, this.guard.explicitTeamType(-1));
+        assertEquals(4, this.guard.explicitTeamType(4));
+    }
+
+    private static class ExposedTeamGameBase extends WiredConditionTeamGameBase {
+        private ExposedTeamGameBase() {
+            super(0, 0, null, "", 0, 0);
+        }
+
+        @Override
+        public com.eu.habbo.habbohotel.wired.WiredConditionType getType() {
+            return com.eu.habbo.habbohotel.wired.WiredConditionType.TEAM_HAS_SCORE;
+        }
+
+        @Override
+        public boolean evaluate(com.eu.habbo.habbohotel.wired.core.WiredContext ctx) {
+            return false;
+        }
+
+        @Override
+        public boolean execute(com.eu.habbo.habbohotel.rooms.RoomUnit roomUnit, com.eu.habbo.habbohotel.rooms.Room room, Object[] stuff) {
+            return false;
+        }
+
+        @Override
+        public boolean saveData(com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings settings) {
+            return false;
+        }
+
+        @Override
+        public void onPickUp() {
+        }
+
+        @Override
+        public String getWiredData() {
+            return "";
+        }
+
+        @Override
+        public void loadWiredData(java.sql.ResultSet set, com.eu.habbo.habbohotel.rooms.Room room) {
+        }
+
+        @Override
+        public void serializeWiredData(com.eu.habbo.messages.ServerMessage message, com.eu.habbo.habbohotel.rooms.Room room) {
+        }
+
+        int score(int value) {
+            return this.normalizeScore(value);
+        }
+
+        int userSource(int value) {
+            return this.normalizeUserSource(value);
+        }
+
+        int placement(int value) {
+            return this.normalizePlacement(value);
+        }
+
+        int explicitTeamType(int value) {
+            return this.normalizeExplicitTeamType(value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- cap wired team score condition inputs to a conservative upper bound
- tolerate malformed JSON wired_data in team rank/score conditions by resetting to defaults
- add coverage for shared team condition input normalization

## Risk fixed
- prevents corrupt persisted team condition JSON from throwing during load
- prevents extreme score thresholds from creating pathological always-false/always-true style conditions
- keeps malformed team rank/score payloads fail-safe at defaults

## Tests
- mvn -Dtest=WiredConditionTeamGameBaseTest test