### PR TITLE
fix(wired): bound furni selection payloads

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveFurni.java
@@ -92,21 +92,40 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
 
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.onPickUp();
         String wiredData = set.getString("wired_data");
+        if (wiredData == null || wiredData.isEmpty()) {
+            return;
+        }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
-            this.all = data.all;
-            this.furniSource = data.furniSource;
-
-            for(int id : data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
-
-                if (item != null) {
-                    this.items.add(item);
-                }
+            JsonData data;
+            try {
+                data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            } catch (RuntimeException exception) {
+                this.onPickUp();
+                return;
             }
 
+            if (data == null) {
+                return;
+            }
+
+            this.all = data.all;
+            this.furniSource = this.normalizeFurniSource(data.furniSource);
+
+            if (data.itemIds != null && room != null) {
+                for (Integer id : data.itemIds) {
+                    if (id == null) {
+                        continue;
+                    }
+
+                    HabboItem item = room.getHabboItem(id);
+                    if (item != null) {
+                        this.items.add(item);
+                    }
+                }
+            }
         } else {
             String[] data = wiredData.split(":");
 
@@ -117,10 +136,13 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
                     String[] items = data[1].split(";");
 
                     for (String s : items) {
-                        HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                        try {
+                            HabboItem item = room.getHabboItem(Integer.parseInt(s));
 
-                        if (item != null)
-                            this.items.add(item);
+                            if (item != null)
+                                this.items.add(item);
+                        } catch (NumberFormatException ignored) {
+                        }
                     }
                 }
             }
@@ -172,7 +194,7 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
 
         int[] params = settings.getIntParams();
         this.all = params[0] == 1;
-        this.furniSource = (params.length > 1) ? params[1] : WiredSourceUtil.SOURCE_TRIGGER;
+        this.furniSource = (params.length > 1) ? this.normalizeFurniSource(params[1]) : WiredSourceUtil.SOURCE_TRIGGER;
 
         int count = settings.getFurniIds().length;
         if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) return false;
@@ -196,6 +218,18 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
             }
         }
         return true;
+    }
+
+    int normalizeFurniSource(int value) {
+        switch (value) {
+            case WiredSourceUtil.SOURCE_SELECTED:
+            case WiredSourceUtil.SOURCE_SELECTOR:
+            case WiredSourceUtil.SOURCE_SIGNAL:
+            case WiredSourceUtil.SOURCE_TRIGGER:
+                return value;
+            default:
+                return WiredSourceUtil.SOURCE_TRIGGER;
+        }
     }
 
     private void refresh() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveHabbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveHabbo.java
@@ -89,19 +89,38 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
 
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
-        this.items.clear();
+        this.onPickUp();
         String wiredData = set.getString("wired_data");
+        if (wiredData == null || wiredData.isEmpty()) {
+            return;
+        }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
-            this.furniSource = data.furniSource;
+            JsonData data;
+            try {
+                data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            } catch (RuntimeException exception) {
+                this.onPickUp();
+                return;
+            }
+
+            if (data == null) {
+                return;
+            }
+
+            this.furniSource = this.normalizeFurniSource(data.furniSource);
             this.all = data.all;
 
-            for(int id : data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+            if (data.itemIds != null && room != null) {
+                for (Integer id : data.itemIds) {
+                    if (id == null) {
+                        continue;
+                    }
 
-                if (item != null) {
-                    this.items.add(item);
+                    HabboItem item = room.getHabboItem(id);
+                    if (item != null) {
+                        this.items.add(item);
+                    }
                 }
             }
         } else {
@@ -112,10 +131,13 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
                 String[] items = data[1].split(";");
 
                 for (String s : items) {
-                    HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                    try {
+                        HabboItem item = room.getHabboItem(Integer.parseInt(s));
 
-                    if (item != null)
-                        this.items.add(item);
+                        if (item != null)
+                            this.items.add(item);
+                    } catch (NumberFormatException ignored) {
+                    }
                 }
             }
             this.furniSource = this.items.isEmpty() ? WiredSourceUtil.SOURCE_TRIGGER : WiredSourceUtil.SOURCE_SELECTED;
@@ -162,7 +184,7 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
 
         int[] params = settings.getIntParams();
         this.all = (params.length > 0) && (params[0] == 1);
-        this.furniSource = (params.length > 1) ? params[1] : ((params.length > 0 && params[0] > 1) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER);
+        this.furniSource = (params.length > 1) ? this.normalizeFurniSource(params[1]) : ((params.length > 0 && params[0] > 1) ? this.normalizeFurniSource(params[0]) : WiredSourceUtil.SOURCE_TRIGGER);
 
         if (count > 0 && this.furniSource == WiredSourceUtil.SOURCE_TRIGGER) {
             this.furniSource = WiredSourceUtil.SOURCE_SELECTED;
@@ -184,6 +206,18 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
         }
 
         return true;
+    }
+
+    int normalizeFurniSource(int value) {
+        switch (value) {
+            case WiredSourceUtil.SOURCE_SELECTED:
+            case WiredSourceUtil.SOURCE_SELECTOR:
+            case WiredSourceUtil.SOURCE_SIGNAL:
+            case WiredSourceUtil.SOURCE_TRIGGER:
+                return value;
+            default:
+                return WiredSourceUtil.SOURCE_TRIGGER;
+        }
     }
 
     protected boolean hasAvatarOnItem(HabboItem item, Room room, Collection<Habbo> habbos, Collection<Bot> bots, Collection<Pet> pets) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTriggerOnFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTriggerOnFurni.java
@@ -42,6 +42,10 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
 
     @Override
     public boolean evaluate(WiredContext ctx) {
+        if (ctx == null || ctx.room() == null) {
+            return false;
+        }
+
         this.refresh();
 
         List<RoomUnit> userTargets = WiredSourceUtil.resolveUsers(ctx, this.userSource);
@@ -104,30 +108,52 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
 
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
-        this.items.clear();
+        this.onPickUp();
         String wiredData = set.getString("wired_data");
+        if (wiredData == null || wiredData.isEmpty()) {
+            return;
+        }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
-            this.furniSource = data.furniSource;
-            this.userSource = data.userSource;
+            JsonData data;
+            try {
+                data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            } catch (RuntimeException exception) {
+                this.onPickUp();
+                return;
+            }
+
+            if (data == null) {
+                return;
+            }
+
+            this.furniSource = this.normalizeFurniSource(data.furniSource);
+            this.userSource = this.normalizeUserSource(data.userSource);
             this.quantifier = this.normalizeQuantifier(data.quantifier);
 
-            for(int id : data.itemIds) {
-                HabboItem item = room.getHabboItem(id);
+            if (data.itemIds != null && room != null) {
+                for (Integer id : data.itemIds) {
+                    if (id == null) {
+                        continue;
+                    }
 
-                if (item != null) {
-                    this.items.add(item);
+                    HabboItem item = room.getHabboItem(id);
+                    if (item != null) {
+                        this.items.add(item);
+                    }
                 }
             }
         } else {
             String[] data = wiredData.split(";");
 
             for (String s : data) {
-                HabboItem item = room.getHabboItem(Integer.parseInt(s));
+                try {
+                    HabboItem item = room.getHabboItem(Integer.parseInt(s));
 
-                if (item != null) {
-                    this.items.add(item);
+                    if (item != null) {
+                        this.items.add(item);
+                    }
+                } catch (NumberFormatException ignored) {
                 }
             }
             this.furniSource = this.items.isEmpty() ? WiredSourceUtil.SOURCE_TRIGGER : WiredSourceUtil.SOURCE_SELECTED;
@@ -182,8 +208,8 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
         if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) return false;
 
         int[] params = settings.getIntParams();
-        this.furniSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
-        this.userSource = (params.length > 1) ? params[1] : WiredSourceUtil.SOURCE_TRIGGER;
+        this.furniSource = (params.length > 0) ? this.normalizeFurniSource(params[0]) : WiredSourceUtil.SOURCE_TRIGGER;
+        this.userSource = (params.length > 1) ? this.normalizeUserSource(params[1]) : WiredSourceUtil.SOURCE_TRIGGER;
         this.quantifier = (params.length > 2) ? this.normalizeQuantifier(params[2]) : QUANTIFIER_ALL;
 
         if (count > 0 && this.furniSource == WiredSourceUtil.SOURCE_TRIGGER) {
@@ -231,6 +257,22 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
 
     protected int normalizeQuantifier(int value) {
         return (value == QUANTIFIER_ANY) ? QUANTIFIER_ANY : QUANTIFIER_ALL;
+    }
+
+    int normalizeFurniSource(int value) {
+        switch (value) {
+            case WiredSourceUtil.SOURCE_SELECTED:
+            case WiredSourceUtil.SOURCE_SELECTOR:
+            case WiredSourceUtil.SOURCE_SIGNAL:
+            case WiredSourceUtil.SOURCE_TRIGGER:
+                return value;
+            default:
+                return WiredSourceUtil.SOURCE_TRIGGER;
+        }
+    }
+
+    int normalizeUserSource(int value) {
+        return WiredSourceUtil.isDefaultUserSource(value) ? value : WiredSourceUtil.SOURCE_TRIGGER;
     }
 
     @Override

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniSelectionPayloadGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniSelectionPayloadGuardTest.java
@@ -1,0 +1,37 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WiredConditionFurniSelectionPayloadGuardTest {
+    @Test
+    void furniHaveFurniBoundsFurniSources() {
+        WiredConditionFurniHaveFurni condition = new WiredConditionFurniHaveFurni(1, 1, null, "", 0, 0);
+
+        assertEquals(WiredSourceUtil.SOURCE_SELECTED, condition.normalizeFurniSource(WiredSourceUtil.SOURCE_SELECTED));
+        assertEquals(WiredSourceUtil.SOURCE_SELECTOR, condition.normalizeFurniSource(WiredSourceUtil.SOURCE_SELECTOR));
+        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, condition.normalizeFurniSource(-10));
+    }
+
+    @Test
+    void furniHaveHabboBoundsFurniSources() {
+        WiredConditionFurniHaveHabbo condition = new WiredConditionFurniHaveHabbo(1, 1, null, "", 0, 0);
+
+        assertEquals(WiredSourceUtil.SOURCE_SIGNAL, condition.normalizeFurniSource(WiredSourceUtil.SOURCE_SIGNAL));
+        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, condition.normalizeFurniSource(8_000));
+    }
+
+    @Test
+    void triggerOnFurniBoundsFurniUserSourcesAndQuantifier() {
+        WiredConditionTriggerOnFurni condition = new WiredConditionTriggerOnFurni(1, 1, null, "", 0, 0);
+
+        assertEquals(WiredSourceUtil.SOURCE_SELECTED, condition.normalizeFurniSource(WiredSourceUtil.SOURCE_SELECTED));
+        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, condition.normalizeFurniSource(77));
+        assertEquals(WiredSourceUtil.SOURCE_CLICKED_USER, condition.normalizeUserSource(WiredSourceUtil.SOURCE_CLICKED_USER));
+        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, condition.normalizeUserSource(WiredSourceUtil.SOURCE_SELECTED));
+        assertEquals(1, condition.normalizeQuantifier(1));
+        assertEquals(0, condition.normalizeQuantifier(2));
+    }
+}


### PR DESCRIPTION
## Summary
- guard furni selection conditions against null or malformed saved payloads
- ignore malformed/null selected item ids while loading legacy and JSON wired data
- normalize furni/user sources from DB and client settings
- add unit coverage for furni-selection source and quantifier normalization

## Risk fixed
- prevents corrupt wired_data from throwing during room/wired load
- prevents invalid source values from selecting unintended fallback behavior
- keeps malformed legacy item id lists from aborting condition load

## Tests
- mvn -Dtest=WiredConditionFurniSelectionPayloadGuardTest test