### PR TITLE
fix(room-items): restore picked item owner

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -877,7 +877,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
       return;
     }
 
-    Habbo habbo = (picker != null && picker.getHabboInfo().getId() == item.getId() ? picker
+    Habbo habbo = (picker != null && picker.getHabboInfo().getId() == item.getUserId() ? picker
             : Emulator.getGameServer().getGameClientManager().getHabbo(item.getUserId()));
     if (!trackedBuildersClubItem && habbo != null) {
       habbo.getInventory().getItemsComponent().addItem(item);

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomPickupOwnershipContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomPickupOwnershipContractTest.java
@@ -1,0 +1,21 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoomPickupOwnershipContractTest {
+    @Test
+    void pickupReturnsItemToPickerWhenPickerOwnsTheItem() throws Exception {
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/Room.java"));
+
+        assertTrue(source.contains("picker.getHabboInfo().getId() == item.getUserId()"),
+                "Room.pickUpItem should compare the picker id against the item owner id");
+        assertFalse(source.contains("picker.getHabboInfo().getId() == item.getId()"),
+                "Room.pickUpItem must not compare user ids against furniture item ids");
+    }
+}


### PR DESCRIPTION
## Summary
- Return picked-up room items directly to the picker when the picker owns the item
- Fix the owner comparison to use item user_id instead of furniture item id
- Add a contract test to prevent regressing the owner comparison

## Tests
- mvn -Dtest=RoomPickupOwnershipContractTest test