### PR TITLE
fix(room-moderation): protect owners

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -1625,6 +1625,9 @@ public class RoomManager {
         if (rights != null && !room.hasRights(rights))
             return;
 
+        if (room.getOwnerId() == userId)
+            return;
+
         String name = "";
 
         Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(userId);

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomManagerModerationContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomManagerModerationContractTest.java
@@ -1,0 +1,23 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoomManagerModerationContractTest {
+    @Test
+    void roomBanCannotTargetRoomOwner() throws Exception {
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java"));
+
+        int rightsGuard = source.indexOf("rights != null && !room.hasRights(rights)");
+        int ownerGuard = source.indexOf("room.getOwnerId() == userId");
+        int banCreate = source.indexOf("new RoomBan(roomId, userId");
+
+        assertTrue(rightsGuard > -1, "room bans must require rights");
+        assertTrue(ownerGuard > rightsGuard, "room bans must guard owner targets after rights are checked");
+        assertTrue(ownerGuard < banCreate, "room owner must be rejected before a RoomBan is created");
+    }
+}


### PR DESCRIPTION
## Summary
- prevent room bans from targeting the room owner through the central RoomManager path
- add a contract test so direct room moderation packets cannot regress owner protection

## Test
- mvn -Dtest=RoomManagerModerationContractTest test