### PR TITLE
fix(sql): guard dynamic identifiers

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/permissions/PermissionsManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/permissions/PermissionsManager.java
@@ -213,6 +213,10 @@ public class PermissionsManager {
     }
 
     private boolean tableHasRows(Connection connection, String tableName) throws SQLException {
+        if (!tableName.matches("^[A-Za-z_][A-Za-z0-9_]*$")) {
+            throw new SQLException("Refusing to query unsafe table name: " + tableName);
+        }
+
         try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT COUNT(*) FROM " + tableName)) {
             return set.next() && set.getInt(1) > 0;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
@@ -832,7 +832,15 @@ public class HabboStats implements Runnable {
         persistFlag("mass_mentions_enabled", enabled);
     }
 
+    private static final Set<String> PERSIST_FLAG_COLUMNS =
+            Set.of("mentions_enabled", "mass_mentions_enabled");
+
     private void persistFlag(String column, boolean enabled) {
+        if (!PERSIST_FLAG_COLUMNS.contains(column)) {
+            LOGGER.error("Refusing to persist unknown users_settings column '{}'", column);
+            return;
+        }
+
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
              PreparedStatement statement = connection.prepareStatement("UPDATE users_settings SET `" + column + "` = ? WHERE user_id = ? LIMIT 1")) {
             statement.setString(1, enabled ? "1" : "0");


### PR DESCRIPTION
## Summary
- validates the dynamic table name used by `PermissionsManager.tableHasRows()` before interpolating it into SQL
- restricts `HabboStats.persistFlag()` to the known `users_settings` boolean columns it is allowed to update
- keeps values parameterized and refuses unknown identifiers instead of building unsafe SQL

## Notes
This is a focused security-hardening slice extracted from simoleo89/Arcturus-Morningstar-Extended#6. It intentionally leaves the unrelated logging cleanup and utility tests for separate PRs.

This branch is stacked on `fix/wired-dev-compile` while the upstream `dev` package/compile repair is pending in #273. Please review after #273 or recheck after rebasing onto `dev` once that lands.

## Verification
- `mvn package` (376 tests, BUILD SUCCESS)