### PR TITLE
fix(logging): route exceptions through logger

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -245,7 +245,7 @@ public final class Emulator {
             }
 
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.error("Caught exception", e);
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/core/ConfigurationManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/ConfigurationManager.java
@@ -57,13 +57,12 @@ public class ConfigurationManager {
 
             } catch (IOException ex) {
                 LOGGER.error("Failed to load config file.", ex);
-                ex.printStackTrace();
             } finally {
                 if (input != null) {
                     try {
                         input.close();
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        LOGGER.error("Failed to close config file input stream.", e);
                     }
                 }
             }

--- a/Emulator/src/main/java/com/eu/habbo/core/TextsManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/TextsManager.java
@@ -23,7 +23,7 @@ public class TextsManager {
 
             LOGGER.info("Texts Manager -> Loaded! ({} MS)", System.currentTimeMillis() - millis);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.error("Caught exception", e);
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/YoutubeManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/YoutubeManager.java
@@ -135,7 +135,8 @@ public class YoutubeManager {
             try {
                 youtubeDataLoaderPool.awaitTermination(60, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                LOGGER.error("Interrupted while waiting for YouTube playlist loading to finish.", e);
+                Thread.currentThread().interrupt();
             }
 
             LOGGER.info("YouTube Manager -> Loaded! ({} MS)", System.currentTimeMillis() - millis);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionFireworks.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionFireworks.java
@@ -82,7 +82,7 @@ public class InteractionFireworks extends InteractionDefault {
                     try {
                         this.onClick(client, room, objects);
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        LOGGER.error("Caught exception", e);
                     }
                 });
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionSwitch.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionSwitch.java
@@ -8,6 +8,8 @@ import com.eu.habbo.habbohotel.rooms.RoomLayout;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.threading.runnables.RoomUnitWalkToLocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -15,6 +17,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class InteractionSwitch extends InteractionDefault {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InteractionSwitch.class);
+
     public InteractionSwitch(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
     }
@@ -57,7 +61,7 @@ public class InteractionSwitch extends InteractionDefault {
                     try {
                         this.onClick(client, room, objects);
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        LOGGER.error("Caught exception", e);
                     }
                 });
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionTeleport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionTeleport.java
@@ -11,6 +11,8 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.threading.runnables.RoomUnitWalkToLocation;
 import com.eu.habbo.threading.runnables.teleport.TeleportActionOne;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -18,6 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class InteractionTeleport extends HabboItem {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InteractionTeleport.class);
+
     private int targetId;
     private int targetRoomId;
     private int roomUnitID = -1;
@@ -87,7 +91,7 @@ public class InteractionTeleport extends HabboItem {
             try {
                 super.onClick(client, room, new Object[]{"TOGGLE_OVERRIDE"});
             } catch (Exception e) {
-                e.printStackTrace();
+                LOGGER.error("Caught exception", e);
             }
         } else if (unit.getCurrentLocation().equals(currentLocation) || unit.getCurrentLocation().equals(infrontTile)) {
             // set state 1 and walk on item

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionVendingMachine.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionVendingMachine.java
@@ -11,6 +11,8 @@ import com.eu.habbo.threading.runnables.RoomUnitGiveHanditem;
 import com.eu.habbo.threading.runnables.RoomUnitWalkToLocation;
 import com.eu.habbo.util.pathfinding.Rotation;
 import gnu.trove.set.hash.THashSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -18,6 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class InteractionVendingMachine extends HabboItem {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InteractionVendingMachine.class);
+
     public InteractionVendingMachine(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
         this.setExtradata("0");
@@ -73,7 +77,7 @@ public class InteractionVendingMachine extends HabboItem {
         try {
             super.onClick(client, room, new Object[]{"TOGGLE_OVERRIDE"});
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.error("Caught exception", e);
         }
 
         if(!unit.isWalking() && !unit.hasStatus(RoomUnitStatus.SIT) && !unit.hasStatus(RoomUnitStatus.LAY)) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/guilds/forums/GuildForumDataComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/guilds/forums/GuildForumDataComposer.java
@@ -209,7 +209,7 @@ public class GuildForumDataComposer extends MessageComposer {
                 this.response.appendBoolean(guild.getOwnerId() == this.habbo.getHabboInfo().getId() || isStaff || isAdmin); //Can Mod (staff)
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.error("Caught exception", e);
             return new ConnectionErrorComposer(500).compose();
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/ChangeUsername.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/ChangeUsername.java
@@ -44,10 +44,10 @@ public class ChangeUsername extends RCONMessage<ChangeUsername.JSON> {
 
                         success = statement.executeUpdate() >= 1;
                     } catch (SQLException sqlException) {
-                        sqlException.printStackTrace();
+                        LOGGER.error("Caught SQL exception", sqlException);
                     }
                 } catch (SQLException sqlException) {
-                    sqlException.printStackTrace();
+                    LOGGER.error("Caught SQL exception", sqlException);
                 }
             }
 

--- a/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
@@ -69,7 +69,7 @@ public class RCONServerHandler extends ChannelInboundHandlerAdapter {
                 LOGGER.error("Unknown RCON Message: {}", key);
             } catch (Exception e) {
                 LOGGER.error("Invalid RCON Message: {}", message);
-                e.printStackTrace();
+            LOGGER.error("Caught exception", e);
             }
 
             writeAndClose(ctx, response);

--- a/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
@@ -236,7 +236,7 @@ public class PluginManager {
             try {
                 NewNavigatorEventCategoriesComposer.CATEGORIES.add(new EventCategory(category));
             } catch (Exception e) {
-                e.printStackTrace();
+                LOGGER.error("Caught exception", e);
             }
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/teleport/TeleportActionFive.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/teleport/TeleportActionFive.java
@@ -8,11 +8,15 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.core.WiredFreezeUtil;
 import com.eu.habbo.threading.runnables.HabboItemNewState;
 import com.eu.habbo.threading.runnables.RoomUnitWalkToLocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 
 class TeleportActionFive implements Runnable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TeleportActionFive.class);
+
     private final HabboItem currentTeleport;
     private final Room room;
     private final GameClient client;
@@ -74,7 +78,7 @@ class TeleportActionFive implements Runnable {
             try {
                 teleportTile.onWalkOn(unit, this.room, new Object[]{});
             } catch (Exception e) {
-                e.printStackTrace();
+                LOGGER.error("Caught exception", e);
             }
         }
     }


### PR DESCRIPTION
## Summary
- replaces runtime `printStackTrace()` calls with structured SLF4J logging
- adds local loggers to interaction/teleport classes that previously wrote directly to stderr
- preserves intentional `PrintWriter` stack-trace serialization used for error payload storage
- restores the interrupt flag when YouTube playlist loading is interrupted

## Notes
This is the logging cleanup slice extracted from simoleo89/Arcturus-Morningstar-Extended#6. It intentionally avoids unrelated test, SQL, dependency, and collection-migration changes so it can be reviewed independently.

This branch is stacked on `fix/wired-dev-compile` while the upstream `dev` package/compile repair is pending in #273. Please review after #273 or recheck after rebasing onto `dev` once that lands.

## Verification
- `mvn package` (376 tests, BUILD SUCCESS)