### PR TITLE
fix(crafting): bound secret ingredients

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftSecretEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftSecretEvent.java
@@ -20,10 +20,17 @@ import java.util.Map;
 import java.util.Set;
 
 public class CraftingCraftSecretEvent extends MessageHandler {
+    static final int MAX_SECRET_CRAFT_INGREDIENTS = 50;
+
     @Override
     public void handle() throws Exception {
         int altarId = this.packet.readInt();
         int count = this.packet.readInt();
+
+        if (count <= 0 || count > MAX_SECRET_CRAFT_INGREDIENTS) {
+            this.client.sendResponse(new CraftingResultComposer(null));
+            return;
+        }
 
         HabboItem craftingAltar = this.client.getHabbo().getHabboInfo().getCurrentRoom().getHabboItem(altarId);
 
@@ -35,14 +42,13 @@ public class CraftingCraftSecretEvent extends MessageHandler {
                 Map<Item, Integer> items = new THashMap<>();
 
                 for (int i = 0; i < count; i++) {
-                    HabboItem habboItem = this.client.getHabbo().getInventory().getItemsComponent().getHabboItem(this.packet.readInt());
+                    int itemId = this.packet.readInt();
+                    HabboItem habboItem = this.client.getHabbo().getInventory().getItemsComponent().getHabboItem(itemId);
 
-                    if (habboItem == null) {
+                    if (habboItem == null || !habboItems.add(habboItem)) {
                         this.client.sendResponse(new CraftingResultComposer(null));
                         return;
                     }
-
-                    habboItems.add(habboItem);
 
                     if (!items.containsKey(habboItem.getBaseItem())) {
                         items.put(habboItem.getBaseItem(), 0);

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftSecretContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftSecretContractTest.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.messages.incoming.crafting;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CraftingCraftSecretContractTest {
+    private static String source() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftSecretEvent.java"));
+    }
+
+    @Test
+    void rejectsInvalidIngredientCountsBeforeReadingItemIds() throws Exception {
+        String source = source();
+
+        int countRead = source.indexOf("int count = this.packet.readInt()");
+        int guard = source.indexOf("count <= 0 || count > MAX_SECRET_CRAFT_INGREDIENTS", countRead);
+        int loop = source.indexOf("for (int i = 0; i < count; i++)", guard);
+
+        assertTrue(countRead > -1, "secret crafting must read the client supplied ingredient count");
+        assertTrue(guard > countRead, "secret crafting must validate the ingredient count");
+        assertTrue(loop > guard, "ingredient count validation must happen before item id reads");
+    }
+
+    @Test
+    void rejectsDuplicateIngredientItemsBeforeRecipeLookup() throws Exception {
+        String source = source();
+
+        int setDeclaration = source.indexOf("Set<HabboItem> habboItems = new THashSet<>()");
+        int duplicateGuard = source.indexOf("habboItem == null || !habboItems.add(habboItem)", setDeclaration);
+        int recipeLookup = source.indexOf("CraftingRecipe recipe = altar.getRecipe(items)", duplicateGuard);
+
+        assertTrue(setDeclaration > -1, "secret crafting should track unique inventory items");
+        assertTrue(duplicateGuard > setDeclaration, "secret crafting must reject duplicate item ids");
+        assertTrue(recipeLookup > duplicateGuard, "duplicate rejection must happen before recipe lookup/reward creation");
+    }
+}


### PR DESCRIPTION
## Summary
- Reject invalid or oversized secret-crafting ingredient counts before reading item ids
- Reject duplicate inventory item ids so one item cannot satisfy multiple ingredient slots
- Keep recipe lookup and reward creation behind validated unique ingredients

## Tests
- mvn -Dtest=CraftingCraftSecretContractTest test