### PR TITLE
fix(auth): centralize bcrypt hashing

### DIFF
--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -194,12 +194,12 @@
             <version>2.4.3</version>
         </dependency>
 
-        <!-- jBCrypt � used by the built-in /api/auth/* HTTP login handler
-             to verify Laravel-style $2y$ BCrypt hashes from users.password -->
+        <!-- favre BCrypt is used by auth endpoints and natively verifies
+             Laravel-style $2y$ hashes from users.password. -->
         <dependency>
-            <groupId>org.mindrot</groupId>
-            <artifactId>jbcrypt</artifactId>
-            <version>0.4</version>
+            <groupId>at.favre.lib</groupId>
+            <artifactId>bcrypt</artifactId>
+            <version>0.10.2</version>
         </dependency>
 
         <!-- Jakarta Mail — used by the built-in forgot-password endpoint

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingResetUserPasswordEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingResetUserPasswordEvent.java
@@ -4,7 +4,7 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.housekeeping.HousekeepingActionResultComposer;
-import org.mindrot.jbcrypt.BCrypt;
+import com.eu.habbo.networking.gameserver.auth.PasswordHasher;
 
 import java.security.SecureRandom;
 import java.sql.Connection;
@@ -13,7 +13,7 @@ import java.sql.SQLException;
 
 /**
  * Reset a user's password to a fresh random 12-character alphanumeric
- * string. Persists a BCrypt `$2a$` hash of the new password into
+ * string. Persists a BCrypt hash of the new password into
  * `users.password` (matches what `AuthHttpUtil.checkPassword` /
  * `SessionEndpoints` / `AccountChangeEndpoints` already write and read),
  * clears `auth_ticket` so any active session can't be re-used to bypass
@@ -55,7 +55,7 @@ public class HousekeepingResetUserPasswordEvent extends MessageHandler {
         String hash;
 
         try {
-            hash = BCrypt.hashpw(plain, BCrypt.gensalt(BCRYPT_COST));
+            hash = PasswordHasher.hash(plain, BCRYPT_COST);
         } catch (IllegalArgumentException e) {
             this.client.sendResponse(new HousekeepingActionResultComposer(ACTION_KEY, false, 0, "housekeeping.error.hash_failed"));
             return;

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/auth/AccountChangeEndpoints.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/auth/AccountChangeEndpoints.java
@@ -6,7 +6,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.mindrot.jbcrypt.BCrypt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,7 +94,7 @@ final class AccountChangeEndpoints {
                 return;
             }
 
-            String hashed = BCrypt.hashpw(newPassword, BCrypt.gensalt(12));
+            String hashed = PasswordHasher.hash(newPassword, 12);
             try (PreparedStatement upd = conn.prepareStatement(
                     "UPDATE users SET password = ? WHERE id = ? LIMIT 1")) {
                 upd.setString(1, hashed);

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/auth/AuthHttpUtil.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/auth/AuthHttpUtil.java
@@ -14,7 +14,6 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
-import org.mindrot.jbcrypt.BCrypt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -183,12 +182,7 @@ public final class AuthHttpUtil {
     }
 
     static boolean checkPassword(String plain, String stored) {
-        String compatible = stored.startsWith("$2y$") ? "$2a$" + stored.substring(4) : stored;
-        try {
-            return BCrypt.checkpw(plain, compatible);
-        } catch (IllegalArgumentException e) {
-            return false;
-        }
+        return PasswordHasher.verify(plain, stored);
     }
 
     static String mintSsoTicket() {

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/auth/PasswordHasher.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/auth/PasswordHasher.java
@@ -1,0 +1,25 @@
+package com.eu.habbo.networking.gameserver.auth;
+
+import at.favre.lib.crypto.bcrypt.BCrypt;
+
+public final class PasswordHasher {
+
+    private PasswordHasher() {
+    }
+
+    public static String hash(String plain, int cost) {
+        return BCrypt.withDefaults().hashToString(cost, plain.toCharArray());
+    }
+
+    public static boolean verify(String plain, String stored) {
+        if (plain == null || stored == null || stored.isEmpty()) {
+            return false;
+        }
+
+        try {
+            return BCrypt.verifyer().verify(plain.toCharArray(), stored.toCharArray()).verified;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/auth/SessionEndpoints.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/auth/SessionEndpoints.java
@@ -5,7 +5,6 @@ import com.google.gson.JsonObject;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.mindrot.jbcrypt.BCrypt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -348,7 +347,7 @@ final class SessionEndpoints {
                 }
             }
 
-            String hashed = BCrypt.hashpw(password, BCrypt.gensalt(12));
+            String hashed = PasswordHasher.hash(password, 12);
             String defaultLook = Emulator.getConfig().getValue("register.default.look",
                     "hr-100-7.hd-180-1.ch-210-66.lg-270-82.sh-290-80");
             String defaultMotto = Emulator.getConfig().getValue("register.default.motto", "I love Habbo!");

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/auth/PasswordHasherTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/auth/PasswordHasherTest.java
@@ -1,0 +1,33 @@
+package com.eu.habbo.networking.gameserver.auth;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PasswordHasherTest {
+
+    @Test
+    void hashesVerifyWithSamePassword() {
+        String hash = PasswordHasher.hash("correct horse battery staple", 4);
+
+        assertTrue(PasswordHasher.verify("correct horse battery staple", hash));
+        assertFalse(PasswordHasher.verify("wrong password", hash));
+    }
+
+    @Test
+    void verifiesLaravelStyle2yHashes() {
+        String hash = PasswordHasher.hash("secret-password", 4);
+        String laravelStyle = "$2y$" + hash.substring(4);
+
+        assertTrue(PasswordHasher.verify("secret-password", laravelStyle));
+        assertFalse(PasswordHasher.verify("not-secret", laravelStyle));
+    }
+
+    @Test
+    void invalidHashesFailClosed() {
+        assertFalse(PasswordHasher.verify("password", ""));
+        assertFalse(PasswordHasher.verify("password", "not-a-bcrypt-hash"));
+        assertFalse(PasswordHasher.verify(null, "$2y$04$abcdefghijklmnopqrstuuabcdefghijklmnopqrstuuabcde"));
+    }
+}


### PR DESCRIPTION
## Summary
- replaces legacy `org.mindrot:jbcrypt` with maintained `at.favre.lib:bcrypt`
- centralizes auth password hashing and verification behind `PasswordHasher`
- updates login verification, registration, password change, and housekeeping password reset to use the same helper
- adds tests covering generated hashes, wrong passwords, invalid hashes, and Laravel-style `$2y$` compatibility

## Notes
This is the bcrypt/auth slice extracted from simoleo89/Arcturus-Morningstar-Extended#6. It intentionally avoids Java compiler alignment and unrelated dependency/version refactors so the auth behavior can be reviewed independently.

This branch is stacked on `fix/wired-dev-compile` while the upstream `dev` package/compile repair is pending in #273. Please review after #273 or recheck after rebasing onto `dev` once that lands.

## Verification
- `mvn -Dtest=PasswordHasherTest test` (3 tests, BUILD SUCCESS)
- `mvn package` (379 tests, BUILD SUCCESS)