### PR TITLE
fix(test): cover core utility helpers

### DIFF
--- a/Emulator/src/test/java/com/eu/habbo/util/HexUtilsTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/util/HexUtilsTest.java
@@ -1,0 +1,38 @@
+package com.eu.habbo.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HexUtilsTest {
+
+    @Test
+    void toHexKnownValues() {
+        assertEquals("00", HexUtils.toHex(new byte[]{0x00}));
+        assertEquals("FF", HexUtils.toHex(new byte[]{(byte) 0xFF}));
+        assertEquals("DEADBEEF", HexUtils.toHex(new byte[]{(byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF}));
+    }
+
+    @Test
+    void toHexEmpty() {
+        assertEquals("", HexUtils.toHex(new byte[]{}));
+    }
+
+    @Test
+    void toBytesKnownValues() {
+        assertArrayEquals(new byte[]{(byte) 0xDE, (byte) 0xAD}, HexUtils.toBytes("DEAD"));
+    }
+
+    @Test
+    void roundTrip() {
+        byte[] original = {0x00, 0x7F, (byte) 0x80, (byte) 0xFF, 0x42, 0x13};
+        assertArrayEquals(original, HexUtils.toBytes(HexUtils.toHex(original)));
+    }
+
+    @Test
+    void getRandomHasRequestedLength() {
+        assertEquals(16, HexUtils.getRandom(16).length());
+        assertEquals(1, HexUtils.getRandom(1).length());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/util/SqlLikeEscaperTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/util/SqlLikeEscaperTest.java
@@ -1,0 +1,32 @@
+package com.eu.habbo.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SqlLikeEscaperTest {
+
+    @Test
+    void nullBecomesEmptyString() {
+        assertEquals("", SqlLikeEscaper.escape(null));
+    }
+
+    @Test
+    void plainInputIsUnchanged() {
+        assertEquals("Alice", SqlLikeEscaper.escape("Alice"));
+    }
+
+    @Test
+    void wildcardsAreEscaped() {
+        assertEquals("100\\% real", SqlLikeEscaper.escape("100% real"));
+        assertEquals("user\\_name", SqlLikeEscaper.escape("user_name"));
+    }
+
+    @Test
+    void backslashIsEscapedFirstToAvoidDoubleEscaping() {
+        // The escape char itself must be doubled before %/_ are escaped,
+        // otherwise the inserted backslashes would be escaped again.
+        assertEquals("a\\\\b", SqlLikeEscaper.escape("a\\b"));
+        assertEquals("\\\\\\%", SqlLikeEscaper.escape("\\%"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/util/figure/FigureUtilTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/util/figure/FigureUtilTest.java
@@ -1,0 +1,56 @@
+package com.eu.habbo.util.figure;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FigureUtilTest {
+
+    @Test
+    void getFigureBitsParsesSetsByType() {
+        Map<String, String> bits = FigureUtil.getFigureBits("hr-100-7.hd-180-1.ch-210-66");
+        assertEquals(3, bits.size());
+        assertEquals("100-7", bits.get("hr"));
+        assertEquals("180-1", bits.get("hd"));
+        assertEquals("210-66", bits.get("ch"));
+    }
+
+    @Test
+    void getFigureBitsHandlesTypeWithoutValue() {
+        Map<String, String> bits = FigureUtil.getFigureBits("hr");
+        assertEquals("", bits.get("hr"));
+    }
+
+    @Test
+    void mergeFiguresCombinesSingleSets() {
+        assertEquals("hr-100-7.hd-180-1", FigureUtil.mergeFigures("hr-100-7", "hd-180-1"));
+    }
+
+    @Test
+    void mergeFiguresRespectsLimitOnFirstFigure() {
+        // Only the "hr" type from figure1 is kept; all of figure2 is appended.
+        assertEquals("hr-1.ch-3", FigureUtil.mergeFigures("hr-1", "ch-3", new String[]{"hr"}));
+    }
+
+    @Test
+    void mergeFiguresDropsExcludedFirstFigureType() {
+        assertEquals("ch-3", FigureUtil.mergeFigures("hr-1", "ch-3", new String[]{"lg"}));
+    }
+
+    @Test
+    void hasBlacklistedClothingDetectsBannedPartId() {
+        assertTrue(FigureUtil.hasBlacklistedClothing("hr-100-7", Set.of(100)));
+        assertFalse(FigureUtil.hasBlacklistedClothing("hr-100-7", Set.of(999)));
+    }
+
+    @Test
+    void hasBlacklistedClothingIgnoresMalformedSets() {
+        // A set without a part id must not throw and must not match.
+        assertFalse(FigureUtil.hasBlacklistedClothing("hr", Set.of(100)));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/util/pathfinding/RotationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/util/pathfinding/RotationTest.java
@@ -1,0 +1,32 @@
+package com.eu.habbo.util.pathfinding;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RotationTest {
+
+    // (X1,Y1) is the origin, (X2,Y2) the target. The emulator uses Habbo's
+    // 8-direction rotation where 0 = north and values increase clockwise.
+
+    @Test
+    void samePointReturnsNorth() {
+        assertEquals(0, Rotation.Calculate(5, 5, 5, 5));
+    }
+
+    @Test
+    void cardinalDirections() {
+        assertEquals(0, Rotation.Calculate(5, 5, 5, 4)); // target north (Y2 < Y1)
+        assertEquals(2, Rotation.Calculate(5, 5, 6, 5)); // target east  (X2 > X1)
+        assertEquals(4, Rotation.Calculate(5, 5, 5, 6)); // target south (Y2 > Y1)
+        assertEquals(6, Rotation.Calculate(5, 5, 4, 5)); // target west  (X2 < X1)
+    }
+
+    @Test
+    void diagonalDirections() {
+        assertEquals(1, Rotation.Calculate(5, 5, 6, 4)); // north-east
+        assertEquals(3, Rotation.Calculate(5, 5, 6, 6)); // south-east
+        assertEquals(5, Rotation.Calculate(5, 5, 4, 6)); // south-west
+        assertEquals(7, Rotation.Calculate(5, 5, 4, 4)); // north-west
+    }
+}


### PR DESCRIPTION
## Summary
- adds unit coverage for `HexUtils` hex conversion and random token length
- adds unit coverage for `SqlLikeEscaper` wildcard and backslash escaping
- adds unit coverage for figure parsing/merging/blacklist helpers and 8-way rotation calculation

## Notes
This is a test-only slice extracted from simoleo89/Arcturus-Morningstar-Extended#6. It intentionally avoids the unrelated runtime logging, SQL hardening, dependency, and collection-migration changes so it can be reviewed independently.

This branch is stacked on `fix/wired-dev-compile` while the upstream `dev` package/compile repair is pending in #273. Please review after #273 or recheck after rebasing onto `dev` once that lands.

## Verification
- `mvn -Dtest=HexUtilsTest,SqlLikeEscaperTest,FigureUtilTest,RotationTest test` (19 tests, BUILD SUCCESS)
- `mvn package` (395 tests, BUILD SUCCESS)