### PR TITLE
fix(ci): add dependency maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/Emulator"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "build"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ci"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev]
+  push:
+    branches-ignore: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Emulator
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Build and test
+        run: mvn -B verify

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ variables:
     -DdeployAtEnd=true  
 
 java-build:
-  image: maven:3.8-openjdk-11
+  image: maven:3.9-eclipse-temurin-21
   stage: build
   cache:
     key: "maven-$CI_COMMIT_REF_SLUG"


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow for emulator Maven verification on PRs to dev and non-dev pushes
- add Dependabot maintenance for Maven and GitHub Actions updates
- update the GitLab CI Maven image to a Java 21 capable image

## Notes
This intentionally extracts only the low-risk CI/dependency-maintenance portion from simoleo89/Arcturus-Morningstar-Extended#6. Runtime dependency/code migration is left for separate smaller PRs.

## Verification
- diff --check

Full Maven verification is intentionally not claimed here because origin/dev currently needs the build repair from duckietm/Arcturus-Morningstar-Extended#273 first.