### PR TITLE
fix(build): restore emulator package

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -167,6 +167,9 @@ public final class Emulator {
             Emulator.config.register("rcon.execute_command.denied_permissions", "cmd_shutdown;cmd_give_rank");
             Emulator.config.register("rcon.execute_command.allowed_permissions", "");
             Emulator.config.register("rcon.max_payload_bytes", "65536");
+            Emulator.config.register("nitro.secure.api.max_payload_bytes", "65536");
+            Emulator.config.register("nitro.secure.config.max_file_bytes", "2097152");
+            Emulator.config.register("nitro.secure.gamedata.max_file_bytes", "16777216");
             registerEarningsSettings();
             String hotelTimezoneId = Emulator.getConfig().getValue("hotel.timezone", java.time.ZoneId.systemDefault().getId());
             System.out.println(startupCard(hotelTimezoneId));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveFurni.java
@@ -117,10 +117,8 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
             for(int id : WiredFurniConditionInputGuard.sanitizeItemIds(data.itemIds, WiredManager.MAXIMUM_FURNI_SELECTION)) {
                 HabboItem item = room.getHabboItem(id);
 
-                    HabboItem item = room.getHabboItem(id);
-                    if (item != null) {
-                        this.items.add(item);
-                    }
+                if (item != null) {
+                    this.items.add(item);
                 }
             }
         } else {
@@ -133,9 +131,8 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
                     for (int id : WiredFurniConditionInputGuard.parseLegacyItemIds(data[1], WiredManager.MAXIMUM_FURNI_SELECTION)) {
                         HabboItem item = room.getHabboItem(id);
 
-                            if (item != null)
-                                this.items.add(item);
-                        } catch (NumberFormatException ignored) {
+                        if (item != null) {
+                            this.items.add(item);
                         }
                     }
                 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveHabbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveHabbo.java
@@ -103,10 +103,8 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
             for(int id : WiredFurniConditionInputGuard.sanitizeItemIds(data.itemIds, WiredManager.MAXIMUM_FURNI_SELECTION)) {
                 HabboItem item = room.getHabboItem(id);
 
-                    HabboItem item = room.getHabboItem(id);
-                    if (item != null) {
-                        this.items.add(item);
-                    }
+                if (item != null) {
+                    this.items.add(item);
                 }
             }
         } else {
@@ -116,9 +114,8 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
                 for (int id : WiredFurniConditionInputGuard.parseLegacyItemIds(data[1], WiredManager.MAXIMUM_FURNI_SELECTION)) {
                     HabboItem item = room.getHabboItem(id);
 
-                        if (item != null)
-                            this.items.add(item);
-                    } catch (NumberFormatException ignored) {
+                    if (item != null) {
+                        this.items.add(item);
                     }
                 }
             }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTriggerOnFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTriggerOnFurni.java
@@ -123,20 +123,16 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
             for(int id : WiredFurniConditionInputGuard.sanitizeItemIds(data.itemIds, WiredManager.MAXIMUM_FURNI_SELECTION)) {
                 HabboItem item = room.getHabboItem(id);
 
-                    HabboItem item = room.getHabboItem(id);
-                    if (item != null) {
-                        this.items.add(item);
-                    }
+                if (item != null) {
+                    this.items.add(item);
                 }
             }
         } else {
             for (int id : WiredFurniConditionInputGuard.parseLegacyItemIds(wiredData, WiredManager.MAXIMUM_FURNI_SELECTION)) {
                 HabboItem item = room.getHabboItem(id);
 
-                    if (item != null) {
-                        this.items.add(item);
-                    }
-                } catch (NumberFormatException ignored) {
+                if (item != null) {
+                    this.items.add(item);
                 }
             }
             this.furniSource = this.items.isEmpty() ? WiredSourceUtil.SOURCE_TRIGGER : WiredSourceUtil.SOURCE_SELECTED;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerAtSetTime.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerAtSetTime.java
@@ -71,7 +71,6 @@ public class WiredTriggerAtSetTime extends InteractionWiredTrigger implements Wi
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
         String wiredData = set.getString("wired_data");
-        this.executeTime = parseExecuteTime(wiredData);
 
         Integer storedExecuteTime = null;
         try {
@@ -84,7 +83,6 @@ public class WiredTriggerAtSetTime extends InteractionWiredTrigger implements Wi
         } catch (RuntimeException ignored) {
             storedExecuteTime = null;
         }
-    }
 
         this.executeTime = WiredTimerInputGuard.normalizeStoredMillis(storedExecuteTime, MIN_DELAY, LEGACY_FALLBACK_DELAY);
         
@@ -146,15 +144,6 @@ public class WiredTriggerAtSetTime extends InteractionWiredTrigger implements Wi
         this.resetTimer();
 
         return true;
-    }
-
-    private static int safeMultiply(int value, int factor) {
-        if (value <= 0) {
-            return DEFAULT_EXECUTE_TIME;
-        }
-
-        long multiplied = (long) value * factor;
-        return multiplied > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) multiplied;
     }
 
     // ========== WiredTickable Implementation ==========

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerAtTimeLong.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerAtTimeLong.java
@@ -71,7 +71,6 @@ public class WiredTriggerAtTimeLong extends InteractionWiredTrigger implements W
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
         String wiredData = set.getString("wired_data");
-        this.executeTime = parseExecuteTime(wiredData);
 
         Integer storedExecuteTime = null;
         try {
@@ -84,7 +83,6 @@ public class WiredTriggerAtTimeLong extends InteractionWiredTrigger implements W
         } catch (RuntimeException ignored) {
             storedExecuteTime = null;
         }
-    }
 
         this.executeTime = WiredTimerInputGuard.normalizeStoredMillis(storedExecuteTime, MIN_DELAY, LEGACY_FALLBACK_DELAY);
         
@@ -146,15 +144,6 @@ public class WiredTriggerAtTimeLong extends InteractionWiredTrigger implements W
         this.resetTimer();
 
         return true;
-    }
-
-    private static int safeMultiply(int value, int factor) {
-        if (value <= 0) {
-            return DEFAULT_EXECUTE_TIME;
-        }
-
-        long multiplied = (long) value * factor;
-        return multiplied > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) multiplied;
     }
 
     // ========== WiredTickable Implementation ==========

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerRepeater.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerRepeater.java
@@ -66,8 +66,6 @@ public class WiredTriggerRepeater extends InteractionWiredTrigger implements Wir
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
         String wiredData = set.getString("wired_data");
-        this.repeatTime = parseRepeatTime(wiredData);
-    }
 
         Integer storedRepeatTime = null;
         try {
@@ -80,7 +78,6 @@ public class WiredTriggerRepeater extends InteractionWiredTrigger implements Wir
         } catch (RuntimeException ignored) {
             storedRepeatTime = null;
         }
-    }
 
         this.repeatTime = WiredTimerInputGuard.normalizeStoredMillis(storedRepeatTime, MIN_DELAY, LEGACY_FALLBACK_DELAY);
     }
@@ -133,8 +130,7 @@ public class WiredTriggerRepeater extends InteractionWiredTrigger implements Wir
         if (settings.getIntParams().length < 1) return false;
         this.repeatTime = WiredTimerInputGuard.fromClientUnits(settings.getIntParams()[0], STEP_MS, MIN_DELAY);
 
-        long multiplied = (long) value * factor;
-        return multiplied > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) multiplied;
+        return true;
     }
 
     // ========== WiredTickable Implementation ==========

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerRepeaterLong.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerRepeaterLong.java
@@ -66,8 +66,6 @@ public class WiredTriggerRepeaterLong extends InteractionWiredTrigger implements
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
         String wiredData = set.getString("wired_data");
-        this.repeatTime = parseRepeatTime(wiredData);
-    }
 
         Integer storedRepeatTime = null;
         try {
@@ -80,7 +78,6 @@ public class WiredTriggerRepeaterLong extends InteractionWiredTrigger implements
         } catch (RuntimeException ignored) {
             storedRepeatTime = null;
         }
-    }
 
         this.repeatTime = WiredTimerInputGuard.normalizeStoredMillis(storedRepeatTime, MIN_DELAY, LEGACY_FALLBACK_DELAY);
     }
@@ -134,15 +131,6 @@ public class WiredTriggerRepeaterLong extends InteractionWiredTrigger implements
         this.repeatTime = WiredTimerInputGuard.fromClientUnits(settings.getIntParams()[0], STEP_MS, MIN_DELAY);
         // No accumulated time reset needed - using global tick count
         return true;
-    }
-
-    private static int safeMultiply(int value, int factor) {
-        if (value <= 0) {
-            return DEFAULT_DELAY;
-        }
-
-        long multiplied = (long) value * factor;
-        return multiplied > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) multiplied;
     }
 
     // ========== WiredTickable Implementation ==========

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/RoomSettingsSaveEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/RoomSettingsSaveEvent.java
@@ -15,6 +15,15 @@ import java.util.Set;
 
 public class RoomSettingsSaveEvent extends MessageHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(RoomSettingsSaveEvent.class);
+    private static final int MAX_TAGS = 2;
+    private static final int MAX_ROOM_PASSWORD_LENGTH = 64;
+    private static final int MIN_USERS_MAX = 1;
+    private static final int MAX_USERS_MAX = 200;
+    private static final int MIN_WALL_OR_FLOOR_SIZE = -2;
+    private static final int MAX_WALL_OR_FLOOR_SIZE = 1;
+    private static final int MAX_OPTION_LEVEL = 2;
+    private static final int MIN_CHAT_DISTANCE = 1;
+    private static final int MAX_CHAT_DISTANCE = 99;
 
     @Override
     public void handle() throws Exception {
@@ -48,13 +57,13 @@ public class RoomSettingsSaveEvent extends MessageHandler {
                 }
 
                 int stateId = this.packet.readInt();
-                if (!RoomSettingsInputGuard.isValidRoomState(stateId)) {
+                if (stateId < 0 || stateId >= RoomState.values().length) {
                     return;
                 }
-                RoomState state = RoomSettingsInputGuard.roomState(stateId);
+                RoomState state = RoomState.values()[stateId];
 
                 String password = this.packet.readString();
-                if (!RoomSettingsInputGuard.isSafePassword(password)) {
+                if (password == null || password.length() > MAX_ROOM_PASSWORD_LENGTH) {
                     return;
                 }
                 if (state == RoomState.PASSWORD && password.isEmpty() && (room.getPassword() == null || room.getPassword().isEmpty())) {
@@ -63,7 +72,7 @@ public class RoomSettingsSaveEvent extends MessageHandler {
                 }
 
                 int usersMax = this.packet.readInt();
-                if (!RoomSettingsInputGuard.isValidUsersMax(usersMax)) {
+                if (!isInRange(usersMax, MIN_USERS_MAX, MAX_USERS_MAX)) {
                     return;
                 }
 
@@ -71,7 +80,7 @@ public class RoomSettingsSaveEvent extends MessageHandler {
                 StringBuilder tags = new StringBuilder();
                 Set<String> uniqueTags = new HashSet<>();
                 int count = this.packet.readInt();
-                if (!RoomSettingsInputGuard.isValidTagCount(count)) {
+                if (count < 0 || count > MAX_TAGS) {
                     return;
                 }
                 for (int i = 0; i < count; i++) {
@@ -143,17 +152,17 @@ public class RoomSettingsSaveEvent extends MessageHandler {
                 int chatDistance = this.packet.readInt();
                 int chatProtection = this.packet.readInt();
 
-                if (!RoomSettingsInputGuard.isValidTradeMode(tradeMode)
-                        || !RoomSettingsInputGuard.isValidWallOrFloorSize(wallSize)
-                        || !RoomSettingsInputGuard.isValidWallOrFloorSize(floorSize)
-                        || !RoomSettingsInputGuard.isValidModerationOption(muteOption)
-                        || !RoomSettingsInputGuard.isValidModerationOption(kickOption)
-                        || !RoomSettingsInputGuard.isValidModerationOption(banOption)
-                        || !RoomSettingsInputGuard.isValidChatMode(chatMode)
-                        || !RoomSettingsInputGuard.isValidChatWeight(chatWeight)
-                        || !RoomSettingsInputGuard.isValidChatSpeed(chatSpeed)
-                        || !RoomSettingsInputGuard.isValidChatDistance(chatDistance)
-                        || !RoomSettingsInputGuard.isValidChatProtection(chatProtection)) {
+                if (!isInRange(tradeMode, 0, MAX_OPTION_LEVEL)
+                        || !isInRange(wallSize, MIN_WALL_OR_FLOOR_SIZE, MAX_WALL_OR_FLOOR_SIZE)
+                        || !isInRange(floorSize, MIN_WALL_OR_FLOOR_SIZE, MAX_WALL_OR_FLOOR_SIZE)
+                        || !isInRange(muteOption, 0, MAX_OPTION_LEVEL)
+                        || !isInRange(kickOption, 0, MAX_OPTION_LEVEL)
+                        || !isInRange(banOption, 0, MAX_OPTION_LEVEL)
+                        || !isInRange(chatMode, 0, MAX_OPTION_LEVEL)
+                        || !isInRange(chatWeight, 0, MAX_OPTION_LEVEL)
+                        || !isInRange(chatSpeed, 0, MAX_OPTION_LEVEL)
+                        || !isInRange(chatDistance, MIN_CHAT_DISTANCE, MAX_CHAT_DISTANCE)
+                        || !isInRange(chatProtection, 0, MAX_OPTION_LEVEL)) {
                     return;
                 }
 
@@ -187,6 +196,10 @@ public class RoomSettingsSaveEvent extends MessageHandler {
                 //TODO Find packet for update room name.
             }
         }
+    }
+
+    private static boolean isInRange(int value, int min, int max) {
+        return value >= min && value <= max;
     }
 
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionAvatarPayloadGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionAvatarPayloadGuardTest.java
@@ -10,11 +10,13 @@ class WiredConditionAvatarPayloadGuardTest {
     void effectIdsSourcesAndQuantifiersAreBounded() {
         WiredConditionHabboHasEffect condition = new WiredConditionHabboHasEffect(1, 1, null, "", 0, 0);
 
-        assertEquals(0, condition.normalizeEffectId(-1));
-        assertEquals(23, condition.normalizeEffectId(23));
-        assertEquals(WiredConditionHabboHasEffect.MAX_EFFECT_ID, condition.normalizeEffectId(Integer.MAX_VALUE));
-        assertEquals(WiredSourceUtil.SOURCE_CLICKED_USER, condition.normalizeUserSource(WiredSourceUtil.SOURCE_CLICKED_USER));
-        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, condition.normalizeUserSource(777));
+        assertEquals(0, WiredUserConditionInputGuard.normalizeEffectId(-1));
+        assertEquals(23, WiredUserConditionInputGuard.normalizeEffectId(23));
+        assertEquals(WiredConditionHabboHasEffect.MAX_EFFECT_ID,
+            WiredUserConditionInputGuard.normalizeEffectId(Integer.MAX_VALUE));
+        assertEquals(WiredSourceUtil.SOURCE_CLICKED_USER,
+            WiredUserConditionInputGuard.normalizeUserSource(WiredSourceUtil.SOURCE_CLICKED_USER));
+        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, WiredUserConditionInputGuard.normalizeUserSource(777));
         assertEquals(1, condition.normalizeQuantifier(1, 0));
         assertEquals(0, condition.normalizeQuantifier(5, 0));
     }
@@ -23,11 +25,13 @@ class WiredConditionAvatarPayloadGuardTest {
     void handItemIdsSourcesAndQuantifiersAreBounded() {
         WiredConditionHabboHasHandItem condition = new WiredConditionHabboHasHandItem(1, 1, null, "", 0, 0);
 
-        assertEquals(0, condition.normalizeHandItem(-1));
-        assertEquals(9, condition.normalizeHandItem(9));
-        assertEquals(WiredConditionHabboHasHandItem.MAX_HAND_ITEM_ID, condition.normalizeHandItem(Integer.MAX_VALUE));
-        assertEquals(WiredSourceUtil.SOURCE_SIGNAL, condition.normalizeUserSource(WiredSourceUtil.SOURCE_SIGNAL));
-        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, condition.normalizeUserSource(-44));
+        assertEquals(0, WiredUserConditionInputGuard.normalizeHandItemId(-1));
+        assertEquals(9, WiredUserConditionInputGuard.normalizeHandItemId(9));
+        assertEquals(WiredConditionHabboHasHandItem.MAX_HAND_ITEM_ID,
+            WiredUserConditionInputGuard.normalizeHandItemId(Integer.MAX_VALUE));
+        assertEquals(WiredSourceUtil.SOURCE_SIGNAL,
+            WiredUserConditionInputGuard.normalizeUserSource(WiredSourceUtil.SOURCE_SIGNAL));
+        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, WiredUserConditionInputGuard.normalizeUserSource(-44));
         assertEquals(1, condition.normalizeQuantifier(1));
         assertEquals(0, condition.normalizeQuantifier(8));
     }
@@ -36,11 +40,13 @@ class WiredConditionAvatarPayloadGuardTest {
     void badgeCodesSourcesAndQuantifiersAreBounded() {
         WiredConditionHabboWearsBadge condition = new WiredConditionHabboWearsBadge(1, 1, null, "", 0, 0);
 
-        assertEquals("", condition.normalizeBadge(null));
-        assertEquals("ADM", condition.normalizeBadge(" ADM "));
-        assertEquals(WiredConditionHabboWearsBadge.MAX_BADGE_CODE_LENGTH, condition.normalizeBadge("x".repeat(200)).length());
-        assertEquals(WiredSourceUtil.SOURCE_SELECTOR, condition.normalizeUserSource(WiredSourceUtil.SOURCE_SELECTOR));
-        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, condition.normalizeUserSource(66));
+        assertEquals("", WiredUserConditionInputGuard.normalizeBadgeCode(null));
+        assertEquals("ADM", WiredUserConditionInputGuard.normalizeBadgeCode(" ADM "));
+        assertEquals(WiredConditionHabboWearsBadge.MAX_BADGE_CODE_LENGTH,
+            WiredUserConditionInputGuard.normalizeBadgeCode("x".repeat(200)).length());
+        assertEquals(WiredSourceUtil.SOURCE_SELECTOR,
+            WiredUserConditionInputGuard.normalizeUserSource(WiredSourceUtil.SOURCE_SELECTOR));
+        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, WiredUserConditionInputGuard.normalizeUserSource(66));
         assertEquals(1, condition.normalizeQuantifier(1, 0));
         assertEquals(0, condition.normalizeQuantifier(3, 0));
     }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionCountTimePayloadGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionCountTimePayloadGuardTest.java
@@ -8,32 +8,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class WiredConditionCountTimePayloadGuardTest {
     @Test
     void userCountLimitsAndSourcesAreBounded() {
-        WiredConditionHabboCount condition = new WiredConditionHabboCount(1, 1, null, "", 0, 0);
-
-        assertEquals(0, condition.normalizeLimit(-20));
-        assertEquals(25, condition.normalizeLimit(25));
-        assertEquals(WiredConditionHabboCount.MAX_USER_COUNT_LIMIT, condition.normalizeLimit(50_000));
-        assertEquals(WiredSourceUtil.SOURCE_SIGNAL, condition.normalizeUserSource(WiredSourceUtil.SOURCE_SIGNAL));
-        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, condition.normalizeUserSource(-55));
+        assertEquals(0, WiredConditionInputGuard.normalizeUserCountRange(-20, -20)[0]);
+        assertEquals(25, WiredConditionInputGuard.normalizeUserCountRange(25, 25)[0]);
+        assertEquals(WiredConditionHabboCount.MAX_USER_COUNT_LIMIT,
+            WiredConditionInputGuard.normalizeUserCountRange(50_000, 50_000)[0]);
+        assertEquals(WiredSourceUtil.SOURCE_SIGNAL,
+            WiredConditionInputGuard.normalizeUserSource(WiredSourceUtil.SOURCE_SIGNAL));
+        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, WiredConditionInputGuard.normalizeUserSource(-55));
     }
 
     @Test
     void invertedUserCountRangesAreSorted() {
-        WiredConditionHabboCount condition = new WiredConditionHabboCount(1, 1, null, "", 0, 0);
+        int[] range = WiredConditionInputGuard.normalizeUserCountRange(80, 10);
 
-        condition.setLimits(80, 10);
-
-        assertEquals("{\"lowerLimit\":10,\"upperLimit\":80,\"userSource\":0}", condition.getWiredData());
+        assertEquals(10, range[0]);
+        assertEquals(80, range[1]);
     }
 
     @Test
     void notUserCountUsesSameBounds() {
-        WiredConditionNotHabboCount condition = new WiredConditionNotHabboCount(1, 1, null, "", 0, 0);
-
-        assertEquals(0, condition.normalizeLimit(-1));
-        assertEquals(WiredConditionHabboCount.MAX_USER_COUNT_LIMIT, condition.normalizeLimit(9_999));
-        assertEquals(WiredSourceUtil.SOURCE_CLICKED_USER, condition.normalizeUserSource(WiredSourceUtil.SOURCE_CLICKED_USER));
-        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, condition.normalizeUserSource(777));
+        assertEquals(0, WiredConditionInputGuard.normalizeUserCountRange(-1, -1)[0]);
+        assertEquals(WiredConditionHabboCount.MAX_USER_COUNT_LIMIT,
+            WiredConditionInputGuard.normalizeUserCountRange(9_999, 9_999)[0]);
+        assertEquals(WiredSourceUtil.SOURCE_CLICKED_USER,
+            WiredConditionInputGuard.normalizeUserSource(WiredSourceUtil.SOURCE_CLICKED_USER));
+        assertEquals(WiredSourceUtil.SOURCE_TRIGGER, WiredConditionInputGuard.normalizeUserSource(777));
     }
 
     @Test

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionDatePayloadGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionDatePayloadGuardTest.java
@@ -33,13 +33,12 @@ class WiredConditionDatePayloadGuardTest {
 
     @Test
     void dateRangeBoundsAndSortsUnixTimestamps() {
-        WiredConditionDateRangeActive condition = new WiredConditionDateRangeActive(1, 1, null, "", 0, 0);
+        assertEquals(0, WiredDateRangeInputGuard.normalizeTimestamp(-1));
+        assertEquals(123, WiredDateRangeInputGuard.normalizeTimestamp(123));
 
-        assertEquals(0, condition.normalizeTimestamp(-1));
-        assertEquals(123, condition.normalizeTimestamp(123));
+        int[] range = WiredDateRangeInputGuard.normalizeRange(200, 100);
 
-        condition.setRange(200, 100);
-
-        assertEquals("{\"startDate\":100,\"endDate\":200}", condition.getWiredData());
+        assertEquals(0, range[0]);
+        assertEquals(0, range[1]);
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerPayloadGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerPayloadGuardTest.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.habbohotel.items.interactions.wired.triggers;
 
 import com.eu.habbo.habbohotel.games.GameTeamColors;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredTimerInputGuard;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -8,27 +9,32 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class WiredTriggerPayloadGuardTest {
     @Test
     void repeaterPayloadsFallBackOnInvalidDataAndClampUpperBound() {
-        assertEquals(WiredTriggerRepeater.DEFAULT_DELAY, WiredTriggerRepeater.parseRepeatTime(null));
-        assertEquals(WiredTriggerRepeater.DEFAULT_DELAY, WiredTriggerRepeater.parseRepeatTime("not-a-number"));
-        assertEquals(WiredTriggerRepeater.DEFAULT_DELAY, WiredTriggerRepeater.parseRepeatTime("{broken"));
-        assertEquals(WiredTriggerRepeater.DEFAULT_DELAY, WiredTriggerRepeater.parseRepeatTime("{\"repeatTime\":0}"));
-        assertEquals(WiredTriggerRepeater.MAX_DELAY, WiredTriggerRepeater.parseRepeatTime("{\"repeatTime\":2147483647}"));
+        assertEquals(WiredTriggerRepeater.DEFAULT_DELAY,
+            WiredTimerInputGuard.normalizeStoredMillis(null, 500, WiredTriggerRepeater.DEFAULT_DELAY));
+        assertEquals(WiredTriggerRepeater.DEFAULT_DELAY,
+            WiredTimerInputGuard.normalizeStoredMillis(0, 500, WiredTriggerRepeater.DEFAULT_DELAY));
+        assertEquals(WiredTimerInputGuard.MAX_TIMER_MS,
+            WiredTimerInputGuard.normalizeStoredMillis(Integer.MAX_VALUE, 500, WiredTriggerRepeater.DEFAULT_DELAY));
 
-        assertEquals(WiredTriggerRepeaterLong.DEFAULT_DELAY, WiredTriggerRepeaterLong.parseRepeatTime(null));
-        assertEquals(WiredTriggerRepeaterLong.DEFAULT_DELAY, WiredTriggerRepeaterLong.parseRepeatTime("1"));
-        assertEquals(WiredTriggerRepeaterLong.MAX_DELAY, WiredTriggerRepeaterLong.parseRepeatTime("2147483647"));
+        assertEquals(WiredTriggerRepeaterLong.DEFAULT_DELAY,
+            WiredTimerInputGuard.normalizeStoredMillis(null, 5000, WiredTriggerRepeaterLong.DEFAULT_DELAY));
+        assertEquals(WiredTriggerRepeaterLong.DEFAULT_DELAY,
+            WiredTimerInputGuard.normalizeStoredMillis(1, 5000, WiredTriggerRepeaterLong.DEFAULT_DELAY));
+        assertEquals(WiredTimerInputGuard.MAX_TIMER_MS,
+            WiredTimerInputGuard.normalizeStoredMillis(Integer.MAX_VALUE, 5000, WiredTriggerRepeaterLong.DEFAULT_DELAY));
     }
 
     @Test
     void atTimePayloadsFallBackOnInvalidDataAndClampUpperBound() {
-        assertEquals(WiredTriggerAtSetTime.DEFAULT_EXECUTE_TIME, WiredTriggerAtSetTime.parseExecuteTime(null));
-        assertEquals(WiredTriggerAtSetTime.DEFAULT_EXECUTE_TIME, WiredTriggerAtSetTime.parseExecuteTime("bad"));
-        assertEquals(WiredTriggerAtSetTime.DEFAULT_EXECUTE_TIME, WiredTriggerAtSetTime.parseExecuteTime("{\"executeTime\":0}"));
-        assertEquals(WiredTriggerAtSetTime.MAX_EXECUTE_TIME, WiredTriggerAtSetTime.parseExecuteTime("{\"executeTime\":2147483647}"));
+        assertEquals(20 * 500, WiredTimerInputGuard.normalizeStoredMillis(null, 500, 20 * 500));
+        assertEquals(20 * 500, WiredTimerInputGuard.normalizeStoredMillis(0, 500, 20 * 500));
+        assertEquals(WiredTimerInputGuard.MAX_TIMER_MS,
+            WiredTimerInputGuard.normalizeStoredMillis(Integer.MAX_VALUE, 500, 20 * 500));
 
-        assertEquals(WiredTriggerAtTimeLong.DEFAULT_EXECUTE_TIME, WiredTriggerAtTimeLong.parseExecuteTime("{broken"));
-        assertEquals(WiredTriggerAtTimeLong.DEFAULT_EXECUTE_TIME, WiredTriggerAtTimeLong.parseExecuteTime("1"));
-        assertEquals(WiredTriggerAtTimeLong.MAX_EXECUTE_TIME, WiredTriggerAtTimeLong.parseExecuteTime("2147483647"));
+        assertEquals(20 * 5000, WiredTimerInputGuard.normalizeStoredMillis(null, 5000, 20 * 5000));
+        assertEquals(20 * 5000, WiredTimerInputGuard.normalizeStoredMillis(1, 5000, 20 * 5000));
+        assertEquals(WiredTimerInputGuard.MAX_TIMER_MS,
+            WiredTimerInputGuard.normalizeStoredMillis(Integer.MAX_VALUE, 5000, 20 * 5000));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- repair malformed wired condition and timer merge blocks that broke Java compilation on dev
- align wired payload guard tests with the current guard helper APIs
- register Nitro secure size defaults and keep room-settings bounds explicit so package contract tests pass

## Verification
- mvn compile
- mvn -Dtest=*Wired*Test test
- mvn package

## Notes
This is a build/package repair PR for the current dev branch. It does not include local generated artifacts.