### PR TITLE
fix(wired): guard extra selector payloads

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraAnimationTime.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraAnimationTime.java
@@ -80,7 +80,7 @@ public class WiredExtraAnimationTime extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
             this.durationMs = normalizeDuration((data != null) ? data.durationMs : WiredMovementsComposer.DEFAULT_DURATION);
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraContextVariable.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraContextVariable.java
@@ -84,7 +84,7 @@ public class WiredExtraContextVariable extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
 
             if (data != null) {
                 this.variableName = WiredVariableNameValidator.normalizeLegacy(data.variableName);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraExecutionLimit.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraExecutionLimit.java
@@ -86,7 +86,7 @@ public class WiredExtraExecutionLimit extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
 
             if (data != null) {
                 this.maxExecutions = normalizeExecutions(data.maxExecutions);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraFilterFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraFilterFurni.java
@@ -78,7 +78,7 @@ public class WiredExtraFilterFurni extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
             this.amount = normalizeAmount((data != null) ? data.amount : 0);
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraFilterUser.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraFilterUser.java
@@ -78,7 +78,7 @@ public class WiredExtraFilterUser extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
             this.amount = normalizeAmount((data != null) ? data.amount : 0);
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraFurniVariable.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraFurniVariable.java
@@ -89,7 +89,7 @@ public class WiredExtraFurniVariable extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
 
             if (data != null) {
                 this.variableName = WiredVariableNameValidator.normalizeLegacy(data.variableName);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraMoveCarryUsers.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraMoveCarryUsers.java
@@ -77,7 +77,7 @@ public class WiredExtraMoveCarryUsers extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
 
             if (data != null) {
                 this.carryMode = this.normalizeCarryMode(data.carryMode);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraMovePhysics.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraMovePhysics.java
@@ -97,7 +97,7 @@ public class WiredExtraMovePhysics extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
 
             if (data != null) {
                 this.keepAltitude = data.keepAltitude;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraOrEval.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraOrEval.java
@@ -128,7 +128,7 @@ public class WiredExtraOrEval extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
 
             if (data != null) {
                 this.evaluationMode = normalizeEvaluationMode(data.evaluationMode);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraPayloadGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraPayloadGuard.java
@@ -1,0 +1,20 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.extra;
+
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+
+final class WiredExtraPayloadGuard {
+    private WiredExtraPayloadGuard() {
+    }
+
+    static <T> T fromJson(String wiredData, Class<T> type) {
+        if (wiredData == null || !wiredData.startsWith("{")) {
+            return null;
+        }
+
+        try {
+            return WiredManager.getGson().fromJson(wiredData, type);
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraRandom.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraRandom.java
@@ -92,7 +92,7 @@ public class WiredExtraRandom extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
             this.pickAmount = normalizePickAmount((data != null) ? data.pickAmount : DEFAULT_PICK_AMOUNT);
             this.skipExecutions = normalizeSkipExecutions((data != null) ? data.skipExecutions : DEFAULT_SKIP_EXECUTIONS);
             return;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraRoomVariable.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraRoomVariable.java
@@ -91,7 +91,7 @@ public class WiredExtraRoomVariable extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
 
             if (data != null) {
                 this.variableName = WiredVariableNameValidator.normalizeLegacy(data.variableName);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraTextInputVariable.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraTextInputVariable.java
@@ -110,7 +110,7 @@ public class WiredExtraTextInputVariable extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
 
             if (data != null) {
                 this.variableToken = normalizeVariableToken((data.variableToken != null)

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraTextOutputFurniName.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraTextOutputFurniName.java
@@ -131,7 +131,7 @@ public class WiredExtraTextOutputFurniName extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
 
             if (data != null) {
                 this.placeholderName = normalizePlaceholderName(data.placeholderName);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraTextOutputUsername.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraTextOutputUsername.java
@@ -88,7 +88,7 @@ public class WiredExtraTextOutputUsername extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
 
             if (data != null) {
                 this.placeholderName = normalizePlaceholderName(data.placeholderName);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraTextOutputVariable.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraTextOutputVariable.java
@@ -181,7 +181,7 @@ public class WiredExtraTextOutputVariable extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
 
             if (data != null) {
                 this.targetType = normalizeTargetType(data.targetType);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraUserVariable.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraUserVariable.java
@@ -90,7 +90,7 @@ public class WiredExtraUserVariable extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
 
             if (data != null) {
                 this.variableName = WiredVariableNameValidator.normalizeLegacy(data.variableName);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraVariableEcho.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraVariableEcho.java
@@ -148,7 +148,7 @@ public class WiredExtraVariableEcho extends InteractionWiredExtra {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) {
             return;
         }
@@ -488,7 +488,7 @@ public class WiredExtraVariableEcho extends InteractionWiredExtra {
             return new ConfigData();
         }
 
-        ConfigData config = WiredManager.getGson().fromJson(value, ConfigData.class);
+        ConfigData config = WiredExtraPayloadGuard.fromJson(value, ConfigData.class);
         return (config != null) ? config : new ConfigData();
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraVariableFilterBase.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraVariableFilterBase.java
@@ -215,7 +215,7 @@ public abstract class WiredExtraVariableFilterBase extends InteractionWiredExtra
         String wiredData = set.getString("wired_data");
         if (wiredData == null || wiredData.isEmpty() || !wiredData.startsWith("{")) return;
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) return;
 
         this.sortBy = normalizeSortBy(data.sortBy);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraVariableLevelUpSystem.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraVariableLevelUpSystem.java
@@ -188,7 +188,7 @@ public class WiredExtraVariableLevelUpSystem extends InteractionWiredExtra {
 
         try {
             if (value.trim().startsWith("{")) {
-                JsonData data = WiredManager.getGson().fromJson(value, JsonData.class);
+                JsonData data = WiredExtraPayloadGuard.fromJson(value, JsonData.class);
                 return (data != null) ? data : new JsonData();
             }
         } catch (Exception ignored) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraVariableReference.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraVariableReference.java
@@ -120,7 +120,7 @@ public class WiredExtraVariableReference extends InteractionWiredExtra {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) {
             return;
         }
@@ -230,7 +230,7 @@ public class WiredExtraVariableReference extends InteractionWiredExtra {
             return new ConfigData();
         }
 
-        ConfigData config = WiredManager.getGson().fromJson(value, ConfigData.class);
+        ConfigData config = WiredExtraPayloadGuard.fromJson(value, ConfigData.class);
         return (config != null) ? config : new ConfigData();
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraVariableTextConnector.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraVariableTextConnector.java
@@ -84,7 +84,7 @@ public class WiredExtraVariableTextConnector extends InteractionWiredExtra {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
 
             if (data != null) {
                 this.setMappingsText(data.mappingsText);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredVariableReferenceSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredVariableReferenceSupport.java
@@ -338,7 +338,7 @@ public final class WiredVariableReferenceSupport {
             return null;
         }
 
-        UserDefinitionData data = WiredManager.getGson().fromJson(wiredData, UserDefinitionData.class);
+        UserDefinitionData data = WiredExtraPayloadGuard.fromJson(wiredData, UserDefinitionData.class);
         if (data == null) {
             return null;
         }
@@ -352,7 +352,7 @@ public final class WiredVariableReferenceSupport {
             return null;
         }
 
-        RoomDefinitionData data = WiredManager.getGson().fromJson(wiredData, RoomDefinitionData.class);
+        RoomDefinitionData data = WiredExtraPayloadGuard.fromJson(wiredData, RoomDefinitionData.class);
         if (data == null) {
             return null;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectFurniAltitude.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectFurniAltitude.java
@@ -120,7 +120,7 @@ public class WiredEffectFurniAltitude extends InteractionWiredEffect {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectFurniArea.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectFurniArea.java
@@ -115,7 +115,7 @@ public class WiredEffectFurniArea extends InteractionWiredEffect {
         String wiredData = set.getString("wired_data");
 
         if (wiredData != null && wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
             this.rootX = data.rootX;
             this.rootY = data.rootY;
             this.areaWidth = data.width;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectFurniByType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectFurniByType.java
@@ -170,7 +170,7 @@ public class WiredEffectFurniByType extends InteractionWiredEffect {
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
         String wiredData = set.getString("wired_data");
         if (wiredData != null && wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
             this.sourceType     = normalizeSourceType(data.sourceType);
             this.matchState     = data.matchState;
             this.filterExisting = data.filterExisting;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectFurniNeighborhood.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectFurniNeighborhood.java
@@ -329,7 +329,7 @@ public class WiredEffectFurniNeighborhood extends InteractionWiredEffect {
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
         String wiredData = set.getString("wired_data");
         if (wiredData != null && wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
             this.sourceType    = data.sourceType;
             this.filterExisting = data.filterExisting;
             this.invert        = data.invert;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectFurniOnFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectFurniOnFurni.java
@@ -156,7 +156,7 @@ public class WiredEffectFurniOnFurni extends InteractionWiredEffect {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectFurniPicks.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectFurniPicks.java
@@ -110,7 +110,7 @@ public class WiredEffectFurniPicks extends InteractionWiredEffect {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectFurniSignal.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectFurniSignal.java
@@ -96,7 +96,7 @@ public class WiredEffectFurniSignal extends InteractionWiredEffect {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersArea.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersArea.java
@@ -101,7 +101,7 @@ public class WiredEffectUsersArea extends InteractionWiredEffect {
         String wiredData = set.getString("wired_data");
 
         if (wiredData != null && wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
             this.rootX = data.rootX;
             this.rootY = data.rootY;
             this.areaWidth = data.width;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersByAction.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersByAction.java
@@ -120,7 +120,7 @@ public class WiredEffectUsersByAction extends InteractionWiredEffect {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersByName.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersByName.java
@@ -110,7 +110,7 @@ public class WiredEffectUsersByName extends InteractionWiredEffect {
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
             if (data == null) {
                 return;
             }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersByType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersByType.java
@@ -95,7 +95,7 @@ public class WiredEffectUsersByType extends InteractionWiredEffect {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersGroup.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersGroup.java
@@ -109,7 +109,7 @@ public class WiredEffectUsersGroup extends InteractionWiredEffect {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersHandItem.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersHandItem.java
@@ -92,7 +92,7 @@ public class WiredEffectUsersHandItem extends InteractionWiredEffect {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersNeighborhood.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersNeighborhood.java
@@ -333,7 +333,7 @@ public class WiredEffectUsersNeighborhood extends InteractionWiredEffect {
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
         String wiredData = set.getString("wired_data");
         if (wiredData != null && wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
             this.sourceType     = data.sourceType;
             this.filterExisting = data.filterExisting;
             this.invert         = data.invert;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersOnFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersOnFurni.java
@@ -142,7 +142,7 @@ public class WiredEffectUsersOnFurni extends InteractionWiredEffect {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersSignal.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersSignal.java
@@ -90,7 +90,7 @@ public class WiredEffectUsersSignal extends InteractionWiredEffect {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersTeam.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectUsersTeam.java
@@ -95,7 +95,7 @@ public class WiredEffectUsersTeam extends InteractionWiredEffect {
             return;
         }
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectVariableSelectorBase.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectVariableSelectorBase.java
@@ -222,7 +222,7 @@ public abstract class WiredEffectVariableSelectorBase extends InteractionWiredEf
         String wiredData = set.getString("wired_data");
         if (wiredData == null || wiredData.isEmpty() || !wiredData.startsWith("{")) return;
 
-        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data == null) return;
 
         this.selectByValue = data.selectByValue;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredSelectorPayloadGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredSelectorPayloadGuard.java
@@ -1,0 +1,20 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.selector;
+
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+
+final class WiredSelectorPayloadGuard {
+    private WiredSelectorPayloadGuard() {
+    }
+
+    static <T> T fromJson(String wiredData, Class<T> type) {
+        if (wiredData == null || !wiredData.startsWith("{")) {
+            return null;
+        }
+
+        try {
+            return WiredManager.getGson().fromJson(wiredData, type);
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraPayloadGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraPayloadGuardTest.java
@@ -1,0 +1,13 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.extra;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class WiredExtraPayloadGuardTest {
+    @Test
+    void malformedJsonReturnsNull() {
+        assertNull(WiredExtraPayloadGuard.fromJson("{broken", WiredExtraAnimationTime.JsonData.class));
+        assertNull(WiredExtraPayloadGuard.fromJson(null, WiredExtraAnimationTime.JsonData.class));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredSelectorPayloadGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredSelectorPayloadGuardTest.java
@@ -1,0 +1,13 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.selector;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class WiredSelectorPayloadGuardTest {
+    @Test
+    void malformedJsonReturnsNull() {
+        assertNull(WiredSelectorPayloadGuard.fromJson("{broken", WiredEffectFurniArea.JsonData.class));
+        assertNull(WiredSelectorPayloadGuard.fromJson(null, WiredEffectFurniArea.JsonData.class));
+    }
+}


### PR DESCRIPTION
## Summary
- route wired extra and selector JSON loads through safe payload guards
- prevent malformed stored JSON from aborting room load for extra/selector wired items
- add regression tests for malformed payload handling

## Tests
- mvn -Dtest=WiredExtraPayloadGuardTest,WiredSelectorPayloadGuardTest test