### PR TITLE
fix(room-rights): require guild membership

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -5,6 +5,7 @@ import com.eu.habbo.habbohotel.bots.Bot;
 import com.eu.habbo.habbohotel.games.Game;
 import com.eu.habbo.habbohotel.guilds.Guild;
 import com.eu.habbo.habbohotel.guilds.GuildMember;
+import com.eu.habbo.habbohotel.guilds.GuildMembershipStatus;
 import com.eu.habbo.habbohotel.guilds.GuildRank;
 import com.eu.habbo.habbohotel.items.FurnitureType;
 import com.eu.habbo.habbohotel.items.Item;
@@ -2257,7 +2258,8 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
         return RoomRightLevels.GUILD_ADMIN;
       }
 
-      if (guild.getRights()) {
+      if ((member != null) && member.getMembershipStatus() == GuildMembershipStatus.MEMBER
+          && guild.getRights()) {
         return RoomRightLevels.GUILD_RIGHTS;
       }
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRightsManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRightsManager.java
@@ -4,6 +4,7 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.database.SqlQueries;
 import com.eu.habbo.habbohotel.guilds.Guild;
 import com.eu.habbo.habbohotel.guilds.GuildMember;
+import com.eu.habbo.habbohotel.guilds.GuildMembershipStatus;
 import com.eu.habbo.habbohotel.guilds.GuildRank;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.users.Habbo;
@@ -108,7 +109,8 @@ public class RoomRightsManager {
                 return RoomRightLevels.GUILD_ADMIN;
             }
 
-            if (guild.getRights()) {
+            if ((member != null) && member.getMembershipStatus() == GuildMembershipStatus.MEMBER
+                && guild.getRights()) {
                 return RoomRightLevels.GUILD_RIGHTS;
             }
         }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomRightsManagerGuildContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomRightsManagerGuildContractTest.java
@@ -1,0 +1,41 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoomRightsManagerGuildContractTest {
+    private static final Pattern ACCEPTED_MEMBER_GUILD_RIGHTS_GUARD = Pattern.compile(
+        "member\\.getMembershipStatus\\(\\)\\s*==\\s*GuildMembershipStatus\\.MEMBER\\s*&&\\s*guild\\.getRights\\(\\)",
+        Pattern.MULTILINE);
+
+    @Test
+    void guildRoomRightsRequireAcceptedMembership() throws Exception {
+        String source = Files.readString(
+            Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/RoomRightsManager.java"),
+            StandardCharsets.UTF_8);
+
+        assertTrue(ACCEPTED_MEMBER_GUILD_RIGHTS_GUARD.matcher(source).find(),
+            "Guild room rights must only apply to accepted guild members.");
+        assertFalse(source.contains("if (guild.getRights())"),
+            "A guild room with shared rights must not grant GUILD_RIGHTS to non-members.");
+    }
+
+    @Test
+    void legacyRoomGuildRightPathUsesSameMembershipGuard() throws Exception {
+        String source = Files.readString(
+            Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/Room.java"),
+            StandardCharsets.UTF_8);
+
+        assertTrue(ACCEPTED_MEMBER_GUILD_RIGHTS_GUARD.matcher(source).find(),
+            "The legacy Room guild-right path must keep the same membership guard.");
+        assertFalse(source.contains("if (guild.getRights())"),
+            "The legacy Room path must not grant GUILD_RIGHTS to non-members.");
+    }
+}


### PR DESCRIPTION
## Summary
- require an accepted guild membership before shared guild room rights grant GUILD_RIGHTS
- keep the legacy Room guild-right path aligned with RoomRightsManager
- add a contract test covering both guild-right code paths

## Test
- mvn -Dtest=RoomRightsManagerGuildContractTest test