### PR TITLE
fix(collections): modernize trove usage

### DIFF
--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -132,6 +132,16 @@
             <scope>compile</scope>
         </dependency>
 
+        <!-- Fastutil primitive collections, introduced incrementally while
+             migrating away from trove4j. Keep trove4j until every package has
+             been migrated and verified. -->
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <version>8.5.15</version>
+            <scope>compile</scope>
+        </dependency>
+
         <!-- HikariCP -->
         <dependency>
             <groupId>com.zaxxer</groupId>

--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.eu.habbo</groupId>
     <artifactId>Habbo</artifactId>
-    <version>4.2.44</version>
+    <version>4.2.45</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -16,7 +16,6 @@
         <netty.version>4.2.15.Final</netty.version>
         <gson.version>2.14.0</gson.version>
         <mariadb.version>3.5.8</mariadb.version>
-        <trove4j.version>3.0.3</trove4j.version>
         <hikaricp.version>7.0.2</hikaricp.version>
         <caffeine.version>3.2.4</caffeine.version>
         <resilience4j.version>2.4.0</resilience4j.version>
@@ -27,7 +26,7 @@
         <slf4j.version>2.0.18</slf4j.version>
         <logback.version>1.5.34</logback.version>
         <jansi.version>2.4.3</jansi.version>
-        <jbcrypt.version>0.4</jbcrypt.version>
+        <bcrypt.version>0.10.2</bcrypt.version>
         <jakarta-mail.version>2.0.5</jakarta-mail.version>
         <junit.version>6.1.0</junit.version>
 
@@ -124,17 +123,7 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- Trove -->
-        <dependency>
-            <groupId>net.sf.trove4j</groupId>
-            <artifactId>trove4j</artifactId>
-            <version>${trove4j.version}</version>
-            <scope>compile</scope>
-        </dependency>
-
-        <!-- Fastutil primitive collections, introduced incrementally while
-             migrating away from trove4j. Keep trove4j until every package has
-             been migrated and verified. -->
+        <!-- Fastutil primitive collections. -->
         <dependency>
             <groupId>it.unimi.dsi</groupId>
             <artifactId>fastutil</artifactId>
@@ -230,9 +219,9 @@
         <!-- favre BCrypt is used by auth endpoints and natively verifies
              Laravel-style $2y$ hashes from users.password. -->
         <dependency>
-            <groupId>org.mindrot</groupId>
-            <artifactId>jbcrypt</artifactId>
-            <version>${jbcrypt.version}</version>
+            <groupId>at.favre.lib</groupId>
+            <artifactId>bcrypt</artifactId>
+            <version>${bcrypt.version}</version>
         </dependency>
 
         <!-- Jakarta Mail — used by the built-in forgot-password endpoint

--- a/Emulator/src/main/java/com/eu/habbo/core/ConfigurationManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/ConfigurationManager.java
@@ -2,7 +2,6 @@ package com.eu.habbo.core;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.plugin.events.emulator.EmulatorConfigUpdatedEvent;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,6 +10,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.*;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -69,7 +69,7 @@ public class ConfigurationManager {
 
         } else {
 
-            Map<String, String> envMapping = new THashMap<>();
+            Map<String, String> envMapping = new HashMap<>();
 
             // Database section
             envMapping.put("db.hostname", "DB_HOSTNAME");

--- a/Emulator/src/main/java/com/eu/habbo/core/consolecommands/ConsoleCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/consolecommands/ConsoleCommand.java
@@ -1,12 +1,14 @@
 package com.eu.habbo.core.consolecommands;
 
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public abstract class ConsoleCommand {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsoleCommand.class);
-    private static final THashMap<String, ConsoleCommand> commands = new THashMap<>();
+    private static final Map<String, ConsoleCommand> commands = new HashMap<>();
 
     public final String key;
     public final String usage;

--- a/Emulator/src/main/java/com/eu/habbo/database/Database.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/Database.java
@@ -3,7 +3,6 @@ package com.eu.habbo.database;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.core.ConfigurationManager;
 import com.zaxxer.hikari.HikariDataSource;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,13 +116,6 @@ public class Database {
             statement.setObject(k + 1, bindValues.get(k));
         }
         return statement;
-    }
-
-    @Deprecated
-    public static PreparedStatement preparedStatementWithParams(Connection connection,
-                                                                String query,
-                                                                THashMap<String, Object> queryParams) throws SQLException {
-        return preparedStatementWithParams(connection, query, (Map<String, Object>) queryParams);
     }
 
     private static boolean isNameStart(char c) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/Achievement.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/Achievement.java
@@ -1,9 +1,9 @@
 package com.eu.habbo.habbohotel.achievements;
 
-import gnu.trove.map.hash.THashMap;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class Achievement {
 
@@ -16,11 +16,11 @@ public class Achievement {
     public final AchievementCategories category;
 
 
-    public final THashMap<Integer, AchievementLevel> levels;
+    public final Map<Integer, AchievementLevel> levels;
 
 
     public Achievement(ResultSet set) throws SQLException {
-        this.levels = new THashMap<>();
+        this.levels = new HashMap<>();
 
         this.id = set.getInt("id");
         this.name = set.getString("name");

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/AchievementManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/AchievementManager.java
@@ -16,12 +16,11 @@ import com.eu.habbo.messages.outgoing.users.UserBadgesComposer;
 import com.eu.habbo.plugin.Event;
 import com.eu.habbo.plugin.events.users.achievements.UserAchievementLeveledEvent;
 import com.eu.habbo.plugin.events.users.achievements.UserAchievementProgressEvent;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.procedure.TObjectIntProcedure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.*;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -30,12 +29,12 @@ public class AchievementManager {
 
     public static boolean TALENTTRACK_ENABLED = false;
 
-    private final THashMap<String, Achievement> achievements;
-    private final THashMap<TalentTrackType, LinkedHashMap<Integer, TalentTrackLevel>> talentTrackLevels;
+    private final Map<String, Achievement> achievements;
+    private final Map<TalentTrackType, LinkedHashMap<Integer, TalentTrackLevel>> talentTrackLevels;
 
     public AchievementManager() {
-        this.achievements = new THashMap<>();
-        this.talentTrackLevels = new THashMap<>();
+        this.achievements = new HashMap<>();
+        this.talentTrackLevels = new HashMap<>();
     }
 
     public static void progressAchievement(int habboId, Achievement achievement) {
@@ -311,7 +310,7 @@ public class AchievementManager {
         return null;
     }
 
-    public THashMap<String, Achievement> getAchievements() {
+    public Map<String, Achievement> getAchievements() {
         return this.achievements;
     }
 
@@ -324,16 +323,12 @@ public class AchievementManager {
 
         for (Map.Entry<Integer, TalentTrackLevel> entry : this.talentTrackLevels.get(type).entrySet()) {
             final boolean[] allCompleted = {true};
-            entry.getValue().achievements.forEachEntry(new TObjectIntProcedure<Achievement>() {
-                @Override
-                public boolean execute(Achievement a, int b) {
-                    if (habbo.getHabboStats().getAchievementProgress(a) < b) {
-                        allCompleted[0] = false;
-                    }
-
-                    return allCompleted[0];
+            for (Map.Entry<Achievement, Integer> achievementEntry : entry.getValue().achievements.entrySet()) {
+                if (habbo.getHabboStats().getAchievementProgress(achievementEntry.getKey()) < achievementEntry.getValue()) {
+                    allCompleted[0] = false;
+                    break;
                 }
-            });
+            }
 
             if (allCompleted[0]) {
                 if (level == null || level.level < entry.getValue().level) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/TalentTrackLevel.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/TalentTrackLevel.java
@@ -2,30 +2,31 @@ package com.eu.habbo.habbohotel.achievements;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.items.Item;
-import gnu.trove.map.TObjectIntMap;
-import gnu.trove.map.hash.TObjectIntHashMap;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class TalentTrackLevel {
     private static final Logger LOGGER = LoggerFactory.getLogger(TalentTrackLevel.class);
 
     public TalentTrackType type;
     public int level;
-    public TObjectIntMap<Achievement> achievements;
-    public THashSet<Item> items;
+    public Map<Achievement, Integer> achievements;
+    public Set<Item> items;
     public String[] perks;
     public String[] badges;
 
     public TalentTrackLevel(ResultSet set) throws SQLException {
         this.type = TalentTrackType.valueOf(set.getString("type").toUpperCase());
         this.level = set.getInt("level");
-        this.achievements = new TObjectIntHashMap<>();
-        this.items = new THashSet<>();
+        this.achievements = new HashMap<>();
+        this.items = new HashSet<>();
 
         String[] achievements = set.getString("achievement_ids").split(",");
         String[] achievementLevels = set.getString("achievement_levels").split(",");

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/BotManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/BotManager.java
@@ -15,12 +15,12 @@ import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUsersComposer;
 import com.eu.habbo.plugin.events.bots.BotPickUpEvent;
 import com.eu.habbo.plugin.events.bots.BotPlacedEvent;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.sql.*;
+import java.util.HashMap;
 import java.util.Map;
 
 
@@ -28,7 +28,7 @@ import java.util.Map;
 public class BotManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(BotManager.class);
 
-    final private static THashMap<String, Class<? extends Bot>> botDefenitions = new THashMap<>();
+    final private static Map<String, Class<? extends Bot>> botDefenitions = new HashMap<>();
     public static int MINIMUM_CHAT_SPEED = 7;
     public static int MAXIMUM_CHAT_SPEED = 604800;
     public static int MAXIMUM_CHAT_LENGTH = 120;
@@ -71,11 +71,11 @@ public class BotManager {
         return true;
     }
 
-    public Bot createBot(THashMap<String, String> data, String type) {
+    public Bot createBot(Map<String, String> data, String type) {
         return this.createBot(data, type, 0);
     }
 
-    public Bot createBot(THashMap<String, String> data, String type, int ownerId) {
+    public Bot createBot(Map<String, String> data, String type, int ownerId) {
         if (ownerId <= 0) {
             LOGGER.error("Cannot create bot of type '{}' without a valid owner user id.", type);
             return null;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/ButlerBot.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/ButlerBot.java
@@ -7,8 +7,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.plugin.events.bots.BotServerItemEvent;
 import com.eu.habbo.threading.runnables.RoomUnitGiveHanditem;
 import com.eu.habbo.threading.runnables.RoomUnitWalkToRoomUnit;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,14 +16,17 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 public class ButlerBot extends Bot {
     private static final Logger LOGGER = LoggerFactory.getLogger(ButlerBot.class);
-    public static THashMap<THashSet<String>, Integer> serveItems = new THashMap<>();
+    public static Map<Set<String>, Integer> serveItems = new HashMap<>();
     private static final ConcurrentHashMap<Pattern, Integer> serveItemsCompiled = new ConcurrentHashMap<>();
 
     public ButlerBot(ResultSet set) throws SQLException {
@@ -38,7 +39,7 @@ public class ButlerBot extends Bot {
 
     public static void initialise() {
         if (serveItems == null)
-            serveItems = new THashMap<>();
+            serveItems = new HashMap<>();
 
         serveItems.clear();
         serveItemsCompiled.clear();
@@ -46,7 +47,7 @@ public class ButlerBot extends Bot {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM bot_serves")) {
             while (set.next()) {
                 String[] keys = set.getString("keys").split(";");
-                THashSet<String> ks = new THashSet<>();
+                Set<String> ks = new HashSet<>();
                 Collections.addAll(ks, keys);
                 serveItems.put(ks, set.getInt("item"));
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/VisitorBot.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/VisitorBot.java
@@ -4,17 +4,18 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.modtool.ModToolRoomVisit;
 import com.eu.habbo.habbohotel.rooms.RoomChatMessage;
 import com.eu.habbo.habbohotel.users.Habbo;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 public class VisitorBot extends Bot {
     private static SimpleDateFormat DATE_FORMAT;
     private boolean showedLog = false;
-    private THashSet<ModToolRoomVisit> visits = new THashSet<>(3);
+    private Set<ModToolRoomVisit> visits = new HashSet<>(3);
 
     public VisitorBot(ResultSet set) throws SQLException {
         super(set);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/campaign/calendar/CalendarCampaign.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/campaign/calendar/CalendarCampaign.java
@@ -1,16 +1,15 @@
 package com.eu.habbo.habbohotel.campaign.calendar;
 
-import gnu.trove.map.hash.THashMap;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Map;
 
 public class CalendarCampaign {
     private int id;
     private final String name;
     private final String image;
-    private Map<Integer , CalendarRewardObject> rewards = new THashMap<>();
+    private Map<Integer , CalendarRewardObject> rewards = new HashMap<>();
     private final Integer start_timestamp;
     private final int total_days;
     private final boolean lock_expired;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/campaign/calendar/CalendarManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/campaign/calendar/CalendarManager.java
@@ -5,7 +5,6 @@ import com.eu.habbo.database.SqlQueries;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.events.calendar.AdventCalendarProductComposer;
 import com.eu.habbo.plugin.events.users.calendar.UserClaimRewardEvent;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,7 +18,7 @@ import static java.time.temporal.ChronoUnit.DAYS;
 public class CalendarManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(CalendarCampaign.class);
 
-    final private static Map<Integer, CalendarCampaign> calendarCampaigns = new THashMap<>();
+    final private static Map<Integer, CalendarCampaign> calendarCampaigns = new HashMap<>();
     public static double HC_MODIFIER;
 
     public CalendarManager() {
@@ -116,7 +115,7 @@ public class CalendarManager {
         if (habbo.getHabboStats().calendarRewardsClaimed.stream().noneMatch(claimed -> claimed.getCampaignId() == campaign.getId() && claimed.getDay() == day)) {
 
             Set<Integer> keys = campaign.getRewards().keySet();
-            Map<Integer, Integer> rewards = new THashMap<>();
+            Map<Integer, Integer> rewards = new HashMap<>();
             if(keys.isEmpty()) return;
             keys.forEach(key -> rewards.put(rewards.size() + 1, key));
             int rand = Emulator.getRandom().nextInt(rewards.size() - 1 + 1) + 1;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogItem.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogItem.java
@@ -5,7 +5,6 @@ import com.eu.habbo.habbohotel.items.FurnitureType;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.messages.ISerialize;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,6 +13,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class CatalogItem implements ISerialize, Runnable, Comparable<CatalogItem> {
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogItem.class);
@@ -48,7 +50,7 @@ public class CatalogItem implements ISerialize, Runnable, Comparable<CatalogItem
     private int orderNumber;
 
 
-    private HashMap<Integer, Integer> bundle;
+    private Map<Integer, Integer> bundle;
 
     public CatalogItem(ResultSet set) throws SQLException {
         this.load(set);
@@ -206,8 +208,8 @@ public class CatalogItem implements ISerialize, Runnable, Comparable<CatalogItem
         Emulator.getThreading().run(this);
     }
 
-    public THashSet<Item> getBaseItems() {
-        THashSet<Item> items = new THashSet<>();
+    public Set<Item> getBaseItems() {
+        Set<Item> items = new HashSet<>();
 
         if (!this.itemId.isEmpty()) {
             String[] itemIds = this.itemId.split(";");
@@ -247,7 +249,7 @@ public class CatalogItem implements ISerialize, Runnable, Comparable<CatalogItem
             return this.amount;
     }
 
-    public HashMap<Integer, Integer> getBundle() {
+    public Map<Integer, Integer> getBundle() {
         return this.bundle;
     }
 
@@ -297,7 +299,7 @@ public class CatalogItem implements ISerialize, Runnable, Comparable<CatalogItem
         message.appendInt(this.getPointsType());
         message.appendBoolean(this.allowGift); //Can gift
 
-        THashSet<Item> items = this.getBaseItems();
+        Set<Item> items = this.getBaseItems();
 
         message.appendInt(items.size());
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -29,14 +29,11 @@ import com.eu.habbo.messages.outgoing.users.AddUserBadgeComposer;
 import com.eu.habbo.plugin.events.emulator.EmulatorLoadCatalogManagerEvent;
 import com.eu.habbo.plugin.events.users.catalog.UserCatalogFurnitureBoughtEvent;
 import com.eu.habbo.plugin.events.users.catalog.UserCatalogItemPurchasedEvent;
-import gnu.trove.TCollections;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntIntHashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
-import gnu.trove.procedure.TObjectProcedure;
-import gnu.trove.set.hash.THashSet;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +45,7 @@ public class CatalogManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogManager.class);
 
-    public static final THashMap<String, Class<? extends CatalogPage>> pageDefinitions = new THashMap<String, Class<? extends CatalogPage>>(CatalogPageLayouts.values().length) {
+    public static final Map<String, Class<? extends CatalogPage>> pageDefinitions = new HashMap<String, Class<? extends CatalogPage>>(CatalogPageLayouts.values().length) {
         {
             for (CatalogPageLayouts layout : CatalogPageLayouts.values()) {
                 switch (layout) {
@@ -187,41 +184,41 @@ public class CatalogManager {
     public static int catalogItemAmount;
     public static int PURCHASE_COOLDOWN = 1;
     public static boolean SORT_USING_ORDERNUM = false;
-    public final TIntObjectMap<CatalogPage> catalogPages;
-    public final TIntObjectMap<CatalogPage> buildersClubCatalogPages;
-    public final TIntObjectMap<CatalogFeaturedPage> catalogFeaturedPages;
-    public final THashMap<Integer, THashSet<Item>> prizes;
-    public final THashMap<Integer, Integer> giftWrappers;
-    public final THashMap<Integer, Integer> giftFurnis;
-    public final THashSet<CatalogItem> clubItems;
-    public final THashMap<Integer, ClubOffer> clubOffers;
-    public final THashMap<Integer, TargetOffer> targetOffers;
-    public final THashMap<Integer, ClothItem> clothing;
-    public final TIntIntHashMap offerDefs;
-    public final TIntIntHashMap buildersClubOfferDefs;
+    public final Int2ObjectMap<CatalogPage> catalogPages;
+    public final Int2ObjectMap<CatalogPage> buildersClubCatalogPages;
+    public final Int2ObjectMap<CatalogFeaturedPage> catalogFeaturedPages;
+    public final Map<Integer, Set<Item>> prizes;
+    public final Map<Integer, Integer> giftWrappers;
+    public final Map<Integer, Integer> giftFurnis;
+    public final Set<CatalogItem> clubItems;
+    public final Map<Integer, ClubOffer> clubOffers;
+    public final Map<Integer, TargetOffer> targetOffers;
+    public final Map<Integer, ClothItem> clothing;
+    public final Int2IntMap offerDefs;
+    public final Int2IntMap buildersClubOfferDefs;
     public final Item ecotronItem;
-    public final THashMap<Integer, CatalogLimitedConfiguration> limitedNumbers;
+    public final Map<Integer, CatalogLimitedConfiguration> limitedNumbers;
     private final List<Voucher> vouchers;
-    public final TIntObjectMap<int[]> furnitureValues;
+    public final Int2ObjectMap<int[]> furnitureValues;
     private volatile byte[] rareValuesPayloadCache;
 
     public CatalogManager() {
         long millis = System.currentTimeMillis();
-        this.catalogPages = TCollections.synchronizedMap(new TIntObjectHashMap<>());
-        this.buildersClubCatalogPages = TCollections.synchronizedMap(new TIntObjectHashMap<>());
-        this.catalogFeaturedPages = new TIntObjectHashMap<>();
-        this.prizes = new THashMap<>();
-        this.giftWrappers = new THashMap<>();
-        this.giftFurnis = new THashMap<>();
-        this.clubItems = new THashSet<>();
-        this.clubOffers = new THashMap<>();
-        this.targetOffers = new THashMap<>();
-        this.clothing = new THashMap<>();
-        this.offerDefs = new TIntIntHashMap();
-        this.buildersClubOfferDefs = new TIntIntHashMap();
+        this.catalogPages = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
+        this.buildersClubCatalogPages = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
+        this.catalogFeaturedPages = new Int2ObjectOpenHashMap<>();
+        this.prizes = new HashMap<>();
+        this.giftWrappers = new HashMap<>();
+        this.giftFurnis = new HashMap<>();
+        this.clubItems = new HashSet<>();
+        this.clubOffers = new HashMap<>();
+        this.targetOffers = new HashMap<>();
+        this.clothing = new HashMap<>();
+        this.offerDefs = new Int2IntOpenHashMap();
+        this.buildersClubOfferDefs = new Int2IntOpenHashMap();
         this.vouchers = new ArrayList<>();
-        this.limitedNumbers = new THashMap<>();
-        this.furnitureValues = new TIntObjectHashMap<>();
+        this.limitedNumbers = new HashMap<>();
+        this.furnitureValues = new Int2ObjectOpenHashMap<>();
 
         this.initialize();
 
@@ -253,8 +250,8 @@ public class CatalogManager {
         this.furnitureValues.clear();
         final int diamondType = Emulator.getConfig().getInt("seasonal.currency.diamond", 5);
 
-        for (CatalogPage page : this.catalogPages.valueCollection()) {
-            for (CatalogItem catalogItem : page.getCatalogItems().valueCollection()) {
+        for (CatalogPage page : this.catalogPages.values()) {
+            for (CatalogItem catalogItem : page.getCatalogItems().values()) {
                 if (catalogItem.getAmount() != 1)
                     continue;
 
@@ -265,7 +262,7 @@ public class CatalogManager {
                 if (points <= 0 || pointsType != diamondType)
                     continue;
 
-                THashSet<Item> baseItems = catalogItem.getBaseItems();
+                Set<Item> baseItems = catalogItem.getBaseItems();
 
                 if (baseItems.size() != 1)
                     continue;
@@ -294,11 +291,9 @@ public class CatalogManager {
         try (java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream(this.furnitureValues.size() * 16 + 8);
              java.io.DataOutputStream out = new java.io.DataOutputStream(baos)) {
             out.writeInt(this.furnitureValues.size());
-            TIntObjectIterator<int[]> iterator = this.furnitureValues.iterator();
-            while (iterator.hasNext()) {
-                iterator.advance();
-                int[] value = iterator.value();
-                out.writeInt(iterator.key()); // spriteId
+            for (Int2ObjectMap.Entry<int[]> entry : this.furnitureValues.int2ObjectEntrySet()) {
+                int[] value = entry.getValue();
+                out.writeInt(entry.getIntKey()); // spriteId
                 out.writeInt(value[0]);        // credits
                 out.writeInt(value[1]);        // points
                 out.writeInt(value[2]);        // pointsType
@@ -310,7 +305,7 @@ public class CatalogManager {
         }
     }
 
-    public TIntObjectMap<int[]> getFurnitureValues() {
+    public Int2ObjectMap<int[]> getFurnitureValues() {
         return this.furnitureValues;
     }
 
@@ -321,8 +316,8 @@ public class CatalogManager {
     private synchronized void loadLimitedNumbers() {
         this.limitedNumbers.clear();
 
-        THashMap<Integer, LinkedList<Integer>> limiteds = new THashMap<>();
-        TIntIntHashMap totals = new TIntIntHashMap();
+        Map<Integer, LinkedList<Integer>> limiteds = new HashMap<>();
+        Int2IntMap totals = new Int2IntOpenHashMap();
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM catalog_items_limited")) {
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
@@ -330,7 +325,8 @@ public class CatalogManager {
                         limiteds.put(set.getInt("catalog_item_id"), new LinkedList<>());
                     }
 
-                    totals.adjustOrPutValue(set.getInt("catalog_item_id"), 1, 1);
+                    int catalogItemId = set.getInt("catalog_item_id");
+                    totals.put(catalogItemId, totals.get(catalogItemId) + 1);
 
                     if (set.getInt("user_id") == 0) {
                         limiteds.get(set.getInt("catalog_item_id")).push(set.getInt("number"));
@@ -350,7 +346,7 @@ public class CatalogManager {
     private synchronized void loadCatalogPages() {
         this.catalogPages.clear();
 
-        final THashMap<Integer, CatalogPage> pages = new THashMap<>();
+        final Map<Integer, CatalogPage> pages = new HashMap<>();
         pages.put(-1, new CatalogRootLayout());
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM catalog_pages ORDER BY parent_id, id")) {
             try (ResultSet set = statement.executeQuery()) {
@@ -374,7 +370,7 @@ public class CatalogManager {
             LOGGER.error("Caught SQL exception", e);
         }
 
-        pages.forEachValue((object) -> {
+        for (CatalogPage object : pages.values()) {
             CatalogPage page = pages.get(object.parentId);
 
             if (page != null) {
@@ -386,8 +382,7 @@ public class CatalogManager {
                     LOGGER.info("Parent Page not found for {} (ID: {}, parent_id: {})", object.getPageName(), object.id, object.parentId);
                 }
             }
-            return true;
-        });
+        }
 
         this.catalogPages.putAll(pages);
 
@@ -397,7 +392,7 @@ public class CatalogManager {
     private synchronized void loadBuildersClubCatalogPages() {
         this.buildersClubCatalogPages.clear();
 
-        final THashMap<Integer, CatalogPage> pages = new THashMap<>();
+        final Map<Integer, CatalogPage> pages = new HashMap<>();
         pages.put(-1, new CatalogRootLayout());
 
         String query = "SELECT id, parent_id, caption, caption AS caption_save, page_layout, icon_color, icon_image, 1 AS min_rank, order_num, visible, enabled, '0' AS club_only, 'BUILDERS_CLUB' AS catalog_mode, page_headline, page_teaser, page_special, page_text1, page_text2, page_text_details, page_text_teaser, '' AS includes FROM catalog_pages_bc ORDER BY parent_id, id";
@@ -425,7 +420,7 @@ public class CatalogManager {
             LOGGER.error("Caught SQL exception", e);
         }
 
-        pages.forEachValue((object) -> {
+        for (CatalogPage object : pages.values()) {
             CatalogPage page = pages.get(object.parentId);
 
             if (page != null) {
@@ -437,8 +432,7 @@ public class CatalogManager {
                     LOGGER.info("Builders Club parent page not found for {} (ID: {}, parent_id: {})", object.getPageName(), object.id, object.parentId);
                 }
             }
-            return true;
-        });
+        }
 
         this.buildersClubCatalogPages.putAll(pages);
 
@@ -511,7 +505,7 @@ public class CatalogManager {
             LOGGER.error("Caught SQL exception", e);
         }
 
-        for (CatalogPage page : this.catalogPages.valueCollection()) {
+        for (CatalogPage page : this.catalogPages.values()) {
             for (Integer id : page.getIncluded()) {
                 CatalogPage p = this.catalogPages.get(id);
 
@@ -558,7 +552,7 @@ public class CatalogManager {
             LOGGER.error("Caught SQL exception", e);
         }
 
-        for (CatalogPage page : this.buildersClubCatalogPages.valueCollection()) {
+        for (CatalogPage page : this.buildersClubCatalogPages.values()) {
             for (Integer id : page.getIncluded()) {
                 CatalogPage includedPage = this.buildersClubCatalogPages.get(id);
 
@@ -626,7 +620,7 @@ public class CatalogManager {
 
                     if (item != null) {
                         if (this.prizes.get(set.getInt("rarity")) == null) {
-                            this.prizes.put(set.getInt("rarity"), new THashSet<>());
+                            this.prizes.put(set.getInt("rarity"), new HashSet<>());
                         }
 
                         this.prizes.get(set.getInt("rarity")).add(item);
@@ -772,13 +766,13 @@ public class CatalogManager {
     }
 
     public CatalogPage getCatalogPage(String captionSafe) {
-        return this.catalogPages.valueCollection().stream()
+        return this.catalogPages.values().stream()
                 .filter(p -> p != null && p.getPageName() != null && p.getPageName().equalsIgnoreCase(captionSafe))
                 .findAny().orElse(null);
     }
 
     public CatalogPage getCatalogPageByLayout(String layoutName) {
-        return this.catalogPages.valueCollection().stream()
+        return this.catalogPages.values().stream()
                 .filter(p -> p != null &&
                         p.isVisible() &&
                         p.isEnabled() &&
@@ -794,17 +788,15 @@ public class CatalogManager {
 
     public CatalogItem getCatalogItem(int id, CatalogPageType pageType) {
         final CatalogItem[] item = {null};
-        final TIntObjectMap<CatalogPage> pagesMap = this.getCatalogPagesMap(pageType);
+        final Int2ObjectMap<CatalogPage> pagesMap = this.getCatalogPagesMap(pageType);
 
         synchronized (pagesMap) {
-            pagesMap.forEachValue(new TObjectProcedure<CatalogPage>() {
-                @Override
-                public boolean execute(CatalogPage object) {
-                    item[0] = object.getCatalogItem(id);
-
-                    return item[0] == null;
+            for (CatalogPage object : pagesMap.values()) {
+                item[0] = object.getCatalogItem(id);
+                if (item[0] != null) {
+                    break;
                 }
-            });
+            }
         }
 
         return item[0];
@@ -817,34 +809,29 @@ public class CatalogManager {
 
     public List<CatalogPage> getCatalogPages(int parentId, final Habbo habbo, final CatalogPageType pageType) {
         final List<CatalogPage> pages = new ArrayList<>();
-        final TIntObjectMap<CatalogPage> pagesMap = this.getCatalogPagesMap(pageType);
+        final Int2ObjectMap<CatalogPage> pagesMap = this.getCatalogPagesMap(pageType);
         CatalogPage parentPage = pagesMap.get(parentId);
 
         if (parentPage == null) {
             return pages;
         }
 
-        parentPage.childPages.forEachValue(new TObjectProcedure<CatalogPage>() {
-            @Override
-            public boolean execute(CatalogPage object) {
+        for (CatalogPage object : parentPage.childPages.values()) {
+            boolean isVisiblePage = object.visible;
+            boolean hasRightRank = object.getRank() <= habbo.getHabboInfo().getRank().getId();
+            boolean clubRightsOkay = !object.isClubOnly() || habbo.getHabboInfo().getHabboStats().hasActiveClub();
+            boolean pageTypeMatches = (pageType == CatalogPageType.BUILDER) || object.getCatalogPageType().matches(pageType);
 
-                boolean isVisiblePage = object.visible;
-                boolean hasRightRank = object.getRank() <= habbo.getHabboInfo().getRank().getId();
-                boolean clubRightsOkay = !object.isClubOnly() || habbo.getHabboInfo().getHabboStats().hasActiveClub();
-                boolean pageTypeMatches = (pageType == CatalogPageType.BUILDER) || object.getCatalogPageType().matches(pageType);
-
-                if (isVisiblePage && hasRightRank && clubRightsOkay && pageTypeMatches) {
-                    pages.add(object);
-                }
-                return true;
+            if (isVisiblePage && hasRightRank && clubRightsOkay && pageTypeMatches) {
+                pages.add(object);
             }
-        });
+        }
         Collections.sort(pages);
 
         return pages;
     }
 
-    public TIntObjectMap<CatalogFeaturedPage> getCatalogFeaturedPages() {
+    public Int2ObjectMap<CatalogFeaturedPage> getCatalogFeaturedPages() {
         return this.catalogFeaturedPages;
     }
 
@@ -1009,12 +996,8 @@ public class CatalogManager {
 
 
     public void dispose() {
-        TIntObjectIterator<CatalogPage> pageIterator = this.catalogPages.iterator();
-
-        while (pageIterator.hasNext()) {
-            pageIterator.advance();
-
-            for (CatalogItem item : pageIterator.value().getCatalogItems().valueCollection()) {
+        for (CatalogPage page : this.catalogPages.values()) {
+            for (CatalogItem item : page.getCatalogItems().values()) {
                 item.run();
                 if (item.isLimited()) {
                     this.limitedNumbers.get(item.getId()).run();
@@ -1083,7 +1066,7 @@ public class CatalogManager {
                     }
                 }
 
-                THashSet<HabboItem> itemsList = new THashSet<>();
+                Set<HabboItem> itemsList = new HashSet<>();
 
 
                 if (amount > 1 && !CatalogItem.haveOffer(item)) {
@@ -1137,7 +1120,7 @@ public class CatalogManager {
                                     }
                                 }
 
-                                THashMap<String, String> data = new THashMap<>();
+                                Map<String, String> data = new HashMap<>();
 
                                 for (String s : item.getExtradata().split(";")) {
                                     if (s.contains(":")) {
@@ -1337,7 +1320,7 @@ public class CatalogManager {
                     Emulator.getThreading().run(badge);
                     habbo.getInventory().getBadgesComponent().addBadge(badge);
                     habbo.getClient().sendResponse(new AddUserBadgeComposer(badge));
-                    THashMap<String, String> keys = new THashMap<>();
+                    Map<String, String> keys = new HashMap<>();
                     keys.put("display", "BUBBLE");
                     keys.put("image", "${image.library.url}album1584/" + badge.getCode() + ".gif");
                     keys.put("message", Emulator.getTexts().getValue("commands.generic.cmd_badge.received"));
@@ -1351,7 +1334,7 @@ public class CatalogManager {
                 habbo.getClient().sendResponse(new PurchaseOKComposer(purchasedEvent.catalogItem));
                 habbo.getClient().sendResponse(new InventoryRefreshComposer());
 
-                THashSet<String> itemIds = new THashSet<>();
+                Set<String> itemIds = new HashSet<>();
 
                 for(HabboItem ix : purchasedEvent.itemsList) {
                     itemIds.add(ix.getId() + "");
@@ -1384,7 +1367,7 @@ public class CatalogManager {
         return this.getClubOffers(ClubOffer.WINDOW_HABBO_CLUB);
     }
 
-    public TIntObjectMap<CatalogPage> getCatalogPagesMap(CatalogPageType pageType) {
+    public Int2ObjectMap<CatalogPage> getCatalogPagesMap(CatalogPageType pageType) {
         return (pageType == CatalogPageType.BUILDER) ? this.buildersClubCatalogPages : this.catalogPages;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPage.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPage.java
@@ -2,24 +2,26 @@ package com.eu.habbo.habbohotel.catalog;
 
 import com.eu.habbo.messages.ISerialize;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.TCollections;
-import gnu.trove.list.array.TIntArrayList;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public abstract class CatalogPage implements Comparable<CatalogPage>, ISerialize {
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogPage.class);
 
-    protected final TIntArrayList offerIds = new TIntArrayList();
-    protected final THashMap<Integer, CatalogPage> childPages = new THashMap<>();
-    private final TIntObjectMap<CatalogItem> catalogItems = TCollections.synchronizedMap(new TIntObjectHashMap<>());
+    protected final IntList offerIds = new IntArrayList();
+    protected final Map<Integer, CatalogPage> childPages = new HashMap<>();
+    private final Int2ObjectMap<CatalogItem> catalogItems = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
     private final ArrayList<Integer> included = new ArrayList<>();
     protected int id;
     protected int parentId;
@@ -171,7 +173,7 @@ public abstract class CatalogPage implements Comparable<CatalogPage>, ISerialize
         return this.textTeaser;
     }
 
-    public TIntArrayList getOfferIds() {
+    public IntList getOfferIds() {
         return this.offerIds;
     }
 
@@ -183,7 +185,7 @@ public abstract class CatalogPage implements Comparable<CatalogPage>, ISerialize
         this.catalogItems.put(item.getId(), item);
     }
 
-    public TIntObjectMap<CatalogItem> getCatalogItems() {
+    public Int2ObjectMap<CatalogItem> getCatalogItems() {
         return this.catalogItems;
     }
 
@@ -195,7 +197,7 @@ public abstract class CatalogPage implements Comparable<CatalogPage>, ISerialize
         return this.included;
     }
 
-    public THashMap<Integer, CatalogPage> getChildPages() {
+    public Map<Integer, CatalogPage> getChildPages() {
         return this.childPages;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/layouts/FrontPageFeaturedLayout.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/layouts/FrontPageFeaturedLayout.java
@@ -38,7 +38,7 @@ public class FrontPageFeaturedLayout extends CatalogPage {
 
         message.appendInt(Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPages().size());
 
-        for (CatalogFeaturedPage page : Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPages().valueCollection()) {
+        for (CatalogFeaturedPage page : Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPages().values()) {
             page.serialize(message);
         }
         message.appendInt(1); //Position

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/layouts/RoomBundleLayout.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/layouts/RoomBundleLayout.java
@@ -198,7 +198,7 @@ public class RoomBundleLayout extends SingleBundle {
                     synchronized (this.room.getCurrentBots()) {
                         statement.setInt(1, userId);
                         statement.setInt(2, roomId);
-                        for (Bot bot : this.room.getCurrentBots().valueCollection()) {
+                        for (Bot bot : this.room.getCurrentBots().values()) {
                             statement.setString(3, bot.getName());
                             statement.setString(4, bot.getMotto());
                             statement.setString(5, bot.getFigure());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/layouts/RoomBundleLayout.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/layouts/RoomBundleLayout.java
@@ -11,13 +11,12 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.navigator.CanCreateRoomComposer;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.procedure.TObjectProcedure;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.*;
+import java.util.HashMap;
 import java.util.Map;
 
 public class RoomBundleLayout extends SingleBundle {
@@ -35,7 +34,7 @@ public class RoomBundleLayout extends SingleBundle {
     }
 
     @Override
-    public TIntObjectMap<CatalogItem> getCatalogItems() {
+    public Int2ObjectMap<CatalogItem> getCatalogItems() {
         if (Emulator.getIntUnixTimestamp() - this.lastUpdate < 120) {
             this.lastUpdate = Emulator.getIntUnixTimestamp();
             return super.getCatalogItems();
@@ -62,16 +61,12 @@ public class RoomBundleLayout extends SingleBundle {
 
         final CatalogItem[] item = {null};
 
-        super.getCatalogItems().forEachValue(new TObjectProcedure<CatalogItem>() {
-            @Override
-            public boolean execute(CatalogItem object) {
-                if (object == null)
-                    return true;
-
+        for (CatalogItem object : super.getCatalogItems().values()) {
+            if (object != null) {
                 item[0] = object;
-                return false;
+                break;
             }
-        });
+        }
 
         if (this.room.isPreLoaded()) {
             this.room.loadData();
@@ -81,10 +76,10 @@ public class RoomBundleLayout extends SingleBundle {
         if (item[0] != null) {
             item[0].getBundle().clear();
 
-            THashMap<Item, Integer> items = new THashMap<>();
+            Map<Item, Integer> items = new HashMap<>();
 
             for (HabboItem i : this.room.getFloorItems()) {
-                if (!items.contains(i.getBaseItem())) {
+                if (!items.containsKey(i.getBaseItem())) {
                     items.put(i.getBaseItem(), 0);
                 }
 
@@ -92,7 +87,7 @@ public class RoomBundleLayout extends SingleBundle {
             }
 
             for (HabboItem i : this.room.getWallItems()) {
-                if (!items.contains(i.getBaseItem())) {
+                if (!items.containsKey(i.getBaseItem())) {
                     items.put(i.getBaseItem(), 0);
                 }
 
@@ -238,7 +233,7 @@ public class RoomBundleLayout extends SingleBundle {
         r.setFloorPaint(this.room.getFloorPaint());
         r.setScore(0);
         r.setNeedsUpdate(true);
-        THashMap<String, String> keys = new THashMap<>();
+        Map<String, String> keys = new HashMap<>();
         keys.put("ROOMNAME", r.getName());
         keys.put("ROOMID", r.getId() + "");
         keys.put("OWNER", r.getOwnerName());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlace.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlace.java
@@ -14,7 +14,6 @@ import com.eu.habbo.messages.outgoing.inventory.RemoveHabboItemComposer;
 import com.eu.habbo.plugin.events.marketplace.MarketPlaceItemCancelledEvent;
 import com.eu.habbo.plugin.events.marketplace.MarketPlaceItemOfferedEvent;
 import com.eu.habbo.plugin.events.marketplace.MarketPlaceItemSoldEvent;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +22,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 
 public class MarketPlace {
@@ -38,8 +39,8 @@ public class MarketPlace {
     public static int MARKETPLACE_CURRENCY = 0;
 
 
-    public static THashSet<MarketPlaceOffer> getOwnOffers(Habbo habbo) {
-        THashSet<MarketPlaceOffer> offers = new THashSet<>();
+    public static Set<MarketPlaceOffer> getOwnOffers(Habbo habbo) {
+        Set<MarketPlaceOffer> offers = new HashSet<>();
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT items_base.type AS type, items.item_id AS base_item_id, items.limited_data AS ltd_data, marketplace_items.* FROM marketplace_items INNER JOIN items ON marketplace_items.item_id = items.id INNER JOIN items_base ON items.item_id = items_base.id WHERE marketplace_items.user_id = ?")) {
             statement.setInt(1, habbo.getHabboInfo().getId());
             try (ResultSet set = statement.executeQuery()) {
@@ -408,7 +409,7 @@ public class MarketPlace {
     public static void getCredits(GameClient client) {
         int credits = 0;
 
-        THashSet<MarketPlaceOffer> offers = new THashSet<>();
+        Set<MarketPlaceOffer> offers = new HashSet<>();
         offers.addAll(client.getHabbo().getInventory().getMarketplaceItems());
 
         synchronized (client.getHabbo().getInventory()) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/BotsCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/BotsCommand.java
@@ -14,7 +14,7 @@ public class BotsCommand extends Command {
         if (gameClient.getHabbo().getHabboInfo().getCurrentRoom() == null || !gameClient.getHabbo().getHabboInfo().getCurrentRoom().hasRights(gameClient.getHabbo()))
             return false;
 
-        StringBuilder data = new StringBuilder(Emulator.getTexts().getValue("total") + ": " + gameClient.getHabbo().getHabboInfo().getCurrentRoom().getCurrentBots().values().length);
+        StringBuilder data = new StringBuilder(Emulator.getTexts().getValue("total") + ": " + gameClient.getHabbo().getHabboInfo().getCurrentRoom().getCurrentBots().values().size());
 
         for (Object bot : gameClient.getHabbo().getHabboInfo().getCurrentRoom().getCurrentBots().values()) {
             if (bot instanceof Bot) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandHandler.java
@@ -114,7 +114,7 @@ public class CommandHandler {
                     if (room.getCurrentPets().isEmpty())
                         return false;
 
-                    for (Pet pet : room.getCurrentPets().valueCollection()) {
+                    for (Pet pet : room.getCurrentPets().values()) {
                         if (pet != null) {
                             if (pet.getName().equalsIgnoreCase(args[0])) {
                                 StringBuilder s = new StringBuilder();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandHandler.java
@@ -14,22 +14,20 @@ import com.eu.habbo.habbohotel.rooms.RoomRightLevels;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserTypingComposer;
 import com.eu.habbo.plugin.events.users.UserCommandEvent;
 import com.eu.habbo.plugin.events.users.UserExecuteCommandEvent;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 public class CommandHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CommandHandler.class);
 
-    private final static THashMap<String, Command> commands = new THashMap<>(5);
+    private final static Map<String, Command> commands = new HashMap<>(5);
     private static final Comparator<Command> ALPHABETICAL_ORDER = new Comparator<Command>() {
         public int compare(Command c1, Command c2) {
             int res = String.CASE_INSENSITIVE_ORDER.compare(c1.permission, c2.permission);
@@ -116,17 +114,7 @@ public class CommandHandler {
                     if (room.getCurrentPets().isEmpty())
                         return false;
 
-                    TIntObjectIterator<Pet> petIterator = room.getCurrentPets().iterator();
-
-                    for (int j = room.getCurrentPets().size(); j-- > 0; ) {
-                        try {
-                            petIterator.advance();
-                        } catch (NoSuchElementException e) {
-                            break;
-                        }
-
-                        Pet pet = petIterator.value();
-
+                    for (Pet pet : room.getCurrentPets().valueCollection()) {
                         if (pet != null) {
                             if (pet.getName().equalsIgnoreCase(args[0])) {
                                 StringBuilder s = new StringBuilder();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandHandler.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 public class CommandHandler {
@@ -310,13 +311,13 @@ public class CommandHandler {
     public List<Command> getCommandsForRank(int rankId) {
         List<Command> allowedCommands = new ArrayList<>();
         if (Emulator.getGameEnvironment().getPermissionsManager().rankExists(rankId)) {
-            THashMap<String, Permission> permissions = Emulator.getGameEnvironment().getPermissionsManager().getRank(rankId).getPermissions();
+            Map<String, Permission> permissions = Emulator.getGameEnvironment().getPermissionsManager().getRank(rankId).getPermissions();
 
             for (Command command : commands.values()) {
                 if (allowedCommands.contains(command))
                     continue;
 
-                if (permissions.contains(command.permission) && permissions.get(command.permission).setting != PermissionSetting.DISALLOWED) {
+                if (permissions.containsKey(command.permission) && permissions.get(command.permission).setting != PermissionSetting.DISALLOWED) {
                     allowedCommands.add(command);
                 }
             }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EmptyBotsInventoryCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EmptyBotsInventoryCommand.java
@@ -8,7 +8,9 @@ import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.inventory.InventoryBotsComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
-import gnu.trove.map.hash.TIntObjectHashMap;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class EmptyBotsInventoryCommand extends Command {
     public EmptyBotsInventoryCommand() {
@@ -34,13 +36,9 @@ public class EmptyBotsInventoryCommand extends Command {
             Habbo habbo = (params.length == 3 && gameClient.getHabbo().hasPermission(Permission.ACC_EMPTY_OTHERS)) ? Emulator.getGameEnvironment().getHabboManager().getHabbo(params[2]) : gameClient.getHabbo();
 
             if (habbo != null) {
-                TIntObjectHashMap<Bot> bots = new TIntObjectHashMap<>();
-                bots.putAll(habbo.getInventory().getBotsComponent().getBots());
+                List<Bot> bots = new ArrayList<>(habbo.getInventory().getBotsComponent().getBots().values());
                 habbo.getInventory().getBotsComponent().getBots().clear();
-                bots.forEachValue(object -> {
-                    Emulator.getGameEnvironment().getBotManager().deleteBot(object);
-                    return true;
-                });
+                bots.forEach(object -> Emulator.getGameEnvironment().getBotManager().deleteBot(object));
 
                 habbo.getClient().sendResponse(new InventoryRefreshComposer());
                 habbo.getClient().sendResponse(new InventoryBotsComposer(habbo));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EmptyInventoryCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EmptyInventoryCommand.java
@@ -9,8 +9,9 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.outgoing.inventory.InventoryItemsComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.threading.runnables.QueryDeleteHabboItems;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class EmptyInventoryCommand extends Command {
     public EmptyInventoryCommand() {
@@ -36,8 +37,7 @@ public class EmptyInventoryCommand extends Command {
             Habbo habbo = (params.length == 3 && gameClient.getHabbo().hasPermission(Permission.ACC_EMPTY_OTHERS)) ? Emulator.getGameEnvironment().getHabboManager().getHabbo(params[2]) : gameClient.getHabbo();
 
             if (habbo != null) {
-                TIntObjectMap<HabboItem> items = new TIntObjectHashMap<>();
-                items.putAll(habbo.getInventory().getItemsComponent().getItems());
+                List<HabboItem> items = new ArrayList<>(habbo.getInventory().getItemsComponent().getItems().valueCollection());
                 habbo.getInventory().getItemsComponent().getItems().clear();
                 Emulator.getThreading().run(new QueryDeleteHabboItems(items));
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EmptyInventoryCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EmptyInventoryCommand.java
@@ -37,7 +37,7 @@ public class EmptyInventoryCommand extends Command {
             Habbo habbo = (params.length == 3 && gameClient.getHabbo().hasPermission(Permission.ACC_EMPTY_OTHERS)) ? Emulator.getGameEnvironment().getHabboManager().getHabbo(params[2]) : gameClient.getHabbo();
 
             if (habbo != null) {
-                List<HabboItem> items = new ArrayList<>(habbo.getInventory().getItemsComponent().getItems().valueCollection());
+                List<HabboItem> items = new ArrayList<>(habbo.getInventory().getItemsComponent().getItems().values());
                 habbo.getInventory().getItemsComponent().getItems().clear();
                 Emulator.getThreading().run(new QueryDeleteHabboItems(items));
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EmptyPetsInventoryCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EmptyPetsInventoryCommand.java
@@ -8,7 +8,9 @@ import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.inventory.InventoryPetsComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
-import gnu.trove.map.hash.TIntObjectHashMap;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class EmptyPetsInventoryCommand extends Command {
     public EmptyPetsInventoryCommand() {
@@ -34,13 +36,9 @@ public class EmptyPetsInventoryCommand extends Command {
             Habbo habbo = (params.length == 3 && gameClient.getHabbo().hasPermission(Permission.ACC_EMPTY_OTHERS)) ? Emulator.getGameEnvironment().getHabboManager().getHabbo(params[2]) : gameClient.getHabbo();
 
             if (habbo != null) {
-                TIntObjectHashMap<Pet> pets = new TIntObjectHashMap<>();
-                pets.putAll(habbo.getInventory().getPetsComponent().getPets());
+                List<Pet> pets = new ArrayList<>(habbo.getInventory().getPetsComponent().getPets().valueCollection());
                 habbo.getInventory().getPetsComponent().getPets().clear();
-                pets.forEachValue(object -> {
-                    Emulator.getGameEnvironment().getPetManager().deletePet(object);
-                    return true;
-                });
+                pets.forEach(object -> Emulator.getGameEnvironment().getPetManager().deletePet(object));
 
                 habbo.getClient().sendResponse(new InventoryRefreshComposer());
                 habbo.getClient().sendResponse(new InventoryPetsComposer(habbo));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EmptyPetsInventoryCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EmptyPetsInventoryCommand.java
@@ -36,7 +36,7 @@ public class EmptyPetsInventoryCommand extends Command {
             Habbo habbo = (params.length == 3 && gameClient.getHabbo().hasPermission(Permission.ACC_EMPTY_OTHERS)) ? Emulator.getGameEnvironment().getHabboManager().getHabbo(params[2]) : gameClient.getHabbo();
 
             if (habbo != null) {
-                List<Pet> pets = new ArrayList<>(habbo.getInventory().getPetsComponent().getPets().valueCollection());
+                List<Pet> pets = new ArrayList<>(habbo.getInventory().getPetsComponent().getPets().values());
                 habbo.getInventory().getPetsComponent().getPets().clear();
                 pets.forEach(object -> Emulator.getGameEnvironment().getPetManager().deletePet(object));
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EventCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EventCommand.java
@@ -5,8 +5,8 @@ import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
-import gnu.trove.map.hash.THashMap;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class EventCommand extends Command {
@@ -25,7 +25,7 @@ public class EventCommand extends Command {
                     message.append(" ");
                 }
 
-                THashMap<String, String> codes = new THashMap<>();
+                Map<String, String> codes = new HashMap<>();
                 codes.put("ROOMNAME", gameClient.getHabbo().getHabboInfo().getCurrentRoom().getName());
                 codes.put("ROOMID", gameClient.getHabbo().getHabboInfo().getCurrentRoom().getId() + "");
                 codes.put("USERNAME", gameClient.getHabbo().getHabboInfo().getUsername());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/GiftCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/GiftCommand.java
@@ -11,7 +11,9 @@ import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
-import gnu.trove.map.hash.THashMap;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class GiftCommand extends Command {
     public GiftCommand() {
@@ -76,7 +78,7 @@ public class GiftCommand extends Command {
             if (habbo != null) {
                 habbo.getClient().sendResponse(new InventoryRefreshComposer());
 
-                THashMap<String, String> keys = new THashMap<>();
+                Map<String, String> keys = new HashMap<>();
                 keys.put("display", "BUBBLE");
                 keys.put("image", "${image.library.url}notifications/gift.gif");
                 keys.put("message", Emulator.getTexts().getValue("generic.gift.received.anonymous"));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/MassBadgeCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/MassBadgeCommand.java
@@ -10,8 +10,8 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.users.AddUserBadgeComposer;
-import gnu.trove.map.hash.THashMap;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class MassBadgeCommand extends Command {
@@ -27,7 +27,7 @@ public class MassBadgeCommand extends Command {
             badge = params[1];
 
             if (!badge.isEmpty()) {
-                THashMap<String, String> keys = new THashMap<>();
+                Map<String, String> keys = new HashMap<>();
                 keys.put("display", "BUBBLE");
                 keys.put("image", "${image.library.url}album1584/" + badge + ".gif");
                 keys.put("message", Emulator.getTexts().getValue("commands.generic.cmd_badge.received"));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/MassGiftCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/MassGiftCommand.java
@@ -10,8 +10,8 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
-import gnu.trove.map.hash.THashMap;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class MassGiftCommand extends Command {
@@ -53,7 +53,7 @@ public class MassGiftCommand extends Command {
 
             final String finalMessage = message.toString();
 
-            THashMap<String, String> keys = new THashMap<>();
+            Map<String, String> keys = new HashMap<>();
             keys.put("display", "BUBBLE");
             keys.put("image", "${image.library.url}notifications/gift.gif");
             keys.put("message", Emulator.getTexts().getValue("generic.gift.received.anonymous"));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/PetInfoCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/PetInfoCommand.java
@@ -5,7 +5,6 @@ import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.pets.Pet;
 import com.eu.habbo.habbohotel.pets.PetManager;
 import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
-import gnu.trove.procedure.TIntObjectProcedure;
 
 public class PetInfoCommand extends Command {
     public PetInfoCommand() {
@@ -20,31 +19,26 @@ public class PetInfoCommand extends Command {
 
             String name = params[1];
 
-            gameClient.getHabbo().getHabboInfo().getCurrentRoom().getCurrentPets().forEachEntry(new TIntObjectProcedure<Pet>() {
-                @Override
-                public boolean execute(int a, Pet pet) {
-                    if (pet.getName().equalsIgnoreCase(name)) {
-                        gameClient.getHabbo().alert("" +
-                                Emulator.getTexts().getValue("commands.generic.cmd_pet_info.title") + ": " + pet.getName() + "\r\n" +
-                                Emulator.getTexts().getValue("generic.pet.id") + ": " + pet.getId() + "\r" +
-                                Emulator.getTexts().getValue("generic.pet.name") + ": " + pet.getName() + "\r" +
-                                Emulator.getTexts().getValue("generic.pet.age") + ": " + pet.daysAlive() + " " + Emulator.getTexts().getValue("generic.pet.days.alive") + "\r" +
-                                Emulator.getTexts().getValue("generic.pet.level") + ": " + pet.getLevel() + "\r" +
-                                "\r" +
-                                Emulator.getTexts().getValue("commands.generic.cmd_pet_info.stats") + "\r\n" +
-                                Emulator.getTexts().getValue("generic.pet.scratches") + ": " + pet.getRespect() + "\r" +
-                                Emulator.getTexts().getValue("generic.pet.energy") + ": " + pet.getEnergy() + "/" + PetManager.maxEnergy(pet.getLevel()) + "\r" +
-                                Emulator.getTexts().getValue("generic.pet.happiness") + ": " + pet.getHappiness() + "\r" +
-                                Emulator.getTexts().getValue("generic.pet.level.thirst") + ": " + pet.levelThirst + "\r" +
-                                Emulator.getTexts().getValue("generic.pet.level.hunger") + ": " + pet.levelHunger + "\r" +
-                                Emulator.getTexts().getValue("generic.pet.current_action") + ": " + (pet.getTask() == null ? Emulator.getTexts().getValue("generic.nothing") : pet.getTask().name()) + "\r" +
-                                Emulator.getTexts().getValue("generic.can.walk") + ": " + (pet.getRoomUnit().canWalk() ? Emulator.getTexts().getValue("generic.yes") : Emulator.getTexts().getValue("generic.no")) + ""
-                        );
-                    }
-
-                    return true;
+            for (Pet pet : gameClient.getHabbo().getHabboInfo().getCurrentRoom().getCurrentPets().valueCollection()) {
+                if (pet.getName().equalsIgnoreCase(name)) {
+                    gameClient.getHabbo().alert("" +
+                            Emulator.getTexts().getValue("commands.generic.cmd_pet_info.title") + ": " + pet.getName() + "\r\n" +
+                            Emulator.getTexts().getValue("generic.pet.id") + ": " + pet.getId() + "\r" +
+                            Emulator.getTexts().getValue("generic.pet.name") + ": " + pet.getName() + "\r" +
+                            Emulator.getTexts().getValue("generic.pet.age") + ": " + pet.daysAlive() + " " + Emulator.getTexts().getValue("generic.pet.days.alive") + "\r" +
+                            Emulator.getTexts().getValue("generic.pet.level") + ": " + pet.getLevel() + "\r" +
+                            "\r" +
+                            Emulator.getTexts().getValue("commands.generic.cmd_pet_info.stats") + "\r\n" +
+                            Emulator.getTexts().getValue("generic.pet.scratches") + ": " + pet.getRespect() + "\r" +
+                            Emulator.getTexts().getValue("generic.pet.energy") + ": " + pet.getEnergy() + "/" + PetManager.maxEnergy(pet.getLevel()) + "\r" +
+                            Emulator.getTexts().getValue("generic.pet.happiness") + ": " + pet.getHappiness() + "\r" +
+                            Emulator.getTexts().getValue("generic.pet.level.thirst") + ": " + pet.levelThirst + "\r" +
+                            Emulator.getTexts().getValue("generic.pet.level.hunger") + ": " + pet.levelHunger + "\r" +
+                            Emulator.getTexts().getValue("generic.pet.current_action") + ": " + (pet.getTask() == null ? Emulator.getTexts().getValue("generic.nothing") : pet.getTask().name()) + "\r" +
+                            Emulator.getTexts().getValue("generic.can.walk") + ": " + (pet.getRoomUnit().canWalk() ? Emulator.getTexts().getValue("generic.yes") : Emulator.getTexts().getValue("generic.no")) + ""
+                    );
                 }
-            });
+            }
         } else {
             gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_pet_info.pet_not_found"), RoomChatMessageBubbles.ALERT);
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/PetInfoCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/PetInfoCommand.java
@@ -19,7 +19,7 @@ public class PetInfoCommand extends Command {
 
             String name = params[1];
 
-            for (Pet pet : gameClient.getHabbo().getHabboInfo().getCurrentRoom().getCurrentPets().valueCollection()) {
+            for (Pet pet : gameClient.getHabbo().getHabboInfo().getCurrentRoom().getCurrentPets().values()) {
                 if (pet.getName().equalsIgnoreCase(name)) {
                     gameClient.getHabbo().alert("" +
                             Emulator.getTexts().getValue("commands.generic.cmd_pet_info.title") + ": " + pet.getName() + "\r\n" +

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/PromoteTargetOfferCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/PromoteTargetOfferCommand.java
@@ -6,10 +6,10 @@ import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.catalog.TargetedOfferComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.MessagesForYouComposer;
-import gnu.trove.map.hash.THashMap;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class PromoteTargetOfferCommand extends Command {
 
@@ -27,7 +27,7 @@ public class PromoteTargetOfferCommand extends Command {
         String offerKey = params[1];
 
         if (offerKey.equalsIgnoreCase(Emulator.getTexts().getValue("commands.cmd_promote_offer.info"))) {
-            THashMap<Integer, TargetOffer> targetOffers = Emulator.getGameEnvironment().getCatalogManager().targetOffers;
+            Map<Integer, TargetOffer> targetOffers = Emulator.getGameEnvironment().getCatalogManager().targetOffers;
             String[] textConfig = Emulator.getTexts().getValue("commands.cmd_promote_offer.list").replace("%amount%", targetOffers.size() + "").split("<br>");
 
             String entryConfig = Emulator.getTexts().getValue("commands.cmd_promote_offer.list.entry");

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/RedeemCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/RedeemCommand.java
@@ -6,12 +6,11 @@ import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.threading.runnables.QueryDeleteHabboItems;
-import gnu.trove.map.TIntIntMap;
-import gnu.trove.map.hash.TIntIntHashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
-import gnu.trove.procedure.TIntIntProcedure;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class RedeemCommand extends Command {
     public RedeemCommand() {
@@ -22,12 +21,12 @@ public class RedeemCommand extends Command {
     public boolean handle(final GameClient gameClient, String[] params) throws Exception {
         if (gameClient.getHabbo().getHabboInfo().getCurrentRoom().getActiveTradeForHabbo(gameClient.getHabbo()) != null)
             return false;
-        ArrayList<HabboItem> items = new ArrayList<>();
+        List<HabboItem> items = new ArrayList<>();
 
         int credits = 0;
         int pixels = 0;
 
-        TIntIntMap points = new TIntIntHashMap();
+        Map<Integer, Integer> points = new HashMap<>();
 
         for (HabboItem item : gameClient.getHabbo().getInventory().getItemsComponent().getItemsAsValueCollection()) {
             if (item.getBaseItem().getName().startsWith("CF_") || item.getBaseItem().getName().startsWith("CFC_") || item.getBaseItem().getName().startsWith("DF_") || item.getBaseItem().getName().startsWith("PF_")) {
@@ -75,10 +74,10 @@ public class RedeemCommand extends Command {
             }
         }
 
-        TIntObjectHashMap<HabboItem> deleted = new TIntObjectHashMap<>();
+        List<HabboItem> deleted = new ArrayList<>();
         for (HabboItem item : items) {
             gameClient.getHabbo().getInventory().getItemsComponent().removeHabboItem(item);
-            deleted.put(item.getId(), item);
+            deleted.add(item);
         }
 
         Emulator.getThreading().run(new QueryDeleteHabboItems(deleted));
@@ -98,14 +97,10 @@ public class RedeemCommand extends Command {
         }
 
         if (!points.isEmpty()) {
-            points.forEachEntry(new TIntIntProcedure() {
-                @Override
-                public boolean execute(int a, int b) {
-                    gameClient.getHabbo().givePoints(a, b);
-                    message[0] += " ," + Emulator.getTexts().getValue("seasonal.name." + a) + ": " + b;
-                    return true;
-                }
-            });
+            for (Map.Entry<Integer, Integer> entry : points.entrySet()) {
+                gameClient.getHabbo().givePoints(entry.getKey(), entry.getValue());
+                message[0] += " ," + Emulator.getTexts().getValue("seasonal.name." + entry.getKey()) + ": " + entry.getValue();
+            }
         }
 
         gameClient.getHabbo().whisper(message[0], RoomChatMessageBubbles.ALERT);
@@ -139,8 +134,8 @@ public class RedeemCommand extends Command {
         }
     }
 
-    static boolean addRedeemPoints(TIntIntMap points, int pointsType, int amount) {
-        int current = points.get(pointsType);
+    static boolean addRedeemPoints(Map<Integer, Integer> points, int pointsType, int amount) {
+        int current = points.getOrDefault(pointsType, 0);
         Integer total = addRedeemValue(current, amount);
         if (total == null) {
             return false;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/RoomBadgeCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/RoomBadgeCommand.java
@@ -10,7 +10,9 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.users.AddUserBadgeComposer;
-import gnu.trove.map.hash.THashMap;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class RoomBadgeCommand extends Command {
     public RoomBadgeCommand() {
@@ -28,7 +30,7 @@ public class RoomBadgeCommand extends Command {
             badge = params[1];
 
             if (!badge.isEmpty()) {
-                THashMap<String, String> keys = new THashMap<>();
+                Map<String, String> keys = new HashMap<>();
                 keys.put("display", "BUBBLE");
                 keys.put("image", "${image.library.url}album1584/" + badge + ".gif");
                 keys.put("message", Emulator.getTexts().getValue("commands.generic.cmd_badge.received"));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/UserInfoCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/UserInfoCommand.java
@@ -8,7 +8,6 @@ import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboInfo;
 import com.eu.habbo.habbohotel.users.HabboManager;
-import gnu.trove.iterator.TIntIntIterator;
 
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -59,17 +58,10 @@ public class UserInfoCommand extends Command {
 
         message.append("<b>").append(Emulator.getTexts().getValue("command.cmd_userinfo.currencies")).append("</b>\r");
         message.append(Emulator.getTexts().getValue("command.cmd_userinfo.credits")).append(": ").append(habbo.getCredits()).append("\r");
-        TIntIntIterator iterator = habbo.getCurrencies().iterator();
-
-        for (int i = habbo.getCurrencies().size(); i-- > 0; ) {
-            try {
-                iterator.advance();
-            } catch (Exception e) {
-                break;
-            }
-
-            message.append(Emulator.getTexts().getValue("seasonal.name." + iterator.key())).append(": ").append(iterator.value()).append("\r");
-        }
+        habbo.getCurrencies().forEachEntry((type, amount) -> {
+            message.append(Emulator.getTexts().getValue("seasonal.name." + type)).append(": ").append(amount).append("\r");
+            return true;
+        });
         message.append("\r").append(onlineHabbo != null ? "<b>" + Emulator.getTexts().getValue("command.cmd_userinfo.current_activity") + "</b>\r" : "").append(onlineHabbo != null ? Emulator.getTexts().getValue("command.cmd_userinfo.room") + ": " + (onlineHabbo.getHabboInfo().getCurrentRoom() != null ? onlineHabbo.getHabboInfo().getCurrentRoom().getName() + "(" + onlineHabbo.getHabboInfo().getCurrentRoom().getId() + ")\r" : "-") : "").append(onlineHabbo != null ? Emulator.getTexts().getValue("command.cmd_userinfo.respect_left") + ": " + onlineHabbo.getHabboStats().respectPointsToGive + "\r" : "").append(onlineHabbo != null ? Emulator.getTexts().getValue("command.cmd_userinfo.pet_respect_left") + ": " + onlineHabbo.getHabboStats().petRespectPointsToGive + "\r" : "").append(onlineHabbo != null ? Emulator.getTexts().getValue("command.cmd_userinfo.allow_trade") + ": " + ((onlineHabbo.getHabboStats().allowTrade()) ? Emulator.getTexts().getValue("generic.yes") : Emulator.getTexts().getValue("generic.no")) + "\r" : "").append(onlineHabbo != null ? Emulator.getTexts().getValue("command.cmd_userinfo.allow_follow") + ": " + ((onlineHabbo.getHabboStats().blockFollowing) ? Emulator.getTexts().getValue("generic.no") : Emulator.getTexts().getValue("generic.yes")) + "\r" : "").append(onlineHabbo != null ? Emulator.getTexts().getValue("command.cmd_userinfo.allow_friend_request") + ": " + ((onlineHabbo.getHabboStats().blockFriendRequests) ? Emulator.getTexts().getValue("generic.no") : Emulator.getTexts().getValue("generic.yes")) + "\r" : "");
 
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/UserInfoCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/UserInfoCommand.java
@@ -58,10 +58,8 @@ public class UserInfoCommand extends Command {
 
         message.append("<b>").append(Emulator.getTexts().getValue("command.cmd_userinfo.currencies")).append("</b>\r");
         message.append(Emulator.getTexts().getValue("command.cmd_userinfo.credits")).append(": ").append(habbo.getCredits()).append("\r");
-        habbo.getCurrencies().forEachEntry((type, amount) -> {
-            message.append(Emulator.getTexts().getValue("seasonal.name." + type)).append(": ").append(amount).append("\r");
-            return true;
-        });
+        habbo.getCurrencies().int2IntEntrySet().forEach(entry ->
+                message.append(Emulator.getTexts().getValue("seasonal.name." + entry.getIntKey())).append(": ").append(entry.getIntValue()).append("\r"));
         message.append("\r").append(onlineHabbo != null ? "<b>" + Emulator.getTexts().getValue("command.cmd_userinfo.current_activity") + "</b>\r" : "").append(onlineHabbo != null ? Emulator.getTexts().getValue("command.cmd_userinfo.room") + ": " + (onlineHabbo.getHabboInfo().getCurrentRoom() != null ? onlineHabbo.getHabboInfo().getCurrentRoom().getName() + "(" + onlineHabbo.getHabboInfo().getCurrentRoom().getId() + ")\r" : "-") : "").append(onlineHabbo != null ? Emulator.getTexts().getValue("command.cmd_userinfo.respect_left") + ": " + onlineHabbo.getHabboStats().respectPointsToGive + "\r" : "").append(onlineHabbo != null ? Emulator.getTexts().getValue("command.cmd_userinfo.pet_respect_left") + ": " + onlineHabbo.getHabboStats().petRespectPointsToGive + "\r" : "").append(onlineHabbo != null ? Emulator.getTexts().getValue("command.cmd_userinfo.allow_trade") + ": " + ((onlineHabbo.getHabboStats().allowTrade()) ? Emulator.getTexts().getValue("generic.yes") : Emulator.getTexts().getValue("generic.no")) + "\r" : "").append(onlineHabbo != null ? Emulator.getTexts().getValue("command.cmd_userinfo.allow_follow") + ": " + ((onlineHabbo.getHabboStats().blockFollowing) ? Emulator.getTexts().getValue("generic.no") : Emulator.getTexts().getValue("generic.yes")) + "\r" : "").append(onlineHabbo != null ? Emulator.getTexts().getValue("command.cmd_userinfo.allow_friend_request") + ": " + ((onlineHabbo.getHabboStats().blockFriendRequests) ? Emulator.getTexts().getValue("generic.no") : Emulator.getTexts().getValue("generic.yes")) + "\r" : "");
 
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/crafting/CraftingAltar.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/crafting/CraftingAltar.java
@@ -2,24 +2,25 @@ package com.eu.habbo.habbohotel.crafting;
 
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.users.Habbo;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class CraftingAltar {
     private final Item baseItem;
-    private final THashSet<Item> ingredients;
-    private final THashMap<Integer, CraftingRecipe> recipes;
+    private final Set<Item> ingredients;
+    private final Map<Integer, CraftingRecipe> recipes;
 
     public CraftingAltar(Item baseItem) {
         this.baseItem = baseItem;
 
-        this.ingredients = new THashSet<>(1);
-        this.recipes = new THashMap<>(1);
+        this.ingredients = new HashSet<>(1);
+        this.recipes = new HashMap<>(1);
     }
 
     public void addIngredient(Item item) {
@@ -31,7 +32,7 @@ public class CraftingAltar {
     }
 
     public Map<CraftingRecipe, Boolean> matchRecipes(Map<Item, Integer> amountMap) {
-        THashMap<CraftingRecipe, Boolean> foundRecepies = new THashMap<>(Math.max(1, this.recipes.size() / 3));
+        Map<CraftingRecipe, Boolean> foundRecepies = new HashMap<>(Math.max(1, this.recipes.size() / 3));
 
         for (Map.Entry<Integer, CraftingRecipe> set : this.recipes.entrySet()) {
             boolean contains = true;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/crafting/CraftingManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/crafting/CraftingManager.java
@@ -2,8 +2,6 @@ package com.eu.habbo.habbohotel.crafting;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.items.Item;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.procedure.TObjectProcedure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,14 +9,16 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class CraftingManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(CraftingManager.class);
 
-    private final THashMap<Item, CraftingAltar> altars;
+    private final Map<Item, CraftingAltar> altars;
 
     public CraftingManager() {
-        this.altars = new THashMap<>();
+        this.altars = new HashMap<>();
 
         this.reload();
     }
@@ -71,16 +71,11 @@ public class CraftingManager {
         final int[] i = {0};
 
         synchronized (this.altars) {
-            this.altars.forEachValue(new TObjectProcedure<CraftingAltar>() {
-                @Override
-                public boolean execute(CraftingAltar altar) {
-                    if (altar.hasIngredient(item)) {
-                        i[0]++;
-                    }
-
-                    return true;
+            for (CraftingAltar altar : this.altars.values()) {
+                if (altar.hasIngredient(item)) {
+                    i[0]++;
                 }
-            });
+            }
         }
 
         return i[0];

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/crafting/CraftingRecipe.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/crafting/CraftingRecipe.java
@@ -2,10 +2,11 @@ package com.eu.habbo.habbohotel.crafting;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.items.Item;
-import gnu.trove.map.hash.THashMap;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class CraftingRecipe {
     private final int id;
@@ -14,7 +15,7 @@ public class CraftingRecipe {
     private final boolean secret;
     private final String achievement;
     private final boolean limited;
-    private final THashMap<Item, Integer> ingredients;
+    private final Map<Item, Integer> ingredients;
     private int remaining;
 
     public CraftingRecipe(ResultSet set) throws SQLException {
@@ -26,7 +27,7 @@ public class CraftingRecipe {
         this.limited = set.getString("limited").equals("1");
         this.remaining = set.getInt("remaining");
 
-        this.ingredients = new THashMap<>();
+        this.ingredients = new HashMap<>();
     }
 
     public boolean canBeCrafted() {
@@ -78,7 +79,7 @@ public class CraftingRecipe {
         return this.limited;
     }
 
-    public THashMap<Item, Integer> getIngredients() {
+    public Map<Item, Integer> getIngredients() {
         return this.ingredients;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/games/Game.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/games/Game.java
@@ -17,16 +17,16 @@ import com.eu.habbo.plugin.events.games.GameHabboLeaveEvent;
 import com.eu.habbo.plugin.events.games.GameStartedEvent;
 import com.eu.habbo.plugin.events.games.GameStoppedEvent;
 import com.eu.habbo.threading.runnables.SaveScoreForTeam;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 public abstract class Game implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(Game.class);
-    protected final THashMap<GameTeamColors, GameTeam> teams = new THashMap<>();
+    protected final Map<GameTeamColors, GameTeam> teams = new HashMap<>();
     protected final Room room;
     private final Class<? extends GameTeam> gameTeamClazz;
     private final Class<? extends GamePlayer> gamePlayerClazz;
@@ -238,7 +238,7 @@ public abstract class Game implements Runnable {
         if (this.room == null)
             return;
 
-        THashMap<GameTeamColors, GameTeam> teamsCopy = new THashMap<>();
+        Map<GameTeamColors, GameTeam> teamsCopy = new HashMap<>();
         teamsCopy.putAll(this.teams);
 
         for (Map.Entry<GameTeamColors, GameTeam> teamEntry : teamsCopy.entrySet()) {
@@ -291,7 +291,7 @@ public abstract class Game implements Runnable {
         return gamePlayerClazz;
     }
 
-    public THashMap<GameTeamColors, GameTeam> getTeams() {
+    public Map<GameTeamColors, GameTeam> getTeams() {
         return teams;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/games/GameTeam.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/games/GameTeam.java
@@ -1,19 +1,21 @@
 package com.eu.habbo.habbohotel.games;
 
 import com.eu.habbo.habbohotel.users.Habbo;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class GameTeam {
 
     public final GameTeamColors teamColor;
-    private final THashSet<GamePlayer> members;
+    private final Set<GamePlayer> members;
     private int teamScore;
 
 
     public GameTeam(GameTeamColors teamColor) {
         this.teamColor = teamColor;
 
-        this.members = new THashSet<>();
+        this.members = new HashSet<>();
     }
 
 
@@ -88,7 +90,7 @@ public class GameTeam {
     }
 
 
-    public THashSet<GamePlayer> getMembers() {
+    public Set<GamePlayer> getMembers() {
         return this.members;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/games/battlebanzai/BattleBanzaiGame.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/games/battlebanzai/BattleBanzaiGame.java
@@ -15,8 +15,6 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserActionComposer;
 import com.eu.habbo.threading.runnables.BattleBanzaiTilesFlicker;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,8 +56,8 @@ public class BattleBanzaiGame extends Game {
             new ThreadPoolExecutor.DiscardOldestPolicy() // Drop oldest task when queue is full
     );
     
-    private final THashMap<GameTeamColors, THashSet<HabboItem>> lockedTiles;
-    private final THashMap<Integer, HabboItem> gameTiles;
+    private final Map<GameTeamColors, Set<HabboItem>> lockedTiles;
+    private final Map<Integer, HabboItem> gameTiles;
     private volatile long lastFloodFillTime = 0;
     private int tileCount;
     private int countDown;
@@ -68,8 +66,8 @@ public class BattleBanzaiGame extends Game {
     public BattleBanzaiGame(Room room) {
         super(BattleBanzaiGameTeam.class, BattleBanzaiGamePlayer.class, room, true);
 
-        this.lockedTiles = new THashMap<>();
-        this.gameTiles = new THashMap<>();
+        this.lockedTiles = new HashMap<>();
+        this.gameTiles = new HashMap<>();
 
         room.setAllowEffects(true);
     }
@@ -154,7 +152,7 @@ public class BattleBanzaiGame extends Game {
 
             int total = 0;
             synchronized (this.lockedTiles) {
-                for (Map.Entry<GameTeamColors, THashSet<HabboItem>> set : this.lockedTiles.entrySet()) {
+                for (Map.Entry<GameTeamColors, Set<HabboItem>> set : this.lockedTiles.entrySet()) {
                     total += set.getValue().size();
                 }
             }
@@ -274,7 +272,7 @@ public class BattleBanzaiGame extends Game {
         synchronized (this.lockedTiles) {
             if (item instanceof InteractionBattleBanzaiTile) {
                 if (!this.lockedTiles.containsKey(teamColor)) {
-                    this.lockedTiles.put(teamColor, new THashSet<>());
+                    this.lockedTiles.put(teamColor, new HashSet<>());
                 }
 
                 this.lockedTiles.get(teamColor).add(item);
@@ -303,7 +301,7 @@ public class BattleBanzaiGame extends Game {
             final int y = item.getY();
 
             final List<List<RoomTile>> filledAreas = new ArrayList<>();
-            final THashSet<HabboItem> lockedTiles = new THashSet<>(this.lockedTiles.get(teamColor));
+            final Set<HabboItem> lockedTiles = new HashSet<>(this.lockedTiles.get(teamColor));
 
             try {
                 executor.execute(() -> {
@@ -338,7 +336,7 @@ public class BattleBanzaiGame extends Game {
         }
     }
 
-    private List<RoomTile> floodFill(int x, int y, THashSet<HabboItem> lockedTiles, List<RoomTile> stack, GameTeamColors color) {
+    private List<RoomTile> floodFill(int x, int y, Set<HabboItem> lockedTiles, List<RoomTile> stack, GameTeamColors color) {
         if (this.isOutOfBounds(x, y) || this.isForeignLockedTile(x, y, color)) return null;
 
         RoomTile tile = this.room.getLayout().getTile((short) x, (short) y);
@@ -361,7 +359,7 @@ public class BattleBanzaiGame extends Game {
 
     }
 
-    private boolean hasLockedTileAtCoordinates(int x, int y, THashSet<HabboItem> lockedTiles) {
+    private boolean hasLockedTileAtCoordinates(int x, int y, Set<HabboItem> lockedTiles) {
         for (HabboItem item : lockedTiles) {
             if (item.getX() == x && item.getY() == y) return true;
         }
@@ -378,7 +376,7 @@ public class BattleBanzaiGame extends Game {
     }
 
     private boolean isForeignLockedTile(int x, int y, GameTeamColors color) {
-        for (HashMap.Entry<GameTeamColors, THashSet<HabboItem>> lockedTilesForColor : this.lockedTiles.entrySet()) {
+        for (Map.Entry<GameTeamColors, Set<HabboItem>> lockedTilesForColor : this.lockedTiles.entrySet()) {
             if (lockedTilesForColor.getKey() == color) continue;
 
             for (HabboItem item : lockedTilesForColor.getValue()) {
@@ -404,7 +402,7 @@ public class BattleBanzaiGame extends Game {
 
         int totalScore = this.teams.get(teamColors).getTotalScore();
 
-        THashMap<Integer, InteractionBattleBanzaiScoreboard> scoreBoards = this.room.getRoomSpecialTypes().getBattleBanzaiScoreboards(teamColors);
+        Map<Integer, InteractionBattleBanzaiScoreboard> scoreBoards = this.room.getRoomSpecialTypes().getBattleBanzaiScoreboards(teamColors);
 
         for (InteractionBattleBanzaiScoreboard scoreboard : scoreBoards.values()) {
             if (scoreboard.getExtradata().isEmpty()) {
@@ -423,7 +421,7 @@ public class BattleBanzaiGame extends Game {
 
     private void refreshGates() {
         Collection<InteractionBattleBanzaiGate> gates = this.room.getRoomSpecialTypes().getBattleBanzaiGates().values();
-        THashSet<RoomTile> tilesToUpdate = new THashSet<>(gates.size());
+        Set<RoomTile> tilesToUpdate = new HashSet<>(gates.size());
         for (HabboItem item : gates) {
             tilesToUpdate.add(this.room.getLayout().getTile(item.getX(), item.getY()));
         }
@@ -432,7 +430,7 @@ public class BattleBanzaiGame extends Game {
     }
 
     public void markTile(Habbo habbo, InteractionBattleBanzaiTile tile, int state) {
-        if (!this.gameTiles.contains(tile.getId())) return;
+        if (!this.gameTiles.containsKey(tile.getId())) return;
 
         int check = state - (habbo.getHabboInfo().getGamePlayer().getTeamColor().type * 3);
         if (check == 0 || check == 1) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/games/freeze/FreezeGame.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/games/freeze/FreezeGame.java
@@ -20,14 +20,13 @@ import com.eu.habbo.plugin.EventHandler;
 import com.eu.habbo.plugin.events.emulator.EmulatorConfigUpdatedEvent;
 import com.eu.habbo.threading.runnables.freeze.FreezeClearEffects;
 import com.eu.habbo.threading.runnables.freeze.FreezeThrowSnowball;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.procedure.TObjectProcedure;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class FreezeGame extends Game {
     private static final Logger LOGGER = LoggerFactory.getLogger(FreezeGame.class);
@@ -103,8 +102,8 @@ public class FreezeGame extends Game {
         }
     }
 
-    public THashSet<RoomTile> affectedTilesByExplosion(short x, short y, int radius) {
-        THashSet<RoomTile> tiles = new THashSet<>();
+    public Set<RoomTile> affectedTilesByExplosion(short x, short y, int radius) {
+        Set<RoomTile> tiles = new HashSet<>();
 
         RoomTile t = this.room.getLayout().getTile(x, y);
 
@@ -123,8 +122,8 @@ public class FreezeGame extends Game {
         return tiles;
     }
 
-    public THashSet<RoomTile> affectedTilesByExplosionDiagonal(short x, short y, int radius) {
-        THashSet<RoomTile> tiles = new THashSet<>();
+    public Set<RoomTile> affectedTilesByExplosionDiagonal(short x, short y, int radius) {
+        Set<RoomTile> tiles = new HashSet<>();
 
         for (int rotation = 1; rotation < 9; rotation += 2) {
             RoomTile t = this.room.getLayout().getTile(x, y);
@@ -248,7 +247,7 @@ public class FreezeGame extends Game {
 
                 int totalScore = team.getTotalScore();
 
-                THashMap<Integer, InteractionFreezeScoreboard> scoreBoards = this.room.getRoomSpecialTypes().getFreezeScoreboards(team.teamColor);
+                Map<Integer, InteractionFreezeScoreboard> scoreBoards = this.room.getRoomSpecialTypes().getFreezeScoreboards(team.teamColor);
 
                 for (InteractionFreezeScoreboard scoreboard : scoreBoards.values()) {
                     if (scoreboard.getExtradata().isEmpty()) {
@@ -282,7 +281,7 @@ public class FreezeGame extends Game {
         }
 
         for (GameTeam team : this.teams.values()) {
-            THashSet<GamePlayer> players = new THashSet<>();
+            Set<GamePlayer> players = new HashSet<>();
 
             players.addAll(team.getMembers());
 
@@ -318,19 +317,15 @@ public class FreezeGame extends Game {
     }
 
     public void setFreezeTileState(String state) {
-        this.room.getRoomSpecialTypes().getFreezeExitTiles().forEachValue(new TObjectProcedure<InteractionFreezeExitTile>() {
-            @Override
-            public boolean execute(InteractionFreezeExitTile object) {
-                object.setExtradata(state);
-                FreezeGame.this.room.updateItemState(object);
-                return true;
-            }
-        });
+        for (InteractionFreezeExitTile object : this.room.getRoomSpecialTypes().getFreezeExitTiles().values()) {
+            object.setExtradata(state);
+            this.room.updateItemState(object);
+        }
 
     }
 
     private void refreshGates() {
-        THashSet<RoomTile> tilesToUpdate = new THashSet<>();
+        Set<RoomTile> tilesToUpdate = new HashSet<>();
         for (HabboItem item : this.room.getRoomSpecialTypes().getFreezeGates().values()) {
             tilesToUpdate.add(this.room.getLayout().getTile(item.getX(), item.getY()));
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/games/tag/TagGame.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/games/tag/TagGame.java
@@ -16,14 +16,14 @@ import com.eu.habbo.plugin.EventHandler;
 import com.eu.habbo.plugin.events.roomunit.RoomUnitLookAtPointEvent;
 import com.eu.habbo.plugin.events.users.UserTakeStepEvent;
 import com.eu.habbo.threading.runnables.HabboItemNewState;
-import gnu.trove.iterator.hash.TObjectHashIterator;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 public abstract class TagGame extends Game {
-    public THashMap<Habbo, InteractionTagPole> taggers = new THashMap<>();
+    public Map<Habbo, InteractionTagPole> taggers = new HashMap<>();
 
     public TagGame(Class<? extends GameTeam> gameTeamClazz, Class<? extends GamePlayer> gamePlayerClazz, Room room) {
         super(gameTeamClazz, gamePlayerClazz, room, false);
@@ -62,7 +62,7 @@ public abstract class TagGame extends Game {
     @EventHandler
     public static void onUserWalkEvent(UserTakeStepEvent event) {
         if (event.habbo.getHabboInfo().getCurrentGame() != null && TagGame.class.isAssignableFrom(event.habbo.getHabboInfo().getCurrentGame())) {
-            THashSet<HabboItem> items = event.habbo.getHabboInfo().getCurrentRoom().getItemsAt(event.toLocation);
+            Set<HabboItem> items = event.habbo.getHabboInfo().getCurrentRoom().getItemsAt(event.toLocation);
 
             TagGame game = (TagGame) event.habbo.getHabboInfo().getCurrentRoom().getGame(event.habbo.getHabboInfo().getCurrentGame());
 
@@ -96,7 +96,7 @@ public abstract class TagGame extends Game {
             return;
         }
 
-        THashSet<HabboItem> poles = room.getRoomSpecialTypes().getItemsOfType(this.getTagPole());
+        Set<HabboItem> poles = room.getRoomSpecialTypes().getItemsOfType(this.getTagPole());
         InteractionTagPole pole = this.taggers.get(tagger);
         room.giveEffect(tagged, this.getTaggedEffect(tagged), -1);
 
@@ -130,14 +130,14 @@ public abstract class TagGame extends Game {
         super.addHabbo(habbo, GameTeamColors.RED);
 
         if (this.getTagPole() != null) {
-            THashSet<HabboItem> poles = habbo.getHabboInfo().getCurrentRoom().getRoomSpecialTypes().getItemsOfType(this.getTagPole());
+            Set<HabboItem> poles = habbo.getHabboInfo().getCurrentRoom().getRoomSpecialTypes().getItemsOfType(this.getTagPole());
 
             if (poles.size() > this.taggers.size()) {
                 for (Map.Entry<Habbo, InteractionTagPole> set : this.taggers.entrySet()) {
                     poles.remove(set.getValue());
                 }
 
-                TObjectHashIterator<HabboItem> iterator = poles.iterator();
+                Iterator<HabboItem> iterator = poles.iterator();
                 if ((iterator.hasNext())) {
                     HabboItem item = iterator.next();
                     habbo.getHabboInfo().getCurrentRoom().giveEffect(habbo, this.getEffect(habbo), -1);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/guides/GuardianTicket.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/guides/GuardianTicket.java
@@ -10,15 +10,15 @@ import com.eu.habbo.messages.outgoing.guardians.*;
 import com.eu.habbo.messages.outgoing.guides.BullyReportClosedComposer;
 import com.eu.habbo.threading.runnables.GuardianNotAccepted;
 import com.eu.habbo.threading.runnables.GuardianVotingFinish;
-import gnu.trove.map.hash.THashMap;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 
 public class GuardianTicket {
-    private final THashMap<Habbo, GuardianVote> votes = new THashMap<>();
+    private final Map<Habbo, GuardianVote> votes = new HashMap<>();
     private final Habbo reporter;
     private final Habbo reported;
     private final Date date;
@@ -164,7 +164,7 @@ public class GuardianTicket {
         return this.votes.get(guardian);
     }
 
-    public THashMap<Habbo, GuardianVote> getVotes() {
+    public Map<Habbo, GuardianVote> getVotes() {
         return this.votes;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/guides/GuideManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/guides/GuideManager.java
@@ -7,26 +7,27 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.guides.*;
 import com.eu.habbo.threading.runnables.GuardianTicketFindMoreSlaves;
 import com.eu.habbo.threading.runnables.GuideFindNewHelper;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class GuideManager {
-    private final THashSet<GuideTour> activeTours;
-    private final THashSet<GuardianTicket> activeTickets;
-    private final THashSet<GuardianTicket> closedTickets;
-    private final THashMap<Habbo, Boolean> activeHelpers;
-    private final THashMap<Habbo, GuardianTicket> activeGuardians;
-    private final THashMap<Integer, Integer> tourRequestTiming;
+    private final Set<GuideTour> activeTours;
+    private final Set<GuardianTicket> activeTickets;
+    private final Set<GuardianTicket> closedTickets;
+    private final Map<Habbo, Boolean> activeHelpers;
+    private final Map<Habbo, GuardianTicket> activeGuardians;
+    private final Map<Integer, Integer> tourRequestTiming;
 
     public GuideManager() {
-        this.activeTours = new THashSet<>();
-        this.activeTickets = new THashSet<>();
-        this.closedTickets = new THashSet<>();
-        this.activeHelpers = new THashMap<>();
-        this.activeGuardians = new THashMap<>();
-        this.tourRequestTiming = new THashMap<>();
+        this.activeTours = new HashSet<>();
+        this.activeTickets = new HashSet<>();
+        this.closedTickets = new HashSet<>();
+        this.activeHelpers = new HashMap<>();
+        this.activeGuardians = new HashMap<>();
+        this.tourRequestTiming = new HashMap<>();
     }
 
     public void userLogsOut(Habbo habbo) {
@@ -224,7 +225,7 @@ public class GuideManager {
         synchronized (this.activeGuardians) {
             int count = ticket.getVotedCount();
 
-            THashSet<Habbo> selectedGuardians = new THashSet<>();
+            Set<Habbo> selectedGuardians = new HashSet<>();
 
             for (Map.Entry<Habbo, GuardianTicket> set : this.activeGuardians.entrySet()) {
                 if (count == 5)
@@ -326,7 +327,7 @@ public class GuideManager {
             this.closedTickets.add(ticket);
         }
 
-        THashSet<Habbo> toUpdate = new THashSet<>();
+        Set<Habbo> toUpdate = new HashSet<>();
 
         synchronized (this.activeGuardians) {
             for (Map.Entry<Habbo, GuardianTicket> set : this.activeGuardians.entrySet()) {
@@ -359,7 +360,7 @@ public class GuideManager {
 
     public void cleanup() {
         synchronized (this.activeTours) {
-            THashSet<GuideTour> tours = new THashSet<>();
+            Set<GuideTour> tours = new HashSet<>();
             for (GuideTour tour : this.activeTours) {
                 if (tour.isEnded() && (Emulator.getIntUnixTimestamp() - tour.getEndTime() > 300)) {
                     tours.add(tour);
@@ -372,7 +373,7 @@ public class GuideManager {
         }
 
         synchronized (this.activeTickets) {
-            THashSet<GuardianTicket> tickets = new THashSet<>();
+            Set<GuardianTicket> tickets = new HashSet<>();
 
             for (GuardianTicket ticket : this.closedTickets) {
                 if (Emulator.getIntUnixTimestamp() - (ticket.getDate().getTime() / 1000) > 15 * 60) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/guides/GuideTour.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/guides/GuideTour.java
@@ -3,13 +3,15 @@ package com.eu.habbo.habbohotel.guides;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.achievements.AchievementManager;
 import com.eu.habbo.habbohotel.users.Habbo;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class GuideTour {
     private final Habbo noob;
     private final String helpRequest;
-    private final THashSet<GuideChatMessage> sendMessages = new THashSet<>();
-    private final THashSet<Integer> declinedHelpers = new THashSet<>();
+    private final Set<GuideChatMessage> sendMessages = new HashSet<>();
+    private final Set<Integer> declinedHelpers = new HashSet<>();
     public int checkSum = 0;
     private Habbo helper;
     private int startTime;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/guilds/GuildManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/guilds/GuildManager.java
@@ -9,12 +9,9 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.guilds.GuildJoinErrorComposer;
 import com.eu.habbo.messages.outgoing.guilds.forums.GuildForumDataComposer;
-import gnu.trove.TCollections;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
-import gnu.trove.set.hash.THashSet;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,16 +23,16 @@ public class GuildManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GuildManager.class);
 
-    private final THashMap<GuildPartType, THashMap<Integer, GuildPart>> guildParts;
+    private final Map<GuildPartType, Map<Integer, GuildPart>> guildParts;
 
-    private final TIntObjectMap<Guild> guilds;
+    private final Int2ObjectMap<Guild> guilds;
 
-    private final THashSet<ForumView> views = new THashSet<>();
+    private final Set<ForumView> views = new HashSet<>();
 
     public GuildManager() {
         long millis = System.currentTimeMillis();
-        this.guildParts = new THashMap<GuildPartType, THashMap<Integer, GuildPart>>();
-        this.guilds = TCollections.synchronizedMap(new TIntObjectHashMap<Guild>());
+        this.guildParts = new HashMap<>();
+        this.guilds = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
 
         this.loadGuildParts();
         this.loadGuildViews();
@@ -48,7 +45,7 @@ public class GuildManager {
         this.guildParts.clear();
 
         for (GuildPartType t : GuildPartType.values()) {
-            this.guildParts.put(t, new THashMap<>());
+            this.guildParts.put(t, new HashMap<>());
         }
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
@@ -123,7 +120,7 @@ public class GuildManager {
 
 
     public void deleteGuild(Guild guild) {
-        THashSet<GuildMember> members = this.getGuildMembers(guild);
+        Set<GuildMember> members = this.getGuildMembers(guild);
 
         for (GuildMember member : members) {
             Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(member.getUserId());
@@ -196,16 +193,11 @@ public class GuildManager {
 
     public void clearInactiveGuilds() {
         List<Integer> toRemove = new ArrayList<Integer>();
-        TIntObjectIterator<Guild> guilds = this.guilds.iterator();
-        for (int i = this.guilds.size(); i-- > 0; ) {
-            try {
-                guilds.advance();
-            } catch (NoSuchElementException e) {
-                break;
-            }
-
-            if (guilds.value().lastRequested < Emulator.getIntUnixTimestamp() - 300) {
-                toRemove.add(guilds.value().getId());
+        synchronized (this.guilds) {
+            for (Guild guild : this.guilds.values()) {
+                if (guild.lastRequested < Emulator.getIntUnixTimestamp() - 300) {
+                    toRemove.add(guild.getId());
+                }
             }
         }
 
@@ -394,13 +386,13 @@ public class GuildManager {
     }
 
 
-    public THashSet<GuildMember> getGuildMembers(int guildId) {
+    public Set<GuildMember> getGuildMembers(int guildId) {
         return this.getGuildMembers(this.getGuild(guildId));
     }
 
 
-    THashSet<GuildMember> getGuildMembers(Guild guild) {
-        THashSet<GuildMember> guildMembers = new THashSet<GuildMember>();
+    Set<GuildMember> getGuildMembers(Guild guild) {
+        Set<GuildMember> guildMembers = new HashSet<>();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT users.username, users.look, guilds_members.* FROM guilds_members INNER JOIN users ON guilds_members.user_id = users.id WHERE guilds_members.guild_id = ?")) {
             statement.setInt(1, guild.getId());
@@ -456,8 +448,8 @@ public class GuildManager {
     }
 
 
-    public THashMap<Integer, GuildMember> getOnlyAdmins(Guild guild) {
-        THashMap<Integer, GuildMember> guildAdmins = new THashMap<Integer, GuildMember>();
+    public Map<Integer, GuildMember> getOnlyAdmins(Guild guild) {
+        Map<Integer, GuildMember> guildAdmins = new HashMap<>();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT users.username, users.look, guilds_members.* FROM guilds_members INNER JOIN users ON guilds_members.user_id = users.id WHERE guilds_members.guild_id = ?  " + (rankQuery(1)))) {
             statement.setInt(1, guild.getId());
@@ -591,7 +583,7 @@ public class GuildManager {
         return false;
     }
 
-    public THashMap<GuildPartType, THashMap<Integer, GuildPart>> getGuildParts() {
+    public Map<GuildPartType, Map<Integer, GuildPart>> getGuildParts() {
         return this.guildParts;
     }
 
@@ -653,14 +645,16 @@ public class GuildManager {
 
 
     public void dispose() {
-        TIntObjectIterator<Guild> guildIterator = this.guilds.iterator();
+        synchronized (this.guilds) {
+            Iterator<Guild> guildIterator = this.guilds.values().iterator();
+            while (guildIterator.hasNext()) {
+                Guild guild = guildIterator.next();
+                if (guild.needsUpdate) {
+                    guild.run();
+                }
 
-        for (int i = this.guilds.size(); i-- > 0; ) {
-            guildIterator.advance();
-            if (guildIterator.value().needsUpdate)
-                guildIterator.value().run();
-
-            guildIterator.remove();
+                guildIterator.remove();
+            }
         }
         LOGGER.info("Guild Manager -> Disposed!");
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/guilds/forums/ForumThread.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/guilds/forums/ForumThread.java
@@ -7,8 +7,6 @@ import com.eu.habbo.messages.ISerialize;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.plugin.events.guilds.forums.GuildForumThreadBeforeCreated;
 import com.eu.habbo.plugin.events.guilds.forums.GuildForumThreadCreated;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,14 +17,14 @@ public class ForumThread implements Runnable, ISerialize {
     private static final Logger LOGGER = LoggerFactory.getLogger(ForumThread.class);
 
 
-    private final static THashMap<Integer, THashSet<ForumThread>> guildThreadsCache = new THashMap<>();
-    private final static THashMap<Integer, ForumThread> forumThreadsCache = new THashMap<>();
+    private final static Map<Integer, Set<ForumThread>> guildThreadsCache = new HashMap<>();
+    private final static Map<Integer, ForumThread> forumThreadsCache = new HashMap<>();
     private final int threadId;
     private final int guildId;
     private final int openerId;
     private final String subject;
     private final int createdAt;
-    private final THashMap<Integer, ForumThreadComment> comments;
+    private final Map<Integer, ForumThreadComment> comments;
     private int postsCount;
     private int updatedAt;
     private ForumThreadState state;
@@ -51,7 +49,7 @@ public class ForumThread implements Runnable, ISerialize {
         this.locked = locked;
         this.adminId = adminId;
         this.lastComment = lastComment;
-        this.comments = new THashMap<>();
+        this.comments = new HashMap<>();
         this.needsUpdate = false;
         this.hasCommentsLoaded = false;
         this.commentIndex = 0;
@@ -77,7 +75,7 @@ public class ForumThread implements Runnable, ISerialize {
             LOGGER.error("ForumThread last_comment_id exception", e);
         }
 
-        this.comments = new THashMap<>();
+        this.comments = new HashMap<>();
         this.needsUpdate = false;
         this.hasCommentsLoaded = false;
         this.commentIndex = 0;
@@ -125,8 +123,8 @@ public class ForumThread implements Runnable, ISerialize {
         return createdThread;
     }
 
-    public static THashSet<ForumThread> getByGuildId(int guildId) {
-        THashSet<ForumThread> threads = null;
+    public static Set<ForumThread> getByGuildId(int guildId) {
+        Set<ForumThread> threads = null;
 
         if (guildThreadsCache.containsKey(guildId)) {
             threads = guildThreadsCache.get(guildId);
@@ -135,7 +133,7 @@ public class ForumThread implements Runnable, ISerialize {
         if (threads != null)
             return threads;
 
-        threads = new THashSet<ForumThread>();
+        threads = new HashSet<>();
 
         guildThreadsCache.put(guildId, threads);
 
@@ -205,10 +203,10 @@ public class ForumThread implements Runnable, ISerialize {
             forumThreadsCache.put(thread.threadId, thread);
         }
 
-        THashSet<ForumThread> guildThreads = guildThreadsCache.get(thread.guildId);
+        Set<ForumThread> guildThreads = guildThreadsCache.get(thread.guildId);
 
         if (guildThreads == null) {
-            guildThreads = new THashSet<>();
+            guildThreads = new HashSet<>();
             synchronized (forumThreadsCache) {
                 guildThreadsCache.put(thread.guildId, guildThreads);
             }
@@ -218,7 +216,7 @@ public class ForumThread implements Runnable, ISerialize {
 
     public static void clearCacheForGuild(int guildId) {
         synchronized (guildThreadsCache) {
-            THashSet<ForumThread> threads = guildThreadsCache.remove(guildId);
+            Set<ForumThread> threads = guildThreadsCache.remove(guildId);
             if (threads != null) {
                 synchronized (forumThreadsCache) {
                     for (ForumThread thread : threads) {
@@ -230,7 +228,7 @@ public class ForumThread implements Runnable, ISerialize {
     }
 
     public static void clearCache() {
-        for (THashSet<ForumThread> threads : guildThreadsCache.values()) {
+        for (Set<ForumThread> threads : guildThreadsCache.values()) {
             for (ForumThread thread : threads) {
                 thread.run();
             }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/guilds/forums/ForumThreadComment.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/guilds/forums/ForumThreadComment.java
@@ -7,16 +7,17 @@ import com.eu.habbo.messages.ISerialize;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.plugin.events.guilds.forums.GuildForumThreadCommentBeforeCreated;
 import com.eu.habbo.plugin.events.guilds.forums.GuildForumThreadCommentCreated;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.*;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ForumThreadComment implements Runnable, ISerialize {
     private static final Logger LOGGER = LoggerFactory.getLogger(ForumThreadComment.class);
 
-    private static final THashMap<Integer, ForumThreadComment> forumCommentsCache = new THashMap<>();
+    private static final Map<Integer, ForumThreadComment> forumCommentsCache = new HashMap<>();
     private final int commentId;
     private final int threadId;
     private final int userId;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/hotelview/HallOfFame.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/hotelview/HallOfFame.java
@@ -1,7 +1,6 @@
 package com.eu.habbo.habbohotel.hotelview;
 
 import com.eu.habbo.Emulator;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,11 +8,13 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
 
 public class HallOfFame {
     private static final Logger LOGGER = LoggerFactory.getLogger(HallOfFame.class);
 
-    private final THashMap<Integer, HallOfFameWinner> winners = new THashMap<>();
+    private final Map<Integer, HallOfFameWinner> winners = new HashMap<>();
 
 
     private String competitionName;
@@ -40,7 +41,7 @@ public class HallOfFame {
         }
     }
 
-    public THashMap<Integer, HallOfFameWinner> getWinners() {
+    public Map<Integer, HallOfFameWinner> getWinners() {
         return this.winners;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/Item.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/Item.java
@@ -5,7 +5,7 @@ import com.eu.habbo.habbohotel.items.interactions.InteractionMultiHeight;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ISerialize;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.list.array.TIntArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -32,7 +32,7 @@ public class Item implements ISerialize {
     private short stateCount;
     private short effectM;
     private short effectF;
-    private TIntArrayList vendingItems;
+    private IntArrayList vendingItems;
     private double[] multiHeights;
     private String customParams;
     private String clothingOnWalk;
@@ -123,12 +123,12 @@ public class Item implements ISerialize {
 
         int[] vendingIds = ItemDataGuard.parsePositiveIntList(set.getString("vending_ids"));
         if (vendingIds.length > 0) {
-            this.vendingItems = new TIntArrayList();
+            this.vendingItems = new IntArrayList();
             for (int vendingId : vendingIds) {
                 this.vendingItems.add(vendingId);
             }
         } else {
-            this.vendingItems = new TIntArrayList();
+            this.vendingItems = new IntArrayList();
         }
 
         //if(this.interactionType.getType() == InteractionMultiHeight.class || this.interactionType.getType().isAssignableFrom(InteractionMultiHeight.class))
@@ -242,7 +242,7 @@ public class Item implements ISerialize {
         return this.interactionType;
     }
 
-    public TIntArrayList getVendingItems() {
+    public IntArrayList getVendingItems() {
         return this.vendingItems;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -83,12 +83,9 @@ import com.eu.habbo.habbohotel.wired.highscores.WiredHighscoreManager;
 import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
 import com.eu.habbo.plugin.events.emulator.EmulatorLoadItemsManagerEvent;
 import com.eu.habbo.threading.runnables.QueryDeleteHabboItem;
-import gnu.trove.TCollections;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
-import gnu.trove.set.hash.THashSet;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,19 +100,19 @@ public class ItemManager {
     //Configuration. Loaded from database & updated accordingly.
     public static boolean RECYCLER_ENABLED = true;
 
-    private final TIntObjectMap<Item> items;
-    private final TIntObjectHashMap<CrackableReward> crackableRewards;
-    private final THashSet<ItemInteraction> interactionsList;
-    private final THashMap<String, SoundTrack> soundTracks;
+    private final Int2ObjectMap<Item> items;
+    private final Int2ObjectMap<CrackableReward> crackableRewards;
+    private final Set<ItemInteraction> interactionsList;
+    private final Map<String, SoundTrack> soundTracks;
     private final YoutubeManager youtubeManager;
     private final WiredHighscoreManager highscoreManager;
     private final TreeMap<Integer, NewUserGift> newuserGifts;
 
     public ItemManager() {
-        this.items = TCollections.synchronizedMap(new TIntObjectHashMap<>());
-        this.crackableRewards = new TIntObjectHashMap<>();
-        this.interactionsList = new THashSet<>();
-        this.soundTracks = new THashMap<>();
+        this.items = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
+        this.crackableRewards = new Int2ObjectOpenHashMap<>();
+        this.interactionsList = new HashSet<>();
+        this.soundTracks = new HashMap<>();
         this.youtubeManager = new YoutubeManager();
         this.highscoreManager = new WiredHighscoreManager();
         this.newuserGifts = new TreeMap<>();
@@ -906,7 +903,7 @@ public class ItemManager {
         return this.items.get(itemId);
     }
 
-    public TIntObjectMap<Item> getItems() {
+    public Int2ObjectMap<Item> getItems() {
         return this.items;
     }
 
@@ -915,16 +912,11 @@ public class ItemManager {
             return null;
         }
 
-        TIntObjectIterator<Item> item = this.items.iterator();
-
-        for (int i = this.items.size(); i-- > 0; ) {
-            try {
-                item.advance();
-                if (item.value() != null && item.value().getName() != null && item.value().getName().equalsIgnoreCase(itemName)) {
-                    return item.value();
+        synchronized (this.items) {
+            for (Item item : this.items.values()) {
+                if (item != null && item.getName() != null && item.getName().equalsIgnoreCase(itemName)) {
+                    return item;
                 }
-            } catch (NoSuchElementException e) {
-                break;
             }
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/YoutubeManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/YoutubeManager.java
@@ -5,7 +5,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,6 +18,7 @@ import java.net.URL;
 import java.sql.*;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -74,8 +74,8 @@ public class YoutubeManager {
         }
     }
 
-    private final THashMap<Integer, ArrayList<YoutubePlaylist>> playlists = new THashMap<>();
-    private final THashMap<String, YoutubePlaylist> playlistCache = new THashMap<>();
+    private final ConcurrentHashMap<Integer, ArrayList<YoutubePlaylist>> playlists = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, YoutubePlaylist> playlistCache = new ConcurrentHashMap<>();
 
     private String getApiKey() {
         String key = Emulator.getConfig().getValue("youtube.apikey");
@@ -251,6 +251,9 @@ public class YoutubeManager {
     }
 
     public void addPlaylistToItem(int itemId, YoutubePlaylist playlist) {
-        this.playlists.computeIfAbsent(itemId, k -> new ArrayList<>()).add(playlist);
+        ArrayList<YoutubePlaylist> itemPlaylists = this.playlists.computeIfAbsent(itemId, k -> new ArrayList<>());
+        synchronized (itemPlaylists) {
+            itemPlaylists.add(playlist);
+        }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionAreaHideControl.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionAreaHideControl.java
@@ -10,13 +10,14 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.WiredEffectType;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.map.hash.THashMap;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class InteractionAreaHideControl extends InteractionCustomValues {
-    public static final THashMap<String, String> defaultValues = new THashMap<String, String>() {
+    public static final Map<String, String> defaultValues = new HashMap<String, String>() {
         {
             this.put("state", "0");
         }
@@ -108,7 +109,7 @@ public class InteractionAreaHideControl extends InteractionCustomValues {
     }
 
     @Override
-    public void onCustomValuesSaved(Room room, GameClient client, THashMap<String, String> oldValues) {
+    public void onCustomValuesSaved(Room room, GameClient client, Map<String, String> oldValues) {
         this.normalizeValues();
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionBuildArea.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionBuildArea.java
@@ -12,7 +12,6 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.messages.outgoing.rooms.items.RemoveFloorItemComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RoomFloorItemsComposer;
-import gnu.trove.map.hash.THashMap;
 import gnu.trove.set.hash.THashSet;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
@@ -22,10 +21,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 public class InteractionBuildArea extends InteractionCustomValues {
-    public static THashMap<String, String> defaultValues = new THashMap<String, String>() {
+    public static Map<String, String> defaultValues = new HashMap<String, String>() {
         {
             this.put("tilesLeft", "0");
         }
@@ -178,7 +179,7 @@ public class InteractionBuildArea extends InteractionCustomValues {
     }
 
     @Override
-    public void onCustomValuesSaved(Room room, GameClient client, THashMap<String, String> oldValues) {
+    public void onCustomValuesSaved(Room room, GameClient client, Map<String, String> oldValues) {
         regenAffectedTiles(room);
         ArrayList<String> builderNames = new ArrayList<>(Arrays.asList(this.values.get("builders").split(";")));
         THashSet<Integer> canBuild = new THashSet<>();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionBuildArea.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionBuildArea.java
@@ -12,7 +12,6 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.messages.outgoing.rooms.items.RemoveFloorItemComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RoomFloorItemsComposer;
-import gnu.trove.set.hash.THashSet;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -21,6 +20,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -48,16 +48,16 @@ public class InteractionBuildArea extends InteractionCustomValues {
         }
     };
 
-    private THashSet<RoomTile> tiles;
+    private Set<RoomTile> tiles;
 
     public InteractionBuildArea(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem, defaultValues);
-        tiles = new THashSet<>();
+        tiles = new HashSet<>();
     }
 
     public InteractionBuildArea(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells, defaultValues);
-        tiles = new THashSet<>();
+        tiles = new HashSet<>();
     }
 
     @Override
@@ -71,7 +71,7 @@ public class InteractionBuildArea extends InteractionCustomValues {
         super.onPickUp(room);
 
         ArrayList<String> builderNames = new ArrayList<>(Arrays.asList(this.values.get("builders").split(";")));
-        THashSet<Integer> canBuild = new THashSet<>();
+        Set<Integer> canBuild = new HashSet<>();
 
         for (String builderName : builderNames) {
             Habbo builder = Emulator.getGameEnvironment().getHabboManager().getHabbo(builderName);
@@ -105,7 +105,7 @@ public class InteractionBuildArea extends InteractionCustomValues {
         super.onMove(room, oldLocation, newLocation);
 
         ArrayList<String> builderNames = new ArrayList<>(Arrays.asList(this.values.get("builders").split(";")));
-        THashSet<Integer> canBuild = new THashSet<>();
+        Set<Integer> canBuild = new HashSet<>();
 
         for (String builderName : builderNames) {
             Habbo builder = Emulator.getGameEnvironment().getHabboManager().getHabbo(builderName);
@@ -120,8 +120,8 @@ public class InteractionBuildArea extends InteractionCustomValues {
             }
         }
 
-        THashSet<RoomTile> oldTiles = this.tiles;
-        THashSet<RoomTile> newTiles = new THashSet<>();
+        Set<RoomTile> oldTiles = this.tiles;
+        Set<RoomTile> newTiles = new HashSet<>();
 
         int minX = Math.max(0, newLocation.x - Integer.parseInt(this.values.get("tilesBack")));
         int minY = Math.max(0, newLocation.y - Integer.parseInt(this.values.get("tilesRight")));
@@ -182,7 +182,7 @@ public class InteractionBuildArea extends InteractionCustomValues {
     public void onCustomValuesSaved(Room room, GameClient client, Map<String, String> oldValues) {
         regenAffectedTiles(room);
         ArrayList<String> builderNames = new ArrayList<>(Arrays.asList(this.values.get("builders").split(";")));
-        THashSet<Integer> canBuild = new THashSet<>();
+        Set<Integer> canBuild = new HashSet<>();
 
         for (String builderName : builderNames) {
             Habbo builder = Emulator.getGameEnvironment().getHabboManager().getHabbo(builderName);
@@ -197,7 +197,7 @@ public class InteractionBuildArea extends InteractionCustomValues {
             }
         }
 
-        THashSet<RoomTile> oldTiles = new THashSet<>();
+        Set<RoomTile> oldTiles = new HashSet<>();
 
         int minX = Math.max(0, this.getX() - Integer.parseInt(oldValues.get("tilesBack")));
         int minY = Math.max(0, this.getY() - Integer.parseInt(oldValues.get("tilesRight")));
@@ -228,7 +228,7 @@ public class InteractionBuildArea extends InteractionCustomValues {
         if(effectItem != null) {
             Int2ObjectMap<String> ownerNames = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
             ownerNames.put(-1, "System");
-            THashSet<HabboItem> items = new THashSet<>();
+            Set<HabboItem> items = new HashSet<>();
 
             int id = 0;
             for(RoomTile tile : this.tiles) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionBuildArea.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionBuildArea.java
@@ -22,6 +22,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Set;
 
 public class InteractionBuildArea extends InteractionCustomValues {
     public static THashMap<String, String> defaultValues = new THashMap<String, String>() {
@@ -86,7 +87,7 @@ public class InteractionBuildArea extends InteractionCustomValues {
 
         if (!canBuild.isEmpty()) {
             for (RoomTile tile : this.tiles) {
-                THashSet<HabboItem> tileItems = room.getItemsAt(tile);
+                Set<HabboItem> tileItems = room.getItemsAt(tile);
                 for (HabboItem tileItem : tileItems) {
                     if (canBuild.contains(tileItem.getUserId()) && tileItem != this) {
                         room.pickUpItem(tileItem, null);
@@ -136,7 +137,7 @@ public class InteractionBuildArea extends InteractionCustomValues {
 
         if (!canBuild.isEmpty()) {
             for (RoomTile tile : oldTiles) {
-                THashSet<HabboItem> tileItems = room.getItemsAt(tile);
+                Set<HabboItem> tileItems = room.getItemsAt(tile);
                 if(newTiles.contains(tile)) continue;
                 for (HabboItem tileItem : tileItems) {
                     if (canBuild.contains(tileItem.getUserId()) && tileItem != this) {
@@ -211,7 +212,7 @@ public class InteractionBuildArea extends InteractionCustomValues {
         }
         if (!canBuild.isEmpty()) {
             for (RoomTile tile : oldTiles) {
-                THashSet<HabboItem> tileItems = room.getItemsAt(tile);
+                Set<HabboItem> tileItems = room.getItemsAt(tile);
                 for (HabboItem tileItem : tileItems) {
                     if (canBuild.contains(tileItem.getUserId()) && tileItem != this) {
                         room.pickUpItem(tileItem, null);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionBuildArea.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionBuildArea.java
@@ -12,11 +12,11 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.messages.outgoing.rooms.items.RemoveFloorItemComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RoomFloorItemsComposer;
-import gnu.trove.TCollections;
-import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.set.hash.THashSet;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -225,7 +225,7 @@ public class InteractionBuildArea extends InteractionCustomValues {
         Item effectItem = Emulator.getGameEnvironment().getItemManager().getItem("mutearea_sign2");
 
         if(effectItem != null) {
-            TIntObjectMap<String> ownerNames = TCollections.synchronizedMap(new TIntObjectHashMap<>(0));
+            Int2ObjectMap<String> ownerNames = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
             ownerNames.put(-1, "System");
             THashSet<HabboItem> items = new THashSet<>();
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionCustomValues.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionCustomValues.java
@@ -6,16 +6,16 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.map.hash.THashMap;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Map;
 
 public abstract class InteractionCustomValues extends HabboItem {
-    public final THashMap<String, String> values = new THashMap<>();
+    public final Map<String, String> values = new HashMap<>();
 
-    public InteractionCustomValues(ResultSet set, Item baseItem, THashMap<String, String> defaultValues) throws SQLException {
+    public InteractionCustomValues(ResultSet set, Item baseItem, Map<String, String> defaultValues) throws SQLException {
         super(set, baseItem);
 
         this.values.putAll(defaultValues);
@@ -29,7 +29,7 @@ public abstract class InteractionCustomValues extends HabboItem {
         }
     }
 
-    public InteractionCustomValues(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells, THashMap<String, String> defaultValues) {
+    public InteractionCustomValues(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells, Map<String, String> defaultValues) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
 
         this.values.putAll(defaultValues);
@@ -80,7 +80,7 @@ public abstract class InteractionCustomValues extends HabboItem {
         super.serializeExtradata(serverMessage);
     }
 
-    public void onCustomValuesSaved(Room room, GameClient client, THashMap<String, String> oldValues) {
+    public void onCustomValuesSaved(Room room, GameClient client, Map<String, String> oldValues) {
 
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionEffectVendingMachineNoSides.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionEffectVendingMachineNoSides.java
@@ -4,10 +4,11 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
 
 public class InteractionEffectVendingMachineNoSides extends InteractionVendingMachine {
     public InteractionEffectVendingMachineNoSides(ResultSet set, Item baseItem) throws SQLException {
@@ -26,9 +27,9 @@ public class InteractionEffectVendingMachineNoSides extends InteractionVendingMa
     }
 
     @Override
-    public THashSet<RoomTile> getActivatorTiles(Room room) {
+    public Set<RoomTile> getActivatorTiles(Room room) {
 
-        THashSet<RoomTile> tiles = new THashSet<RoomTile>();
+        Set<RoomTile> tiles = new HashSet<RoomTile>();
         for(int x = -1; x <= 1; x++) {
             for(int y = -1; y <= 1; y++) {
                 RoomTile tile = room.getLayout().getTile((short)(this.getX() + x), (short)(this.getY() + y));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionGift.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionGift.java
@@ -7,12 +7,13 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class InteractionGift extends HabboItem {
@@ -139,8 +140,8 @@ public class InteractionGift extends HabboItem {
         return this.ribbonId;
     }
 
-    public THashSet<HabboItem> loadItems() {
-        THashSet<HabboItem> items = new THashSet<>();
+    public Set<HabboItem> loadItems() {
+        Set<HabboItem> items = new HashSet<>();
         for (int anItemId : this.itemId) {
             if (anItemId == 0)
                 continue;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionGuildFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionGuildFurni.java
@@ -6,14 +6,15 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
 
 public class InteractionGuildFurni extends InteractionDefault {
     private int guildId;
-    private static final THashSet<String> ROTATION_8_ITEMS = new THashSet<String>() {
+    private static final Set<String> ROTATION_8_ITEMS = new HashSet<String>() {
         {
             this.add("gld_wall_tall");
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionInformationTerminal.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionInformationTerminal.java
@@ -5,13 +5,14 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.habboway.nux.NuxAlertComposer;
-import gnu.trove.map.hash.THashMap;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class InteractionInformationTerminal extends InteractionCustomValues {
-    public static final THashMap<String, String> defaultValues = new THashMap<String, String>() {
+    public static final Map<String, String> defaultValues = new HashMap<String, String>() {
         {
             this.put("internalLink", "habbopages/chat/commands");
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionMoodLight.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionMoodLight.java
@@ -46,7 +46,7 @@ public class InteractionMoodLight extends HabboItem {
     @Override
     public void onPlace(Room room) {
         if (room != null) {
-            for (RoomMoodlightData data : room.getMoodlightData().valueCollection()) {
+            for (RoomMoodlightData data : room.getMoodlightData().values()) {
                 if (data.isEnabled()) {
                     this.setExtradata(data.toString());
                     this.needsUpdate(true);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionMultiHeight.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionMultiHeight.java
@@ -8,11 +8,11 @@ import com.eu.habbo.habbohotel.users.HabboGender;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.WiredEffectType;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.Set;
 
 public class InteractionMultiHeight extends HabboItem {
     public InteractionMultiHeight(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
@@ -73,7 +73,7 @@ public class InteractionMultiHeight extends HabboItem {
     }
 
     public void updateUnitsOnItem(Room room) {
-        THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(room.getLayout().getTile(this.getX(), this.getY()), this.getBaseItem().getWidth(), this.getBaseItem().getLength(), this.getRotation());
+        Set<RoomTile> occupiedTiles = room.getLayout().getTilesAt(room.getLayout().getTile(this.getX(), this.getY()), this.getBaseItem().getWidth(), this.getBaseItem().getLength(), this.getRotation());
 
         for(RoomTile tile : occupiedTiles) {
             Collection<RoomUnit> unitsOnItem = room.getRoomUnitsAt(room.getLayout().getTile(tile.x, tile.y));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionMuteArea.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionMuteArea.java
@@ -11,7 +11,6 @@ import com.eu.habbo.habbohotel.wired.WiredEffectType;
 import com.eu.habbo.messages.outgoing.rooms.items.ItemExtraDataComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RemoveFloorItemComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RoomFloorItemsComposer;
-import gnu.trove.map.hash.THashMap;
 import gnu.trove.set.hash.THashSet;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
@@ -19,9 +18,11 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class InteractionMuteArea extends InteractionCustomValues {
-    public static THashMap<String, String> defaultValues = new THashMap<String, String>() {
+    public static Map<String, String> defaultValues = new HashMap<String, String>() {
         {
             this.put("tilesLeft", "0");
         }
@@ -124,7 +125,7 @@ public class InteractionMuteArea extends InteractionCustomValues {
     }
 
     @Override
-    public void onCustomValuesSaved(Room room, GameClient client, THashMap<String, String> oldValues) {
+    public void onCustomValuesSaved(Room room, GameClient client, Map<String, String> oldValues) {
         super.onCustomValuesSaved(room, client, oldValues);
 
         this.regenAffectedTiles(room);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionMuteArea.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionMuteArea.java
@@ -11,15 +11,16 @@ import com.eu.habbo.habbohotel.wired.WiredEffectType;
 import com.eu.habbo.messages.outgoing.rooms.items.ItemExtraDataComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RemoveFloorItemComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RoomFloorItemsComposer;
-import gnu.trove.set.hash.THashSet;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class InteractionMuteArea extends InteractionCustomValues {
     public static Map<String, String> defaultValues = new HashMap<String, String>() {
@@ -44,16 +45,16 @@ public class InteractionMuteArea extends InteractionCustomValues {
         }
     };
 
-    private THashSet<RoomTile> tiles;
+    private Set<RoomTile> tiles;
 
     public InteractionMuteArea(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem, defaultValues);
-        tiles = new THashSet<>();
+        tiles = new HashSet<>();
     }
 
     public InteractionMuteArea(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells, defaultValues);
-        tiles = new THashSet<>();
+        tiles = new HashSet<>();
     }
 
     @Override
@@ -136,7 +137,7 @@ public class InteractionMuteArea extends InteractionCustomValues {
         if(effectItem != null) {
             Int2ObjectMap<String> ownerNames = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
             ownerNames.put(-1, "System");
-            THashSet<HabboItem> items = new THashSet<>();
+            Set<HabboItem> items = new HashSet<>();
 
             int id = 0;
             for(RoomTile tile : this.tiles) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionMuteArea.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionMuteArea.java
@@ -11,11 +11,11 @@ import com.eu.habbo.habbohotel.wired.WiredEffectType;
 import com.eu.habbo.messages.outgoing.rooms.items.ItemExtraDataComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RemoveFloorItemComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RoomFloorItemsComposer;
-import gnu.trove.TCollections;
-import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.set.hash.THashSet;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -133,7 +133,7 @@ public class InteractionMuteArea extends InteractionCustomValues {
         Item effectItem = Emulator.getGameEnvironment().getItemManager().getItem("mutearea_sign2");
 
         if(effectItem != null) {
-            TIntObjectMap<String> ownerNames = TCollections.synchronizedMap(new TIntObjectHashMap<>(0));
+            Int2ObjectMap<String> ownerNames = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
             ownerNames.put(-1, "System");
             THashSet<HabboItem> items = new THashSet<>();
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionNoSidesVendingMachine.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionNoSidesVendingMachine.java
@@ -3,10 +3,11 @@ package com.eu.habbo.habbohotel.items.interactions;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
 
 public class InteractionNoSidesVendingMachine extends InteractionVendingMachine {
     public InteractionNoSidesVendingMachine(ResultSet set, Item baseItem) throws SQLException {
@@ -18,9 +19,9 @@ public class InteractionNoSidesVendingMachine extends InteractionVendingMachine 
     }
 
     @Override
-    public THashSet<RoomTile> getActivatorTiles(Room room) {
+    public Set<RoomTile> getActivatorTiles(Room room) {
 
-        THashSet<RoomTile> tiles = new THashSet<RoomTile>();
+        Set<RoomTile> tiles = new HashSet<RoomTile>();
         for(int x = -1; x <= 1; x++) {
             for(int y = -1; y <= 1; y++) {
                 RoomTile tile = room.getLayout().getTile((short)(this.getX() + x), (short)(this.getY() + y));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionObstacle.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionObstacle.java
@@ -13,26 +13,27 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.threading.runnables.HabboItemNewState;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 public class InteractionObstacle extends HabboItem implements ICycleable {
 
-    private THashSet<RoomTile> middleTiles;
+    private Set<RoomTile> middleTiles;
 
     public InteractionObstacle(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
         this.setExtradata("0");
-        this.middleTiles = new THashSet<>();
+        this.middleTiles = new HashSet<>();
     }
 
     public InteractionObstacle(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
         this.setExtradata("0");
-        this.middleTiles = new THashSet<>();
+        this.middleTiles = new HashSet<>();
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionPressurePlate.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionPressurePlate.java
@@ -6,10 +6,11 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Set;
 
 public class InteractionPressurePlate extends InteractionDefault {
     public InteractionPressurePlate(ResultSet set, Item baseItem) throws SQLException {
@@ -77,12 +78,12 @@ public class InteractionPressurePlate extends InteractionDefault {
 
         if (tileAtItem == null) return;
 
-        THashSet<RoomTile> tiles = room.getLayout().getTilesAt(tileAtItem, this.getBaseItem().getWidth(), this.getBaseItem().getLength(), this.getRotation());
+        Set<RoomTile> tiles = room.getLayout().getTilesAt(tileAtItem, this.getBaseItem().getWidth(), this.getBaseItem().getLength(), this.getRotation());
 
         if (tiles == null) return;
 
         for (RoomTile tile : tiles) {
-            THashSet<RoomUnit> tileHasHabboOrBot = room.getHabbosAndBotsAt(tile.x, tile.y);
+            Collection<RoomUnit> tileHasHabboOrBot = room.getHabbosAndBotsAt(tile.x, tile.y);
             if (tileHasHabboOrBot.isEmpty() && this.requiresAllTilesOccupied()) {
                 occupied = false;
                 break;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionRentableSpace.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionRentableSpace.java
@@ -12,7 +12,6 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.rooms.items.rentablespaces.RentableSpaceInfoComposer;
 import com.eu.habbo.threading.runnables.ClearRentedSpace;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,6 +20,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
 
 public class InteractionRentableSpace extends HabboItem {
     private static final Logger LOGGER = LoggerFactory.getLogger(InteractionRentableSpace.class);
@@ -166,7 +167,7 @@ public class InteractionRentableSpace extends HabboItem {
 
         Rectangle rect = RoomLayout.getRectangle(this.getX(), this.getY(), this.getBaseItem().getWidth(), this.getBaseItem().getLength(), this.getRotation());
 
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
         for (int i = rect.x; i < rect.x + rect.getWidth(); i++) {
             for (int j = rect.y; j < rect.y + rect.getHeight(); j++) {
                 items.addAll(room.getItemsAt(i, j, this.getZ()));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionRoller.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionRoller.java
@@ -7,12 +7,12 @@ import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 import org.apache.commons.math3.util.Pair;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
 
 public class InteractionRoller extends HabboItem {
     public static boolean NO_RULES = false;
@@ -68,11 +68,11 @@ public class InteractionRoller extends HabboItem {
 
 
     @Override
-    public boolean canStackAt(Room room, List<Pair<RoomTile, THashSet<HabboItem>>> itemsAtLocation) {
+    public boolean canStackAt(Room room, List<Pair<RoomTile, Set<HabboItem>>> itemsAtLocation) {
         if (NO_RULES) return true;
         if (itemsAtLocation.isEmpty()) return false;
 
-        for (Pair<RoomTile, THashSet<HabboItem>> set : itemsAtLocation) {
+        for (Pair<RoomTile, Set<HabboItem>> set : itemsAtLocation) {
             if (set.getValue() != null && !set.getValue().isEmpty()) {
                 if (set.getValue().size() > 1) {
                     return false;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionRoomAds.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionRoomAds.java
@@ -3,13 +3,14 @@ package com.eu.habbo.habbohotel.items.interactions;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
-import gnu.trove.map.hash.THashMap;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class InteractionRoomAds extends InteractionCustomValues {
-    public final static THashMap<String, String> defaultValues = new THashMap<String, String>() {
+    public final static Map<String, String> defaultValues = new HashMap<String, String>() {
         {
             this.put("imageUrl", "");
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionSnowboardSlope.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionSnowboardSlope.java
@@ -10,11 +10,11 @@ import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
 
 import java.awt.*;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Set;
 
 public class InteractionSnowboardSlope extends InteractionMultiHeight {
     public InteractionSnowboardSlope(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
@@ -42,7 +42,7 @@ public class InteractionSnowboardSlope extends InteractionMultiHeight {
     @Override
     public void onPlace(Room room) {
         super.onPlace(room);
-        THashSet<HabboItem> items = room.getRoomSpecialTypes().getItemsOfType(InteractionSnowboardSlope.class);
+        Set<HabboItem> items = room.getRoomSpecialTypes().getItemsOfType(InteractionSnowboardSlope.class);
 
         Achievement snowboardBuild = Emulator.getGameEnvironment().getAchievementManager().getAchievement("snowBoardBuild");
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionTileEffectProvider.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionTileEffectProvider.java
@@ -4,13 +4,14 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
-import gnu.trove.map.hash.THashMap;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class InteractionTileEffectProvider extends InteractionCustomValues {
-    public static THashMap<String, String> defaultValues = new THashMap<String, String>() {
+    public static Map<String, String> defaultValues = new HashMap<String, String>() {
         {
             this.put("effectId", "0");
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionVendingMachine.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionVendingMachine.java
@@ -10,14 +10,15 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.threading.runnables.RoomUnitGiveHanditem;
 import com.eu.habbo.threading.runnables.RoomUnitWalkToLocation;
 import com.eu.habbo.util.pathfinding.Rotation;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class InteractionVendingMachine extends HabboItem {
     private static final Logger LOGGER = LoggerFactory.getLogger(InteractionVendingMachine.class);
@@ -32,8 +33,8 @@ public class InteractionVendingMachine extends HabboItem {
         this.setExtradata("0");
     }
     
-    public THashSet<RoomTile> getActivatorTiles(Room room) {
-        THashSet<RoomTile> tiles = new THashSet<>();
+    public Set<RoomTile> getActivatorTiles(Room room) {
+        Set<RoomTile> tiles = new HashSet<>();
         RoomTile tileInFront = getSquareInFront(room.getLayout(), this);
 
         if (tileInFront != null)
@@ -52,7 +53,7 @@ public class InteractionVendingMachine extends HabboItem {
     }
 
     private void tryInteract(GameClient client, Room room, RoomUnit unit) {
-        THashSet<RoomTile> activatorTiles = getActivatorTiles(room);
+        Set<RoomTile> activatorTiles = getActivatorTiles(room);
 
         if(activatorTiles.size() == 0)
             return;
@@ -109,7 +110,7 @@ public class InteractionVendingMachine extends HabboItem {
 
         RoomUnit unit = client.getHabbo().getRoomUnit();
 
-        THashSet<RoomTile> activatorTiles = getActivatorTiles(room);
+        Set<RoomTile> activatorTiles = getActivatorTiles(room);
 
         if(activatorTiles.size() == 0)
             return;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionWater.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionWater.java
@@ -6,13 +6,13 @@ import com.eu.habbo.habbohotel.pets.Pet;
 import com.eu.habbo.habbohotel.rooms.*;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
 import org.apache.commons.math3.util.Pair;
 
 import java.awt.*;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
 
 public class InteractionWater extends InteractionDefault {
 
@@ -105,8 +105,8 @@ public class InteractionWater extends InteractionDefault {
     }
 
     @Override
-    public boolean canStackAt(Room room, List<Pair<RoomTile, THashSet<HabboItem>>> itemsAtLocation) {
-        for (Pair<RoomTile, THashSet<HabboItem>> set : itemsAtLocation) {
+    public boolean canStackAt(Room room, List<Pair<RoomTile, Set<HabboItem>>> itemsAtLocation) {
+        for (Pair<RoomTile, Set<HabboItem>> set : itemsAtLocation) {
             for (HabboItem item : set.getValue()) {
                 if (!(item instanceof InteractionWater)) {
                     return false;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionWaterItem.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionWaterItem.java
@@ -6,11 +6,11 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
 
 import java.awt.*;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Set;
 
 public class InteractionWaterItem extends InteractionMultiHeight {
     public InteractionWaterItem(ResultSet set, Item baseItem) throws SQLException {
@@ -60,7 +60,7 @@ public class InteractionWaterItem extends InteractionMultiHeight {
         for (short x = (short) rectangle.x; x < rectangle.getWidth() + rectangle.x && foundWater; x++) {
             for (short y = (short) rectangle.y; y < rectangle.getHeight() + rectangle.y && foundWater; y++) {
                 boolean tile = false;
-                THashSet<HabboItem> items = room.getItemsAt(room.getLayout().getTile(x, y));
+                Set<HabboItem> items = room.getItemsAt(room.getLayout().getTile(x, y));
 
                 for (HabboItem item : items) {
                     if (item instanceof InteractionWater) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/games/battlebanzai/InteractionBattleBanzaiTile.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/games/battlebanzai/InteractionBattleBanzaiTile.java
@@ -9,12 +9,12 @@ import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 import org.apache.commons.math3.util.Pair;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
 
 public class InteractionBattleBanzaiTile extends HabboItem {
     public InteractionBattleBanzaiTile(ResultSet set, Item baseItem) throws SQLException {
@@ -92,8 +92,8 @@ public class InteractionBattleBanzaiTile extends HabboItem {
     }
 
     @Override
-    public boolean canStackAt(Room room, List<Pair<RoomTile, THashSet<HabboItem>>> itemsAtLocation) {
-        for (Pair<RoomTile, THashSet<HabboItem>> set : itemsAtLocation) {
+    public boolean canStackAt(Room room, List<Pair<RoomTile, Set<HabboItem>>> itemsAtLocation) {
+        for (Pair<RoomTile, Set<HabboItem>> set : itemsAtLocation) {
             if (set.getValue() != null && !set.getValue().isEmpty()) return false;
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/games/freeze/InteractionFreezeBlock.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/games/freeze/InteractionFreezeBlock.java
@@ -12,10 +12,10 @@ import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Set;
 
 public class InteractionFreezeBlock extends HabboItem {
     public InteractionFreezeBlock(ResultSet set, Item baseItem) throws SQLException {
@@ -34,7 +34,7 @@ public class InteractionFreezeBlock extends HabboItem {
             return;
 
         HabboItem item = null;
-        THashSet<HabboItem> items = room.getItemsAt(room.getLayout().getTile(this.getX(), this.getY()));
+        Set<HabboItem> items = room.getItemsAt(room.getLayout().getTile(this.getX(), this.getY()));
 
         for (HabboItem i : items) {
             if (i instanceof InteractionFreezeTile) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/games/freeze/InteractionFreezeTile.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/games/freeze/InteractionFreezeTile.java
@@ -8,12 +8,12 @@ import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 import org.apache.commons.math3.util.Pair;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
 
 public class InteractionFreezeTile extends HabboItem {
     public InteractionFreezeTile(ResultSet set, Item baseItem) throws SQLException {
@@ -74,8 +74,8 @@ public class InteractionFreezeTile extends HabboItem {
 
 
     @Override
-    public boolean canStackAt(Room room, List<Pair<RoomTile, THashSet<HabboItem>>> itemsAtLocation) {
-        for (Pair<RoomTile, THashSet<HabboItem>> set : itemsAtLocation) {
+    public boolean canStackAt(Room room, List<Pair<RoomTile, Set<HabboItem>>> itemsAtLocation) {
+        for (Pair<RoomTile, Set<HabboItem>> set : itemsAtLocation) {
             if (set.getValue() != null && !set.getValue().isEmpty()) return false;
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/totems/InteractionTotemPlanet.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/totems/InteractionTotemPlanet.java
@@ -5,10 +5,10 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionDefault;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Set;
 
 public class InteractionTotemPlanet extends InteractionDefault {
     public InteractionTotemPlanet(ResultSet set, Item baseItem) throws SQLException {
@@ -39,7 +39,7 @@ public class InteractionTotemPlanet extends InteractionDefault {
         InteractionTotemLegs legs = null;
         InteractionTotemHead head = null;
 
-        THashSet<HabboItem> items = room.getItemsAt(room.getLayout().getTile(this.getX(), this.getY()));
+        Set<HabboItem> items = room.getItemsAt(room.getLayout().getTile(this.getX(), this.getY()));
 
         for(HabboItem item : items) {
             if(item instanceof InteractionTotemLegs && item.getZ() < this.getZ())

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionCounterTimeMatches.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionCounterTimeMatches.java
@@ -13,11 +13,13 @@ import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredConditionCounterTimeMatches extends InteractionWiredCondition {
@@ -31,7 +33,7 @@ public class WiredConditionCounterTimeMatches extends InteractionWiredCondition 
 
     public static final WiredConditionType type = WiredConditionType.COUNTER_TIME_MATCHES;
 
-    private final THashSet<HabboItem> items;
+    private final Set<HabboItem> items;
     private int comparison = COMPARISON_EQUAL;
     private int minutes = 0;
     private int halfSecondSteps = 0;
@@ -40,12 +42,12 @@ public class WiredConditionCounterTimeMatches extends InteractionWiredCondition 
 
     public WiredConditionCounterTimeMatches(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredConditionCounterTimeMatches(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -240,7 +242,7 @@ public class WiredConditionCounterTimeMatches extends InteractionWiredCondition 
     }
 
     private void refresh(Room room) {
-        THashSet<HabboItem> remove = new THashSet<>();
+        Set<HabboItem> remove = new HashSet<>();
 
         for (HabboItem item : this.items) {
             HabboItem roomItem = room.getHabboItem(item.getId());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveFurni.java
@@ -13,28 +13,30 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
     public static final WiredConditionType type = WiredConditionType.FURNI_HAS_FURNI;
 
     private boolean all;
-    private THashSet<HabboItem> items;
+    private Set<HabboItem> items;
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
 
     public WiredConditionFurniHaveFurni(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredConditionFurniHaveFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -56,7 +58,7 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
                 RoomTile baseTile = room.getLayout().getTile(item.getX(), item.getY());
                 if (baseTile == null) return false;
                 double minZ = item.getZ() + Item.getCurrentHeight(item);
-                THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
+                Set<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
                 if (occupiedTiles == null) return false;
                 return occupiedTiles.stream().anyMatch(tile -> tile != null && room.getItemsAt(tile).stream().anyMatch(matchedItem -> matchedItem != item && matchedItem.getZ() >= minZ));
             });
@@ -67,7 +69,7 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
                 RoomTile baseTile = room.getLayout().getTile(item.getX(), item.getY());
                 if (baseTile == null) return false;
                 double minZ = item.getZ() + Item.getCurrentHeight(item);
-                THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
+                Set<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
                 if (occupiedTiles == null) return false;
                 return occupiedTiles.stream().anyMatch(tile -> tile != null && room.getItemsAt(tile).stream().anyMatch(matchedItem -> matchedItem != item && matchedItem.getZ() >= minZ));
             });
@@ -220,7 +222,7 @@ public class WiredConditionFurniHaveFurni extends InteractionWiredCondition {
     }
 
     private void refresh() {
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
         if (room == null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveHabbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveHabbo.java
@@ -16,28 +16,30 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
     public static final WiredConditionType type = WiredConditionType.FURNI_HAVE_HABBO;
-    protected THashSet<HabboItem> items;
+    protected Set<HabboItem> items;
     protected boolean all;
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
 
     public WiredConditionFurniHaveHabbo(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredConditionFurniHaveHabbo(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -199,7 +201,7 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
         RoomTile baseTile = room.getLayout().getTile(item.getX(), item.getY());
         if (baseTile == null) return false;
 
-        THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
+        Set<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
         return occupiedTiles != null && (
                 habbos.stream().anyMatch(character -> character.getRoomUnit() != null && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation())) ||
                 bots.stream().anyMatch(character -> character.getRoomUnit() != null && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation())) ||
@@ -208,7 +210,7 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
     }
 
     private void refresh() {
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
         if (room == null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveHabbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniHaveHabbo.java
@@ -63,8 +63,8 @@ public class WiredConditionFurniHaveHabbo extends InteractionWiredCondition {
             return false;
 
         Collection<Habbo> habbos = room.getHabbos();
-        Collection<Bot> bots = room.getCurrentBots().valueCollection();
-        Collection<Pet> pets = room.getCurrentPets().valueCollection();
+        Collection<Bot> bots = room.getCurrentBots().values();
+        Collection<Pet> pets = room.getCurrentPets().values();
 
         if (this.all) {
             return targets.stream().filter(item -> item != null).allMatch(item -> this.hasAvatarOnItem(item, room, habbos, bots, pets));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniTypeMatch.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniTypeMatch.java
@@ -12,12 +12,14 @@ import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
@@ -27,8 +29,8 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
 
     public static final WiredConditionType type = WiredConditionType.STUFF_IS;
 
-    protected THashSet<HabboItem> items = new THashSet<>();
-    protected THashSet<HabboItem> secondaryItems = new THashSet<>();
+    protected Set<HabboItem> items = new LinkedHashSet<>();
+    protected Set<HabboItem> secondaryItems = new LinkedHashSet<>();
     protected int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
     protected int compareFurniSource = WiredSourceUtil.SOURCE_TRIGGER;
     protected int quantifier = QUANTIFIER_ALL;
@@ -69,7 +71,7 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
             return false;
         }
 
-        THashSet<Integer> compareTypeIds = this.resolveCompareTypeIds(ctx);
+        Set<Integer> compareTypeIds = this.resolveCompareTypeIds(ctx);
         if (compareTypeIds.isEmpty()) {
             return false;
         }
@@ -89,7 +91,7 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
             return false;
         }
 
-        THashSet<Integer> compareTypeIds = this.resolveCompareTypeIds(ctx);
+        Set<Integer> compareTypeIds = this.resolveCompareTypeIds(ctx);
         if (compareTypeIds.isEmpty()) {
             return false;
         }
@@ -108,10 +110,10 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
         return this.resolveConfiguredItems(ctx, this.furniSource);
     }
 
-    protected THashSet<Integer> resolveCompareTypeIds(WiredContext ctx) {
+    protected Set<Integer> resolveCompareTypeIds(WiredContext ctx) {
         this.refresh();
 
-        THashSet<Integer> compareTypeIds = new THashSet<>();
+        Set<Integer> compareTypeIds = new HashSet<>();
 
         for (HabboItem item : this.resolveConfiguredItems(ctx, this.compareFurniSource)) {
             if (item != null && item.getBaseItem() != null) {
@@ -122,7 +124,7 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
         return compareTypeIds;
     }
 
-    protected boolean matchesType(HabboItem item, THashSet<Integer> compareTypeIds) {
+    protected boolean matchesType(HabboItem item, Set<Integer> compareTypeIds) {
         return item != null && item.getBaseItem() != null && compareTypeIds.contains(item.getBaseItem().getId());
     }
 
@@ -302,8 +304,8 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
         this.refreshSelection(this.secondaryItems);
     }
 
-    private void refreshSelection(THashSet<HabboItem> selection) {
-        THashSet<HabboItem> remove = new THashSet<>();
+    private void refreshSelection(Set<HabboItem> selection) {
+        Set<HabboItem> remove = new HashSet<>();
 
         Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
         if (room == null) {
@@ -321,7 +323,7 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
         }
     }
 
-    void loadItems(Room room, List<Integer> itemIds, THashSet<HabboItem> target) {
+    void loadItems(Room room, List<Integer> itemIds, Set<HabboItem> target) {
         if (room == null || itemIds == null || target == null) {
             return;
         }
@@ -338,7 +340,7 @@ public class WiredConditionFurniTypeMatch extends InteractionWiredCondition {
         }
     }
 
-    private String serializeIds(THashSet<HabboItem> source) {
+    private String serializeIds(Set<HabboItem> source) {
         return source.stream()
                 .map(HabboItem::getId)
                 .filter(id -> id > 0)

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHasAltitude.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHasAltitude.java
@@ -12,13 +12,15 @@ import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredConditionHasAltitude extends InteractionWiredCondition {
@@ -30,7 +32,7 @@ public class WiredConditionHasAltitude extends InteractionWiredCondition {
 
     public static final WiredConditionType type = WiredConditionType.HAS_ALTITUDE;
 
-    private final THashSet<HabboItem> items;
+    private final Set<HabboItem> items;
     private int comparison = COMPARISON_EQUAL;
     private double altitude = 0.0D;
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
@@ -38,12 +40,12 @@ public class WiredConditionHasAltitude extends InteractionWiredCondition {
 
     public WiredConditionHasAltitude(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredConditionHasAltitude(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -223,7 +225,7 @@ public class WiredConditionHasAltitude extends InteractionWiredCondition {
     }
 
     private void refresh(Room room) {
-        THashSet<HabboItem> remove = new THashSet<>();
+        Set<HabboItem> remove = new HashSet<>();
 
         for (HabboItem item : this.items) {
             if (room.getHabboItem(item.getId()) == null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHasVariable.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHasVariable.java
@@ -22,14 +22,16 @@ import com.eu.habbo.habbohotel.wired.core.WiredInternalVariableSupport;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 public class WiredConditionHasVariable extends InteractionWiredCondition {
     private static final Logger LOGGER = LoggerFactory.getLogger(WiredConditionHasVariable.class);
@@ -45,7 +47,7 @@ public class WiredConditionHasVariable extends InteractionWiredCondition {
 
     public static final WiredConditionType type = WiredConditionType.HAS_VAR;
 
-    protected final THashSet<HabboItem> selectedItems = new THashSet<>();
+    protected final Set<HabboItem> selectedItems = new LinkedHashSet<>();
     protected int targetType = TARGET_USER;
     protected int userSource = WiredSourceUtil.SOURCE_TRIGGER;
     protected int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
@@ -375,7 +377,7 @@ public class WiredConditionHasVariable extends InteractionWiredCondition {
     }
 
     protected void refresh() {
-        THashSet<HabboItem> staleItems = new THashSet<>();
+        Set<HabboItem> staleItems = new HashSet<>();
         Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
 
         if (room == null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionMatchStatePosition.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionMatchStatePosition.java
@@ -14,13 +14,14 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.WiredMatchFurniSetting;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.math.BigDecimal;
+import java.util.Set;
 
 public class WiredConditionMatchStatePosition extends InteractionWiredCondition implements InteractionWiredMatchFurniSettings {
     protected static final int QUANTIFIER_ALL = 0;
@@ -28,7 +29,7 @@ public class WiredConditionMatchStatePosition extends InteractionWiredCondition 
 
     public static final WiredConditionType type = WiredConditionType.MATCH_SSHOT;
 
-    private THashSet<WiredMatchFurniSetting> settings;
+    private Set<WiredMatchFurniSetting> settings;
 
     private boolean state;
     private boolean position;
@@ -39,12 +40,12 @@ public class WiredConditionMatchStatePosition extends InteractionWiredCondition 
 
     public WiredConditionMatchStatePosition(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.settings = new THashSet<>();
+        this.settings = new HashSet<>();
     }
 
     public WiredConditionMatchStatePosition(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.settings = new THashSet<>();
+        this.settings = new HashSet<>();
     }
 
     @Override
@@ -406,7 +407,7 @@ public class WiredConditionMatchStatePosition extends InteractionWiredCondition 
         Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
 
         if (room != null) {
-            THashSet<WiredMatchFurniSetting> remove = new THashSet<>();
+            Set<WiredMatchFurniSetting> remove = new HashSet<>();
 
             for (WiredMatchFurniSetting setting : this.settings) {
                 HabboItem item = room.getHabboItem(setting.item_id);
@@ -422,7 +423,7 @@ public class WiredConditionMatchStatePosition extends InteractionWiredCondition 
     }
 
     @Override
-    public THashSet<WiredMatchFurniSetting> getMatchFurniSettings() {
+    public Set<WiredMatchFurniSetting> getMatchFurniSettings() {
         return this.settings;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotFurniHaveFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotFurniHaveFurni.java
@@ -14,28 +14,30 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredConditionNotFurniHaveFurni extends InteractionWiredCondition {
     public static final WiredConditionType type = WiredConditionType.NOT_FURNI_HAVE_FURNI;
 
     private boolean all;
-    private THashSet<HabboItem> items;
+    private Set<HabboItem> items;
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
 
     public WiredConditionNotFurniHaveFurni(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredConditionNotFurniHaveFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -57,7 +59,7 @@ public class WiredConditionNotFurniHaveFurni extends InteractionWiredCondition {
                 RoomTile baseTile = room.getLayout().getTile(item.getX(), item.getY());
                 if (baseTile == null) return true;
                 double minZ = item.getZ() + Item.getCurrentHeight(item);
-                THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
+                Set<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
                 if (occupiedTiles == null) return true;
                 return occupiedTiles.stream().noneMatch(tile -> tile != null && room.getItemsAt(tile).stream().anyMatch(matchedItem -> matchedItem != item && matchedItem.getZ() >= minZ));
             });
@@ -68,7 +70,7 @@ public class WiredConditionNotFurniHaveFurni extends InteractionWiredCondition {
                 RoomTile baseTile = room.getLayout().getTile(item.getX(), item.getY());
                 if (baseTile == null) return true;
                 double minZ = item.getZ() + Item.getCurrentHeight(item);
-                THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
+                Set<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
                 if (occupiedTiles == null) return true;
                 return occupiedTiles.stream().noneMatch(tile -> tile != null && room.getItemsAt(tile).stream().anyMatch(matchedItem -> matchedItem != item && matchedItem.getZ() >= minZ));
             });
@@ -193,7 +195,7 @@ public class WiredConditionNotFurniHaveFurni extends InteractionWiredCondition {
     }
 
     private void refresh() {
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
         if (room == null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotFurniHaveHabbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotFurniHaveHabbo.java
@@ -16,29 +16,31 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredConditionNotFurniHaveHabbo extends InteractionWiredCondition {
     public static final WiredConditionType type = WiredConditionType.NOT_FURNI_HAVE_HABBO;
     
-    protected THashSet<HabboItem> items;
+    protected Set<HabboItem> items;
     protected boolean all;
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
 
     public WiredConditionNotFurniHaveHabbo(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredConditionNotFurniHaveHabbo(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -183,7 +185,7 @@ public class WiredConditionNotFurniHaveHabbo extends InteractionWiredCondition {
         RoomTile baseTile = room.getLayout().getTile(item.getX(), item.getY());
         if (baseTile == null) return false;
 
-        THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
+        Set<RoomTile> occupiedTiles = room.getLayout().getTilesAt(baseTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
         return occupiedTiles != null && (
                 habbos.stream().anyMatch(character -> character.getRoomUnit() != null && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation())) ||
                 bots.stream().anyMatch(character -> character.getRoomUnit() != null && occupiedTiles.contains(character.getRoomUnit().getCurrentLocation())) ||
@@ -192,7 +194,7 @@ public class WiredConditionNotFurniHaveHabbo extends InteractionWiredCondition {
     }
 
     private void refresh() {
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
         if (room == null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotFurniHaveHabbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotFurniHaveHabbo.java
@@ -64,8 +64,8 @@ public class WiredConditionNotFurniHaveHabbo extends InteractionWiredCondition {
             return false;
 
         Collection<Habbo> habbos = room.getHabbos();
-        Collection<Bot> bots = room.getCurrentBots().valueCollection();
-        Collection<Pet> pets = room.getCurrentPets().valueCollection();
+        Collection<Bot> bots = room.getCurrentBots().values();
+        Collection<Pet> pets = room.getCurrentPets().values();
 
         if (this.all) {
             return targets.stream().filter(item -> item != null).allMatch(item -> !this.hasAvatarOnItem(item, room, habbos, bots, pets));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionSelectionQuantity.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionSelectionQuantity.java
@@ -12,11 +12,13 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredConditionSelectionQuantity extends InteractionWiredCondition {
@@ -35,7 +37,7 @@ public class WiredConditionSelectionQuantity extends InteractionWiredCondition {
 
     public static final WiredConditionType type = WiredConditionType.SLC_QUANTITY;
 
-    private final THashSet<HabboItem> items;
+    private final Set<HabboItem> items;
     private int comparison = COMPARISON_EQUAL;
     private int quantity = 0;
     private int sourceGroup = SOURCE_GROUP_USERS;
@@ -43,12 +45,12 @@ public class WiredConditionSelectionQuantity extends InteractionWiredCondition {
 
     public WiredConditionSelectionQuantity(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredConditionSelectionQuantity(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -335,7 +337,7 @@ public class WiredConditionSelectionQuantity extends InteractionWiredCondition {
             return;
         }
 
-        THashSet<HabboItem> itemsToRemove = new THashSet<>();
+        Set<HabboItem> itemsToRemove = new HashSet<>();
 
         for (HabboItem item : this.items) {
             if (item == null || room.getHabboItem(item.getId()) == null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTriggerOnFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTriggerOnFurni.java
@@ -13,12 +13,14 @@ import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
@@ -27,7 +29,7 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
 
     public static final WiredConditionType type = WiredConditionType.TRIGGER_ON_FURNI;
 
-    protected THashSet<HabboItem> items = new THashSet<>();
+    protected Set<HabboItem> items = new LinkedHashSet<>();
     protected int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
     protected int userSource = WiredSourceUtil.SOURCE_TRIGGER;
     protected int quantifier = QUANTIFIER_ALL;
@@ -72,7 +74,7 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
     protected boolean isAnyUserOnFurni(Collection<RoomUnit> users, Collection<HabboItem> items, Room room) {
         for (RoomUnit roomUnit : users) {
             if (roomUnit == null) continue;
-            THashSet<HabboItem> itemsAtUser = room.getItemsAt(roomUnit.getCurrentLocation());
+            Set<HabboItem> itemsAtUser = room.getItemsAt(roomUnit.getCurrentLocation());
             if (items.stream().anyMatch(itemsAtUser::contains)) {
                 return true;
             }
@@ -86,7 +88,7 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
                 return false;
             }
 
-            THashSet<HabboItem> itemsAtUser = room.getItemsAt(roomUnit.getCurrentLocation());
+            Set<HabboItem> itemsAtUser = room.getItemsAt(roomUnit.getCurrentLocation());
             if (itemsAtUser == null || items.stream().noneMatch(itemsAtUser::contains)) {
                 return false;
             }
@@ -211,7 +213,7 @@ public class WiredConditionTriggerOnFurni extends InteractionWiredCondition {
     }
 
     protected void refresh() {
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
         if (room == null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionVariableValueMatch.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionVariableValueMatch.java
@@ -25,16 +25,18 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.util.HotelDateTimeUtil;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.ZonedDateTime;
 import java.time.temporal.WeekFields;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 public class WiredConditionVariableValueMatch extends WiredConditionHasVariable {
     public static final WiredConditionType type = WiredConditionType.VAR_VAL_MATCH;
@@ -61,7 +63,7 @@ public class WiredConditionVariableValueMatch extends WiredConditionHasVariable 
     protected int referenceFurniSource = WiredSourceUtil.SOURCE_TRIGGER;
     protected String referenceVariableToken = "";
     protected int referenceVariableItemId = 0;
-    protected final THashSet<HabboItem> referenceSelectedItems = new THashSet<>();
+    protected final Set<HabboItem> referenceSelectedItems = new LinkedHashSet<>();
 
     public WiredConditionVariableValueMatch(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
@@ -680,7 +682,7 @@ public class WiredConditionVariableValueMatch extends WiredConditionHasVariable 
     }
 
     private void refreshReferenceItems() {
-        THashSet<HabboItem> staleItems = new THashSet<>();
+        Set<HabboItem> staleItems = new HashSet<>();
         Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
 
         if (room == null) {
@@ -704,7 +706,7 @@ public class WiredConditionVariableValueMatch extends WiredConditionHasVariable 
         return (value == null || value.isEmpty()) ? new String[0] : value.split("\\t", -1);
     }
 
-    private List<Integer> toIds(THashSet<HabboItem> items) {
+    private List<Integer> toIds(Set<HabboItem> items) {
         List<Integer> ids = new ArrayList<>();
         for (HabboItem item : items) {
             if (item != null) ids.add(item.getId());
@@ -712,7 +714,7 @@ public class WiredConditionVariableValueMatch extends WiredConditionHasVariable 
         return ids;
     }
 
-    private String serializeIds(THashSet<HabboItem> items) {
+    private String serializeIds(Set<HabboItem> items) {
         StringBuilder builder = new StringBuilder();
 
         for (HabboItem item : items) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotFollowHabbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotFollowHabbo.java
@@ -17,7 +17,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -58,15 +57,11 @@ public class WiredEffectBotFollowHabbo extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotGiveHandItem.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotGiveHandItem.java
@@ -19,7 +19,6 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
 import com.eu.habbo.threading.runnables.RoomUnitGiveHanditem;
 import com.eu.habbo.threading.runnables.RoomUnitWalkToLocation;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -61,15 +60,11 @@ public class WiredEffectBotGiveHandItem extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotTalkToHabbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotTalkToHabbo.java
@@ -18,7 +18,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.habbohotel.wired.core.WiredTextPlaceholderUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -61,15 +60,11 @@ public class WiredEffectBotTalkToHabbo extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotTeleport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotTeleport.java
@@ -21,30 +21,32 @@ import com.eu.habbo.messages.incoming.wired.WiredSaveException;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserEffectComposer;
 import com.eu.habbo.threading.runnables.RoomUnitTeleport;
 import com.eu.habbo.threading.runnables.SendRoomUnitEffectComposer;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 public class WiredEffectBotTeleport extends InteractionWiredEffect {
     public static final WiredEffectType type = WiredEffectType.BOT_TELEPORT;
 
-    private THashSet<HabboItem> items;
+    private Set<HabboItem> items;
     private String botName = "";
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
     private int botSource = WiredBotSourceUtil.SOURCE_BOT_NAME;
 
     public WiredEffectBotTeleport(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredEffectBotTeleport(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public static void teleportUnitToTile(RoomUnit roomUnit, RoomTile tile) {
@@ -91,7 +93,7 @@ public class WiredEffectBotTeleport extends InteractionWiredEffect {
     @Override
     public void serializeWiredData(ServerMessage message, Room room) {
         List<HabboItem> itemsSnapshot = new ArrayList<>(this.items);
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         for (HabboItem item : itemsSnapshot) {
             if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
@@ -227,7 +229,7 @@ public class WiredEffectBotTeleport extends InteractionWiredEffect {
 
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
 
         String wiredData = set.getString("wired_data");
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotWalkToFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotWalkToFurni.java
@@ -16,12 +16,13 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredEffectBotWalkToFurni extends InteractionWiredEffect {
@@ -44,7 +45,7 @@ public class WiredEffectBotWalkToFurni extends InteractionWiredEffect {
 
     @Override
     public void serializeWiredData(ServerMessage message, Room room) {
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         for (HabboItem item : this.items) {
             if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectChangeFurniDirection.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectChangeFurniDirection.java
@@ -14,14 +14,16 @@ import com.eu.habbo.habbohotel.wired.core.WiredMoveCarryHelper;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class WiredEffectChangeFurniDirection extends InteractionWiredEffect {
@@ -35,7 +37,7 @@ public class WiredEffectChangeFurniDirection extends InteractionWiredEffect {
 
     public static final WiredEffectType type = WiredEffectType.MOVE_DIRECTION;
 
-    private final THashMap<HabboItem, WiredChangeDirectionSetting> items = new THashMap<>(0);
+    private final Map<HabboItem, WiredChangeDirectionSetting> items = new LinkedHashMap<>(0);
     private final ConcurrentHashMap<Integer, WiredChangeDirectionSetting> runtimeItems = new ConcurrentHashMap<>();
     private RoomUserRotation startRotation = RoomUserRotation.NORTH;
     private int blockedAction = 0;
@@ -56,11 +58,11 @@ public class WiredEffectChangeFurniDirection extends InteractionWiredEffect {
         if (room == null || room.getLayout() == null) return;
 
         List<HabboItem> resolvedItems = WiredSourceUtil.resolveItems(ctx, this.furniSource, this.items.keySet());
-        THashMap<HabboItem, WiredChangeDirectionSetting> effectiveItems;
+        Map<HabboItem, WiredChangeDirectionSetting> effectiveItems;
 
         if (this.furniSource == WiredSourceUtil.SOURCE_SELECTED) {
             this.runtimeItems.clear();
-            THashSet<HabboItem> toRemove = new THashSet<>();
+            Set<HabboItem> toRemove = new HashSet<>();
             for (HabboItem item : this.items.keySet()) {
                 if (item == null || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
                     toRemove.add(item);
@@ -71,7 +73,7 @@ public class WiredEffectChangeFurniDirection extends InteractionWiredEffect {
             effectiveItems = this.items;
         } else {
             this.pruneRuntimeItems(room);
-            effectiveItems = new THashMap<>();
+            effectiveItems = new HashMap<>();
             for (HabboItem item : resolvedItems) {
                 if (item != null) {
                     WiredChangeDirectionSetting setting = this.runtimeItems.computeIfAbsent(
@@ -294,7 +296,7 @@ public class WiredEffectChangeFurniDirection extends InteractionWiredEffect {
             this.furniSource = WiredSourceUtil.SOURCE_SELECTED;
         }
 
-        THashMap<HabboItem, WiredChangeDirectionSetting> newItems = new THashMap<>();
+        Map<HabboItem, WiredChangeDirectionSetting> newItems = new LinkedHashMap<>();
 
         for (int i = 0; i < itemsCount; i++) {
             int itemId = settings.getFurniIds()[i];

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectFreeze.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectFreeze.java
@@ -15,7 +15,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -112,15 +111,11 @@ public class WiredEffectFreeze extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewBonusRarePoints.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewBonusRarePoints.java
@@ -16,7 +16,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.hotelview.BonusRareComposer;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -53,15 +52,11 @@ public class WiredEffectGiveHotelviewBonusRarePoints extends InteractionWiredEff
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewHofPoints.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewHofPoints.java
@@ -15,7 +15,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -52,15 +51,11 @@ public class WiredEffectGiveHotelviewHofPoints extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveRespect.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveRespect.java
@@ -16,7 +16,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -53,15 +52,11 @@ public class WiredEffectGiveRespect extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveReward.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveReward.java
@@ -19,7 +19,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
 import com.eu.habbo.messages.outgoing.generic.alerts.UpdateFailedComposer;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -165,15 +164,11 @@ public class WiredEffectGiveReward extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveScore.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveScore.java
@@ -16,7 +16,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -126,15 +125,11 @@ public class WiredEffectGiveScore extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveVariable.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveVariable.java
@@ -17,12 +17,13 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 public class WiredEffectGiveVariable extends InteractionWiredEffect {
     public static final WiredEffectType type = WiredEffectType.GIVE_VAR;
@@ -37,16 +38,16 @@ public class WiredEffectGiveVariable extends InteractionWiredEffect {
     private int initialValue = 0;
     private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
-    private final THashSet<HabboItem> selectedFurni;
+    private final Set<HabboItem> selectedFurni;
 
     public WiredEffectGiveVariable(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.selectedFurni = new THashSet<>();
+        this.selectedFurni = new LinkedHashSet<>();
     }
 
     public WiredEffectGiveVariable(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.selectedFurni = new THashSet<>();
+        this.selectedFurni = new LinkedHashSet<>();
     }
 
     @Override
@@ -369,7 +370,7 @@ public class WiredEffectGiveVariable extends InteractionWiredEffect {
         return this.furniSource;
     }
 
-    public THashSet<HabboItem> getSelectedFurni() {
+    public Set<HabboItem> getSelectedFurni() {
         return this.selectedFurni;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectJoinTeam.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectJoinTeam.java
@@ -20,7 +20,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -147,15 +146,11 @@ public class WiredEffectJoinTeam extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectKickHabbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectKickHabbo.java
@@ -21,7 +21,6 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserWhisperComposer;
 import com.eu.habbo.threading.runnables.RoomUnitKick;
-import gnu.trove.procedure.TObjectProcedure;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -150,15 +149,11 @@ public class WiredEffectKickHabbo extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectLeaveTeam.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectLeaveTeam.java
@@ -17,7 +17,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -111,15 +110,11 @@ public class WiredEffectLeaveTeam extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMatchFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMatchFurni.java
@@ -16,14 +16,15 @@ import com.eu.habbo.habbohotel.wired.core.WiredMoveCarryHelper;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.math.BigDecimal;
 
@@ -32,7 +33,7 @@ public class WiredEffectMatchFurni extends InteractionWiredEffect implements Int
 
     private static final WiredEffectType type = WiredEffectType.MATCH_SSHOT;
     public boolean checkForWiredResetPermission = true;
-    private THashSet<WiredMatchFurniSetting> settings;
+    private Set<WiredMatchFurniSetting> settings;
     private boolean state = false;
     private boolean direction = false;
     private boolean position = false;
@@ -41,12 +42,12 @@ public class WiredEffectMatchFurni extends InteractionWiredEffect implements Int
 
     public WiredEffectMatchFurni(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.settings = new THashSet<>(0);
+        this.settings = new HashSet<>(0);
     }
 
     public WiredEffectMatchFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.settings = new THashSet<>(0);
+        this.settings = new HashSet<>(0);
     }
 
     @Override
@@ -304,7 +305,7 @@ public class WiredEffectMatchFurni extends InteractionWiredEffect implements Int
     }
 
     @Override
-    public THashSet<WiredMatchFurniSetting> getMatchFurniSettings() {
+    public Set<WiredMatchFurniSetting> getMatchFurniSettings() {
         return this.settings;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveFurniAway.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveFurniAway.java
@@ -15,20 +15,22 @@ import com.eu.habbo.habbohotel.wired.core.WiredSimulation;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 
 public class WiredEffectMoveFurniAway extends InteractionWiredEffect {
     public static final WiredEffectType type = WiredEffectType.FLEE;
 
-    private THashSet<HabboItem> items = new THashSet<>();
+    private Set<HabboItem> items = new LinkedHashSet<>();
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
 
     public WiredEffectMoveFurniAway(ResultSet set, Item baseItem) throws SQLException {
@@ -46,7 +48,7 @@ public class WiredEffectMoveFurniAway extends InteractionWiredEffect {
 
         List<HabboItem> effectiveItems = WiredSourceUtil.resolveItems(ctx, this.furniSource, this.items);
         if (this.furniSource == WiredSourceUtil.SOURCE_SELECTED) {
-            THashSet<HabboItem> toRemove = new THashSet<>();
+            Set<HabboItem> toRemove = new HashSet<>();
             for (HabboItem item : effectiveItems) {
                 if (item != null && item.getRoomId() == 0) {
                     toRemove.add(item);
@@ -173,7 +175,7 @@ public class WiredEffectMoveFurniAway extends InteractionWiredEffect {
 
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
         String wiredData = set.getString("wired_data");
 
         if (wiredData.startsWith("{")) {
@@ -224,7 +226,7 @@ public class WiredEffectMoveFurniAway extends InteractionWiredEffect {
     @Override
     public void serializeWiredData(ServerMessage message, Room room) {
         List<HabboItem> itemsSnapshot = new ArrayList<>(this.items);
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         for (HabboItem item : itemsSnapshot) {
             if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveFurniTo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveFurniTo.java
@@ -18,13 +18,14 @@ import com.eu.habbo.habbohotel.wired.core.WiredSimulation;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.set.hash.THashSet;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
@@ -192,7 +193,7 @@ public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
 
     @Override
     public String getWiredData() {
-        THashSet<HabboItem> itemsToRemove = new THashSet<>();
+        Set<HabboItem> itemsToRemove = new HashSet<>();
         List<HabboItem> itemsSnapshot = new ArrayList<>(this.items);
 
         for (HabboItem item : itemsSnapshot) {
@@ -217,7 +218,7 @@ public class WiredEffectMoveFurniTo extends InteractionWiredEffect {
     @Override
     public void serializeWiredData(ServerMessage message, Room room) {
         List<HabboItem> itemsSnapshot = new ArrayList<>(this.items);
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         for (HabboItem item : itemsSnapshot) {
             if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveFurniTowards.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveFurniTowards.java
@@ -16,14 +16,17 @@ import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
 import com.eu.habbo.threading.runnables.WiredCollissionRunnable;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -35,22 +38,22 @@ import java.util.stream.Collectors;
 public class WiredEffectMoveFurniTowards extends InteractionWiredEffect {
     public static final WiredEffectType type = WiredEffectType.CHASE;
 
-    private THashSet<HabboItem> items;
+    private Set<HabboItem> items;
 
-    private THashMap<Integer, RoomUserRotation> lastDirections;
+    private Map<Integer, RoomUserRotation> lastDirections;
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
 
 
     public WiredEffectMoveFurniTowards(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
-        this.lastDirections = new THashMap<>();
+        this.items = new LinkedHashSet<>();
+        this.lastDirections = new LinkedHashMap<>();
     }
 
     public WiredEffectMoveFurniTowards(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
-        this.lastDirections = new THashMap<>();
+        this.items = new LinkedHashSet<>();
+        this.lastDirections = new LinkedHashMap<>();
     }
 
     public List<RoomUserRotation> getAvailableDirections(HabboItem item, Room room, WiredContext ctx) {
@@ -94,7 +97,7 @@ public class WiredEffectMoveFurniTowards extends InteractionWiredEffect {
 
         List<HabboItem> effectiveItems = WiredSourceUtil.resolveItems(ctx, this.furniSource, this.items);
         if (this.furniSource == WiredSourceUtil.SOURCE_SELECTED) {
-            THashSet<HabboItem> toRemove = new THashSet<>();
+            Set<HabboItem> toRemove = new HashSet<>();
             for (HabboItem item : effectiveItems) {
                 if (item != null && Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null) {
                     toRemove.add(item);
@@ -324,7 +327,7 @@ public class WiredEffectMoveFurniTowards extends InteractionWiredEffect {
 
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
         String wiredData = set.getString("wired_data");
 
         if (wiredData.startsWith("{")) {
@@ -376,7 +379,7 @@ public class WiredEffectMoveFurniTowards extends InteractionWiredEffect {
     @Override
     public void serializeWiredData(ServerMessage message, Room room) {
         List<HabboItem> itemsSnapshot = new ArrayList<>(this.items);
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         for (HabboItem item : itemsSnapshot) {
             if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveRotateFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveRotateFurni.java
@@ -16,7 +16,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredSimulation;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -305,7 +304,7 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
             } else if (this.rotation == 2) {
                 return item.getRotation() > 0 ? item.getRotation() - 1 : item.getMaximumRotations() - 1;
             } else if (this.rotation == 3) { //Random rotation
-                THashSet<Integer> possibleRotations = new THashSet<>();
+                Set<Integer> possibleRotations = new HashSet<>();
                 for (int i = 0; i < item.getMaximumRotations(); i++)
                 {
                     possibleRotations.add(i);
@@ -333,7 +332,7 @@ public class WiredEffectMoveRotateFurni extends InteractionWiredEffect implement
                 }
                 return rot;
             } else if (this.rotation == 3) { //Random rotation
-                THashSet<Integer> possibleRotations = new THashSet<>();
+                Set<Integer> possibleRotations = new HashSet<>();
                 for (int i = 0; i < item.getMaximumRotations(); i++)
                 {
                     possibleRotations.add(i * 2);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveRotateUser.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveRotateUser.java
@@ -20,7 +20,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.habbohotel.wired.core.WiredUserMovementHelper;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -148,15 +147,11 @@ public class WiredEffectMoveRotateUser extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectRemoveVariable.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectRemoveVariable.java
@@ -17,12 +17,13 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 public class WiredEffectRemoveVariable extends InteractionWiredEffect {
     public static final WiredEffectType type = WiredEffectType.REMOVE_VAR;
@@ -35,16 +36,16 @@ public class WiredEffectRemoveVariable extends InteractionWiredEffect {
     private int targetType = TARGET_USER;
     private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
-    private final THashSet<HabboItem> selectedFurni;
+    private final Set<HabboItem> selectedFurni;
 
     public WiredEffectRemoveVariable(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.selectedFurni = new THashSet<>();
+        this.selectedFurni = new LinkedHashSet<>();
     }
 
     public WiredEffectRemoveVariable(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.selectedFurni = new THashSet<>();
+        this.selectedFurni = new LinkedHashSet<>();
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectResetTimers.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectResetTimers.java
@@ -13,7 +13,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.threading.runnables.WiredResetTimers;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -49,15 +48,11 @@ public class WiredEffectResetTimers extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSendSignal.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSendSignal.java
@@ -16,8 +16,6 @@ import com.eu.habbo.habbohotel.wired.core.*;
 import com.eu.habbo.habbohotel.wired.core.WiredEvent;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.procedure.TObjectProcedure;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,8 +40,8 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
     private static final long ANTENNA_PULSE_MS = 300L;
     private static final ConcurrentHashMap<Integer, Long> ANTENNA_PULSE_TOKENS = new ConcurrentHashMap<>();
 
-    private THashSet<HabboItem> items;
-    private THashSet<HabboItem> forwardItems;
+    private Set<HabboItem> items;
+    private Set<HabboItem> forwardItems;
     private int     antennaSource   = ANTENNA_PICKED;
     private int     furniForward    = WiredSourceUtil.SOURCE_TRIGGER;
     private int     userForward     = WiredSourceUtil.SOURCE_TRIGGER;
@@ -53,14 +51,14 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
 
     public WiredEffectSendSignal(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
-        this.forwardItems = new THashSet<>();
+        this.items = new LinkedHashSet<>();
+        this.forwardItems = new LinkedHashSet<>();
     }
 
     public WiredEffectSendSignal(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
-        this.forwardItems = new THashSet<>();
+        this.items = new LinkedHashSet<>();
+        this.forwardItems = new LinkedHashSet<>();
     }
 
     @Override
@@ -246,15 +244,11 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger trigger : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!trigger.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(trigger.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);
@@ -346,8 +340,8 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
 
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
-        this.items = new THashSet<>();
-        this.forwardItems = new THashSet<>();
+        this.items = new LinkedHashSet<>();
+        this.forwardItems = new LinkedHashSet<>();
         String wiredData = set.getString("wired_data");
 
         JsonData data = WiredUtilityPayloadGuard.fromJson(wiredData, JsonData.class);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectTeleport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectTeleport.java
@@ -21,14 +21,14 @@ import com.eu.habbo.messages.outgoing.rooms.users.RoomUserEffectComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
 import com.eu.habbo.threading.runnables.RoomUnitTeleport;
 import com.eu.habbo.threading.runnables.SendRoomUnitEffectComposer;
-import gnu.trove.procedure.TObjectProcedure;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredEffectTeleport extends InteractionWiredEffect {
@@ -119,7 +119,7 @@ public class WiredEffectTeleport extends InteractionWiredEffect {
     @Override
     public void serializeWiredData(ServerMessage message, Room room) {
         List<HabboItem> itemsSnapshot = new ArrayList<>(this.items);
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         for (HabboItem item : itemsSnapshot) {
             if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
@@ -148,15 +148,11 @@ public class WiredEffectTeleport extends InteractionWiredEffect {
         message.appendInt(this.getDelay());
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectToggleFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectToggleFurni.java
@@ -27,15 +27,16 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.procedure.TObjectProcedure;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredEffectToggleFurni extends InteractionWiredEffect {
@@ -45,7 +46,7 @@ public class WiredEffectToggleFurni extends InteractionWiredEffect {
 
     public static final WiredEffectType type = WiredEffectType.TOGGLE_STATE;
 
-    private final THashSet<HabboItem> items;
+    private final Set<HabboItem> items;
     private int toggleType = TOGGLE_TYPE_NEXT;
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
 
@@ -91,12 +92,12 @@ public class WiredEffectToggleFurni extends InteractionWiredEffect {
 
     public WiredEffectToggleFurni(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredEffectToggleFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -135,15 +136,11 @@ public class WiredEffectToggleFurni extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);
@@ -206,11 +203,11 @@ public class WiredEffectToggleFurni extends InteractionWiredEffect {
         Room room = ctx.room();
         Habbo habbo = ctx.actor().map(unit -> room.getHabbo(unit)).orElse(null);
 
-        // Snapshot this.items into a new list to avoid undefined behavior from concurrent
-        // THashSet access (serializeWiredData can modify items from the network thread).
+        // Snapshot this.items into a new list to avoid undefined behavior from concurrent access
+        // (serializeWiredData can modify items from the network thread).
         List<HabboItem> effectiveItems = WiredSourceUtil.resolveItems(ctx, this.furniSource, this.items);
 
-        THashSet<HabboItem> itemsToRemove = new THashSet<>();
+        Set<HabboItem> itemsToRemove = new HashSet<>();
         for (HabboItem item : effectiveItems) {
             if (item == null || item.getRoomId() == 0 || FORBIDDEN_TYPES.stream().anyMatch(a -> a.isAssignableFrom(item.getClass()))) {
                 itemsToRemove.add(item);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectToggleRandom.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectToggleRandom.java
@@ -25,15 +25,16 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.procedure.TObjectProcedure;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredEffectToggleRandom extends InteractionWiredEffect {
@@ -41,7 +42,7 @@ public class WiredEffectToggleRandom extends InteractionWiredEffect {
 
     public static final WiredEffectType type = WiredEffectType.TOGGLE_RANDOM;
 
-    private final THashSet<HabboItem> items = new THashSet<>();
+    private final Set<HabboItem> items = new LinkedHashSet<>();
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
 
     private static final List<Class<? extends HabboItem>> FORBIDDEN_TYPES = new ArrayList<Class<? extends HabboItem>>() {
@@ -95,7 +96,7 @@ public class WiredEffectToggleRandom extends InteractionWiredEffect {
     @Override
     public void serializeWiredData(ServerMessage message, Room room) {
         List<HabboItem> itemsSnapshot = new ArrayList<>(this.items);
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         for (HabboItem item : itemsSnapshot) {
             if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
@@ -124,15 +125,11 @@ public class WiredEffectToggleRandom extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectTriggerStacks.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectTriggerStacks.java
@@ -16,35 +16,36 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.procedure.TObjectProcedure;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredEffectTriggerStacks extends InteractionWiredEffect {
     public static final WiredEffectType type = WiredEffectType.CALL_STACKS;
 
-    protected THashSet<HabboItem> items;
+    protected Set<HabboItem> items;
     protected int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
 
     public WiredEffectTriggerStacks(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredEffectTriggerStacks(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
     public void serializeWiredData(ServerMessage message, Room room) {
         List<HabboItem> itemsSnapshot = new ArrayList<>(this.items);
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         for (HabboItem item : itemsSnapshot) {
             if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
@@ -72,15 +73,11 @@ public class WiredEffectTriggerStacks extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger trigger : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!trigger.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(trigger.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);
@@ -151,7 +148,7 @@ public class WiredEffectTriggerStacks extends InteractionWiredEffect {
             return;
         }
 
-        THashSet<RoomTile> usedTiles = collectTargetTiles(room, ctx);
+        Set<RoomTile> usedTiles = collectTargetTiles(room, ctx);
 
         WiredManager.executeEffectsAtTiles(usedTiles, roomUnit, room, currentDepth + 1);
     }
@@ -175,7 +172,7 @@ public class WiredEffectTriggerStacks extends InteractionWiredEffect {
 
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
         String wiredData = set.getString("wired_data");
 
         JsonData jsonData = WiredMovementPayloadGuard.fromJson(wiredData, JsonData.class);
@@ -236,8 +233,8 @@ public class WiredEffectTriggerStacks extends InteractionWiredEffect {
         return WiredSourceUtil.resolveItems(ctx, this.furniSource, this.items);
     }
 
-    protected THashSet<RoomTile> collectTargetTiles(Room room, WiredContext ctx) {
-        THashSet<RoomTile> usedTiles = new THashSet<>();
+    protected Set<RoomTile> collectTargetTiles(Room room, WiredContext ctx) {
+        Set<RoomTile> usedTiles = new LinkedHashSet<>();
 
         if (room == null || room.getLayout() == null) {
             return usedTiles;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectUnfreeze.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectUnfreeze.java
@@ -15,7 +15,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -100,15 +99,11 @@ public class WiredEffectUnfreeze extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectUserFurniBase.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectUserFurniBase.java
@@ -20,7 +20,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
 import com.eu.habbo.messages.outgoing.rooms.WiredMovementsComposer;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -248,15 +247,11 @@ public abstract class WiredEffectUserFurniBase extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectUserToFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectUserToFurni.java
@@ -20,7 +20,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.habbohotel.wired.core.WiredUserMovementHelper;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -171,15 +170,11 @@ public class WiredEffectUserToFurni extends WiredEffectUserFurniBase {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectWhisper.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectWhisper.java
@@ -17,7 +17,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredTextPlaceholderUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserWhisperComposer;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -68,15 +67,11 @@ public class WiredEffectWhisper extends InteractionWiredEffect {
 
         if (this.requiresTriggeringUser()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredTrigger>() {
-                @Override
-                public boolean execute(InteractionWiredTrigger object) {
-                    if (!object.isTriggeredByRoomUnit()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraOrEval.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraOrEval.java
@@ -11,11 +11,13 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredExtraOrEval extends InteractionWiredExtra {
@@ -30,19 +32,19 @@ public class WiredExtraOrEval extends InteractionWiredExtra {
     public static final int MIN_COMPARE_VALUE = 0;
     public static final int MAX_COMPARE_VALUE = 100;
 
-    private final THashSet<HabboItem> items;
+    private final Set<HabboItem> items;
     private int evaluationMode = MODE_ALL;
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
     private int compareValue = 1;
 
     public WiredExtraOrEval(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredExtraOrEval(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -201,7 +203,7 @@ public class WiredExtraOrEval extends InteractionWiredExtra {
     }
 
     private void refresh(Room room) {
-        THashSet<HabboItem> remove = new THashSet<>();
+        Set<HabboItem> remove = new HashSet<>();
 
         for (HabboItem item : this.items) {
             HabboItem roomItem = room.getHabboItem(item.getId());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraTextOutputFurniName.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraTextOutputFurniName.java
@@ -11,11 +11,13 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -30,7 +32,7 @@ public class WiredExtraTextOutputFurniName extends InteractionWiredExtra {
 
     private static final Pattern WRAPPED_PLACEHOLDER_PATTERN = Pattern.compile("^\\$\\((.*)\\)$");
 
-    private final THashSet<HabboItem> items;
+    private final Set<HabboItem> items;
     private String placeholderName = DEFAULT_PLACEHOLDER_NAME;
     private int placeholderType = TYPE_SINGLE;
     private String delimiter = DEFAULT_DELIMITER;
@@ -38,12 +40,12 @@ public class WiredExtraTextOutputFurniName extends InteractionWiredExtra {
 
     public WiredExtraTextOutputFurniName(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredExtraTextOutputFurniName(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -197,12 +199,12 @@ public class WiredExtraTextOutputFurniName extends InteractionWiredExtra {
         return this.furniSource;
     }
 
-    public THashSet<HabboItem> getItems() {
+    public Set<HabboItem> getItems() {
         return this.items;
     }
 
     private void refresh(Room room) {
-        THashSet<HabboItem> remove = new THashSet<>();
+        Set<HabboItem> remove = new HashSet<>();
 
         for (HabboItem item : this.items) {
             if (room.getHabboItem(item.getId()) == null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraTextOutputVariable.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraTextOutputVariable.java
@@ -15,12 +15,14 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -44,7 +46,7 @@ public class WiredExtraTextOutputVariable extends InteractionWiredExtra {
     private static final String INTERNAL_TOKEN_PREFIX = "internal:";
     private static final Pattern WRAPPED_PLACEHOLDER_PATTERN = Pattern.compile("^\\$\\((.*)\\)$");
 
-    private final THashSet<HabboItem> items;
+    private final Set<HabboItem> items;
     private int targetType = TARGET_USER;
     private int displayType = DISPLAY_NUMERIC;
     private int placeholderType = TYPE_SINGLE;
@@ -57,12 +59,12 @@ public class WiredExtraTextOutputVariable extends InteractionWiredExtra {
 
     public WiredExtraTextOutputVariable(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredExtraTextOutputVariable(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -284,7 +286,7 @@ public class WiredExtraTextOutputVariable extends InteractionWiredExtra {
         return this.furniSource;
     }
 
-    public THashSet<HabboItem> getItems() {
+    public Set<HabboItem> getItems() {
         return this.items;
     }
 
@@ -294,7 +296,7 @@ public class WiredExtraTextOutputVariable extends InteractionWiredExtra {
     }
 
     public void refresh(Room room) {
-        THashSet<HabboItem> remove = new THashSet<>();
+        Set<HabboItem> remove = new HashSet<>();
 
         for (HabboItem item : this.items) {
             if (room == null || room.getHabboItem(item.getId()) == null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/interfaces/InteractionWiredMatchFurniSettings.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/interfaces/InteractionWiredMatchFurniSettings.java
@@ -1,10 +1,11 @@
 package com.eu.habbo.habbohotel.items.interactions.wired.interfaces;
 
 import com.eu.habbo.habbohotel.wired.WiredMatchFurniSetting;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public interface InteractionWiredMatchFurniSettings {
-    public THashSet<WiredMatchFurniSetting> getMatchFurniSettings();
+    public Set<WiredMatchFurniSetting> getMatchFurniSettings();
     public boolean shouldMatchState();
     public boolean shouldMatchRotation();
     public boolean shouldMatchPosition();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectVariableSelectorBase.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectVariableSelectorBase.java
@@ -34,17 +34,18 @@ import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
 import com.eu.habbo.util.HotelDateTimeUtil;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.ZonedDateTime;
 import java.time.temporal.WeekFields;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 public abstract class WiredEffectVariableSelectorBase extends InteractionWiredEffect {
     protected static final int TARGET_USER = 0;
@@ -81,7 +82,7 @@ public abstract class WiredEffectVariableSelectorBase extends InteractionWiredEf
     protected int variableItemId = 0;
     protected String referenceVariableToken = "";
     protected int referenceVariableItemId = 0;
-    protected final THashSet<HabboItem> referenceSelectedItems = new THashSet<>();
+    protected final Set<HabboItem> referenceSelectedItems = new LinkedHashSet<>();
 
     protected WiredEffectVariableSelectorBase(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
@@ -663,7 +664,7 @@ public abstract class WiredEffectVariableSelectorBase extends InteractionWiredEf
     }
 
     private void refreshReferenceItems() {
-        THashSet<HabboItem> staleItems = new THashSet<>();
+        Set<HabboItem> staleItems = new HashSet<>();
         Room room = this.getRoom();
 
         if (room == null) {
@@ -693,7 +694,7 @@ public abstract class WiredEffectVariableSelectorBase extends InteractionWiredEf
         this.referenceVariableItemId = getCustomItemId(this.referenceVariableToken);
     }
 
-    private List<Integer> toIds(THashSet<HabboItem> items) {
+    private List<Integer> toIds(Set<HabboItem> items) {
         List<Integer> ids = new ArrayList<>();
 
         for (HabboItem item : items) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerAtSetTime.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerAtSetTime.java
@@ -14,7 +14,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredEvent;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.tick.WiredTickable;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -118,15 +117,11 @@ public class WiredTriggerAtSetTime extends InteractionWiredTrigger implements Wi
 
         if (!this.isTriggeredByRoomUnit()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getEffects(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredEffect>() {
-                @Override
-                public boolean execute(InteractionWiredEffect object) {
-                    if (object.requiresTriggeringUser()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredEffect effect : room.getRoomSpecialTypes().getEffects(this.getX(), this.getY())) {
+                if (effect.requiresTriggeringUser()) {
+                    invalidTriggers.add(effect.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerAtTimeLong.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerAtTimeLong.java
@@ -14,7 +14,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredEvent;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.tick.WiredTickable;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -118,15 +117,11 @@ public class WiredTriggerAtTimeLong extends InteractionWiredTrigger implements W
 
         if (!this.isTriggeredByRoomUnit()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getEffects(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredEffect>() {
-                @Override
-                public boolean execute(InteractionWiredEffect object) {
-                    if (object.requiresTriggeringUser()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredEffect effect : room.getRoomSpecialTypes().getEffects(this.getX(), this.getY())) {
+                if (effect.requiresTriggeringUser()) {
+                    invalidTriggers.add(effect.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerBotReachedFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerBotReachedFurni.java
@@ -15,15 +15,16 @@ import com.eu.habbo.habbohotel.wired.core.WiredEvent;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.habbohotel.wired.core.WiredTriggerSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.procedure.TObjectProcedure;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredTriggerBotReachedFurni extends InteractionWiredTrigger {
@@ -33,19 +34,19 @@ public class WiredTriggerBotReachedFurni extends InteractionWiredTrigger {
 
     public final static WiredTriggerType type = WiredTriggerType.BOT_REACHED_STF;
 
-    private final THashSet<HabboItem> items;
+    private final Set<HabboItem> items;
     private String botName = "";
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
     private int botSource = BOT_SOURCE_NAME;
 
     public WiredTriggerBotReachedFurni(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredTriggerBotReachedFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -55,7 +56,7 @@ public class WiredTriggerBotReachedFurni extends InteractionWiredTrigger {
 
     @Override
     public void serializeWiredData(ServerMessage message, Room room) {
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         if (Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()) == null) {
             items.addAll(this.items);
@@ -87,15 +88,11 @@ public class WiredTriggerBotReachedFurni extends InteractionWiredTrigger {
 
         if (!this.isTriggeredByRoomUnit()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getEffects(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredEffect>() {
-                @Override
-                public boolean execute(InteractionWiredEffect object) {
-                    if (object.requiresTriggeringUser()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredEffect effect : room.getRoomSpecialTypes().getEffects(this.getX(), this.getY())) {
+                if (effect.requiresTriggeringUser()) {
+                    invalidTriggers.add(effect.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerClockCounter.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerClockCounter.java
@@ -16,11 +16,13 @@ import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.habbohotel.wired.core.WiredTriggerSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredTriggerSaveException;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredTriggerClockCounter extends InteractionWiredTrigger {
@@ -29,19 +31,19 @@ public class WiredTriggerClockCounter extends InteractionWiredTrigger {
 
     public static final WiredTriggerType type = WiredTriggerType.CLOCK_COUNTER;
 
-    private final THashSet<HabboItem> items;
+    private final Set<HabboItem> items;
     private int minutes = 0;
     private int halfSecondSteps = 0;
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
 
     public WiredTriggerClockCounter(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredTriggerClockCounter(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -200,7 +202,7 @@ public class WiredTriggerClockCounter extends InteractionWiredTrigger {
     }
 
     private void refresh(Room room) {
-        THashSet<HabboItem> remove = new THashSet<>();
+        Set<HabboItem> remove = new HashSet<>();
 
         for (HabboItem item : this.items) {
             HabboItem roomItem = room.getHabboItem(item.getId());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerFurniStateToggled.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerFurniStateToggled.java
@@ -13,30 +13,32 @@ import com.eu.habbo.habbohotel.wired.core.WiredEvent;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.habbohotel.wired.core.WiredTriggerSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 public class WiredTriggerFurniStateToggled extends InteractionWiredTrigger {
     private static final WiredTriggerType type = WiredTriggerType.STATE_CHANGED;
     private static final int MODE_ALL_STATES = 0;
     private static final int MODE_SAVED_STATE = 1;
 
-    private THashSet<StateSnapshot> snapshots;
+    private Set<StateSnapshot> snapshots;
     private int triggerMode = MODE_ALL_STATES;
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
 
     public WiredTriggerFurniStateToggled(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.snapshots = new THashSet<>();
+        this.snapshots = new LinkedHashSet<>();
     }
 
     public WiredTriggerFurniStateToggled(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.snapshots = new THashSet<>();
+        this.snapshots = new LinkedHashSet<>();
     }
 
     @Override
@@ -82,7 +84,7 @@ public class WiredTriggerFurniStateToggled extends InteractionWiredTrigger {
 
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
-        this.snapshots = new THashSet<>();
+        this.snapshots = new LinkedHashSet<>();
         this.triggerMode = MODE_ALL_STATES;
         this.furniSource = WiredSourceUtil.SOURCE_TRIGGER;
         String wiredData = set.getString("wired_data");
@@ -150,7 +152,7 @@ public class WiredTriggerFurniStateToggled extends InteractionWiredTrigger {
 
     @Override
     public void serializeWiredData(ServerMessage message, Room room) {
-        THashSet<StateSnapshot> snapshotsToRemove = new THashSet<>();
+        Set<StateSnapshot> snapshotsToRemove = new HashSet<>();
 
         for (StateSnapshot snapshot : this.snapshots) {
             HabboItem item = room.getHabboItem(snapshot.itemId);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerGameEnds.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerGameEnds.java
@@ -10,7 +10,6 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.WiredTriggerType;
 import com.eu.habbo.habbohotel.wired.core.WiredEvent;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -72,15 +71,11 @@ public class WiredTriggerGameEnds extends InteractionWiredTrigger {
 
         if (!this.isTriggeredByRoomUnit()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getEffects(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredEffect>() {
-                @Override
-                public boolean execute(InteractionWiredEffect object) {
-                    if (object.requiresTriggeringUser()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredEffect effect : room.getRoomSpecialTypes().getEffects(this.getX(), this.getY())) {
+                if (effect.requiresTriggeringUser()) {
+                    invalidTriggers.add(effect.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerGameStarts.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerGameStarts.java
@@ -10,7 +10,6 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.WiredTriggerType;
 import com.eu.habbo.habbohotel.wired.core.WiredEvent;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -72,15 +71,11 @@ public class WiredTriggerGameStarts extends InteractionWiredTrigger {
 
         if (!this.isTriggeredByRoomUnit()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getEffects(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredEffect>() {
-                @Override
-                public boolean execute(InteractionWiredEffect object) {
-                    if (object.requiresTriggeringUser()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredEffect effect : room.getRoomSpecialTypes().getEffects(this.getX(), this.getY())) {
+                if (effect.requiresTriggeringUser()) {
+                    invalidTriggers.add(effect.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboClicksFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboClicksFurni.java
@@ -15,27 +15,29 @@ import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.habbohotel.wired.core.WiredTriggerSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredTriggerSaveException;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredTriggerHabboClicksFurni extends InteractionWiredTrigger {
     public static final WiredTriggerType type = WiredTriggerType.CLICKS_FURNI;
 
-    protected final THashSet<HabboItem> items;
+    protected final Set<HabboItem> items;
     protected int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
 
     public WiredTriggerHabboClicksFurni(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredTriggerHabboClicksFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -61,7 +63,7 @@ public class WiredTriggerHabboClicksFurni extends InteractionWiredTrigger {
 
     @Override
     public void serializeWiredData(ServerMessage message, Room room) {
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         if (Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()) == null) {
             items.addAll(this.items);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboWalkOffFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboWalkOffFurni.java
@@ -14,27 +14,29 @@ import com.eu.habbo.habbohotel.wired.core.WiredEvent;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.habbohotel.wired.core.WiredTriggerSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredTriggerHabboWalkOffFurni extends InteractionWiredTrigger {
     public static final WiredTriggerType type = WiredTriggerType.WALKS_OFF_FURNI;
 
-    private final THashSet<HabboItem> items;
+    private final Set<HabboItem> items;
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
 
     public WiredTriggerHabboWalkOffFurni(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredTriggerHabboWalkOffFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -113,7 +115,7 @@ public class WiredTriggerHabboWalkOffFurni extends InteractionWiredTrigger {
 
     @Override
     public void serializeWiredData(ServerMessage message, Room room) {
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         if (room == null) {
             items.addAll(this.items);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboWalkOnFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboWalkOnFurni.java
@@ -14,27 +14,29 @@ import com.eu.habbo.habbohotel.wired.core.WiredEvent;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.habbohotel.wired.core.WiredTriggerSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class WiredTriggerHabboWalkOnFurni extends InteractionWiredTrigger {
     public static final WiredTriggerType type = WiredTriggerType.WALKS_ON_FURNI;
 
-    private final THashSet<HabboItem> items;
+    private final Set<HabboItem> items;
     private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
 
     public WiredTriggerHabboWalkOnFurni(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredTriggerHabboWalkOnFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -60,7 +62,7 @@ public class WiredTriggerHabboWalkOnFurni extends InteractionWiredTrigger {
 
     @Override
     public void serializeWiredData(ServerMessage message, Room room) {
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         if (Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()) == null) {
             items.addAll(this.items);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerReceiveSignal.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerReceiveSignal.java
@@ -17,12 +17,14 @@ import com.eu.habbo.habbohotel.wired.core.WiredTriggerSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredTriggerSaveException;
 import com.eu.habbo.messages.outgoing.rooms.items.ItemStateComposer;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -34,18 +36,18 @@ public class WiredTriggerReceiveSignal extends InteractionWiredTrigger {
     private static final String REQUIRE_ANTENNA_ERROR = "You can only select antenna furni.";
 
     private int channel = 0; // signal channel (0-based)
-    private THashSet<HabboItem> items;
+    private Set<HabboItem> items;
     private int furniSource = WiredSourceUtil.SOURCE_SELECTED;
     private final AtomicLong activationToken = new AtomicLong();
 
     public WiredTriggerReceiveSignal(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     public WiredTriggerReceiveSignal(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
     }
 
     @Override
@@ -76,7 +78,7 @@ public class WiredTriggerReceiveSignal extends InteractionWiredTrigger {
         boolean changed = false;
 
         if (!this.items.isEmpty()) {
-            THashSet<HabboItem> itemsToRemove = new THashSet<>();
+            Set<HabboItem> itemsToRemove = new HashSet<>();
 
             for (HabboItem item : this.items) {
                 if (item == null || item.getId() == antennaItemId) {
@@ -140,7 +142,7 @@ public class WiredTriggerReceiveSignal extends InteractionWiredTrigger {
         } catch (Exception e) {
         }
 
-        THashSet<HabboItem> itemsToRemove = new THashSet<>();
+        Set<HabboItem> itemsToRemove = new HashSet<>();
         for (HabboItem item : this.items) {
             if (item.getRoomId() != this.getRoomId() || room.getHabboItem(item.getId()) == null) {
                 itemsToRemove.add(item);
@@ -246,7 +248,7 @@ public class WiredTriggerReceiveSignal extends InteractionWiredTrigger {
 
     @Override
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
-        this.items = new THashSet<>();
+        this.items = new LinkedHashSet<>();
         String wiredData = set.getString("wired_data");
         this.furniSource = WiredSourceUtil.SOURCE_SELECTED;
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerRepeater.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerRepeater.java
@@ -14,7 +14,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredEvent;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.tick.WiredTickable;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -107,15 +106,11 @@ public class WiredTriggerRepeater extends InteractionWiredTrigger implements Wir
 
         if (!this.isTriggeredByRoomUnit()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getEffects(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredEffect>() {
-                @Override
-                public boolean execute(InteractionWiredEffect object) {
-                    if (object.requiresTriggeringUser()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredEffect effect : room.getRoomSpecialTypes().getEffects(this.getX(), this.getY())) {
+                if (effect.requiresTriggeringUser()) {
+                    invalidTriggers.add(effect.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerRepeaterLong.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerRepeaterLong.java
@@ -14,7 +14,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredEvent;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.tick.WiredTickable;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -107,15 +106,11 @@ public class WiredTriggerRepeaterLong extends InteractionWiredTrigger implements
 
         if (!this.isTriggeredByRoomUnit()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getEffects(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredEffect>() {
-                @Override
-                public boolean execute(InteractionWiredEffect object) {
-                    if (object.requiresTriggeringUser()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredEffect effect : room.getRoomSpecialTypes().getEffects(this.getX(), this.getY())) {
+                if (effect.requiresTriggeringUser()) {
+                    invalidTriggers.add(effect.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerRepeaterShort.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerRepeaterShort.java
@@ -8,7 +8,6 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.wired.WiredTriggerType;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.procedure.TObjectProcedure;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -73,15 +72,11 @@ public class WiredTriggerRepeaterShort extends WiredTriggerRepeater {
 
         if (!this.isTriggeredByRoomUnit()) {
             List<Integer> invalidTriggers = new ArrayList<>();
-            room.getRoomSpecialTypes().getEffects(this.getX(), this.getY()).forEach(new TObjectProcedure<InteractionWiredEffect>() {
-                @Override
-                public boolean execute(InteractionWiredEffect object) {
-                    if (object.requiresTriggeringUser()) {
-                        invalidTriggers.add(object.getBaseItem().getSpriteId());
-                    }
-                    return true;
+            for (InteractionWiredEffect effect : room.getRoomSpecialTypes().getEffects(this.getX(), this.getY())) {
+                if (effect.requiresTriggeringUser()) {
+                    invalidTriggers.add(effect.getBaseItem().getSpriteId());
                 }
-            });
+            }
             message.appendInt(invalidTriggers.size());
             for (Integer i : invalidTriggers) {
                 message.appendInt(i);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/Messenger.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/Messenger.java
@@ -8,8 +8,6 @@ import com.eu.habbo.habbohotel.users.HabboInfo;
 import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.messages.outgoing.friends.UpdateFriendComposer;
 import com.eu.habbo.plugin.events.users.friends.UserAcceptFriendRequestEvent;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +16,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class Messenger {
@@ -31,11 +32,11 @@ public class Messenger {
     public static int MAXIMUM_FRIENDS_HC = 500;
 
     private final ConcurrentHashMap<Integer, MessengerBuddy> friends;
-    private final THashSet<FriendRequest> friendRequests;
+    private final Set<FriendRequest> friendRequests;
 
     public Messenger() {
         this.friends = new ConcurrentHashMap<>();
-        this.friendRequests = new THashSet<>();
+        this.friendRequests = new HashSet<>();
     }
 
     public static void unfriend(int userOne, int userTwo) {
@@ -50,8 +51,8 @@ public class Messenger {
         }
     }
 
-    public static THashSet<MessengerBuddy> searchUsers(String username) {
-        THashSet<MessengerBuddy> users = new THashSet<>();
+    public static Set<MessengerBuddy> searchUsers(String username) {
+        Set<MessengerBuddy> users = new HashSet<>();
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM users WHERE username LIKE ? ORDER BY username ASC LIMIT " + Emulator.getConfig().getInt("hotel.messenger.search.maxresults"))) {
             statement.setString(1, com.eu.habbo.util.SqlLikeEscaper.escape(username) + "%");
             try (ResultSet set = statement.executeQuery()) {
@@ -149,11 +150,11 @@ public class Messenger {
         return count;
     }
 
-    public static THashMap<Integer, THashSet<MessengerBuddy>> getFriends(int userId) {
-        THashMap<Integer, THashSet<MessengerBuddy>> map = new THashMap<>();
-        map.put(1, new THashSet<>());
-        map.put(2, new THashSet<>());
-        map.put(3, new THashSet<>());
+    public static Map<Integer, Set<MessengerBuddy>> getFriends(int userId) {
+        Map<Integer, Set<MessengerBuddy>> map = new HashMap<>();
+        map.put(1, new HashSet<>());
+        map.put(2, new HashSet<>());
+        map.put(3, new HashSet<>());
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT users.id, users.look, users.username, messenger_friendships.relation FROM messenger_friendships INNER JOIN users ON users.id = messenger_friendships.user_two_id WHERE user_one_id = ? ORDER BY RAND() LIMIT 50")) {
             statement.setInt(1, userId);
@@ -276,8 +277,8 @@ public class Messenger {
         this.friends.put(buddy.getId(), buddy);
     }
 
-    public THashSet<MessengerBuddy> getFriends(String username) {
-        THashSet<MessengerBuddy> users = new THashSet<>();
+    public Set<MessengerBuddy> getFriends(String username) {
+        Set<MessengerBuddy> users = new HashSet<>();
 
         for (Map.Entry<Integer, MessengerBuddy> map : this.friends.entrySet()) {
             if (StringUtils.containsIgnoreCase(map.getValue().getUsername(), username)) {
@@ -386,7 +387,7 @@ public class Messenger {
         return this.friends;
     }
 
-    public THashSet<FriendRequest> getFriendRequests() {
+    public Set<FriendRequest> getFriendRequests() {
         synchronized (this.friendRequests) {
             return this.friendRequests;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/CfhCategory.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/CfhCategory.java
@@ -1,23 +1,23 @@
 package com.eu.habbo.habbohotel.modtool;
 
-import gnu.trove.TCollections;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 public class CfhCategory {
     private final String name;
-    private final TIntObjectMap<CfhTopic> topics;
+    private final Int2ObjectMap<CfhTopic> topics;
 
     public CfhCategory(int id, String name) {
         this.name = name;
-        this.topics = TCollections.synchronizedMap(new TIntObjectHashMap<>());
+        this.topics = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
     }
 
     public void addTopic(CfhTopic topic) {
         this.topics.put(topic.id, topic);
     }
 
-    public TIntObjectMap<CfhTopic> getTopics() {
+    public Int2ObjectMap<CfhTopic> getTopics() {
         return this.topics;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolCategory.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolCategory.java
@@ -1,23 +1,23 @@
 package com.eu.habbo.habbohotel.modtool;
 
-import gnu.trove.TCollections;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 public class ModToolCategory {
     private final String name;
-    private final TIntObjectMap<ModToolPreset> presets;
+    private final Int2ObjectMap<ModToolPreset> presets;
 
     public ModToolCategory(String name) {
         this.name = name;
-        this.presets = TCollections.synchronizedMap(new TIntObjectHashMap<>());
+        this.presets = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
     }
 
     public void addPreset(ModToolPreset preset) {
         this.presets.put(preset.id, preset);
     }
 
-    public TIntObjectMap<ModToolPreset> getPresets() {
+    public Int2ObjectMap<ModToolPreset> getPresets() {
         return this.presets;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolManager.java
@@ -15,13 +15,12 @@ import com.eu.habbo.messages.outgoing.modtool.ModToolIssueInfoComposer;
 import com.eu.habbo.messages.outgoing.modtool.ModToolUserInfoComposer;
 import com.eu.habbo.plugin.events.support.*;
 import com.eu.habbo.threading.runnables.InsertModToolIssue;
-import gnu.trove.TCollections;
-import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
-import gnu.trove.procedure.TObjectProcedure;
 import gnu.trove.set.hash.THashSet;
 import io.netty.channel.Channel;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,17 +33,17 @@ import java.util.Map;
 public class ModToolManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(ModToolManager.class);
 
-    private final TIntObjectMap<ModToolCategory> category;
+    private final Int2ObjectMap<ModToolCategory> category;
     private final THashMap<String, THashSet<String>> presets;
     private final THashMap<Integer, ModToolIssue> tickets;
-    private final TIntObjectMap<CfhCategory> cfhCategories;
+    private final Int2ObjectMap<CfhCategory> cfhCategories;
 
     public ModToolManager() {
         long millis = System.currentTimeMillis();
-        this.category = TCollections.synchronizedMap(new TIntObjectHashMap<>());
+        this.category = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
         this.presets = new THashMap<>();
         this.tickets = new THashMap<>();
-        this.cfhCategories = new TIntObjectHashMap<>();
+        this.cfhCategories = new Int2ObjectOpenHashMap<>();
         this.loadModTool();
         LOGGER.info("ModTool Manager -> Loaded! ({} MS)", System.currentTimeMillis() - millis);
     }
@@ -168,8 +167,8 @@ public class ModToolManager {
     }
 
     public CfhTopic getCfhTopic(int topicId) {
-        for (CfhCategory category : this.getCfhCategories().valueCollection()) {
-            for (CfhTopic topic : category.getTopics().valueCollection()) {
+        for (CfhCategory category : this.getCfhCategories().values()) {
+            for (CfhTopic topic : category.getTopics().values()) {
                 if (topic.id == topicId) {
                     return topic;
                 }
@@ -183,16 +182,14 @@ public class ModToolManager {
         if (id == 0)
             return null;
 
-        final ModToolPreset[] preset = {null};
-        this.category.forEachValue(new TObjectProcedure<ModToolCategory>() {
-            @Override
-            public boolean execute(ModToolCategory object) {
-                preset[0] = object.getPresets().get(id);
-                return preset[0] == null;
+        for (ModToolCategory object : this.category.values()) {
+            ModToolPreset preset = object.getPresets().get(id);
+            if (preset != null) {
+                return preset;
             }
-        });
+        }
 
-        return preset[0];
+        return null;
     }
 
     public void quickTicket(Habbo reported, String reason, String message) {
@@ -742,7 +739,7 @@ public class ModToolManager {
         return total;
     }
 
-    public TIntObjectMap<ModToolCategory> getCategory() {
+    public Int2ObjectMap<ModToolCategory> getCategory() {
         return this.category;
     }
 
@@ -762,23 +759,18 @@ public class ModToolManager {
         return this.tickets.get(ticketId);
     }
 
-    public TIntObjectMap<CfhCategory> getCfhCategories() {
+    public Int2ObjectMap<CfhCategory> getCfhCategories() {
         return this.cfhCategories;
     }
 
     public List<ModToolIssue> openTicketsForHabbo(Habbo habbo) {
         List<ModToolIssue> issues = new ArrayList<>();
         synchronized (this.tickets) {
-            this.tickets.forEachValue(new TObjectProcedure<ModToolIssue>() {
-                @Override
-                public boolean execute(ModToolIssue object) {
-                    if (object.senderId == habbo.getHabboInfo().getId() && object.state == ModToolTicketState.OPEN) {
-                        issues.add(object);
-                    }
-
-                    return true;
+            for (ModToolIssue object : this.tickets.values()) {
+                if (object.senderId == habbo.getHabboInfo().getId() && object.state == ModToolTicketState.OPEN) {
+                    issues.add(object);
                 }
-            });
+            }
         }
 
         return issues;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolManager.java
@@ -15,8 +15,6 @@ import com.eu.habbo.messages.outgoing.modtool.ModToolIssueInfoComposer;
 import com.eu.habbo.messages.outgoing.modtool.ModToolUserInfoComposer;
 import com.eu.habbo.plugin.events.support.*;
 import com.eu.habbo.threading.runnables.InsertModToolIssue;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 import io.netty.channel.Channel;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
@@ -27,22 +25,25 @@ import org.slf4j.LoggerFactory;
 import java.net.InetSocketAddress;
 import java.sql.*;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class ModToolManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(ModToolManager.class);
 
     private final Int2ObjectMap<ModToolCategory> category;
-    private final THashMap<String, THashSet<String>> presets;
-    private final THashMap<Integer, ModToolIssue> tickets;
+    private final Map<String, Set<String>> presets;
+    private final Map<Integer, ModToolIssue> tickets;
     private final Int2ObjectMap<CfhCategory> cfhCategories;
 
     public ModToolManager() {
         long millis = System.currentTimeMillis();
         this.category = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
-        this.presets = new THashMap<>();
-        this.tickets = new THashMap<>();
+        this.presets = new HashMap<>();
+        this.tickets = new HashMap<>();
         this.cfhCategories = new Int2ObjectOpenHashMap<>();
         this.loadModTool();
         LOGGER.info("ModTool Manager -> Loaded! ({} MS)", System.currentTimeMillis() - millis);
@@ -85,8 +86,8 @@ public class ModToolManager {
         this.presets.clear();
         this.cfhCategories.clear();
 
-        this.presets.put("user", new THashSet<>());
-        this.presets.put("room", new THashSet<>());
+        this.presets.put("user", new HashSet<>());
+        this.presets.put("room", new HashSet<>());
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
             this.loadCategory(connection);
@@ -290,8 +291,8 @@ public class ModToolManager {
         return chatlogs;
     }
 
-    public THashSet<ModToolRoomVisit> getUserRoomVisits(int userId) {
-        THashSet<ModToolRoomVisit> roomVisits = new THashSet<>();
+    public Set<ModToolRoomVisit> getUserRoomVisits(int userId) {
+        Set<ModToolRoomVisit> roomVisits = new HashSet<>();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT rooms.name, room_enter_log.* FROM room_enter_log INNER JOIN rooms ON rooms.id = room_enter_log.room_id WHERE user_id = ? ORDER BY timestamp DESC LIMIT 50")) {
             statement.setInt(1, userId);
@@ -308,12 +309,12 @@ public class ModToolManager {
         return roomVisits;
     }
 
-    public THashSet<ModToolRoomVisit> getVisitsForRoom(Room room, int amount, boolean groupUser, int fromTimestamp, int toTimestamp) {
+    public Set<ModToolRoomVisit> getVisitsForRoom(Room room, int amount, boolean groupUser, int fromTimestamp, int toTimestamp) {
         return this.getVisitsForRoom(room, amount, groupUser, fromTimestamp, toTimestamp, "");
     }
 
-    public THashSet<ModToolRoomVisit> getVisitsForRoom(Room room, int amount, boolean groupUser, int fromTimestamp, int toTimestamp, String excludeUsername) {
-        THashSet<ModToolRoomVisit> roomVisits = new THashSet<>();
+    public Set<ModToolRoomVisit> getVisitsForRoom(Room room, int amount, boolean groupUser, int fromTimestamp, int toTimestamp, String excludeUsername) {
+        Set<ModToolRoomVisit> roomVisits = new HashSet<>();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM (" +
                 "SELECT " +
@@ -747,11 +748,11 @@ public class ModToolManager {
         return this.category.get(id);
     }
 
-    public THashMap<String, THashSet<String>> getPresets() {
+    public Map<String, Set<String>> getPresets() {
         return this.presets;
     }
 
-    public THashMap<Integer, ModToolIssue> getTickets() {
+    public Map<Integer, ModToolIssue> getTickets() {
         return this.tickets;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolRoomVisit.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolRoomVisit.java
@@ -1,16 +1,16 @@
 package com.eu.habbo.habbohotel.modtool;
 
-import gnu.trove.set.hash.THashSet;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
 
 public class ModToolRoomVisit implements Comparable<ModToolRoomVisit> {
     public int roomId;
     public String roomName;
     public int timestamp;
     public int exitTimestamp;
-    public THashSet<ModToolChatLog> chat;
+    public Set<ModToolChatLog> chat;
 
     public ModToolRoomVisit(ResultSet set) throws SQLException {
         this.roomId = set.getInt("room_id");
@@ -23,7 +23,7 @@ public class ModToolRoomVisit implements Comparable<ModToolRoomVisit> {
         this.roomName = roomName;
         this.timestamp = timestamp;
         this.exitTimestamp = exitTimestamp;
-        this.chat = new THashSet<>();
+        this.chat = new HashSet<>();
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolSanctions.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolSanctions.java
@@ -3,7 +3,6 @@ package com.eu.habbo.habbohotel.modtool;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.plugin.events.sanctions.SanctionEvent;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,17 +12,19 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ModToolSanctions {
     private static final Logger LOGGER = LoggerFactory.getLogger(ModToolSanctions.class);
 
-    private final THashMap<Integer, ArrayList<ModToolSanctionItem>> sanctionHashmap;
-    private final THashMap<Integer, ModToolSanctionLevelItem> sanctionLevelsHashmap;
+    private final Map<Integer, ArrayList<ModToolSanctionItem>> sanctionHashmap;
+    private final Map<Integer, ModToolSanctionLevelItem> sanctionLevelsHashmap;
 
     public ModToolSanctions() {
         long millis = System.currentTimeMillis();
-        this.sanctionHashmap = new THashMap<>();
-        this.sanctionLevelsHashmap = new THashMap<>();
+        this.sanctionHashmap = new HashMap<>();
+        this.sanctionLevelsHashmap = new HashMap<>();
         this.loadModSanctions();
 
         LOGGER.info("Sanctions Manager -> Loaded! ({} MS)", System.currentTimeMillis() - millis);
@@ -52,7 +53,7 @@ public class ModToolSanctions {
         return this.sanctionLevelsHashmap.get(sanctionLevel);
     }
 
-    public THashMap<Integer, ArrayList<ModToolSanctionItem>> getSanctions(int habboId) {
+    public Map<Integer, ArrayList<ModToolSanctionItem>> getSanctions(int habboId) {
         synchronized (this.sanctionHashmap) {
             this.sanctionHashmap.clear();
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM sanctions WHERE habbo_id = ? ORDER BY id ASC")) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/WordFilter.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/WordFilter.java
@@ -6,8 +6,6 @@ import com.eu.habbo.habbohotel.rooms.RoomChatMessage;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.friends.FriendChatMessageComposer;
 import com.eu.habbo.plugin.events.users.UserTriggerWordFilterEvent;
-import gnu.trove.iterator.hash.TObjectHashIterator;
-import gnu.trove.set.hash.THashSet;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +15,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.text.Normalizer;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public class WordFilter {
@@ -25,9 +25,9 @@ public class WordFilter {
     private static final Pattern DIACRITICS_AND_FRIENDS = Pattern.compile("[\\p{InCombiningDiacriticalMarks}\\p{IsLm}\\p{IsSk}]+");
     public static boolean ENABLED_FRIENDCHAT = true;
     public static String DEFAULT_REPLACEMENT = "bobba";
-    protected THashSet<WordFilterWord> autoReportWords = new THashSet<>();
-    protected THashSet<WordFilterWord> hideMessageWords = new THashSet<>();
-    protected THashSet<WordFilterWord> words = new THashSet<>();
+    protected Set<WordFilterWord> autoReportWords = new HashSet<>();
+    protected Set<WordFilterWord> hideMessageWords = new HashSet<>();
+    protected Set<WordFilterWord> words = new HashSet<>();
 
     public WordFilter() {
         long start = System.currentTimeMillis();
@@ -92,11 +92,7 @@ public class WordFilter {
     public boolean autoReportCheck(RoomChatMessage roomChatMessage) {
         String message = this.normalise(roomChatMessage.getMessage()).toLowerCase();
 
-        TObjectHashIterator<WordFilterWord> iterator = this.autoReportWords.iterator();
-
-        while (iterator.hasNext()) {
-            WordFilterWord word = (WordFilterWord) iterator.next();
-
+        for (WordFilterWord word : this.autoReportWords) {
             if (message.contains(word.key)) {
                 Emulator.getGameEnvironment().getModToolManager().quickTicket(roomChatMessage.getHabbo(), "Automatic WordFilter", roomChatMessage.getMessage());
 
@@ -113,11 +109,7 @@ public class WordFilter {
     public boolean hideMessageCheck(String message) {
         message = this.normalise(message).toLowerCase();
 
-        TObjectHashIterator<WordFilterWord> iterator = this.hideMessageWords.iterator();
-
-        while (iterator.hasNext()) {
-            WordFilterWord word = (WordFilterWord) iterator.next();
-
+        for (WordFilterWord word : this.hideMessageWords) {
             if (message.contains(word.key)) {
                 return true;
             }
@@ -140,13 +132,9 @@ public class WordFilter {
             filteredMessage = this.normalise(filteredMessage);
         }
 
-        TObjectHashIterator<WordFilterWord> iterator = this.words.iterator();
-
         boolean foundShit = false;
 
-        while (iterator.hasNext()) {
-            WordFilterWord word = (WordFilterWord) iterator.next();
-
+        for (WordFilterWord word : this.words) {
             if (word.prefixOnly) continue;
 
             if (StringUtils.containsIgnoreCase(filteredMessage, word.key)) {
@@ -177,11 +165,7 @@ public class WordFilter {
             message = this.normalise(message);
         }
 
-        TObjectHashIterator<WordFilterWord> iterator = this.words.iterator();
-
-        while (iterator.hasNext()) {
-            WordFilterWord word = (WordFilterWord) iterator.next();
-
+        for (WordFilterWord word : this.words) {
             if (word.prefixOnly) continue;
 
             if (StringUtils.containsIgnoreCase(message, word.key)) {
@@ -200,8 +184,8 @@ public class WordFilter {
         }
     }
 
-    public THashSet<WordFilterWord> getWords() {
-        return new THashSet<>(this.words);
+    public Set<WordFilterWord> getWords() {
+        return new HashSet<>(this.words);
     }
 
     public void addWord(WordFilterWord word) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/navigation/NavigatorManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/navigation/NavigatorManager.java
@@ -3,7 +3,6 @@ package com.eu.habbo.habbohotel.navigation;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.Habbo;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,6 +13,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -25,9 +25,9 @@ public class NavigatorManager {
     public static int MAXIMUM_RESULTS_PER_PAGE = 10;
     public static boolean CATEGORY_SORT_USING_ORDER_NUM = false;
 
-    public final THashMap<Integer, NavigatorPublicCategory> publicCategories = new THashMap<>();
+    public final Map<Integer, NavigatorPublicCategory> publicCategories = new HashMap<>();
     public final ConcurrentHashMap<String, NavigatorFilterField> filterSettings = new ConcurrentHashMap<>();
-    public final THashMap<String, NavigatorFilter> filters = new THashMap<>();
+    public final Map<String, NavigatorFilter> filters = new HashMap<>();
 
     public NavigatorManager() {
         long millis = System.currentTimeMillis();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/permissions/PermissionsManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/permissions/PermissionsManager.java
@@ -3,32 +3,35 @@ package com.eu.habbo.habbohotel.permissions;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.plugin.HabboPlugin;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntIntHashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class PermissionsManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(PermissionsManager.class);
 
-    private final TIntObjectHashMap<Rank> ranks;
-    private final TIntIntHashMap enables;
-    private final THashMap<String, List<Rank>> badges;
+    private final Int2ObjectMap<Rank> ranks;
+    private final Int2IntMap enables;
+    private final Map<String, List<Rank>> badges;
     private volatile boolean normalizedSchemaEnabled;
 
     public PermissionsManager() {
         long millis = System.currentTimeMillis();
-        this.ranks = new TIntObjectHashMap<>();
-        this.enables = new TIntIntHashMap();
-        this.badges = new THashMap<String, List<Rank>>();
+        this.ranks = new Int2ObjectOpenHashMap<>();
+        this.enables = new Int2IntOpenHashMap();
+        this.badges = new HashMap<>();
 
         this.reload();
 
@@ -157,7 +160,7 @@ public class PermissionsManager {
     }
 
     private void pruneMissingRanks(Set<Integer> loadedRankIds) {
-        for (int rankId : this.ranks.keys()) {
+        for (int rankId : this.ranks.keySet().toIntArray()) {
             if (!loadedRankIds.contains(rankId)) {
                 this.ranks.remove(rankId);
             }
@@ -258,7 +261,7 @@ public class PermissionsManager {
 
 
     public Rank getRankByName(String rankName) {
-        for (Rank rank : this.ranks.valueCollection()) {
+        for (Rank rank : this.ranks.values()) {
             if (rank.getName().equalsIgnoreCase(rankName))
                 return rank;
         }
@@ -268,7 +271,7 @@ public class PermissionsManager {
 
 
     public boolean isEffectBlocked(int effectId, int rank) {
-        return this.enables.contains(effectId) && this.enables.get(effectId) > rank;
+        return this.enables.containsKey(effectId) && this.enables.get(effectId) > rank;
     }
 
 
@@ -310,7 +313,7 @@ public class PermissionsManager {
     }
 
     public List<Rank> getAllRanks() {
-        return new ArrayList<>(this.ranks.valueCollection());
+        return new ArrayList<>(this.ranks.values());
     }
 
     public boolean isNormalizedSchemaEnabled() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/permissions/Rank.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/permissions/Rank.java
@@ -1,10 +1,10 @@
 package com.eu.habbo.habbohotel.permissions;
 
-import gnu.trove.map.hash.THashMap;
-
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class Rank {
 
@@ -12,8 +12,8 @@ public class Rank {
 
 
     private int level;
-    private final THashMap<String, Permission> permissions;
-    private final THashMap<String, String> variables;
+    private final Map<String, Permission> permissions;
+    private final Map<String, String> variables;
     private String name;
     private String badge;
     private int roomEffect;
@@ -40,8 +40,8 @@ public class Rank {
     }
 
     public Rank(int id) {
-        this.permissions = new THashMap<>();
-        this.variables = new THashMap<>();
+        this.permissions = new HashMap<>();
+        this.variables = new HashMap<>();
         this.id = id;
         this.level = 1;
         this.diamondsTimerAmount = 1;
@@ -147,11 +147,11 @@ public class Rank {
         return this.badge;
     }
 
-    public THashMap<String, Permission> getPermissions() {
+    public Map<String, Permission> getPermissions() {
         return this.permissions;
     }
 
-    public THashMap<String, String> getVariables() {
+    public Map<String, String> getVariables() {
         return this.variables;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/Pet.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/Pet.java
@@ -17,14 +17,14 @@ import com.eu.habbo.messages.outgoing.rooms.pets.RoomPetRespectComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserRemoveComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserTalkComposer;
 import com.eu.habbo.plugin.events.pets.PetTalkEvent;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.*;
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -487,7 +487,7 @@ public class Pet implements ISerialize, Runnable {
     }
 
     public void clearPosture() {
-        THashMap<RoomUnitStatus, String> keys = new THashMap<>();
+        Map<RoomUnitStatus, String> keys = new HashMap<>();
 
         if (this.roomUnit.hasStatus(RoomUnitStatus.MOVE))
             keys.put(RoomUnitStatus.MOVE, this.roomUnit.getStatus(RoomUnitStatus.MOVE));
@@ -633,7 +633,7 @@ public class Pet implements ISerialize, Runnable {
         }
         
         // Get all pet toys in the room
-        THashSet<InteractionPetToy> toys = this.room.getRoomSpecialTypes().getPetToys();
+        Set<InteractionPetToy> toys = this.room.getRoomSpecialTypes().getPetToys();
         if (toys.isEmpty()) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/PetData.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/PetData.java
@@ -7,14 +7,16 @@ import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetDrink;
 import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetFood;
 import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetToy;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class PetData implements Comparable<PetData> {
 
@@ -26,11 +28,11 @@ public class PetData implements Comparable<PetData> {
     public static final List<Item> generalFoodItems = new ArrayList<>();
     public static final List<Item> generalNestItems = new ArrayList<>();
     public static final List<Item> generalToyItems = new ArrayList<>();
-    public static final THashMap<PetVocalsType, THashSet<PetVocal>> generalPetVocals = new THashMap<>();
+    public static final Map<PetVocalsType, Set<PetVocal>> generalPetVocals = new HashMap<>();
     public String[] actionsHappy;
     public String[] actionsTired;
     public String[] actionsRandom;
-    public THashMap<PetVocalsType, THashSet<PetVocal>> petVocals;
+    public Map<PetVocalsType, Set<PetVocal>> petVocals;
     public boolean canSwim;
     private int type;
     private String name;
@@ -105,7 +107,7 @@ public class PetData implements Comparable<PetData> {
     }
 
 
-    public HabboItem randomNest(THashSet<InteractionNest> items) {
+    public HabboItem randomNest(Set<InteractionNest> items) {
         List<HabboItem> nestList = new ArrayList<>();
         
         // If no nest items are registered, allow all nests in the room
@@ -151,7 +153,7 @@ public class PetData implements Comparable<PetData> {
     }
 
 
-    public HabboItem randomFoodItem(THashSet<InteractionPetFood> items) {
+    public HabboItem randomFoodItem(Set<InteractionPetFood> items) {
         List<HabboItem> foodList = new ArrayList<>();
         
         // If no food items are registered, allow all food in the room
@@ -196,7 +198,7 @@ public class PetData implements Comparable<PetData> {
     }
 
 
-    public HabboItem randomDrinkItem(THashSet<InteractionPetDrink> items) {
+    public HabboItem randomDrinkItem(Set<InteractionPetDrink> items) {
         List<HabboItem> drinkList = new ArrayList<>();
         
         // If no drink items are registered, allow all drinks in the room
@@ -241,7 +243,7 @@ public class PetData implements Comparable<PetData> {
     }
 
 
-    public HabboItem randomToyItem(THashSet<InteractionPetToy> toys) {
+    public HabboItem randomToyItem(Set<InteractionPetToy> toys) {
         List<HabboItem> toyList = new ArrayList<>();
         
         // If no toy items are registered, allow all toys in the room
@@ -265,7 +267,7 @@ public class PetData implements Comparable<PetData> {
      * Finds a random toy item from a generic set of HabboItems.
      * Used for finding pet items like trampolines, trees, etc.
      */
-    public HabboItem randomToyHabboItem(THashSet<HabboItem> items) {
+    public HabboItem randomToyHabboItem(Set<HabboItem> items) {
         List<HabboItem> itemList = new ArrayList<>();
         
         // If no toy items are registered, allow all toys in the room
@@ -287,8 +289,8 @@ public class PetData implements Comparable<PetData> {
 
 
     public PetVocal randomVocal(PetVocalsType type) {
-        THashSet<PetVocal> petTypeVocals = this.petVocals.get(type);
-        THashSet<PetVocal> generalVocals = PetData.generalPetVocals.get(type);
+        Set<PetVocal> petTypeVocals = this.petVocals.get(type);
+        Set<PetVocal> generalVocals = PetData.generalPetVocals.get(type);
 
         int petTypeSize = petTypeVocals != null ? petTypeVocals.size() : 0;
         int generalSize = generalVocals != null ? generalVocals.size() : 0;
@@ -355,15 +357,15 @@ public class PetData implements Comparable<PetData> {
         this.drinkItems = new ArrayList<>();
         this.toyItems = new ArrayList<>();
 
-        this.petVocals = new THashMap<>();
+        this.petVocals = new HashMap<>();
 
         for (PetVocalsType type : PetVocalsType.values()) {
-            this.petVocals.put(type, new THashSet<>());
+            this.petVocals.put(type, new HashSet<>());
         }
 
         if (PetData.generalPetVocals.isEmpty()) {
             for (PetVocalsType type : PetVocalsType.values()) {
-                PetData.generalPetVocals.put(type, new THashSet<>());
+                PetData.generalPetVocals.put(type, new HashSet<>());
             }
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/PetManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/PetManager.java
@@ -9,12 +9,10 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.Habbo;
-import gnu.trove.map.TIntIntMap;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntIntHashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
-import gnu.trove.procedure.TIntObjectProcedure;
-import gnu.trove.set.hash.THashSet;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.apache.commons.math3.distribution.NormalDistribution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,14 +20,17 @@ import org.slf4j.LoggerFactory;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class PetManager {
     public static int MAXIMUM_PET_INVENTORY_SIZE = 25;
     private static final Logger LOGGER = LoggerFactory.getLogger(PetManager.class);
     public static final int[] experiences = new int[]{100, 200, 400, 600, 900, 1300, 1800, 2400, 3200, 4300, 5700, 7600, 10100, 13300, 17500, 23000, 30200, 39600, 51900};
     static int[] skins = new int[]{0, 1, 6, 7};
-    public final THashMap<Integer, PetAction> petActions = new THashMap<Integer, PetAction>() {
+    public final Map<Integer, PetAction> petActions = new HashMap<Integer, PetAction>() {
         {
             this.put(0, new ActionFree());
             this.put(1, new ActionSit());
@@ -80,19 +81,19 @@ public class PetManager {
 
         }
     };
-    private final THashMap<Integer, THashSet<PetRace>> petRaces;
-    private final THashMap<Integer, PetData> petData;
-    private final TIntIntMap breedingPetType;
-    private final THashMap<Integer, TIntObjectHashMap<ArrayList<PetBreedingReward>>> breedingReward;
+    private final Map<Integer, Set<PetRace>> petRaces;
+    private final Map<Integer, PetData> petData;
+    private final Int2IntMap breedingPetType;
+    private final Map<Integer, Int2ObjectMap<ArrayList<PetBreedingReward>>> breedingReward;
 
 
     public PetManager() {
         long millis = System.currentTimeMillis();
 
-        this.petRaces = new THashMap<>();
-        this.petData = new THashMap<>();
-        this.breedingPetType = new TIntIntHashMap();
-        this.breedingReward = new THashMap<>();
+        this.petRaces = new HashMap<>();
+        this.petData = new HashMap<>();
+        this.breedingPetType = new Int2IntOpenHashMap();
+        this.breedingReward = new HashMap<>();
 
         reloadPetData();
 
@@ -191,7 +192,7 @@ public class PetManager {
         try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM pet_breeds ORDER BY race, color_one, color_two ASC")) {
             while (set.next()) {
                 if (this.petRaces.get(set.getInt("race")) == null)
-                    this.petRaces.put(set.getInt("race"), new THashSet<>());
+                    this.petRaces.put(set.getInt("race"), new HashSet<>());
 
                 this.petRaces.get(set.getInt("race")).add(new PetRace(set));
             }
@@ -267,7 +268,7 @@ public class PetManager {
                     }
                 } else {
                     if (!PetData.generalPetVocals.containsKey(PetVocalsType.valueOf(set.getString("type").toUpperCase())))
-                        PetData.generalPetVocals.put(PetVocalsType.valueOf(set.getString("type").toUpperCase()), new THashSet<>());
+                        PetData.generalPetVocals.put(PetVocalsType.valueOf(set.getString("type").toUpperCase()), new HashSet<>());
 
                     PetData.generalPetVocals.get(PetVocalsType.valueOf(set.getString("type").toUpperCase())).add(new PetVocal(set.getString("message")));
                 }
@@ -278,7 +279,7 @@ public class PetManager {
     }
 
     private void loadPetCommands(Connection connection) {
-        THashMap<Integer, PetCommand> commandsList = new THashMap<>();
+        Map<Integer, PetCommand> commandsList = new HashMap<>();
         try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM pet_commands_data")) {
             while (set.next()) {
                 commandsList.put(set.getInt("command_id"), new PetCommand(set, this.petActions.get(set.getInt("command_id"))));
@@ -313,7 +314,7 @@ public class PetManager {
             while (set.next()) {
                 PetBreedingReward reward = new PetBreedingReward(set);
                 if (!this.breedingReward.containsKey(reward.petType)) {
-                    this.breedingReward.put(reward.petType, new TIntObjectHashMap<>());
+                    this.breedingReward.put(reward.petType, new Int2ObjectOpenHashMap<>());
                 }
 
                 if (!this.breedingReward.get(reward.petType).containsKey(reward.rarityLevel)) {
@@ -327,7 +328,7 @@ public class PetManager {
         }
     }
 
-    public THashSet<PetRace> getBreeds(String petName) {
+    public Set<PetRace> getBreeds(String petName) {
         if (!petName.matches("a0 pet\\d{1,3}")) {
             LOGGER.error("Pet data '{}' not found. Expected format: a0 pet<0-999>", petName);
             return null;
@@ -337,28 +338,23 @@ public class PetManager {
         return this.petRaces.get(petId);
     }
 
-    public TIntObjectHashMap<ArrayList<PetBreedingReward>> getBreedingRewards(int petType) {
+    public Int2ObjectMap<ArrayList<PetBreedingReward>> getBreedingRewards(int petType) {
         return this.breedingReward.get(petType);
     }
 
     public int getRarityForOffspring(Pet pet) {
         final int[] rarityLevel = {0};
 
-        TIntObjectHashMap<ArrayList<PetBreedingReward>> offspringList = this.breedingReward.get(pet.getPetData().getType());
+        Int2ObjectMap<ArrayList<PetBreedingReward>> offspringList = this.breedingReward.get(pet.getPetData().getType());
 
-        offspringList.forEachEntry(new TIntObjectProcedure<ArrayList<PetBreedingReward>>() {
-            @Override
-            public boolean execute(int i, ArrayList<PetBreedingReward> petBreedingRewards) {
-                for (PetBreedingReward reward : petBreedingRewards) {
-                    if (reward.breed == pet.getRace()) {
-                        rarityLevel[0] = i;
-                        return false;
-                    }
+        for (Int2ObjectMap.Entry<ArrayList<PetBreedingReward>> entry : offspringList.int2ObjectEntrySet()) {
+            for (PetBreedingReward reward : entry.getValue()) {
+                if (reward.breed == pet.getRace()) {
+                    rarityLevel[0] = entry.getIntKey();
+                    return 4 - rarityLevel[0];
                 }
-
-                return true;
             }
-        });
+        }
 
         return 4 - rarityLevel[0];
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/actions/ActionDip.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/actions/ActionDip.java
@@ -7,7 +7,8 @@ import com.eu.habbo.habbohotel.pets.PetAction;
 import com.eu.habbo.habbohotel.pets.PetVocalsType;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class ActionDip extends PetAction {
     public ActionDip() {
@@ -16,7 +17,7 @@ public class ActionDip extends PetAction {
 
     @Override
     public boolean apply(Pet pet, Habbo habbo, String[] data) {
-        THashSet<HabboItem> waterItems = pet.getRoom().getRoomSpecialTypes().getItemsOfType(InteractionWater.class);
+        Set<HabboItem> waterItems = pet.getRoom().getRoomSpecialTypes().getItemsOfType(InteractionWater.class);
 
         if (waterItems.isEmpty())
             return false;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/actions/ActionPlay.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/actions/ActionPlay.java
@@ -7,9 +7,10 @@ import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.rooms.RoomUnitStatus;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
 
 public class ActionPlay extends PetAction {
     private static final Logger LOGGER = LoggerFactory.getLogger(ActionPlay.class);
@@ -36,7 +37,7 @@ public class ActionPlay extends PetAction {
         }
         
         // Get all pet toys in the room
-        THashSet<InteractionPetToy> toys = pet.getRoom().getRoomSpecialTypes().getPetToys();
+        Set<InteractionPetToy> toys = pet.getRoom().getRoomSpecialTypes().getPetToys();
         LOGGER.info("[ActionPlay] Found {} pet toys in room", toys.size());
         
         // Find a toy to play with

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/polls/PollManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/polls/PollManager.java
@@ -2,16 +2,17 @@ package com.eu.habbo.habbohotel.polls;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.users.Habbo;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.*;
+import java.util.HashMap;
+import java.util.Map;
 
 public class PollManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(PollManager.class);
 
-    private final THashMap<Integer, Poll> activePolls = new THashMap<>();
+    private final Map<Integer, Poll> activePolls = new HashMap<>();
 
     public PollManager() {
         this.loadPolls();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/polls/PollQuestion.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/polls/PollQuestion.java
@@ -2,12 +2,12 @@ package com.eu.habbo.habbohotel.polls;
 
 import com.eu.habbo.messages.ISerialize;
 import com.eu.habbo.messages.ServerMessage;
-import gnu.trove.map.hash.THashMap;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class PollQuestion implements ISerialize, Comparable<PollQuestion> {
@@ -24,7 +24,7 @@ public class PollQuestion implements ISerialize, Comparable<PollQuestion> {
     public final String question;
 
 
-    public final THashMap<Integer, String[]> options;
+    public final Map<Integer, String[]> options;
 
 
     public final int minSelections;
@@ -42,7 +42,7 @@ public class PollQuestion implements ISerialize, Comparable<PollQuestion> {
         this.minSelections = set.getInt("min_selections");
         this.order = set.getInt("order");
 
-        this.options = new THashMap<>();
+        this.options = new HashMap<>();
         this.subQuestions = new ArrayList<>();
 
         String opts = set.getString("options");

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/BuildersClubRoomSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/BuildersClubRoomSupport.java
@@ -13,8 +13,6 @@ import com.eu.habbo.messages.outgoing.catalog.BuildersClubSubscriptionStatusComp
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.generic.alerts.SimpleAlertComposer;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +20,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class BuildersClubRoomSupport {
     private static final Logger LOGGER = LoggerFactory.getLogger(BuildersClubRoomSupport.class);
@@ -290,7 +292,7 @@ public class BuildersClubRoomSupport {
             return;
         }
 
-        THashSet<Integer> updatedUsers = new THashSet<>();
+        Set<Integer> updatedUsers = new HashSet<>();
 
         if (room != null) {
             for (Habbo habbo : room.getHabbos()) {
@@ -484,7 +486,7 @@ public class BuildersClubRoomSupport {
     }
 
     public static void sendVisitDeniedOwnerBubble(int ownerId, String username) {
-        THashMap<String, String> keys = new THashMap<>();
+        Map<String, String> keys = new HashMap<>();
         keys.put("USERNAME", username);
 
         sendBubbleNotification(ownerId, BubbleAlertKeys.BUILDERS_CLUB_VISIT_DENIED_OWNER, keys);
@@ -507,7 +509,7 @@ public class BuildersClubRoomSupport {
         );
     }
 
-    private static void sendBubbleNotification(int userId, BubbleAlertKeys key, THashMap<String, String> keys) {
+    private static void sendBubbleNotification(int userId, BubbleAlertKeys key, Map<String, String> keys) {
         Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(userId);
 
         if (habbo == null || habbo.getClient() == null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -2676,7 +2676,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
   public void refreshGuild(Guild guild) {
     if (guild.getRoomId() == this.id) {
-      THashSet<GuildMember> members = Emulator.getGameEnvironment().getGuildManager()
+      Set<GuildMember> members = Emulator.getGameEnvironment().getGuildManager()
               .getGuildMembers(guild.getId());
 
       for (Habbo habbo : this.getHabbos()) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -38,15 +38,11 @@ import com.eu.habbo.plugin.events.furniture.FurniturePickedUpEvent;
 import com.eu.habbo.plugin.events.rooms.RoomLoadedEvent;
 import com.eu.habbo.plugin.events.rooms.RoomUnloadedEvent;
 import com.eu.habbo.plugin.events.rooms.RoomUnloadingEvent;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.list.array.TIntArrayList;
-import gnu.trove.map.TIntIntMap;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntIntHashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
-import gnu.trove.set.hash.THashSet;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,7 +82,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
   public static final Comparator<Room> SORT_SCORE = (o1, o2) -> o2.getScore() - o1.getScore();
   public static final Comparator<Room> SORT_ID = (o1, o2) -> o2.getId() - o1.getId();
-  private static final TIntObjectHashMap<RoomMoodlightData> defaultMoodData = new TIntObjectHashMap<>();
+  private static final Int2ObjectMap<RoomMoodlightData> defaultMoodData = new Int2ObjectOpenHashMap<>();
   //Configuration. Loaded from database & updated accordingly.
   public static boolean HABBO_CHAT_DELAY = false;
   public static int MAXIMUM_BOTS = 10;
@@ -119,11 +115,11 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
   public final Object roomUnitLock = new Object();
   public final List<Integer> userVotes;
-  private final TIntArrayList rights;
-  private final TIntIntHashMap mutedHabbos;
-  private final TIntObjectHashMap<RoomBan> bannedHabbos;
+  private final IntList rights;
+  private final Int2IntMap mutedHabbos;
+  private final Int2ObjectMap<RoomBan> bannedHabbos;
   private final Set<Game> games;
-  private final TIntObjectMap<RoomMoodlightData> moodlightData;
+  private final Int2ObjectMap<RoomMoodlightData> moodlightData;
   public volatile double lastCycleCpuMs = 0.0;
   public volatile String lastCycleThread = "N/A";
 
@@ -228,10 +224,10 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     this.youtubePlaylist.clear();
   }
 
-  public final THashMap<String, Object> cache;
+  public final Map<String, Object> cache;
 
   public Room(ResultSet set) throws SQLException {
-    this.cache = new THashMap<>(1000);
+    this.cache = new HashMap<>(1000);
     this.id = set.getInt("id");
     this.ownerId = set.getInt("owner_id");
     this.ownerName = set.getString("owner_name");
@@ -287,7 +283,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
       this.buildersClubOriginalState = RoomState.OPEN;
     }
 
-    this.bannedHabbos = new TIntObjectHashMap<>();
+    this.bannedHabbos = new Int2ObjectOpenHashMap<>();
 
     try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
       // Load bans eagerly (needed for entry check before loadData)
@@ -303,17 +299,17 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     this.preLoaded = true;
     this.allowBotsWalk = true;
     this.allowEffects = true;
-    this.moodlightData = new TIntObjectHashMap<>(defaultMoodData);
+    this.moodlightData = new Int2ObjectOpenHashMap<>(defaultMoodData);
 
     for (String s : set.getString("moodlight_data").split(";")) {
       RoomMoodlightData data = RoomMoodlightData.fromString(s);
       this.moodlightData.put(data.getId(), data);
     }
 
-    this.mutedHabbos = new TIntIntHashMap();
+    this.mutedHabbos = new Int2IntOpenHashMap();
     this.games = ConcurrentHashMap.newKeySet();
 
-    this.rights = new TIntArrayList();
+    this.rights = new IntArrayList();
     this.userVotes = new ArrayList<>();
 
     // Initialize managers
@@ -1189,7 +1185,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
         StringBuilder moodLightData = new StringBuilder();
 
         int id = 1;
-        for (RoomMoodlightData data : this.moodlightData.valueCollection()) {
+        for (RoomMoodlightData data : this.moodlightData.values()) {
           data.setId(id);
           moodLightData.append(data.toString()).append(";");
           id++;
@@ -1769,7 +1765,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     return this.itemManager.getFurniOwnerCount();
   }
 
-  public TIntObjectMap<RoomMoodlightData> getMoodlightData() {
+  public Int2ObjectMap<RoomMoodlightData> getMoodlightData() {
     return this.moodlightData;
   }
 
@@ -1832,7 +1828,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     this.needsUpdate = needsUpdate;
   }
 
-  public TIntArrayList getRights() {
+  public IntList getRights() {
     return this.rights;
   }
 
@@ -2369,7 +2365,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
   public void removeRights(int userId) {
     this.rightsManager.removeRights(userId);
-    this.rights.remove(userId);
+    this.rights.rem(userId);
     this.pushWiredSettingsToCurrentHabbos();
   }
 
@@ -2399,7 +2395,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     return this.rightsManager.isBanned(habbo);
   }
 
-  public TIntObjectHashMap<RoomBan> getBannedHabbos() {
+  public Int2ObjectMap<RoomBan> getBannedHabbos() {
     return this.bannedHabbos;
   }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -849,7 +849,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
       this.sendComposer(new RemoveFloorItemComposer(item).compose());
 
-      THashSet<RoomTile> updatedTiles = new THashSet<>();
+      Set<RoomTile> updatedTiles = new HashSet<>();
       Rectangle rectangle = RoomLayout.getRectangle(item.getX(), item.getY(),
               item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
 
@@ -2069,7 +2069,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     this.chatManager.talk(habbo, roomChatMessage, chatType, ignoreWired);
   }
 
-  public THashSet<RoomTile> getLockedTiles() {
+  public Set<RoomTile> getLockedTiles() {
     return this.itemManager.getLockedTiles();
   }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -1039,30 +1039,15 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
           this.sendComposer(new HotelViewComposer().compose());
 
           // Save bots BEFORE clearing - must happen before unitManager.clear()
-          TIntObjectIterator<Bot> botIterator = this.getCurrentBots().iterator();
-
-          for (int i = this.getCurrentBots().size(); i-- > 0; ) {
-            try {
-              botIterator.advance();
-              botIterator.value().needsUpdate(true);
-              botIterator.value().run();  // Run synchronously to ensure DB is updated before room reload
-            } catch (NoSuchElementException e) {
-              LOGGER.error("Caught exception", e);
-              break;
-            }
+          for (Bot bot : this.getCurrentBots().values()) {
+            bot.needsUpdate(true);
+            bot.run();  // Run synchronously to ensure DB is updated before room reload
           }
 
           // Save ALL remaining pets (including owner's pets) BEFORE clearing
-          TIntObjectIterator<Pet> petIterator = this.getCurrentPets().iterator();
-          for (int i = this.getCurrentPets().size(); i-- > 0; ) {
-            try {
-              petIterator.advance();
-              petIterator.value().needsUpdate = true;
-              petIterator.value().run();  // Run synchronously to ensure DB is updated before room reload
-            } catch (NoSuchElementException e) {
-              LOGGER.error("Caught exception", e);
-              break;
-            }
+          for (Pet pet : this.getCurrentPets().values()) {
+            pet.needsUpdate = true;
+            pet.run();  // Run synchronously to ensure DB is updated before room reload
           }
 
           this.unitManager.clear();
@@ -1772,7 +1757,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     return this.unitManager.getHabbos();
   }
 
-  public TIntObjectMap<Habbo> getHabboQueue() {
+  public Int2ObjectMap<Habbo> getHabboQueue() {
     return this.unitManager.getHabboQueue();
   }
 
@@ -1816,11 +1801,11 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     return true;
   }
 
-  public TIntObjectMap<Bot> getCurrentBots() {
+  public Int2ObjectMap<Bot> getCurrentBots() {
     return this.unitManager.getCurrentBots();
   }
 
-  public TIntObjectMap<Pet> getCurrentPets() {
+  public Int2ObjectMap<Pet> getCurrentPets() {
     return this.unitManager.getCurrentPets();
   }
 
@@ -1986,35 +1971,35 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     return this.unitManager.hasPetsAt(x, y);
   }
 
-  public THashSet<Bot> getBotsAt(RoomTile tile) {
+  public Set<Bot> getBotsAt(RoomTile tile) {
     return this.unitManager.getBotsAt(tile);
   }
 
-  public THashSet<Pet> getPetsAt(RoomTile tile) {
+  public Set<Pet> getPetsAt(RoomTile tile) {
     return this.unitManager.getPetsAt(tile);
   }
 
-  public THashSet<Habbo> getHabbosAt(short x, short y) {
+  public Set<Habbo> getHabbosAt(short x, short y) {
     return this.unitManager.getHabbosAt(x, y);
   }
 
-  public THashSet<Habbo> getHabbosAt(RoomTile tile) {
+  public Set<Habbo> getHabbosAt(RoomTile tile) {
     return this.unitManager.getHabbosAt(tile);
   }
 
-  public THashSet<RoomUnit> getHabbosAndBotsAt(short x, short y) {
+  public Set<RoomUnit> getHabbosAndBotsAt(short x, short y) {
     return this.unitManager.getHabbosAndBotsAt(x, y);
   }
 
-  public THashSet<RoomUnit> getHabbosAndBotsAt(RoomTile tile) {
+  public Set<RoomUnit> getHabbosAndBotsAt(RoomTile tile) {
     return this.unitManager.getHabbosAndBotsAt(tile);
   }
 
-  public THashSet<Habbo> getHabbosOnItem(HabboItem item) {
+  public Set<Habbo> getHabbosOnItem(HabboItem item) {
     return this.unitManager.getHabbosOnItem(item);
   }
 
-  public THashSet<Bot> getBotsOnItem(HabboItem item) {
+  public Set<Bot> getBotsOnItem(HabboItem item) {
     return this.unitManager.getBotsOnItem(item);
   }
 
@@ -2891,11 +2876,11 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
 
 
-  public THashSet<RoomUnit> getRoomUnits() {
+  public Set<RoomUnit> getRoomUnits() {
     return this.unitManager.getRoomUnits();
   }
 
-  public THashSet<RoomUnit> getRoomUnits(RoomTile atTile) {
+  public Set<RoomUnit> getRoomUnits(RoomTile atTile) {
     return this.unitManager.getRoomUnits(atTile);
   }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -1823,7 +1823,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     return this.unitManager.getCurrentPets();
   }
 
-  public THashSet<String> getWordFilterWords() {
+  public Set<String> getWordFilterWords() {
     return this.chatManager.getWordFilterWords();
   }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -934,7 +934,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     this.unitManager.updateHabbosAt(x, y);
   }
 
-  public void updateHabbosAt(short x, short y, THashSet<Habbo> habbos) {
+  public void updateHabbosAt(short x, short y, Collection<Habbo> habbos) {
     this.unitManager.updateHabbosAt(x, y, habbos);
   }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -804,7 +804,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     this.tileManager.updateTile(tile);
   }
 
-  public void updateTiles(THashSet<RoomTile> tiles) {
+  public void updateTiles(Collection<RoomTile> tiles) {
     this.tileManager.updateTiles(tiles);
   }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -2073,23 +2073,23 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   }
 
   @Deprecated
-  public THashSet<HabboItem> getItemsAt(int x, int y) {
+  public Set<HabboItem> getItemsAt(int x, int y) {
     return this.itemManager.getItemsAt(x, y);
   }
 
-  public THashSet<HabboItem> getItemsAt(RoomTile tile) {
+  public Set<HabboItem> getItemsAt(RoomTile tile) {
     return this.itemManager.getItemsAt(tile);
   }
 
-  public THashSet<HabboItem> getItemsAt(RoomTile tile, boolean returnOnFirst) {
+  public Set<HabboItem> getItemsAt(RoomTile tile, boolean returnOnFirst) {
     return this.itemManager.getItemsAt(tile, returnOnFirst);
   }
 
-  public THashSet<HabboItem> getItemsAt(int x, int y, double minZ) {
+  public Set<HabboItem> getItemsAt(int x, int y, double minZ) {
     return this.itemManager.getItemsAt(x, y, minZ);
   }
 
-  public THashSet<HabboItem> getItemsAt(Class<? extends HabboItem> type, int x, int y) {
+  public Set<HabboItem> getItemsAt(Class<? extends HabboItem> type, int x, int y) {
     return this.itemManager.getItemsAt(type, x, y);
   }
 
@@ -2105,7 +2105,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     return this.itemManager.getTopItemAt(x, y, exclude);
   }
 
-  public HabboItem getTopItemAt(THashSet<RoomTile> tiles, HabboItem exclude) {
+  public HabboItem getTopItemAt(Set<RoomTile> tiles, HabboItem exclude) {
     return this.itemManager.getTopItemAt(tiles, exclude);
   }
 
@@ -2150,7 +2150,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     return this.tileManager.canWalkAt(roomTile);
   }
 
-  boolean canSitAt(THashSet<HabboItem> items) {
+  boolean canSitAt(Set<HabboItem> items) {
     return this.tileManager.canSitAt(items);
   }
 
@@ -2158,7 +2158,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     return this.tileManager.canLayAt(x, y);
   }
 
-  boolean canLayAt(THashSet<HabboItem> items) {
+  boolean canLayAt(Set<HabboItem> items) {
     return this.tileManager.canLayAt(items);
   }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -46,6 +46,7 @@ import gnu.trove.map.hash.THashMap;
 import gnu.trove.map.hash.TIntIntHashMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.set.hash.THashSet;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1775,7 +1776,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     return this.unitManager.getHabboQueue();
   }
 
-  public TIntObjectMap<String> getFurniOwnerNames() {
+  public Int2ObjectMap<String> getFurniOwnerNames() {
     return this.itemManager.getFurniOwnerNames();
   }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -1883,15 +1883,15 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     this.itemManager.removeHabboItem(item);
   }
 
-  public THashSet<HabboItem> getFloorItems() {
+  public Set<HabboItem> getFloorItems() {
     return this.itemManager.getFloorItems();
   }
 
-  public THashSet<HabboItem> getWallItems() {
+  public Set<HabboItem> getWallItems() {
     return this.itemManager.getWallItems();
   }
 
-  public THashSet<HabboItem> getPostItNotes() {
+  public Set<HabboItem> getPostItNotes() {
     return this.itemManager.getPostItNotes();
   }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -46,6 +46,7 @@ import gnu.trove.map.hash.THashMap;
 import gnu.trove.map.hash.TIntIntHashMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.set.hash.THashSet;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1577,14 +1578,10 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
   public Color getBackgroundTonerColor() {
     Color color = new Color(0, 0, 0);
-    TIntObjectMap<HabboItem> items = this.itemManager.getRoomItems();
-    TIntObjectIterator<HabboItem> iterator = items.iterator();
+    Int2ObjectMap<HabboItem> items = this.itemManager.getRoomItems();
 
-    for (int i = items.size(); i > 0; i--) {
-      try {
-        iterator.advance();
-        HabboItem object = iterator.value();
-
+    synchronized (items) {
+      for (HabboItem object : items.values()) {
         if (object instanceof InteractionBackgroundToner) {
           String[] extraData = object.getExtradata().split(":");
 
@@ -1595,7 +1592,6 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
             }
           }
         }
-      } catch (Exception e) {
       }
     }
 
@@ -1769,7 +1765,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     return this.itemManager.getFurniOwnerName(userId);
   }
 
-  public TIntIntMap getFurniOwnerCount() {
+  public Int2IntMap getFurniOwnerCount() {
     return this.itemManager.getFurniOwnerCount();
   }
 
@@ -2683,23 +2679,15 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
   public void refreshGuildColors(Guild guild) {
     if (guild.getRoomId() == this.id) {
-      TIntObjectMap<HabboItem> items = this.itemManager.getRoomItems();
-      TIntObjectIterator<HabboItem> iterator = items.iterator();
-
-      for (int i = items.size(); i-- > 0; ) {
-        try {
-          iterator.advance();
-        } catch (Exception e) {
-          break;
-        }
-
-        HabboItem habboItem = iterator.value();
-
+      Int2ObjectMap<HabboItem> items = this.itemManager.getRoomItems();
+      synchronized (items) {
+      for (HabboItem habboItem : items.values()) {
         if (habboItem instanceof InteractionGuildFurni) {
           if (((InteractionGuildFurni) habboItem).getGuildId() == guild.getId()) {
             this.updateItem(habboItem);
           }
         }
+      }
       }
     }
   }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatManager.java
@@ -591,7 +591,7 @@ public class RoomChatManager {
      */
     private void notifyBots(RoomChatMessage roomChatMessage) {
         synchronized (this.room.getUnitManager().getCurrentBots()) {
-            for (Bot bot : this.room.getUnitManager().getCurrentBots().valueCollection()) {
+            for (Bot bot : this.room.getUnitManager().getCurrentBots().values()) {
                 try {
                     bot.onUserSay(roomChatMessage);
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatManager.java
@@ -21,7 +21,8 @@ import com.eu.habbo.plugin.events.users.UsernameTalkEvent;
 import com.eu.habbo.threading.runnables.YouAreAPirate;
 import com.eu.habbo.util.pathfinding.Rotation;
 import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.hash.TIntIntHashMap;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +48,7 @@ public class RoomChatManager {
     private final Set<String> wordFilterWords;
 
     // Muted Habbos: userId -> unmute timestamp
-    private final TIntIntHashMap mutedHabbos;
+    private final Int2IntMap mutedHabbos;
 
     // Flood protection settings
     private final int muteTime;
@@ -61,7 +62,7 @@ public class RoomChatManager {
     public RoomChatManager(Room room) {
         this.room = room;
         this.wordFilterWords = new HashSet<>(0);
-        this.mutedHabbos = new TIntIntHashMap();
+        this.mutedHabbos = new Int2IntOpenHashMap();
         this.muteTime = Emulator.getConfig().getInt("hotel.flood.mute.time", 30);
     }
 
@@ -202,7 +203,7 @@ public class RoomChatManager {
     /**
      * Gets the muted Habbos map.
      */
-    public TIntIntHashMap getMutedHabbos() {
+    public Int2IntMap getMutedHabbos() {
         return this.mutedHabbos;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatManager.java
@@ -22,7 +22,6 @@ import com.eu.habbo.threading.runnables.YouAreAPirate;
 import com.eu.habbo.util.pathfinding.Rotation;
 import gnu.trove.iterator.TIntObjectIterator;
 import gnu.trove.map.hash.TIntIntHashMap;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +30,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -44,7 +44,7 @@ public class RoomChatManager {
     private final Room room;
 
     // Word filter
-    private final THashSet<String> wordFilterWords;
+    private final Set<String> wordFilterWords;
 
     // Muted Habbos: userId -> unmute timestamp
     private final TIntIntHashMap mutedHabbos;
@@ -60,7 +60,7 @@ public class RoomChatManager {
 
     public RoomChatManager(Room room) {
         this.room = room;
-        this.wordFilterWords = new THashSet<>(0);
+        this.wordFilterWords = new HashSet<>(0);
         this.mutedHabbos = new TIntIntHashMap();
         this.muteTime = Emulator.getConfig().getInt("hotel.flood.mute.time", 30);
     }
@@ -134,7 +134,7 @@ public class RoomChatManager {
     /**
      * Gets the word filter words.
      */
-    public THashSet<String> getWordFilterWords() {
+    public Set<String> getWordFilterWords() {
         return this.wordFilterWords;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatManager.java
@@ -31,6 +31,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -611,7 +612,7 @@ public class RoomChatManager {
      */
     private void handleTalkingFurniture(Habbo habbo, RoomChatMessage roomChatMessage) {
         if (roomChatMessage.getBubble().triggersTalkingFurniture()) {
-            THashSet<HabboItem> items = this.room.getRoomSpecialTypes().getItemsOfType(
+            Set<HabboItem> items = this.room.getRoomSpecialTypes().getItemsOfType(
                 InteractionTalkingFurniture.class);
 
             for (HabboItem item : items) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatManager.java
@@ -20,7 +20,6 @@ import com.eu.habbo.plugin.events.users.UserIdleEvent;
 import com.eu.habbo.plugin.events.users.UsernameTalkEvent;
 import com.eu.habbo.threading.runnables.YouAreAPirate;
 import com.eu.habbo.util.pathfinding.Rotation;
-import gnu.trove.iterator.TIntObjectIterator;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import org.slf4j.Logger;
@@ -592,12 +591,8 @@ public class RoomChatManager {
      */
     private void notifyBots(RoomChatMessage roomChatMessage) {
         synchronized (this.room.getUnitManager().getCurrentBots()) {
-            TIntObjectIterator<Bot> botIterator = this.room.getUnitManager().getCurrentBots().iterator();
-
-            for (int i = this.room.getUnitManager().getCurrentBots().size(); i-- > 0; ) {
+            for (Bot bot : this.room.getUnitManager().getCurrentBots().valueCollection()) {
                 try {
-                    botIterator.advance();
-                    Bot bot = botIterator.value();
                     bot.onUserSay(roomChatMessage);
 
                 } catch (Exception e) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomConfInvisSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomConfInvisSupport.java
@@ -5,8 +5,9 @@ import com.eu.habbo.habbohotel.items.FurnitureType;
 import com.eu.habbo.habbohotel.items.interactions.InteractionConfInvisControl;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.outgoing.rooms.items.ConfInvisStateComposer;
-import gnu.trove.list.array.TIntArrayList;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public final class RoomConfInvisSupport {
@@ -29,8 +30,8 @@ public final class RoomConfInvisSupport {
             && hasCustomParamToken(item.getBaseItem().getCustomParams(), "is_invisible");
     }
 
-    public static TIntArrayList collectHiddenFloorItemIds(Room room) {
-        TIntArrayList hiddenItemIds = new TIntArrayList();
+    public static List<Integer> collectHiddenFloorItemIds(Room room) {
+        List<Integer> hiddenItemIds = new ArrayList<>();
 
         if (room == null) {
             return hiddenItemIds;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomCycleManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomCycleManager.java
@@ -17,6 +17,7 @@ import com.eu.habbo.messages.outgoing.rooms.users.RoomUnitIdleComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserIgnoredComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
 import com.eu.habbo.plugin.events.users.UserExitRoomEvent;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import gnu.trove.iterator.TIntObjectIterator;
 import gnu.trove.map.TIntObjectMap;
 import gnu.trove.procedure.TIntObjectProcedure;
@@ -295,7 +296,7 @@ public class RoomCycleManager {
      * Processes all bots in the room.
      */
     private void processBots(THashSet<RoomUnit> updatedUnit) {
-        TIntObjectMap<Bot> currentBots = this.room.getCurrentBots();
+        Int2ObjectMap<Bot> currentBots = this.room.getCurrentBots();
         if (currentBots.isEmpty()) {
             return;
         }
@@ -307,7 +308,7 @@ public class RoomCycleManager {
         // roomUnitLock -> currentBots taken by RoomUnitManager.addBot/clear.
         final ArrayList<Bot> bots;
         synchronized (currentBots) {
-            bots = new ArrayList<>(currentBots.valueCollection());
+            bots = new ArrayList<>(currentBots.values());
         }
 
         for (Bot bot : bots) {
@@ -337,7 +338,7 @@ public class RoomCycleManager {
      * Processes all pets in the room.
      */
     private void processPets(THashSet<RoomUnit> updatedUnit) {
-        TIntObjectMap<Pet> currentPets = this.room.getCurrentPets();
+        Int2ObjectMap<Pet> currentPets = this.room.getCurrentPets();
         if (currentPets.isEmpty() || !this.room.isAllowBotsWalk()) {
             return;
         }
@@ -346,7 +347,7 @@ public class RoomCycleManager {
         // holding currentPets for the whole tick and the roomUnitLock inversion.
         final ArrayList<Pet> pets;
         synchronized (currentPets) {
-            pets = new ArrayList<>(currentPets.valueCollection());
+            pets = new ArrayList<>(currentPets.values());
         }
 
         for (Pet pet : pets) {
@@ -395,21 +396,17 @@ public class RoomCycleManager {
      * Processes the habbo queue.
      */
     private void processHabboQueue(boolean foundRightHolder) {
-        TIntObjectMap<Habbo> habboQueue = this.room.getHabboQueue();
+        Int2ObjectMap<Habbo> habboQueue = this.room.getHabboQueue();
         synchronized (habboQueue) {
             if (!habboQueue.isEmpty() && !foundRightHolder) {
                 final Room room = this.room;
-                habboQueue.forEachEntry(new TIntObjectProcedure<Habbo>() {
-                    @Override
-                    public boolean execute(int a, Habbo b) {
-                        if (b.isOnline()) {
-                            if (b.getHabboInfo().getRoomQueueId() == room.getId()) {
-                                b.getClient().sendResponse(new RoomAccessDeniedComposer(""));
-                            }
+                for (Habbo queuedHabbo : habboQueue.values()) {
+                    if (queuedHabbo.isOnline()) {
+                        if (queuedHabbo.getHabboInfo().getRoomQueueId() == room.getId()) {
+                            queuedHabbo.getClient().sendResponse(new RoomAccessDeniedComposer(""));
                         }
-                        return true;
                     }
-                });
+                }
                 habboQueue.clear();
             }
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomCycleManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomCycleManager.java
@@ -18,15 +18,11 @@ import com.eu.habbo.messages.outgoing.rooms.users.RoomUserIgnoredComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
 import com.eu.habbo.plugin.events.users.UserExitRoomEvent;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.procedure.TIntObjectProcedure;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.NoSuchElementException;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -85,7 +81,7 @@ public class RoomCycleManager {
             if (!this.room.getCurrentHabbos().isEmpty()) {
                 this.idleCycles = 0;
 
-                THashSet<RoomUnit> updatedUnit = new THashSet<>();
+                Set<RoomUnit> updatedUnit = new HashSet<>();
                 ArrayList<Habbo> toKick = new ArrayList<>();
 
                 final long millis = System.currentTimeMillis();
@@ -295,7 +291,7 @@ public class RoomCycleManager {
     /**
      * Processes all bots in the room.
      */
-    private void processBots(THashSet<RoomUnit> updatedUnit) {
+    private void processBots(Set<RoomUnit> updatedUnit) {
         Int2ObjectMap<Bot> currentBots = this.room.getCurrentBots();
         if (currentBots.isEmpty()) {
             return;
@@ -337,7 +333,7 @@ public class RoomCycleManager {
     /**
      * Processes all pets in the room.
      */
-    private void processPets(THashSet<RoomUnit> updatedUnit) {
+    private void processPets(Set<RoomUnit> updatedUnit) {
         Int2ObjectMap<Pet> currentPets = this.room.getCurrentPets();
         if (currentPets.isEmpty() || !this.room.isAllowBotsWalk()) {
             return;
@@ -381,7 +377,7 @@ public class RoomCycleManager {
     /**
      * Processes roller cycle.
      */
-    private void processRollers(THashSet<RoomUnit> updatedUnit) {
+    private void processRollers(Set<RoomUnit> updatedUnit) {
         Integer controlledRollerSpeed = RoomQueueSpeedControlSupport.getEffectiveRollerSpeed(this.room);
         int rollerSpeed = (controlledRollerSpeed != null) ? controlledRollerSpeed : this.room.getRollerSpeed();
         if (rollerSpeed != -1 && this.rollerCycle >= rollerSpeed) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomFurniVariableManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomFurniVariableManager.java
@@ -626,7 +626,7 @@ public class RoomFurniVariableManager {
             return Collections.emptyList();
         }
 
-        THashSet<InteractionWiredExtra> extras = this.room.getRoomSpecialTypes().getExtras();
+        Collection<InteractionWiredExtra> extras = this.room.getRoomSpecialTypes().getExtras();
         List<WiredExtraFurniVariable> result = new ArrayList<>();
 
         for (InteractionWiredExtra extra : extras) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomFurniVariableManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomFurniVariableManager.java
@@ -11,7 +11,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredVariableLevelSystemSupport;
 import com.eu.habbo.habbohotel.wired.core.WiredVariableTextConnectorSupport;
 import com.eu.habbo.messages.outgoing.wired.WiredUserVariablesDataComposer;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,10 +22,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class RoomFurniVariableManager {
@@ -512,7 +513,7 @@ public class RoomFurniVariableManager {
         }
 
         List<FurniAssignmentsEntry> furnis = new ArrayList<>();
-        THashSet<Integer> furniIds = new THashSet<>();
+        Set<Integer> furniIds = new HashSet<>();
         furniIds.addAll(this.activeAssignmentsByFurniId.keySet());
 
         for (HabboItem item : this.room.getFloorItems()) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -38,7 +38,6 @@ import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.hash.THashMap;
 import gnu.trove.map.hash.TIntIntHashMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
-import gnu.trove.set.hash.THashSet;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -1028,7 +1027,7 @@ public class RoomItemManager {
                 RoomHanditemBlockSupport.sendState(this.room);
             }
 
-            THashSet<RoomTile> updatedTiles = this.room.getLayout().getTilesAt(
+            Set<RoomTile> updatedTiles = this.room.getLayout().getTilesAt(
                     this.room.getLayout().getTile(item.getX(), item.getY()),
                     item.getBaseItem().getWidth(),
                     item.getBaseItem().getLength(),
@@ -1162,8 +1161,8 @@ public class RoomItemManager {
     /**
      * Gets all tiles that are locked by furniture.
      */
-    public THashSet<RoomTile> getLockedTiles() {
-        THashSet<RoomTile> lockedTiles = new THashSet<>();
+    public Set<RoomTile> getLockedTiles() {
+        Set<RoomTile> lockedTiles = new HashSet<>();
 
         TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
 
@@ -1366,7 +1365,7 @@ public class RoomItemManager {
         return null;
     }
 
-    private double getMinimumTileHeight(THashSet<RoomTile> occupiedTiles) {
+    private double getMinimumTileHeight(Set<RoomTile> occupiedTiles) {
         double minimumHeight = 0.0D;
 
         for (RoomTile occupiedTile : occupiedTiles) {
@@ -1376,7 +1375,7 @@ public class RoomItemManager {
         return minimumHeight;
     }
 
-    private double getConfiguredStackWalkHelperHeight(HabboItem item, THashSet<RoomTile> occupiedTiles) {
+    private double getConfiguredStackWalkHelperHeight(HabboItem item, Set<RoomTile> occupiedTiles) {
         double height = 0.0D;
 
         try {
@@ -1389,7 +1388,7 @@ public class RoomItemManager {
         return Math.max(height, this.getMinimumTileHeight(occupiedTiles));
     }
 
-    private double resolveStackWalkHelperHeight(HabboItem item, RoomTile tile, THashSet<RoomTile> occupiedTiles) {
+    private double resolveStackWalkHelperHeight(HabboItem item, RoomTile tile, Set<RoomTile> occupiedTiles) {
         HabboItem helper = this.findStackHeightHelperAt(tile, item);
         if (helper != null) {
             return Math.max(helper.getZ(), this.getMinimumTileHeight(occupiedTiles));
@@ -1408,7 +1407,7 @@ public class RoomItemManager {
             return FurnitureMovementError.NONE;
         }
 
-        THashSet<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
+        Set<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
                 item.getBaseItem().getLength(), rotation);
         for (RoomTile t : occupiedTiles) {
             if (t.state == RoomTileState.INVALID) {
@@ -1460,7 +1459,7 @@ public class RoomItemManager {
             return FurnitureMovementError.NONE;
         }
 
-        THashSet<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
+        Set<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
                 item.getBaseItem().getLength(), rotation);
         for (RoomTile t : occupiedTiles) {
             if (t.state == RoomTileState.INVALID) {
@@ -1523,7 +1522,7 @@ public class RoomItemManager {
         }
 
         RoomLayout layout = this.room.getLayout();
-        THashSet<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
+        Set<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
                 item.getBaseItem().getLength(), rotation);
 
         FurnitureMovementError fits = furnitureFitsAt(tile, item, rotation);
@@ -1654,14 +1653,14 @@ public class RoomItemManager {
 
         boolean magicTile = this.isStackPlacementBypassItem(item);
 
-        THashSet<RoomTile> occupiedTiles = layout.getTilesAt(
+        Set<RoomTile> occupiedTiles = layout.getTilesAt(
                 tile,
                 item.getBaseItem().getWidth(),
                 item.getBaseItem().getLength(),
                 rotation
         );
 
-        THashSet<RoomTile> oldOccupiedTiles = layout.getTilesAt(
+        Set<RoomTile> oldOccupiedTiles = layout.getTilesAt(
                 layout.getTile(item.getX(), item.getY()),
                 item.getBaseItem().getWidth(),
                 item.getBaseItem().getLength(),
@@ -1765,7 +1764,7 @@ public class RoomItemManager {
 
         // Preserve your newer "place under" behavior if enabled
         if (Emulator.getConfig().getBoolean("wired.place.under", false)) {
-            THashSet<RoomTile> newOccupiedTiles = layout.getTilesAt(
+            Set<RoomTile> newOccupiedTiles = layout.getTilesAt(
                     tile,
                     item.getBaseItem().getWidth(),
                     item.getBaseItem().getLength(),
@@ -1813,14 +1812,14 @@ public class RoomItemManager {
 
         boolean magicTile = this.isStackPlacementBypassItem(item);
 
-        THashSet<RoomTile> occupiedTiles = layout.getTilesAt(
+        Set<RoomTile> occupiedTiles = layout.getTilesAt(
                 tile,
                 item.getBaseItem().getWidth(),
                 item.getBaseItem().getLength(),
                 rotation
         );
 
-        THashSet<RoomTile> oldOccupiedTiles = layout.getTilesAt(
+        Set<RoomTile> oldOccupiedTiles = layout.getTilesAt(
                 layout.getTile(item.getX(), item.getY()),
                 item.getBaseItem().getWidth(),
                 item.getBaseItem().getLength(),
@@ -1916,7 +1915,7 @@ public class RoomItemManager {
         }
 
         if (Emulator.getConfig().getBoolean("wired.place.under", false)) {
-            THashSet<RoomTile> newOccupiedTiles = layout.getTilesAt(
+            Set<RoomTile> newOccupiedTiles = layout.getTilesAt(
                     tile,
                     item.getBaseItem().getWidth(),
                     item.getBaseItem().getLength(),
@@ -1972,9 +1971,9 @@ public class RoomItemManager {
         HabboItem stackHelper = this.findStackHeightHelperAt(tile, item);
 
         // Check if can be placed at new position
-        THashSet<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
+        Set<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
                 item.getBaseItem().getLength(), rotation);
-        THashSet<RoomTile> newOccupiedTiles = layout.getTilesAt(tile,
+        Set<RoomTile> newOccupiedTiles = layout.getTilesAt(tile,
                 item.getBaseItem().getWidth(), item.getBaseItem().getLength(), rotation);
 
         HabboItem topItem = this.getTopItemAt(occupiedTiles, null);
@@ -2018,7 +2017,7 @@ public class RoomItemManager {
             }
         }
 
-        THashSet<RoomTile> oldOccupiedTiles = layout.getTilesAt(
+        Set<RoomTile> oldOccupiedTiles = layout.getTilesAt(
                 layout.getTile(item.getX(), item.getY()), item.getBaseItem().getWidth(),
                 item.getBaseItem().getLength(), item.getRotation());
 
@@ -2180,9 +2179,9 @@ public class RoomItemManager {
 
         HabboItem stackHelper = this.findStackHeightHelperAt(tile, item);
 
-        THashSet<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
+        Set<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
                 item.getBaseItem().getLength(), rotation);
-        THashSet<RoomTile> newOccupiedTiles = layout.getTilesAt(tile,
+        Set<RoomTile> newOccupiedTiles = layout.getTilesAt(tile,
                 item.getBaseItem().getWidth(), item.getBaseItem().getLength(), rotation);
 
         HabboItem topItem = this.getTopPhysicsItemAt(occupiedTiles, null, physics);
@@ -2221,7 +2220,7 @@ public class RoomItemManager {
             }
         }
 
-        THashSet<RoomTile> oldOccupiedTiles = layout.getTilesAt(
+        Set<RoomTile> oldOccupiedTiles = layout.getTilesAt(
                 layout.getTile(item.getX(), item.getY()), item.getBaseItem().getWidth(),
                 item.getBaseItem().getLength(), item.getRotation());
 
@@ -2364,7 +2363,7 @@ public class RoomItemManager {
         RoomLayout layout = this.room.getLayout();
 
         // Check if can be placed at new position
-        THashSet<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
+        Set<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
                 item.getBaseItem().getLength(), rotation);
 
         java.util.List<Pair<RoomTile, Set<HabboItem>>> tileFurniList = new java.util.ArrayList<>();
@@ -2437,7 +2436,7 @@ public class RoomItemManager {
         return FurnitureMovementError.NONE;
     }
 
-    private boolean hasBlockingPhysicsFurni(THashSet<RoomTile> occupiedTiles, HabboItem exclude, WiredMovementPhysics physics) {
+    private boolean hasBlockingPhysicsFurni(Set<RoomTile> occupiedTiles, HabboItem exclude, WiredMovementPhysics physics) {
         if (physics == null || !physics.hasBlockingFurni()) {
             return false;
         }
@@ -2496,7 +2495,7 @@ public class RoomItemManager {
         return highestItem;
     }
 
-    private HabboItem getTopPhysicsItemAt(THashSet<RoomTile> tiles, HabboItem exclude, WiredMovementPhysics physics) {
+    private HabboItem getTopPhysicsItemAt(Set<RoomTile> tiles, HabboItem exclude, WiredMovementPhysics physics) {
         HabboItem highestItem = null;
 
         for (RoomTile tile : tiles) {
@@ -2553,3 +2552,4 @@ public class RoomItemManager {
         return height;
     }
 }
+

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -47,6 +47,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -970,7 +971,7 @@ public class RoomItemManager {
      * Gets the unique furniture count for a user.
      */
     public int getUserUniqueFurniCount(int userId) {
-        THashSet<Item> items = new THashSet<>();
+        Set<Item> items = new HashSet<>();
 
         synchronized (this.roomItems) {
             for (HabboItem item : this.roomItems.valueCollection()) {
@@ -1051,8 +1052,8 @@ public class RoomItemManager {
      * Ejects all furniture belonging to a user.
      */
     public void ejectUserFurni(int userId) {
-        THashSet<HabboItem> items = new THashSet<>();
-        THashSet<HabboItem> inventoryItems = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
+        Set<HabboItem> inventoryItems = new HashSet<>();
 
         TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
 
@@ -1105,7 +1106,7 @@ public class RoomItemManager {
      * Ejects all items from the room except those belonging to the specified Habbo.
      */
     public void ejectAll(Habbo habbo) {
-        THashMap<Integer, THashSet<HabboItem>> userItemsMap = new THashMap<>();
+        Map<Integer, Set<HabboItem>> userItemsMap = new HashMap<>();
 
         synchronized (this.roomItems) {
             TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
@@ -1125,13 +1126,13 @@ public class RoomItemManager {
                     continue;
                 }
 
-                userItemsMap.computeIfAbsent(iterator.value().getUserId(), k -> new THashSet<>())
+                userItemsMap.computeIfAbsent(iterator.value().getUserId(), k -> new HashSet<>())
                         .add(iterator.value());
             }
         }
 
-        for (Map.Entry<Integer, THashSet<HabboItem>> entrySet : userItemsMap.entrySet()) {
-            THashSet<HabboItem> inventoryItems = new THashSet<>();
+        for (Map.Entry<Integer, Set<HabboItem>> entrySet : userItemsMap.entrySet()) {
+            Set<HabboItem> inventoryItems = new HashSet<>();
 
             for (HabboItem item : entrySet.getValue()) {
                 if (!BuildersClubRoomSupport.isTrackedItem(item.getId())) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -47,7 +47,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -165,8 +167,8 @@ public class RoomItemManager {
     /**
      * Gets all floor items.
      */
-    public THashSet<HabboItem> getFloorItems() {
-        THashSet<HabboItem> items = new THashSet<>();
+    public Set<HabboItem> getFloorItems() {
+        Set<HabboItem> items = new HashSet<>();
         // roomItems is a TCollections.synchronizedMap; its iterator is not safe
         // against concurrent put/remove (item place/pickup), so hold the map
         // monitor for the whole traversal, matching the mutation sites.
@@ -192,8 +194,8 @@ public class RoomItemManager {
     /**
      * Gets all wall items.
      */
-    public THashSet<HabboItem> getWallItems() {
-        THashSet<HabboItem> items = new THashSet<>();
+    public Set<HabboItem> getWallItems() {
+        Set<HabboItem> items = new HashSet<>();
         synchronized (this.roomItems) {
             TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
 
@@ -216,8 +218,8 @@ public class RoomItemManager {
     /**
      * Gets all post-it notes.
      */
-    public THashSet<HabboItem> getPostItNotes() {
-        THashSet<HabboItem> items = new THashSet<>();
+    public Set<HabboItem> getPostItNotes() {
+        Set<HabboItem> items = new HashSet<>();
         synchronized (this.roomItems) {
             TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -31,13 +31,9 @@ import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.*;
 import com.eu.habbo.plugin.Event;
 import com.eu.habbo.plugin.events.furniture.*;
-import gnu.trove.TCollections;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.TIntIntMap;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntIntHashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntMaps;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -65,20 +61,20 @@ public class RoomItemManager {
     private final Room room;
 
     // Item storage
-    private final TIntObjectMap<HabboItem> roomItems;
+    private final Int2ObjectMap<HabboItem> roomItems;
 
     // Furniture owner tracking
     private final Int2ObjectMap<String> furniOwnerNames;
-    private final TIntIntMap furniOwnerCount;
+    private final Int2IntMap furniOwnerCount;
 
     // Tile cache for item lookups
     public final ConcurrentHashMap<RoomTile, Set<HabboItem>> tileCache;
 
     public RoomItemManager(Room room) {
         this.room = room;
-        this.roomItems = TCollections.synchronizedMap(new TIntObjectHashMap<>(0));
+        this.roomItems = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
         this.furniOwnerNames = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
-        this.furniOwnerCount = TCollections.synchronizedMap(new TIntIntHashMap(0));
+        this.furniOwnerCount = Int2IntMaps.synchronize(new Int2IntOpenHashMap(0));
         this.tileCache = new ConcurrentHashMap<>();
     }
 
@@ -172,21 +168,13 @@ public class RoomItemManager {
      */
     public Set<HabboItem> getFloorItems() {
         Set<HabboItem> items = new HashSet<>();
-        // roomItems is a TCollections.synchronizedMap; its iterator is not safe
+        // roomItems is a synchronized map; its iterator is not safe
         // against concurrent put/remove (item place/pickup), so hold the map
         // monitor for the whole traversal, matching the mutation sites.
         synchronized (this.roomItems) {
-            TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
-
-            for (int i = this.roomItems.size(); i-- > 0; ) {
-                try {
-                    iterator.advance();
-                } catch (Exception e) {
-                    break;
-                }
-
-                if (iterator.value().getBaseItem().getType() == FurnitureType.FLOOR) {
-                    items.add(iterator.value());
+            for (HabboItem item : this.roomItems.values()) {
+                if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
+                    items.add(item);
                 }
             }
         }
@@ -200,17 +188,9 @@ public class RoomItemManager {
     public Set<HabboItem> getWallItems() {
         Set<HabboItem> items = new HashSet<>();
         synchronized (this.roomItems) {
-            TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
-
-            for (int i = this.roomItems.size(); i-- > 0; ) {
-                try {
-                    iterator.advance();
-                } catch (Exception e) {
-                    break;
-                }
-
-                if (iterator.value().getBaseItem().getType() == FurnitureType.WALL) {
-                    items.add(iterator.value());
+            for (HabboItem item : this.roomItems.values()) {
+                if (item.getBaseItem().getType() == FurnitureType.WALL) {
+                    items.add(item);
                 }
             }
         }
@@ -224,18 +204,10 @@ public class RoomItemManager {
     public Set<HabboItem> getPostItNotes() {
         Set<HabboItem> items = new HashSet<>();
         synchronized (this.roomItems) {
-            TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
-
-            for (int i = this.roomItems.size(); i-- > 0; ) {
-                try {
-                    iterator.advance();
-                } catch (Exception e) {
-                    break;
-                }
-
-                if (iterator.value().getBaseItem().getInteractionType().getType()
+            for (HabboItem item : this.roomItems.values()) {
+                if (item.getBaseItem().getInteractionType().getType()
                         == InteractionPostIt.class) {
-                    items.add(iterator.value());
+                    items.add(item);
                 }
             }
         }
@@ -246,7 +218,7 @@ public class RoomItemManager {
     /**
      * Gets the room items map.
      */
-    public TIntObjectMap<HabboItem> getRoomItems() {
+    public Int2ObjectMap<HabboItem> getRoomItems() {
         return this.roomItems;
     }
 
@@ -294,17 +266,7 @@ public class RoomItemManager {
         // place/pickup can't rehash the map mid-traversal (which the per-advance
         // try/catch would otherwise silently swallow into an incomplete result).
         synchronized (this.roomItems) {
-            TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
-
-            for (int i = this.roomItems.size(); i-- > 0; ) {
-                HabboItem item;
-                try {
-                    iterator.advance();
-                    item = iterator.value();
-                } catch (Exception e) {
-                    break;
-                }
-
+            for (HabboItem item : this.roomItems.values()) {
                 if (item == null) {
                     continue;
                 }
@@ -951,7 +913,7 @@ public class RoomItemManager {
     /**
      * Gets furniture owner count map.
      */
-    public TIntIntMap getFurniOwnerCount() {
+    public Int2IntMap getFurniOwnerCount() {
         return this.furniOwnerCount;
     }
 
@@ -976,7 +938,7 @@ public class RoomItemManager {
         Set<Item> items = new HashSet<>();
 
         synchronized (this.roomItems) {
-            for (HabboItem item : this.roomItems.valueCollection()) {
+            for (HabboItem item : this.roomItems.values()) {
                 if (!items.contains(item.getBaseItem()) && item.getUserId() == userId) {
                     items.add(item.getBaseItem());
                 }
@@ -1057,23 +1019,17 @@ public class RoomItemManager {
         Set<HabboItem> items = new HashSet<>();
         Set<HabboItem> inventoryItems = new HashSet<>();
 
-        TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
+        synchronized (this.roomItems) {
+            for (HabboItem item : this.roomItems.values()) {
+                if (item.getUserId() == userId) {
+                    items.add(item);
 
-        for (int i = this.roomItems.size(); i-- > 0; ) {
-            try {
-                iterator.advance();
-            } catch (Exception e) {
-                break;
-            }
+                    if (!BuildersClubRoomSupport.isTrackedItem(item.getId())) {
+                        inventoryItems.add(item);
+                    }
 
-            if (iterator.value().getUserId() == userId) {
-                items.add(iterator.value());
-
-                if (!BuildersClubRoomSupport.isTrackedItem(iterator.value().getId())) {
-                    inventoryItems.add(iterator.value());
+                    item.setRoomId(0);
                 }
-
-                iterator.value().setRoomId(0);
             }
         }
 
@@ -1111,25 +1067,16 @@ public class RoomItemManager {
         Map<Integer, Set<HabboItem>> userItemsMap = new HashMap<>();
 
         synchronized (this.roomItems) {
-            TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
-
-            for (int i = this.roomItems.size(); i-- > 0; ) {
-                try {
-                    iterator.advance();
-                } catch (Exception e) {
-                    break;
-                }
-
-                if (habbo != null && iterator.value().getUserId() == habbo.getHabboInfo().getId()) {
+            for (HabboItem item : this.roomItems.values()) {
+                if (habbo != null && item.getUserId() == habbo.getHabboInfo().getId()) {
                     continue;
                 }
 
-                if (iterator.value() instanceof InteractionPostIt) {
+                if (item instanceof InteractionPostIt) {
                     continue;
                 }
 
-                userItemsMap.computeIfAbsent(iterator.value().getUserId(), k -> new HashSet<>())
-                        .add(iterator.value());
+                userItemsMap.computeIfAbsent(item.getUserId(), k -> new HashSet<>()).add(item);
             }
         }
 
@@ -1164,49 +1111,41 @@ public class RoomItemManager {
     public Set<RoomTile> getLockedTiles() {
         Set<RoomTile> lockedTiles = new HashSet<>();
 
-        TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
-
-        for (int i = this.roomItems.size(); i-- > 0; ) {
-            HabboItem item;
-            try {
-                iterator.advance();
-                item = iterator.value();
-            } catch (Exception e) {
-                break;
-            }
-
-            if (item.getBaseItem().getType() != FurnitureType.FLOOR) {
-                continue;
-            }
-
-            boolean found = false;
-            for (RoomTile tile : lockedTiles) {
-                if (tile.x == item.getX() && tile.y == item.getY()) {
-                    found = true;
-                    break;
+        synchronized (this.roomItems) {
+            for (HabboItem item : this.roomItems.values()) {
+                if (item.getBaseItem().getType() != FurnitureType.FLOOR) {
+                    continue;
                 }
-            }
 
-            if (!found) {
-                if (item.getRotation() == 0 || item.getRotation() == 4) {
-                    for (short y = 0; y < item.getBaseItem().getLength(); y++) {
-                        for (short x = 0; x < item.getBaseItem().getWidth(); x++) {
-                            RoomTile tile = this.room.getLayout().getTile(
-                                    (short) (item.getX() + x), (short) (item.getY() + y));
+                boolean found = false;
+                for (RoomTile tile : lockedTiles) {
+                    if (tile.x == item.getX() && tile.y == item.getY()) {
+                        found = true;
+                        break;
+                    }
+                }
 
-                            if (tile != null) {
-                                lockedTiles.add(tile);
+                if (!found) {
+                    if (item.getRotation() == 0 || item.getRotation() == 4) {
+                        for (short y = 0; y < item.getBaseItem().getLength(); y++) {
+                            for (short x = 0; x < item.getBaseItem().getWidth(); x++) {
+                                RoomTile tile = this.room.getLayout().getTile(
+                                        (short) (item.getX() + x), (short) (item.getY() + y));
+
+                                if (tile != null) {
+                                    lockedTiles.add(tile);
+                                }
                             }
                         }
-                    }
-                } else {
-                    for (short y = 0; y < item.getBaseItem().getWidth(); y++) {
-                        for (short x = 0; x < item.getBaseItem().getLength(); x++) {
-                            RoomTile tile = this.room.getLayout().getTile(
-                                    (short) (item.getX() + x), (short) (item.getY() + y));
+                    } else {
+                        for (short y = 0; y < item.getBaseItem().getWidth(); y++) {
+                            for (short x = 0; x < item.getBaseItem().getLength(); x++) {
+                                RoomTile tile = this.room.getLayout().getTile(
+                                        (short) (item.getX() + x), (short) (item.getY() + y));
 
-                            if (tile != null) {
-                                lockedTiles.add(tile);
+                                if (tile != null) {
+                                    lockedTiles.add(tile);
+                                }
                             }
                         }
                     }
@@ -1224,17 +1163,9 @@ public class RoomItemManager {
      */
     public void saveAllPendingItems() {
         synchronized (this.roomItems) {
-            TIntObjectIterator<HabboItem> iterator = this.roomItems.iterator();
-
-            for (int i = this.roomItems.size(); i-- > 0; ) {
-                try {
-                    iterator.advance();
-
-                    if (iterator.value().needsUpdate()) {
-                        iterator.value().run();
-                    }
-                } catch (java.util.NoSuchElementException e) {
-                    break;
+            for (HabboItem item : this.roomItems.values()) {
+                if (item.needsUpdate()) {
+                    item.run();
                 }
             }
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -2454,8 +2454,8 @@ public class RoomItemManager {
         return false;
     }
 
-    private THashSet<HabboItem> getPhysicsItemsAt(RoomTile tile, HabboItem exclude, WiredMovementPhysics physics) {
-        THashSet<HabboItem> items = new THashSet<>();
+    private Set<HabboItem> getPhysicsItemsAt(RoomTile tile, HabboItem exclude, WiredMovementPhysics physics) {
+        Set<HabboItem> items = new HashSet<>();
 
         for (HabboItem item : this.getItemsAt(tile)) {
             if (item == null || item == exclude) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -39,6 +39,9 @@ import gnu.trove.map.hash.THashMap;
 import gnu.trove.map.hash.TIntIntHashMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.set.hash.THashSet;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.apache.commons.math3.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +69,7 @@ public class RoomItemManager {
     private final TIntObjectMap<HabboItem> roomItems;
 
     // Furniture owner tracking
-    private final TIntObjectMap<String> furniOwnerNames;
+    private final Int2ObjectMap<String> furniOwnerNames;
     private final TIntIntMap furniOwnerCount;
 
     // Tile cache for item lookups
@@ -75,7 +78,7 @@ public class RoomItemManager {
     public RoomItemManager(Room room) {
         this.room = room;
         this.roomItems = TCollections.synchronizedMap(new TIntObjectHashMap<>(0));
-        this.furniOwnerNames = TCollections.synchronizedMap(new TIntObjectHashMap<>(0));
+        this.furniOwnerNames = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
         this.furniOwnerCount = TCollections.synchronizedMap(new TIntIntHashMap(0));
         this.tileCache = new ConcurrentHashMap<>();
     }
@@ -942,7 +945,7 @@ public class RoomItemManager {
     /**
      * Gets furniture owner names map.
      */
-    public TIntObjectMap<String> getFurniOwnerNames() {
+    public Int2ObjectMap<String> getFurniOwnerNames() {
         return this.furniOwnerNames;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -70,7 +70,7 @@ public class RoomItemManager {
     private final TIntIntMap furniOwnerCount;
 
     // Tile cache for item lookups
-    public final ConcurrentHashMap<RoomTile, THashSet<HabboItem>> tileCache;
+    public final ConcurrentHashMap<RoomTile, Set<HabboItem>> tileCache;
 
     public RoomItemManager(Room room) {
         this.room = room;
@@ -254,35 +254,35 @@ public class RoomItemManager {
      * Gets items at a position (deprecated version using int).
      */
     @Deprecated
-    public THashSet<HabboItem> getItemsAt(int x, int y) {
+    public Set<HabboItem> getItemsAt(int x, int y) {
         RoomTile tile = this.room.getLayout().getTile((short) x, (short) y);
 
         if (tile != null) {
             return this.getItemsAt(tile);
         }
 
-        return new THashSet<>(0);
+        return new HashSet<>(0);
     }
 
     /**
      * Gets items at a tile.
      */
-    public THashSet<HabboItem> getItemsAt(RoomTile tile) {
+    public Set<HabboItem> getItemsAt(RoomTile tile) {
         return getItemsAt(tile, false);
     }
 
     /**
      * Gets items at a tile with option to return on first match.
      */
-    public THashSet<HabboItem> getItemsAt(RoomTile tile, boolean returnOnFirst) {
-        THashSet<HabboItem> items = new THashSet<>(0);
+    public Set<HabboItem> getItemsAt(RoomTile tile, boolean returnOnFirst) {
+        Set<HabboItem> items = new HashSet<>(0);
 
         if (tile == null) {
             return items;
         }
 
         if (this.room.isLoaded()) {
-            THashSet<HabboItem> cachedItems = this.tileCache.get(tile);
+            Set<HabboItem> cachedItems = this.tileCache.get(tile);
             if (cachedItems != null) {
                 return cachedItems;
             }
@@ -344,8 +344,8 @@ public class RoomItemManager {
     /**
      * Gets items at a position above a minimum Z height.
      */
-    public THashSet<HabboItem> getItemsAt(int x, int y, double minZ) {
-        THashSet<HabboItem> items = new THashSet<>();
+    public Set<HabboItem> getItemsAt(int x, int y, double minZ) {
+        Set<HabboItem> items = new HashSet<>();
 
         for (HabboItem item : this.getItemsAt(x, y)) {
             if (item.getZ() < minZ) {
@@ -360,8 +360,8 @@ public class RoomItemManager {
     /**
      * Gets items of a specific type at a position.
      */
-    public THashSet<HabboItem> getItemsAt(Class<? extends HabboItem> type, int x, int y) {
-        THashSet<HabboItem> items = new THashSet<>();
+    public Set<HabboItem> getItemsAt(Class<? extends HabboItem> type, int x, int y) {
+        Set<HabboItem> items = new HashSet<>();
 
         for (HabboItem item : this.getItemsAt(x, y)) {
             if (!item.getClass().equals(type)) {
@@ -466,7 +466,7 @@ public class RoomItemManager {
     /**
      * Gets the top item from a set of tiles.
      */
-    public HabboItem getTopItemAt(THashSet<RoomTile> tiles, HabboItem exclude) {
+    public HabboItem getTopItemAt(Set<RoomTile> tiles, HabboItem exclude) {
         HabboItem highestItem = null;
         for (RoomTile tile : tiles) {
 
@@ -528,7 +528,7 @@ public class RoomItemManager {
     public HabboItem getLowestChair(RoomTile tile) {
         HabboItem lowestChair = null;
 
-        THashSet<HabboItem> items = this.getItemsAt(tile);
+        Set<HabboItem> items = this.getItemsAt(tile);
         if (items != null && !items.isEmpty()) {
             for (HabboItem item : items) {
 
@@ -553,7 +553,7 @@ public class RoomItemManager {
     public HabboItem getTallestChair(RoomTile tile) {
         HabboItem lowestChair = null;
 
-        THashSet<HabboItem> items = this.getItemsAt(tile);
+        Set<HabboItem> items = this.getItemsAt(tile);
         if (items != null && !items.isEmpty()) {
             for (HabboItem item : items) {
 
@@ -1267,7 +1267,7 @@ public class RoomItemManager {
      * Checks if an item has a certain object type at a position.
      */
     public boolean hasObjectTypeAt(Class<?> type, int x, int y) {
-        THashSet<HabboItem> items = this.getItemsAt(x, y);
+        Set<HabboItem> items = this.getItemsAt(x, y);
 
         for (HabboItem item : items) {
             if (item.getClass() == type) {
@@ -1426,7 +1426,7 @@ public class RoomItemManager {
             }
         }
 
-        java.util.List<Pair<RoomTile, THashSet<HabboItem>>> tileFurniList = new java.util.ArrayList<>();
+        java.util.List<Pair<RoomTile, Set<HabboItem>>> tileFurniList = new java.util.ArrayList<>();
         for (RoomTile t : occupiedTiles) {
             tileFurniList.add(Pair.create(t, this.getItemsAt(t)));
 
@@ -1476,7 +1476,7 @@ public class RoomItemManager {
             return FurnitureMovementError.CANT_STACK;
         }
 
-        java.util.List<Pair<RoomTile, THashSet<HabboItem>>> tileFurniList = new java.util.ArrayList<>();
+        java.util.List<Pair<RoomTile, Set<HabboItem>>> tileFurniList = new java.util.ArrayList<>();
         for (RoomTile t : occupiedTiles) {
             tileFurniList.add(Pair.create(t, this.getPhysicsItemsAt(t, item, physics)));
 
@@ -2005,7 +2005,7 @@ public class RoomItemManager {
                 }
             }
 
-            java.util.List<Pair<RoomTile, THashSet<HabboItem>>> tileFurniList = new java.util.ArrayList<>();
+            java.util.List<Pair<RoomTile, Set<HabboItem>>> tileFurniList = new java.util.ArrayList<>();
             for (RoomTile t : occupiedTiles) {
                 tileFurniList.add(Pair.create(t, this.getItemsAt(t)));
             }
@@ -2208,7 +2208,7 @@ public class RoomItemManager {
                 return FurnitureMovementError.CANT_STACK;
             }
 
-            java.util.List<Pair<RoomTile, THashSet<HabboItem>>> tileFurniList = new java.util.ArrayList<>();
+            java.util.List<Pair<RoomTile, Set<HabboItem>>> tileFurniList = new java.util.ArrayList<>();
             for (RoomTile t : occupiedTiles) {
                 tileFurniList.add(Pair.create(t, this.getPhysicsItemsAt(t, item, physics)));
             }
@@ -2364,7 +2364,7 @@ public class RoomItemManager {
         THashSet<RoomTile> occupiedTiles = layout.getTilesAt(tile, item.getBaseItem().getWidth(),
                 item.getBaseItem().getLength(), rotation);
 
-        java.util.List<Pair<RoomTile, THashSet<HabboItem>>> tileFurniList = new java.util.ArrayList<>();
+        java.util.List<Pair<RoomTile, Set<HabboItem>>> tileFurniList = new java.util.ArrayList<>();
         for (RoomTile t : occupiedTiles) {
             tileFurniList.add(Pair.create(t, this.getItemsAt(t)));
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLayout.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLayout.java
@@ -3,12 +3,13 @@ package com.eu.habbo.habbohotel.rooms;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.rooms.pathfinding.Pathfinder;
 import com.eu.habbo.habbohotel.rooms.pathfinding.impl.PathfinderImpl;
-import gnu.trove.set.hash.THashSet;
 import java.awt.Rectangle;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -456,8 +457,8 @@ public class RoomLayout {
     return true;
   }
 
-  public THashSet<RoomTile> getTilesAt(RoomTile tile, int width, int length, int rotation) {
-    THashSet<RoomTile> pointList = new THashSet<>(width * length, 0.1f);
+  public Set<RoomTile> getTilesAt(RoomTile tile, int width, int length, int rotation) {
+    Set<RoomTile> pointList = new HashSet<>(width * length);
 
     if (tile != null) {
       if (rotation == 0 || rotation == 4) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -851,16 +851,9 @@ public class RoomManager {
         }
 
 
-        habbo.getClient().sendResponse(new RoomUsersComposer(room.getCurrentBots().valueCollection(), true));
+        habbo.getClient().sendResponse(new RoomUsersComposer(room.getCurrentBots().values(), true));
         if (!room.getCurrentBots().isEmpty()) {
-            TIntObjectIterator<Bot> botIterator = room.getCurrentBots().iterator();
-            for (int i = room.getCurrentBots().size(); i-- > 0; ) {
-                try {
-                    botIterator.advance();
-                } catch (NoSuchElementException e) {
-                    break;
-                }
-                Bot bot = botIterator.value();
+            for (Bot bot : room.getCurrentBots().values()) {
                 if (!bot.getRoomUnit().getDanceType().equals(DanceType.NONE)) {
                     habbo.getClient().sendResponse(new RoomUserDanceComposer(bot.getRoomUnit()));
                 }
@@ -913,8 +906,8 @@ public class RoomManager {
         habbo.getClient().sendResponse(new HanditemBlockStateComposer(room).compose());
 
         if (!room.getCurrentPets().isEmpty()) {
-            habbo.getClient().sendResponse(new RoomPetComposer(room.getCurrentPets().valueCollection()));
-            for (Pet pet : room.getCurrentPets().valueCollection()) {
+            habbo.getClient().sendResponse(new RoomPetComposer(room.getCurrentPets().values()));
+            for (Pet pet : room.getCurrentPets().values()) {
                 habbo.getClient().sendResponse(new RoomUserStatusComposer(pet.getRoomUnit()));
             }
         }
@@ -981,7 +974,7 @@ public class RoomManager {
 
         if (room.hasRights(habbo) || (room.hasGuild() && room.getGuildRightLevel(habbo).isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS))) {
             if (!room.getHabboQueue().isEmpty()) {
-                for (Habbo waiting : room.getHabboQueue().valueCollection()) {
+                for (Habbo waiting : room.getHabboQueue().values()) {
                     habbo.getClient().sendResponse(new DoorbellAddUserComposer(waiting.getHabboInfo().getUsername()));
                 }
             }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -914,7 +914,7 @@ public class RoomManager {
         habbo.getClient().sendResponse(new HanditemBlockStateComposer(room).compose());
 
         if (!room.getCurrentPets().isEmpty()) {
-            habbo.getClient().sendResponse(new RoomPetComposer(room.getCurrentPets()));
+            habbo.getClient().sendResponse(new RoomPetComposer(room.getCurrentPets().valueCollection()));
             for (Pet pet : room.getCurrentPets().valueCollection()) {
                 habbo.getClient().sendResponse(new RoomUserStatusComposer(pet.getRoomUnit()));
             }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -930,7 +930,7 @@ public class RoomManager {
             habbo.getHabboStats().mutedBubbleTracker = false;
         }
 
-        THashMap<Integer, String> guildBadges = new THashMap<>();
+        Map<Integer, String> guildBadges = new HashMap<>();
         for (Habbo roomHabbo : habbos) {
             {
                 if (roomHabbo.getRoomUnit().getDanceType().getType() > 0) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -50,10 +50,6 @@ import com.eu.habbo.plugin.events.rooms.UserVoteRoomEvent;
 import com.eu.habbo.plugin.events.users.HabboAddedToRoomEvent;
 import com.eu.habbo.plugin.events.users.UserEnterRoomEvent;
 import com.eu.habbo.plugin.events.users.UserExitRoomEvent;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.procedure.TObjectProcedure;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +67,7 @@ public class RoomManager {
     public static int MAXIMUM_ROOMS_HC = 35;
     public static int HOME_ROOM_ID = 0;
     public static boolean SHOW_PUBLIC_IN_POPULAR_TAB = false;
-    private final THashMap<Integer, RoomCategory> roomCategories;
+    private final Map<Integer, RoomCategory> roomCategories;
     private final List<String> mapNames;
     private final ConcurrentHashMap<String, RoomLayoutData> layoutCache;
     private final ConcurrentHashMap<Integer, Room> activeRooms;
@@ -80,7 +76,7 @@ public class RoomManager {
 
     public RoomManager() {
         long millis = System.currentTimeMillis();
-        this.roomCategories = new THashMap<>();
+        this.roomCategories = new HashMap<>();
         this.mapNames = new ArrayList<>();
         this.layoutCache = new ConcurrentHashMap<>();
         this.activeRooms = new ConcurrentHashMap<>();
@@ -174,8 +170,8 @@ public class RoomManager {
         }
     }
 
-    public THashMap<Integer, List<Room>> findRooms(NavigatorFilterField filterField, String value, int category, boolean showInvisible) {
-        THashMap<Integer, List<Room>> rooms = new THashMap<>();
+    public Map<Integer, List<Room>> findRooms(NavigatorFilterField filterField, String value, int category, boolean showInvisible) {
+        Map<Integer, List<Room>> rooms = new HashMap<>();
         String query = filterField.databaseQuery + " AND rooms.state NOT LIKE " + (showInvisible ? "''" : "'invisible'") + (category >= 0 ? "AND rooms.category = '" + category + "'" : "") + "  ORDER BY rooms.users, rooms.id DESC LIMIT " + (page * NavigatorManager.MAXIMUM_RESULTS_PER_PAGE) + "" + ((page * NavigatorManager.MAXIMUM_RESULTS_PER_PAGE) + NavigatorManager.MAXIMUM_RESULTS_PER_PAGE);
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement(query)) {
             statement.setString(1, (filterField.comparator == NavigatorFilterComparator.EQUALS ? value : "%" + value + "%"));
@@ -244,7 +240,7 @@ public class RoomManager {
         return category != null && category.getMinRank() <= habbo.getHabboInfo().getRank().getId();
     }
 
-    public THashMap<Integer, RoomCategory> getRoomCategories() {
+    public Map<Integer, RoomCategory> getRoomCategories() {
         return this.roomCategories;
     }
 
@@ -425,7 +421,7 @@ public class RoomManager {
     }
 
     public void clearInactiveRooms() {
-        THashSet<Room> roomsToDispose = new THashSet<>();
+        Set<Room> roomsToDispose = new HashSet<>();
         for (Map.Entry<Integer, Set<Integer>> entry : this.roomsByOwner.entrySet()) {
             int ownerId = entry.getKey();
             if (!Emulator.getGameServer().getGameClientManager().containsHabbo(ownerId)) {
@@ -870,9 +866,9 @@ public class RoomManager {
 
         habbo.getClient().sendResponse(new RoomWallItemsComposer(room));
         {
-            final THashSet<HabboItem> floorItems = new THashSet<>();
+            final Set<HabboItem> floorItems = new HashSet<>();
 
-            THashSet<HabboItem> allFloorItems = new THashSet<>(room.getFloorItems());
+            Set<HabboItem> allFloorItems = new HashSet<>(room.getFloorItems());
 
             if (Emulator.getPluginManager().isRegistered(RoomFloorItemsLoadEvent.class, true)) {
                 RoomFloorItemsLoadEvent roomFloorItemsLoadEvent = Emulator.getPluginManager().fireEvent(new RoomFloorItemsLoadEvent(habbo, allFloorItems));
@@ -881,21 +877,17 @@ public class RoomManager {
                 }
             }
 
-            allFloorItems.forEach(new TObjectProcedure<HabboItem>() {
-                @Override
-                public boolean execute(HabboItem object) {
-                    if (room.isHideWired() && object instanceof InteractionWired)
-                        return true;
-
-                    floorItems.add(object);
-                    if (floorItems.size() == 250) {
-                        habbo.getClient().sendResponse(new RoomFloorItemsComposer(room.getFurniOwnerNames(), floorItems));
-                        floorItems.clear();
-                    }
-
-                    return true;
+            for (HabboItem object : allFloorItems) {
+                if (room.isHideWired() && object instanceof InteractionWired) {
+                    continue;
                 }
-            });
+
+                floorItems.add(object);
+                if (floorItems.size() == 250) {
+                    habbo.getClient().sendResponse(new RoomFloorItemsComposer(room.getFurniOwnerNames(), floorItems));
+                    floorItems.clear();
+                }
+            }
 
             habbo.getClient().sendResponse(new RoomFloorItemsComposer(room.getFurniOwnerNames(), floorItems));
             floorItems.clear();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -52,7 +52,6 @@ import com.eu.habbo.plugin.events.users.UserEnterRoomEvent;
 import com.eu.habbo.plugin.events.users.UserExitRoomEvent;
 import gnu.trove.iterator.TIntObjectIterator;
 import gnu.trove.map.hash.THashMap;
-import gnu.trove.procedure.TIntProcedure;
 import gnu.trove.procedure.TObjectProcedure;
 import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
@@ -493,7 +492,7 @@ public class RoomManager {
 
             room.setScore(room.getScore() + 1);
             room.setNeedsUpdate(true);
-            habbo.getHabboStats().votedRooms.push(room.getId());
+            habbo.getHabboStats().votedRooms.add(room.getId());
             for (Habbo h : room.getHabbos()) {
                 h.getClient().sendResponse(new RoomScoreComposer(room.getScore(), !this.hasVotedForRoom(h, room)));
             }
@@ -512,7 +511,7 @@ public class RoomManager {
         if (room.getOwnerId() == habbo.getHabboInfo().getId())
             return true;
 
-        for (int i : habbo.getHabboStats().votedRooms.toArray()) {
+        for (int i : habbo.getHabboStats().votedRooms) {
             if (i == room.getId())
                 return true;
         }
@@ -1366,21 +1365,17 @@ public class RoomManager {
     public ArrayList<Room> getRoomsFavourite(Habbo habbo) {
         final ArrayList<Room> rooms = new ArrayList<>();
 
-        habbo.getHabboStats().getFavoriteRooms().forEach(new TIntProcedure() {
-            @Override
-            public boolean execute(int value) {
-                Room room = RoomManager.this.getRoom(value);
+        for (int value : habbo.getHabboStats().getFavoriteRooms()) {
+            Room room = RoomManager.this.getRoom(value);
 
-                if (room != null) {
-                    if (room.getState() == RoomState.INVISIBLE) {
-                        room.loadData();
-                        if (!room.hasRights(habbo)) return true;
-                    }
-                    rooms.add(room);
+            if (room != null) {
+                if (room.getState() == RoomState.INVISIBLE) {
+                    room.loadData();
+                    if (!room.hasRights(habbo)) continue;
                 }
-                return true;
+                rooms.add(room);
             }
-        });
+        }
 
         return rooms;
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRightsManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRightsManager.java
@@ -17,9 +17,12 @@ import com.eu.habbo.messages.outgoing.rooms.users.RoomUserUnbannedComposer;
 import com.eu.habbo.habbohotel.messenger.MessengerBuddy;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.plugin.events.users.UserRightsTakenEvent;
-import gnu.trove.list.array.TIntArrayList;
-import gnu.trove.map.hash.TIntIntHashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,15 +41,15 @@ public class RoomRightsManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(RoomRightsManager.class);
 
     private final Room room;
-    private final TIntArrayList rights;
-    private final TIntObjectHashMap<RoomBan> bannedHabbos;
-    private final TIntIntHashMap mutedHabbos;
+    private final IntSet rights;
+    private final Int2ObjectMap<RoomBan> bannedHabbos;
+    private final Int2IntMap mutedHabbos;
 
     public RoomRightsManager(Room room) {
         this.room = room;
-        this.rights = new TIntArrayList();
-        this.bannedHabbos = new TIntObjectHashMap<>();
-        this.mutedHabbos = new TIntIntHashMap();
+        this.rights = new IntOpenHashSet();
+        this.bannedHabbos = new Int2ObjectOpenHashMap<>();
+        this.mutedHabbos = new Int2IntOpenHashMap();
     }
 
     /**
@@ -227,7 +230,7 @@ public class RoomRightsManager {
      * Removes all rights from the room.
      */
     public void removeAllRights() {
-        for (int userId : rights.toArray()) {
+        for (int userId : rights) {
             this.room.getItemManager().ejectUserFurni(userId);
         }
 
@@ -350,7 +353,7 @@ public class RoomRightsManager {
     /**
      * Gets all banned users.
      */
-    public TIntObjectHashMap<RoomBan> getBannedHabbos() {
+    public Int2ObjectMap<RoomBan> getBannedHabbos() {
         return this.bannedHabbos;
     }
 
@@ -403,14 +406,14 @@ public class RoomRightsManager {
     /**
      * Gets the rights list.
      */
-    public TIntArrayList getRights() {
+    public IntSet getRights() {
         return this.rights;
     }
 
     /**
      * Gets the muted habbos map.
      */
-    public TIntIntHashMap getMutedHabbos() {
+    public Int2IntMap getMutedHabbos() {
         return this.mutedHabbos;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java
@@ -50,10 +50,9 @@ public class RoomRollerManager {
         THashSet<Integer> rollerFurniIds = new THashSet<>();
         THashSet<Integer> rolledUnitIds = new THashSet<>();
 
-        this.room.getRoomSpecialTypes().getRollers().forEachValue(roller -> {
+        for (InteractionRoller roller : this.room.getRoomSpecialTypes().getRollers().values()) {
             processRoller(roller, messages, rollerFurniIds, rolledUnitIds, updatedUnit);
-            return true;
-        });
+        }
 
         // Process pyramids
         int currentTime = (int) (cycleTimestamp / 1000);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java
@@ -15,7 +15,6 @@ import com.eu.habbo.messages.outgoing.rooms.users.RoomUnitOnRollerComposer;
 import com.eu.habbo.plugin.Event;
 import com.eu.habbo.plugin.events.furniture.FurnitureRolledEvent;
 import com.eu.habbo.plugin.events.users.UserRolledEvent;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,14 +42,14 @@ public class RoomRollerManager {
      * @param cycleTimestamp Current cycle timestamp
      * @return true if roller cycle was processed
      */
-    public boolean processRollerCycle(THashSet<RoomUnit> updatedUnit, long cycleTimestamp) {
+    public boolean processRollerCycle(Set<RoomUnit> updatedUnit, long cycleTimestamp) {
         // Note: cycle gating is handled by RoomCycleManager.processRollers().
         // Do not add a second gate here — it would cause rollers to fire at
         // speed^2 intervals instead of the intended speed.
 
-        THashSet<MessageComposer> messages = new THashSet<>();
-        THashSet<Integer> rollerFurniIds = new THashSet<>();
-        THashSet<Integer> rolledUnitIds = new THashSet<>();
+        Set<MessageComposer> messages = new HashSet<>();
+        Set<Integer> rollerFurniIds = new HashSet<>();
+        Set<Integer> rolledUnitIds = new HashSet<>();
 
         for (InteractionRoller roller : this.room.getRoomSpecialTypes().getRollers().values()) {
             processRoller(roller, messages, rollerFurniIds, rolledUnitIds, updatedUnit);
@@ -72,9 +71,9 @@ public class RoomRollerManager {
     /**
      * Processes a single roller and its contents.
      */
-    private void processRoller(InteractionRoller roller, THashSet<MessageComposer> messages,
-                               THashSet<Integer> rollerFurniIds, THashSet<Integer> rolledUnitIds,
-                               THashSet<RoomUnit> updatedUnit) {
+    private void processRoller(InteractionRoller roller, Set<MessageComposer> messages,
+                               Set<Integer> rollerFurniIds, Set<Integer> rolledUnitIds,
+                               Set<RoomUnit> updatedUnit) {
 
         HabboItem newRoller = null;
         RoomLayout layout = this.room.getLayout();
@@ -247,8 +246,8 @@ public class RoomRollerManager {
                                       Set<HabboItem> itemsOnRoller,
                                       Set<HabboItem> itemsNewTile,
                                       boolean stackContainsRoller, boolean allowFurniture,
-                                      double zOffset, THashSet<MessageComposer> messages,
-                                      THashSet<Integer> rolledUnitIds, THashSet<RoomUnit> updatedUnit) {
+                                      double zOffset, Set<MessageComposer> messages,
+                                      Set<Integer> rolledUnitIds, Set<RoomUnit> updatedUnit) {
 
         Event roomUserRolledEvent = null;
 
@@ -271,7 +270,7 @@ public class RoomRollerManager {
 
         this.room.getTallestChair(tileInFront);
 
-        THashSet<Integer> usersRolledThisTile = new THashSet<>();
+        Set<Integer> usersRolledThisTile = new HashSet<>();
 
         for (RoomUnit unit : unitsOnTile) {
             if (rolledUnitIds.contains(unit.getId())) {
@@ -370,8 +369,8 @@ public class RoomRollerManager {
      */
     private void processFurnitureOnRoller(InteractionRoller roller, Set<HabboItem> itemsOnRoller,
                                           HabboItem newRoller, HabboItem topItem, RoomTile tileInFront,
-                                          double zOffset, THashSet<MessageComposer> messages,
-                                          THashSet<Integer> rollerFurniIds) {
+                                          double zOffset, Set<MessageComposer> messages,
+                                          Set<Integer> rollerFurniIds) {
 
         Event furnitureRolledEvent = null;
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java
@@ -20,7 +20,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Manages roller mechanics within a room.
@@ -82,7 +84,7 @@ public class RoomRollerManager {
             return;
         }
 
-        THashSet<HabboItem> itemsOnRoller = new THashSet<>();
+        Set<HabboItem> itemsOnRoller = new HashSet<>();
         for (HabboItem item : this.room.getItemsAt(rollerTile)) {
             if (item.getZ() >= roller.getZ() + Item.getCurrentHeight(roller)) {
                 itemsOnRoller.add(item);
@@ -148,7 +150,7 @@ public class RoomRollerManager {
             return;
         }
 
-        THashSet<HabboItem> itemsNewTile = new THashSet<>();
+        Set<HabboItem> itemsNewTile = new HashSet<>();
         itemsNewTile.addAll(this.room.getItemsAt(tileInFront));
         itemsNewTile.removeAll(itemsOnRoller);
 
@@ -242,8 +244,8 @@ public class RoomRollerManager {
      */
     private void processUnitsOnRoller(InteractionRoller roller, RoomTile rollerTile,
                                       RoomTile tileInFront, HabboItem topItem,
-                                      THashSet<HabboItem> itemsOnRoller,
-                                      THashSet<HabboItem> itemsNewTile,
+                                      Set<HabboItem> itemsOnRoller,
+                                      Set<HabboItem> itemsNewTile,
                                       boolean stackContainsRoller, boolean allowFurniture,
                                       double zOffset, THashSet<MessageComposer> messages,
                                       THashSet<Integer> rolledUnitIds, THashSet<RoomUnit> updatedUnit) {
@@ -366,7 +368,7 @@ public class RoomRollerManager {
     /**
      * Processes furniture items on a roller.
      */
-    private void processFurnitureOnRoller(InteractionRoller roller, THashSet<HabboItem> itemsOnRoller,
+    private void processFurnitureOnRoller(InteractionRoller roller, Set<HabboItem> itemsOnRoller,
                                           HabboItem newRoller, HabboItem topItem, RoomTile tileInFront,
                                           double zOffset, THashSet<MessageComposer> messages,
                                           THashSet<Integer> rollerFurniIds) {
@@ -401,7 +403,7 @@ public class RoomRollerManager {
         }
     }
 
-    private double calculateTargetZ(RoomTile targetTile, THashSet<HabboItem> itemsBeingRolled) {
+    private double calculateTargetZ(RoomTile targetTile, Set<HabboItem> itemsBeingRolled) {
         HabboItem topItem = this.room.getTopItemAt(targetTile.x, targetTile.y);
 
         // Ignore items that are being rolled along with the unit

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypes.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypes.java
@@ -25,13 +25,12 @@ import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectSendS
 import com.eu.habbo.habbohotel.wired.WiredConditionType;
 import com.eu.habbo.habbohotel.wired.WiredEffectType;
 import com.eu.habbo.habbohotel.wired.WiredTriggerType;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -45,13 +44,13 @@ import java.util.concurrent.ConcurrentHashMap;
  * to support high-frequency access patterns.
  */
 public class RoomSpecialTypes {
-    private final THashMap<Integer, InteractionBattleBanzaiTeleporter> banzaiTeleporters;
-    private final THashMap<Integer, InteractionNest> nests;
-    private final THashMap<Integer, InteractionPetDrink> petDrinks;
-    private final THashMap<Integer, InteractionPetFood> petFoods;
-    private final THashMap<Integer, InteractionPetToy> petToys;
-    private final THashMap<Integer, InteractionPetTree> petTrees;
-    private final THashMap<Integer, InteractionRoller> rollers;
+    private final Map<Integer, InteractionBattleBanzaiTeleporter> banzaiTeleporters;
+    private final Map<Integer, InteractionNest> nests;
+    private final Map<Integer, InteractionPetDrink> petDrinks;
+    private final Map<Integer, InteractionPetFood> petFoods;
+    private final Map<Integer, InteractionPetToy> petToys;
+    private final Map<Integer, InteractionPetTree> petTrees;
+    private final Map<Integer, InteractionRoller> rollers;
 
     // Thread-safe wired collections using ConcurrentHashMap for better concurrency
     private final ConcurrentHashMap<WiredTriggerType, Set<InteractionWiredTrigger>> wiredTriggers;
@@ -65,23 +64,23 @@ public class RoomSpecialTypes {
     private final ConcurrentHashMap<Long, Set<InteractionWiredCondition>> wiredConditionsByLocation;
     private final ConcurrentHashMap<Long, Set<InteractionWiredExtra>> wiredExtrasByLocation;
 
-    private final THashMap<Integer, InteractionGameScoreboard> gameScoreboards;
-    private final THashMap<Integer, InteractionGameGate> gameGates;
-    private final THashMap<Integer, InteractionGameTimer> gameTimers;
+    private final Map<Integer, InteractionGameScoreboard> gameScoreboards;
+    private final Map<Integer, InteractionGameGate> gameGates;
+    private final Map<Integer, InteractionGameTimer> gameTimers;
 
-    private final THashMap<Integer, InteractionFreezeExitTile> freezeExitTile;
-    private final THashMap<Integer, HabboItem> undefined;
+    private final Map<Integer, InteractionFreezeExitTile> freezeExitTile;
+    private final Map<Integer, HabboItem> undefined;
     private final Set<ICycleable> cycleTasks;
     private final ConcurrentHashMap<Integer, HabboItem> specialItemsById = new ConcurrentHashMap<>();
 
     public RoomSpecialTypes() {
-        this.banzaiTeleporters = new THashMap<>(0);
-        this.nests = new THashMap<>(0);
-        this.petDrinks = new THashMap<>(0);
-        this.petFoods = new THashMap<>(0);
-        this.petToys = new THashMap<>(0);
-        this.petTrees = new THashMap<>(0);
-        this.rollers = new THashMap<>(0);
+        this.banzaiTeleporters = new HashMap<>(0);
+        this.nests = new HashMap<>(0);
+        this.petDrinks = new HashMap<>(0);
+        this.petFoods = new HashMap<>(0);
+        this.petToys = new HashMap<>(0);
+        this.petTrees = new HashMap<>(0);
+        this.rollers = new HashMap<>(0);
 
         this.wiredTriggers = new ConcurrentHashMap<>();
         this.wiredEffects = new ConcurrentHashMap<>();
@@ -94,12 +93,12 @@ public class RoomSpecialTypes {
         this.wiredConditionsByLocation = new ConcurrentHashMap<>();
         this.wiredExtrasByLocation = new ConcurrentHashMap<>();
 
-        this.gameScoreboards = new THashMap<>(0);
-        this.gameGates = new THashMap<>(0);
-        this.gameTimers = new THashMap<>(0);
+        this.gameScoreboards = new HashMap<>(0);
+        this.gameGates = new HashMap<>(0);
+        this.gameTimers = new HashMap<>(0);
 
-        this.freezeExitTile = new THashMap<>(0);
-        this.undefined = new THashMap<>(0);
+        this.freezeExitTile = new HashMap<>(0);
+        this.undefined = new HashMap<>(0);
         this.cycleTasks = ConcurrentHashMap.newKeySet();
     }
     
@@ -124,9 +123,9 @@ public class RoomSpecialTypes {
         this.banzaiTeleporters.remove(item.getId()); this.specialItemsById.remove(item.getId());
     }
 
-    public THashSet<InteractionBattleBanzaiTeleporter> getBanzaiTeleporters() {
+    public Set<InteractionBattleBanzaiTeleporter> getBanzaiTeleporters() {
         synchronized (this.banzaiTeleporters) {
-            THashSet<InteractionBattleBanzaiTeleporter> battleBanzaiTeleporters = new THashSet<>();
+            Set<InteractionBattleBanzaiTeleporter> battleBanzaiTeleporters = new LinkedHashSet<>();
             battleBanzaiTeleporters.addAll(this.banzaiTeleporters.values());
 
             return battleBanzaiTeleporters;
@@ -172,9 +171,9 @@ public class RoomSpecialTypes {
         this.specialItemsById.remove(item.getId());
     }
 
-    public THashSet<InteractionNest> getNests() {
+    public Set<InteractionNest> getNests() {
         synchronized (this.nests) {
-            THashSet<InteractionNest> nests = new THashSet<>();
+            Set<InteractionNest> nests = new LinkedHashSet<>();
             nests.addAll(this.nests.values());
 
             return nests;
@@ -202,9 +201,9 @@ public class RoomSpecialTypes {
         this.specialItemsById.remove(item.getId());
     }
 
-    public THashSet<InteractionPetDrink> getPetDrinks() {
+    public Set<InteractionPetDrink> getPetDrinks() {
         synchronized (this.petDrinks) {
-            THashSet<InteractionPetDrink> petDrinks = new THashSet<>();
+            Set<InteractionPetDrink> petDrinks = new LinkedHashSet<>();
             petDrinks.addAll(this.petDrinks.values());
 
             return petDrinks;
@@ -232,9 +231,9 @@ public class RoomSpecialTypes {
         this.specialItemsById.remove(petFood.getId());
     }
 
-    public THashSet<InteractionPetFood> getPetFoods() {
+    public Set<InteractionPetFood> getPetFoods() {
         synchronized (this.petFoods) {
-            THashSet<InteractionPetFood> petFoods = new THashSet<>();
+            Set<InteractionPetFood> petFoods = new LinkedHashSet<>();
             petFoods.addAll(this.petFoods.values());
 
             return petFoods;
@@ -262,9 +261,9 @@ public class RoomSpecialTypes {
         this.specialItemsById.remove(petToy.getId());
     }
 
-    public THashSet<InteractionPetToy> getPetToys() {
+    public Set<InteractionPetToy> getPetToys() {
         synchronized (this.petToys) {
-            THashSet<InteractionPetToy> petToys = new THashSet<>();
+            Set<InteractionPetToy> petToys = new LinkedHashSet<>();
             petToys.addAll(this.petToys.values());
 
             return petToys;
@@ -292,9 +291,9 @@ public class RoomSpecialTypes {
         this.specialItemsById.remove(petTree.getId());
     }
 
-    public THashSet<InteractionPetTree> getPetTrees() {
+    public Set<InteractionPetTree> getPetTrees() {
         synchronized (this.petTrees) {
-            THashSet<InteractionPetTree> petTrees = new THashSet<>();
+            Set<InteractionPetTree> petTrees = new LinkedHashSet<>();
             petTrees.addAll(this.petTrees.values());
 
             return petTrees;
@@ -322,7 +321,7 @@ public class RoomSpecialTypes {
         this.specialItemsById.remove(roller.getId());
     }
 
-    public THashMap<Integer, InteractionRoller> getRollers() {
+    public Map<Integer, InteractionRoller> getRollers() {
         return this.rollers;
     }
 
@@ -931,9 +930,9 @@ public class RoomSpecialTypes {
         this.gameScoreboards.remove(scoreboard.getId()); this.specialItemsById.remove(scoreboard.getId());
     }
 
-    public THashMap<Integer, InteractionFreezeScoreboard> getFreezeScoreboards() {
+    public Map<Integer, InteractionFreezeScoreboard> getFreezeScoreboards() {
         synchronized (this.gameScoreboards) {
-            THashMap<Integer, InteractionFreezeScoreboard> boards = new THashMap<>();
+            Map<Integer, InteractionFreezeScoreboard> boards = new HashMap<>();
 
             for (Map.Entry<Integer, InteractionGameScoreboard> set : this.gameScoreboards.entrySet()) {
                 if (set.getValue() instanceof InteractionFreezeScoreboard) {
@@ -945,9 +944,9 @@ public class RoomSpecialTypes {
         }
     }
 
-    public THashMap<Integer, InteractionFreezeScoreboard> getFreezeScoreboards(GameTeamColors teamColor) {
+    public Map<Integer, InteractionFreezeScoreboard> getFreezeScoreboards(GameTeamColors teamColor) {
         synchronized (this.gameScoreboards) {
-            THashMap<Integer, InteractionFreezeScoreboard> boards = new THashMap<>();
+            Map<Integer, InteractionFreezeScoreboard> boards = new HashMap<>();
 
             for (Map.Entry<Integer, InteractionGameScoreboard> set : this.gameScoreboards.entrySet()) {
                 if (set.getValue() instanceof InteractionFreezeScoreboard) {
@@ -960,9 +959,9 @@ public class RoomSpecialTypes {
         }
     }
 
-    public THashMap<Integer, InteractionBattleBanzaiScoreboard> getBattleBanzaiScoreboards() {
+    public Map<Integer, InteractionBattleBanzaiScoreboard> getBattleBanzaiScoreboards() {
         synchronized (this.gameScoreboards) {
-            THashMap<Integer, InteractionBattleBanzaiScoreboard> boards = new THashMap<>();
+            Map<Integer, InteractionBattleBanzaiScoreboard> boards = new HashMap<>();
 
             for (Map.Entry<Integer, InteractionGameScoreboard> set : this.gameScoreboards.entrySet()) {
                 if (set.getValue() instanceof InteractionBattleBanzaiScoreboard) {
@@ -974,9 +973,9 @@ public class RoomSpecialTypes {
         }
     }
 
-    public THashMap<Integer, InteractionBattleBanzaiScoreboard> getBattleBanzaiScoreboards(GameTeamColors teamColor) {
+    public Map<Integer, InteractionBattleBanzaiScoreboard> getBattleBanzaiScoreboards(GameTeamColors teamColor) {
         synchronized (this.gameScoreboards) {
-            THashMap<Integer, InteractionBattleBanzaiScoreboard> boards = new THashMap<>();
+            Map<Integer, InteractionBattleBanzaiScoreboard> boards = new HashMap<>();
 
             for (Map.Entry<Integer, InteractionGameScoreboard> set : this.gameScoreboards.entrySet()) {
                 if (set.getValue() instanceof InteractionBattleBanzaiScoreboard) {
@@ -989,9 +988,9 @@ public class RoomSpecialTypes {
         }
     }
 
-    public THashMap<Integer, InteractionFootballScoreboard> getFootballScoreboards() {
+    public Map<Integer, InteractionFootballScoreboard> getFootballScoreboards() {
         synchronized (this.gameScoreboards) {
-            THashMap<Integer, InteractionFootballScoreboard> boards = new THashMap<>();
+            Map<Integer, InteractionFootballScoreboard> boards = new HashMap<>();
 
             for (Map.Entry<Integer, InteractionGameScoreboard> set : this.gameScoreboards.entrySet()) {
                 if (set.getValue() instanceof InteractionFootballScoreboard) {
@@ -1003,9 +1002,9 @@ public class RoomSpecialTypes {
         }
     }
 
-    public THashMap<Integer, InteractionFootballScoreboard> getFootballScoreboards(GameTeamColors teamColor) {
+    public Map<Integer, InteractionFootballScoreboard> getFootballScoreboards(GameTeamColors teamColor) {
         synchronized (this.gameScoreboards) {
-            THashMap<Integer, InteractionFootballScoreboard> boards = new THashMap<>();
+            Map<Integer, InteractionFootballScoreboard> boards = new HashMap<>();
 
             for (Map.Entry<Integer, InteractionGameScoreboard> set : this.gameScoreboards.entrySet()) {
                 if (set.getValue() instanceof InteractionFootballScoreboard) {
@@ -1031,9 +1030,9 @@ public class RoomSpecialTypes {
         this.gameGates.remove(gameGate.getId()); this.specialItemsById.remove(gameGate.getId());
     }
 
-    public THashMap<Integer, InteractionFreezeGate> getFreezeGates() {
+    public Map<Integer, InteractionFreezeGate> getFreezeGates() {
         synchronized (this.gameGates) {
-            THashMap<Integer, InteractionFreezeGate> gates = new THashMap<>();
+            Map<Integer, InteractionFreezeGate> gates = new HashMap<>();
 
             for (Map.Entry<Integer, InteractionGameGate> set : this.gameGates.entrySet()) {
                 if (set.getValue() instanceof InteractionFreezeGate) {
@@ -1045,9 +1044,9 @@ public class RoomSpecialTypes {
         }
     }
 
-    public THashMap<Integer, InteractionBattleBanzaiGate> getBattleBanzaiGates() {
+    public Map<Integer, InteractionBattleBanzaiGate> getBattleBanzaiGates() {
         synchronized (this.gameGates) {
-            THashMap<Integer, InteractionBattleBanzaiGate> gates = new THashMap<>();
+            Map<Integer, InteractionBattleBanzaiGate> gates = new HashMap<>();
 
             for (Map.Entry<Integer, InteractionGameGate> set : this.gameGates.entrySet()) {
                 if (set.getValue() instanceof InteractionBattleBanzaiGate) {
@@ -1072,7 +1071,7 @@ public class RoomSpecialTypes {
         this.gameTimers.remove(gameTimer.getId()); this.specialItemsById.remove(gameTimer.getId());
     }
 
-    public THashMap<Integer, InteractionGameTimer> getGameTimers() {
+    public Map<Integer, InteractionGameTimer> getGameTimers() {
         return this.gameTimers;
     }
 
@@ -1090,7 +1089,7 @@ public class RoomSpecialTypes {
         this.freezeExitTile.put(freezeExitTile.getId(), freezeExitTile); this.specialItemsById.put(freezeExitTile.getId(), freezeExitTile);
     }
 
-    public THashMap<Integer, InteractionFreezeExitTile> getFreezeExitTiles() {
+    public Map<Integer, InteractionFreezeExitTile> getFreezeExitTiles() {
         return this.freezeExitTile;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypes.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypes.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -346,8 +347,8 @@ public class RoomSpecialTypes {
      * Gets all wired triggers in the room.
      * @return A new set containing all triggers (safe for iteration)
      */
-    public THashSet<InteractionWiredTrigger> getTriggers() {
-        THashSet<InteractionWiredTrigger> result = new THashSet<>();
+    public Set<InteractionWiredTrigger> getTriggers() {
+        Set<InteractionWiredTrigger> result = new LinkedHashSet<>();
         for (Set<InteractionWiredTrigger> triggers : this.wiredTriggers.values()) {
             result.addAll(triggers);
         }
@@ -359,12 +360,12 @@ public class RoomSpecialTypes {
      * @param type The trigger type to filter by
      * @return A new set containing matching triggers (safe for iteration)
      */
-    public THashSet<InteractionWiredTrigger> getTriggers(WiredTriggerType type) {
+    public Set<InteractionWiredTrigger> getTriggers(WiredTriggerType type) {
         Set<InteractionWiredTrigger> triggers = this.wiredTriggers.get(type);
         if (triggers == null) {
-            return new THashSet<>(0);
+            return new LinkedHashSet<>(0);
         }
-        return new THashSet<>(triggers);
+        return new LinkedHashSet<>(triggers);
     }
 
     /**
@@ -373,13 +374,13 @@ public class RoomSpecialTypes {
      * @param y The Y coordinate
      * @return A new set containing triggers at the location (safe for iteration)
      */
-    public THashSet<InteractionWiredTrigger> getTriggers(int x, int y) {
+    public Set<InteractionWiredTrigger> getTriggers(int x, int y) {
         long key = coordinateKey(x, y);
         Set<InteractionWiredTrigger> triggers = this.wiredTriggersByLocation.get(key);
         if (triggers == null) {
-            return new THashSet<>(0);
+            return new LinkedHashSet<>(0);
         }
-        return new THashSet<>(triggers);
+        return new LinkedHashSet<>(triggers);
     }
 
     /**
@@ -459,7 +460,7 @@ public class RoomSpecialTypes {
 
         boolean changed = false;
 
-        THashSet<InteractionWiredTrigger> receivers = this.getTriggers(WiredTriggerType.RECEIVE_SIGNAL);
+        Set<InteractionWiredTrigger> receivers = this.getTriggers(WiredTriggerType.RECEIVE_SIGNAL);
         for (InteractionWiredTrigger trigger : receivers) {
             if (!(trigger instanceof com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerReceiveSignal receiver)) {
                 continue;
@@ -588,8 +589,8 @@ public class RoomSpecialTypes {
      * Gets all wired effects in the room.
      * @return A new set containing all effects (safe for iteration)
      */
-    public THashSet<InteractionWiredEffect> getEffects() {
-        THashSet<InteractionWiredEffect> result = new THashSet<>();
+    public Set<InteractionWiredEffect> getEffects() {
+        Set<InteractionWiredEffect> result = new LinkedHashSet<>();
         for (Set<InteractionWiredEffect> effects : this.wiredEffects.values()) {
             result.addAll(effects);
         }
@@ -601,12 +602,12 @@ public class RoomSpecialTypes {
      * @param type The effect type to filter by
      * @return A new set containing matching effects (safe for iteration)
      */
-    public THashSet<InteractionWiredEffect> getEffects(WiredEffectType type) {
+    public Set<InteractionWiredEffect> getEffects(WiredEffectType type) {
         Set<InteractionWiredEffect> effects = this.wiredEffects.get(type);
         if (effects == null) {
-            return new THashSet<>(0);
+            return new LinkedHashSet<>(0);
         }
-        return new THashSet<>(effects);
+        return new LinkedHashSet<>(effects);
     }
 
     /**
@@ -615,13 +616,13 @@ public class RoomSpecialTypes {
      * @param y The Y coordinate
      * @return A new set containing effects at the location (safe for iteration)
      */
-    public THashSet<InteractionWiredEffect> getEffects(int x, int y) {
+    public Set<InteractionWiredEffect> getEffects(int x, int y) {
         long key = coordinateKey(x, y);
         Set<InteractionWiredEffect> effects = this.wiredEffectsByLocation.get(key);
         if (effects == null) {
-            return new THashSet<>(0);
+            return new LinkedHashSet<>(0);
         }
-        return new THashSet<>(effects);
+        return new LinkedHashSet<>(effects);
     }
 
     /**
@@ -708,8 +709,8 @@ public class RoomSpecialTypes {
      * Gets all wired conditions in the room.
      * @return A new set containing all conditions (safe for iteration)
      */
-    public THashSet<InteractionWiredCondition> getConditions() {
-        THashSet<InteractionWiredCondition> result = new THashSet<>();
+    public Set<InteractionWiredCondition> getConditions() {
+        Set<InteractionWiredCondition> result = new LinkedHashSet<>();
         for (Set<InteractionWiredCondition> conditions : this.wiredConditions.values()) {
             result.addAll(conditions);
         }
@@ -721,12 +722,12 @@ public class RoomSpecialTypes {
      * @param type The condition type to filter by
      * @return A new set containing matching conditions (safe for iteration)
      */
-    public THashSet<InteractionWiredCondition> getConditions(WiredConditionType type) {
+    public Set<InteractionWiredCondition> getConditions(WiredConditionType type) {
         Set<InteractionWiredCondition> conditions = this.wiredConditions.get(type);
         if (conditions == null) {
-            return new THashSet<>(0);
+            return new LinkedHashSet<>(0);
         }
-        return new THashSet<>(conditions);
+        return new LinkedHashSet<>(conditions);
     }
 
     /**
@@ -735,13 +736,13 @@ public class RoomSpecialTypes {
      * @param y The Y coordinate
      * @return A new set containing conditions at the location (safe for iteration)
      */
-    public THashSet<InteractionWiredCondition> getConditions(int x, int y) {
+    public Set<InteractionWiredCondition> getConditions(int x, int y) {
         long key = coordinateKey(x, y);
         Set<InteractionWiredCondition> conditions = this.wiredConditionsByLocation.get(key);
         if (conditions == null) {
-            return new THashSet<>(0);
+            return new LinkedHashSet<>(0);
         }
-        return new THashSet<>(conditions);
+        return new LinkedHashSet<>(conditions);
     }
 
     /**
@@ -812,8 +813,8 @@ public class RoomSpecialTypes {
      * Gets all wired extras in the room.
      * @return A new set containing all extras (safe for iteration)
      */
-    public THashSet<InteractionWiredExtra> getExtras() {
-        THashSet<InteractionWiredExtra> result = new THashSet<>();
+    public Set<InteractionWiredExtra> getExtras() {
+        Set<InteractionWiredExtra> result = new LinkedHashSet<>();
         result.addAll(this.wiredExtras.values());
         return result;
     }
@@ -833,13 +834,13 @@ public class RoomSpecialTypes {
      * @param y The Y coordinate
      * @return A new set containing extras at the location (safe for iteration)
      */
-    public THashSet<InteractionWiredExtra> getExtras(int x, int y) {
+    public Set<InteractionWiredExtra> getExtras(int x, int y) {
         long key = coordinateKey(x, y);
         Set<InteractionWiredExtra> extras = this.wiredExtrasByLocation.get(key);
         if (extras == null) {
-            return new THashSet<>(0);
+            return new LinkedHashSet<>(0);
         }
-        return new THashSet<>(extras);
+        return new LinkedHashSet<>(extras);
     }
 
     /**
@@ -1115,8 +1116,8 @@ public class RoomSpecialTypes {
         this.specialItemsById.remove(item.getId());
     }
 
-    public THashSet<HabboItem> getItemsOfType(Class<? extends HabboItem> type) {
-        THashSet<HabboItem> items = new THashSet<>();
+    public Set<HabboItem> getItemsOfType(Class<? extends HabboItem> type) {
+        Set<HabboItem> items = new LinkedHashSet<>();
         
         // Check pet trees collection for InteractionPetTree type
         if (type == InteractionPetTree.class) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTile.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTile.java
@@ -1,16 +1,17 @@
 package com.eu.habbo.habbohotel.rooms;
 
 import com.eu.habbo.habbohotel.items.Item;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class RoomTile {
     public final short x;
     public final short y;
     public final short z;
-    private final THashSet<RoomUnit> units;
+    private final Set<RoomUnit> units;
     public RoomTileState state;
     private double stackHeight;
     private boolean allowStack = true;
@@ -27,7 +28,7 @@ public class RoomTile {
         this.stackHeight = z;
         this.state = state;
         this.setAllowStack(allowStack);
-        this.units = new THashSet<>();
+        this.units = new HashSet<>();
     }
 
     public RoomTile(RoomTile tile) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTileManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTileManager.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Set;
 
 /**
  * Manages tile state calculations and heightmap operations for a room.
@@ -534,7 +535,7 @@ public class RoomTileManager {
     public void loadHeightmap() {
         RoomLayout layout = this.room.getLayout();
         if (layout != null) {
-            THashSet<HabboItem> floorItems = this.room.getFloorItems();
+            Set<HabboItem> floorItems = this.room.getFloorItems();
 
             if (floorItems.isEmpty()) {
                 // No items - only update door tile

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTileManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTileManager.java
@@ -67,7 +67,7 @@ public class RoomTileManager {
         }
 
         RoomTileState result = RoomTileState.OPEN;
-        THashSet<HabboItem> items = this.room.getItemManager().getItemsAt(tile);
+        Set<HabboItem> items = this.room.getItemManager().getItemsAt(tile);
 
         if (items == null) {
             return RoomTileState.INVALID;
@@ -107,7 +107,7 @@ public class RoomTileManager {
      * Calculates the walk surface height for underpass checks.
      * Returns the floor height or the top of the highest walkable item below any blocking items.
      */
-    private double getUnderpassWalkHeight(RoomTile tile, THashSet<HabboItem> items, HabboItem exclude) {
+    private double getUnderpassWalkHeight(RoomTile tile, Set<HabboItem> items, HabboItem exclude) {
         RoomLayout layout = this.room.getLayout();
         double walkHeight = layout != null ? layout.getHeightAtSquare(tile.x, tile.y) : 0;
 
@@ -212,7 +212,7 @@ public class RoomTileManager {
         double height = layout.getHeightAtSquare(x, y);
         boolean canStack = true;
 
-        THashSet<HabboItem> stackHelpers = this.room.getItemManager().getItemsAt(InteractionStackHelper.class, x, y);
+        Set<HabboItem> stackHelpers = this.room.getItemManager().getItemsAt(InteractionStackHelper.class, x, y);
         stackHelpers.addAll(this.room.getItemManager().getItemsAt(InteractionStackWalkHelper.class, x, y));
         stackHelpers.addAll(this.room.getItemManager().getItemsAt(InteractionTileWalkMagic.class, x, y));
 
@@ -239,7 +239,7 @@ public class RoomTileManager {
             if (this.room.isAllowUnderpass() && !item.isWalkable() && !item.getBaseItem().allowWalk() && !item.getBaseItem().allowSit() && !item.getBaseItem().allowLay()) {
                 RoomLayout layout2 = this.room.getLayout();
                 RoomTile tile = layout2 != null ? layout2.getTile(x, y) : null;
-                THashSet<HabboItem> allItems = tile != null ? this.room.getItemManager().getItemsAt(tile) : null;
+                Set<HabboItem> allItems = tile != null ? this.room.getItemManager().getItemsAt(tile) : null;
                 double walkSurface = this.getUnderpassWalkHeight(tile, allItems, exclude);
                 if (item.getZ() - walkSurface >= RoomLayout.UNDERPASS_HEIGHT) {
                     height = walkSurface;
@@ -296,7 +296,7 @@ public class RoomTileManager {
     public HabboItem getLowestChair(RoomTile tile) {
         HabboItem lowestChair = null;
 
-        THashSet<HabboItem> items = this.room.getItemManager().getItemsAt(tile);
+        Set<HabboItem> items = this.room.getItemManager().getItemsAt(tile);
         if (items != null && !items.isEmpty()) {
             for (HabboItem item : items) {
                 if (!item.getBaseItem().allowSit()) {
@@ -320,7 +320,7 @@ public class RoomTileManager {
     public HabboItem getTallestChair(RoomTile tile) {
         HabboItem tallestChair = null;
 
-        THashSet<HabboItem> items = this.room.getItemManager().getItemsAt(tile);
+        Set<HabboItem> items = this.room.getItemManager().getItemsAt(tile);
         if (items != null && !items.isEmpty()) {
             for (HabboItem item : items) {
                 if (!item.getBaseItem().allowSit()) {
@@ -348,7 +348,7 @@ public class RoomTileManager {
         }
 
         RoomTile tile = this.room.getLayout().getTile((short) x, (short) y);
-        THashSet<HabboItem> items = this.room.getItemManager().getItemsAt(tile);
+        Set<HabboItem> items = this.room.getItemManager().getItemsAt(tile);
 
         return this.canSitAt(items) || this.canLayAt(items);
     }
@@ -368,7 +368,7 @@ public class RoomTileManager {
     /**
      * Checks if items allow sitting.
      */
-    public boolean canSitAt(THashSet<HabboItem> items) {
+    public boolean canSitAt(Set<HabboItem> items) {
         if (items == null) {
             return false;
         }
@@ -402,7 +402,7 @@ public class RoomTileManager {
     /**
      * Checks if items allow laying.
      */
-    public boolean canLayAt(THashSet<HabboItem> items) {
+    public boolean canLayAt(Set<HabboItem> items) {
         if (items == null || items.isEmpty()) {
             return true;
         }
@@ -432,7 +432,7 @@ public class RoomTileManager {
 
         HabboItem topItem = null;
         boolean canWalk = true;
-        THashSet<HabboItem> items = this.room.getItemManager().getItemsAt(roomTile);
+        Set<HabboItem> items = this.room.getItemManager().getItemsAt(roomTile);
         if (items != null && items.stream().anyMatch(item -> item instanceof InteractionTileWalkMagic || item instanceof InteractionStackWalkHelper)) {
             return true;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTileManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTileManager.java
@@ -8,11 +8,11 @@ import com.eu.habbo.habbohotel.items.interactions.InteractionStackWalkHelper;
 import com.eu.habbo.habbohotel.items.interactions.InteractionTileWalkMagic;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.plugin.events.furniture.FurnitureStackHeightEvent;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -547,7 +547,7 @@ public class RoomTileManager {
             }
 
             // Collect unique tiles occupied by items (handles rotation)
-            THashSet<RoomTile> tilesToUpdate = new THashSet<>();
+            Set<RoomTile> tilesToUpdate = new HashSet<>();
             for (HabboItem item : floorItems) {
                 RoomTile baseTile = layout.getTile(item.getX(), item.getY());
                 if (baseTile != null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTileManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTileManager.java
@@ -12,6 +12,8 @@ import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
+
 /**
  * Manages tile state calculations and heightmap operations for a room.
  */
@@ -38,7 +40,7 @@ public class RoomTileManager {
     /**
      * Updates multiple tiles and sends the update to clients.
      */
-    public void updateTiles(THashSet<RoomTile> tiles) {
+    public void updateTiles(Collection<RoomTile> tiles) {
         for (RoomTile tile : tiles) {
             this.room.getItemManager().tileCache.remove(tile);
             tile.setStackHeight(this.getStackHeight(tile.x, tile.y, false));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTrade.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTrade.java
@@ -10,13 +10,14 @@ import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
 import com.eu.habbo.messages.outgoing.trading.*;
 import com.eu.habbo.plugin.events.trading.TradeConfirmEvent;
 import com.eu.habbo.threading.runnables.QueryDeleteHabboItem;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.*;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class RoomTrade {
     private static final Logger LOGGER = LoggerFactory.getLogger(RoomTrade.class);
@@ -69,7 +70,7 @@ public class RoomTrade {
         this.updateWindow();
     }
 
-    public synchronized void offerMultipleItems(Habbo habbo, THashSet<HabboItem> items) {
+    public synchronized void offerMultipleItems(Habbo habbo, Set<HabboItem> items) {
         RoomTradeUser user = this.getRoomTradeUserForHabbo(habbo);
 
         if (user == null || items == null)
@@ -260,14 +261,14 @@ public class RoomTrade {
             item.setUserId(userOne.getHabbo().getHabboInfo().getId());
         }
 
-        THashSet<HabboItem> itemsUserOne = new THashSet<>(userOne.getItems());
-        THashSet<HabboItem> itemsUserTwo = new THashSet<>(userTwo.getItems());
+        Set<HabboItem> itemsUserOne = new HashSet<>(userOne.getItems());
+        Set<HabboItem> itemsUserTwo = new HashSet<>(userTwo.getItems());
 
         userOne.clearItems();
         userTwo.clearItems();
 
         int creditsForUserTwo = 0;
-        THashSet<HabboItem> creditFurniUserOne = new THashSet<>();
+        Set<HabboItem> creditFurniUserOne = new HashSet<>();
         for (HabboItem item : itemsUserOne) {
             int worth = RoomTrade.getCreditsByItem(item);
             if (worth > 0) {
@@ -279,7 +280,7 @@ public class RoomTrade {
         itemsUserOne.removeAll(creditFurniUserOne);
 
         int creditsForUserOne = 0;
-        THashSet<HabboItem> creditFurniUserTwo = new THashSet<>();
+        Set<HabboItem> creditFurniUserTwo = new HashSet<>();
         for (HabboItem item : itemsUserTwo) {
             int worth = RoomTrade.getCreditsByItem(item);
             if (worth > 0) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTradeManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTradeManager.java
@@ -1,18 +1,20 @@
 package com.eu.habbo.habbohotel.rooms;
 
 import com.eu.habbo.habbohotel.users.Habbo;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Manages trading operations within a room.
  */
 public class RoomTradeManager {
     private final Room room;
-    private final THashSet<RoomTrade> activeTrades;
+    private final Set<RoomTrade> activeTrades;
 
     public RoomTradeManager(Room room) {
         this.room = room;
-        this.activeTrades = new THashSet<>(0);
+        this.activeTrades = new HashSet<>(0);
     }
 
     /**
@@ -60,7 +62,7 @@ public class RoomTradeManager {
     /**
      * Gets all active trades.
      */
-    public THashSet<RoomTrade> getActiveTrades() {
+    public Set<RoomTrade> getActiveTrades() {
         return this.activeTrades;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTradeUser.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTradeUser.java
@@ -2,11 +2,13 @@ package com.eu.habbo.habbohotel.rooms;
 
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class RoomTradeUser {
     private final Habbo habbo;
-    private final THashSet<HabboItem> items;
+    private final Set<HabboItem> items;
     private int userId;
     private boolean accepted;
     private boolean confirmed;
@@ -20,7 +22,7 @@ public class RoomTradeUser {
 
         this.accepted = false;
         this.confirmed = false;
-        this.items = new THashSet<>();
+        this.items = new HashSet<>();
     }
 
     public int getUserId() {
@@ -69,7 +71,7 @@ public class RoomTradeUser {
         return null;
     }
 
-    public THashSet<HabboItem> getItems() {
+    public Set<HabboItem> getItems() {
         return this.items;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnit.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnit.java
@@ -23,9 +23,6 @@ import com.eu.habbo.plugin.events.users.UserIdleEvent;
 import com.eu.habbo.plugin.events.users.UserTakeStepEvent;
 import com.eu.habbo.threading.runnables.RoomUnitKick;
 import com.eu.habbo.util.pathfinding.Rotation;
-import gnu.trove.map.TMap;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +39,7 @@ public class RoomUnit {
   public boolean isWiredTeleporting = false;
   public boolean isLeavingTeleporter = false;
   private final ConcurrentHashMap<RoomUnitStatus, String> status;
-  private final THashMap<String, Object> cacheable;
+  private final Map<String, Object> cacheable;
   public boolean canRotate = true;
   public boolean animateWalk = false;
   public boolean cmdTeleport = false;
@@ -88,14 +85,14 @@ public class RoomUnit {
   private int idleTimer;
   private Room room;
   private RoomRightLevels rightsLevel = RoomRightLevels.NONE;
-  private THashSet<Integer> overridableTiles;
+  private Set<Integer> overridableTiles;
 
   public RoomUnit() {
     this.id = 0;
     this.inRoom = false;
     this.canWalk = true;
     this.status = new ConcurrentHashMap<>();
-    this.cacheable = new THashMap<>();
+    this.cacheable = new HashMap<>();
     this.roomUnitType = RoomUnitType.UNKNOWN;
     this.danceType = DanceType.NONE;
     this.handItem = 0;
@@ -103,7 +100,7 @@ public class RoomUnit {
     this.walkTimeOut = Emulator.getIntUnixTimestamp();
     this.effectId = 0;
     this.isKicked = false;
-    this.overridableTiles = new THashSet<>();
+    this.overridableTiles = new HashSet<>();
   }
 
   public void clearWalking() {
@@ -654,7 +651,7 @@ public class RoomUnit {
     return this.statusUpdate;
   }
 
-  public TMap<String, Object> getCacheable() {
+  public Map<String, Object> getCacheable() {
     return this.cacheable;
   }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitManager.java
@@ -21,12 +21,9 @@ import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorMessagesCompose
 import com.eu.habbo.messages.outgoing.inventory.AddPetComposer;
 import com.eu.habbo.messages.outgoing.rooms.pets.RoomPetComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.*;
-import gnu.trove.TCollections;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
-import gnu.trove.procedure.TObjectProcedure;
-import gnu.trove.set.hash.THashSet;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,8 +33,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
-import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -53,9 +51,9 @@ public class RoomUnitManager {
 
     // Unit collections - these are the actual data stores
     private final ConcurrentHashMap<Integer, Habbo> currentHabbos = new ConcurrentHashMap<>(3);
-    private final TIntObjectMap<Habbo> habboQueue = TCollections.synchronizedMap(new TIntObjectHashMap<>(0));
-    private final TIntObjectMap<Bot> currentBots = TCollections.synchronizedMap(new TIntObjectHashMap<>(0));
-    private final TIntObjectMap<Pet> currentPets = TCollections.synchronizedMap(new TIntObjectHashMap<>(0));
+    private final Int2ObjectMap<Habbo> habboQueue = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
+    private final Int2ObjectMap<Bot> currentBots = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
+    private final Int2ObjectMap<Pet> currentPets = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
 
     // Unit counter for assigning IDs
     private volatile int unitCounter;
@@ -77,13 +75,13 @@ public class RoomUnitManager {
                     WiredUserMovementHelper.cleanupRoomUnit(habbo.getRoomUnit());
                 }
             }
-            for (Bot bot : this.currentBots.valueCollection()) {
+            for (Bot bot : this.currentBots.values()) {
                 if (bot.getRoomUnit() != null) {
                     WiredMoveCarryHelper.cleanupRoomUnit(bot.getRoomUnit());
                     WiredUserMovementHelper.cleanupRoomUnit(bot.getRoomUnit());
                 }
             }
-            for (Pet pet : this.currentPets.valueCollection()) {
+            for (Pet pet : this.currentPets.values()) {
                 if (pet.getRoomUnit() != null) {
                     WiredMoveCarryHelper.cleanupRoomUnit(pet.getRoomUnit());
                     WiredUserMovementHelper.cleanupRoomUnit(pet.getRoomUnit());
@@ -327,15 +325,15 @@ public class RoomUnitManager {
     /**
      * Gets all Habbos at a specific position.
      */
-    public THashSet<Habbo> getHabbosAt(short x, short y) {
+    public Set<Habbo> getHabbosAt(short x, short y) {
         return this.getHabbosAt(this.room.getLayout().getTile(x, y));
     }
 
     /**
      * Gets all Habbos at a specific tile.
      */
-    public THashSet<Habbo> getHabbosAt(RoomTile tile) {
-        THashSet<Habbo> habbos = new THashSet<>();
+    public Set<Habbo> getHabbosAt(RoomTile tile) {
+        Set<Habbo> habbos = new HashSet<>();
 
         for (Habbo habbo : this.getHabbos()) {
             if (habbo.getRoomUnit().getCurrentLocation().equals(tile)) {
@@ -349,8 +347,8 @@ public class RoomUnitManager {
     /**
      * Gets all Habbos on a specific item.
      */
-    public THashSet<Habbo> getHabbosOnItem(HabboItem item) {
-        THashSet<Habbo> habbos = new THashSet<>();
+    public Set<Habbo> getHabbosOnItem(HabboItem item) {
+        Set<Habbo> habbos = new HashSet<>();
         for (short x = item.getX(); x < item.getX() + item.getBaseItem().getLength(); x++) {
             for (short y = item.getY(); y < item.getY() + item.getBaseItem().getWidth(); y++) {
                 habbos.addAll(this.getHabbosAt(x, y));
@@ -420,7 +418,7 @@ public class RoomUnitManager {
 
                 // For double beds: if another user already occupies this pillow, use the other side
                 if (pillowTile != null && bedProfile.isDouble()) {
-                    THashSet<Habbo> habbosAtPillow = this.getHabbosAt(pillowTile.x, pillowTile.y);
+                    Set<Habbo> habbosAtPillow = this.getHabbosAt(pillowTile.x, pillowTile.y);
                     for (Habbo other : habbosAtPillow) {
                         if (other == habbo || other.getRoomUnit() == null) continue;
                         RoomTile otherSide = bedProfile.getOtherSide(this.room, topItem, pillowTile);
@@ -459,7 +457,7 @@ public class RoomUnitManager {
         }
 
         if (!habbos.isEmpty()) {
-            THashSet<RoomUnit> roomUnits = new THashSet<>();
+            Set<RoomUnit> roomUnits = new HashSet<>();
             for (Habbo habbo : habbos) {
                 if (habbo.getRoomUnit() == null
                         || WiredMoveCarryHelper.shouldSuppressStatusUpdate(habbo.getRoomUnit())
@@ -509,7 +507,7 @@ public class RoomUnitManager {
     /**
      * Gets the Habbo queue.
      */
-    public TIntObjectMap<Habbo> getHabboQueue() {
+    public Int2ObjectMap<Habbo> getHabboQueue() {
         return this.habboQueue;
     }
 
@@ -566,18 +564,9 @@ public class RoomUnitManager {
      */
     public Bot getBot(RoomUnit roomUnit) {
         synchronized (this.currentBots) {
-            TIntObjectIterator<Bot> iterator = this.currentBots.iterator();
-
-            for (int i = this.currentBots.size(); i-- > 0; ) {
-                try {
-                    iterator.advance();
-                } catch (NoSuchElementException e) {
-                    LOGGER.error("Caught exception", e);
-                    break;
-                }
-
-                if (iterator.value().getRoomUnit() == roomUnit) {
-                    return iterator.value();
+            for (Bot bot : this.currentBots.values()) {
+                if (bot.getRoomUnit() == roomUnit) {
+                    return bot;
                 }
             }
         }
@@ -590,18 +579,9 @@ public class RoomUnitManager {
      */
     public Bot getBotByRoomUnitId(int id) {
         synchronized (this.currentBots) {
-            TIntObjectIterator<Bot> iterator = this.currentBots.iterator();
-
-            for (int i = this.currentBots.size(); i-- > 0; ) {
-                try {
-                    iterator.advance();
-                } catch (NoSuchElementException e) {
-                    LOGGER.error("Caught exception", e);
-                    break;
-                }
-
-                if (iterator.value().getRoomUnit().getId() == id) {
-                    return iterator.value();
+            for (Bot bot : this.currentBots.values()) {
+                if (bot.getRoomUnit().getId() == id) {
+                    return bot;
                 }
             }
         }
@@ -616,18 +596,9 @@ public class RoomUnitManager {
         List<Bot> bots = new ArrayList<>();
 
         synchronized (this.currentBots) {
-            TIntObjectIterator<Bot> iterator = this.currentBots.iterator();
-
-            for (int i = this.currentBots.size(); i-- > 0; ) {
-                try {
-                    iterator.advance();
-                } catch (NoSuchElementException e) {
-                    LOGGER.error("Caught exception", e);
-                    break;
-                }
-
-                if (iterator.value().getName().equalsIgnoreCase(name)) {
-                    bots.add(iterator.value());
+            for (Bot bot : this.currentBots.values()) {
+                if (bot.getName().equalsIgnoreCase(name)) {
+                    bots.add(bot);
                 }
             }
         }
@@ -639,13 +610,13 @@ public class RoomUnitManager {
      * Gets all Bots in the room.
      */
     public Collection<Bot> getBots() {
-        return this.currentBots.valueCollection();
+        return this.currentBots.values();
     }
 
     /**
      * Gets the Bot map.
      */
-    public TIntObjectMap<Bot> getCurrentBots() {
+    public Int2ObjectMap<Bot> getCurrentBots() {
         return this.currentBots;
     }
 
@@ -694,41 +665,26 @@ public class RoomUnitManager {
      * Checks if there are Bots at the specified position.
      */
     public boolean hasBotsAt(final int x, final int y) {
-        final boolean[] result = {false};
-
         synchronized (this.currentBots) {
-            this.currentBots.forEachValue(new TObjectProcedure<Bot>() {
-                @Override
-                public boolean execute(Bot object) {
-                    if (object.getRoomUnit().getX() == x && object.getRoomUnit().getY() == y) {
-                        result[0] = true;
-                        return false;
-                    }
+            for (Bot bot : this.currentBots.values()) {
+                if (bot.getRoomUnit().getX() == x && bot.getRoomUnit().getY() == y) {
                     return true;
                 }
-            });
+            }
         }
 
-        return result[0];
+        return false;
     }
 
     /**
      * Gets all Bots at a specific tile.
      */
-    public THashSet<Bot> getBotsAt(RoomTile tile) {
-        THashSet<Bot> bots = new THashSet<>();
+    public Set<Bot> getBotsAt(RoomTile tile) {
+        Set<Bot> bots = new HashSet<>();
         synchronized (this.currentBots) {
-            TIntObjectIterator<Bot> botIterator = this.currentBots.iterator();
-
-            for (int i = this.currentBots.size(); i-- > 0; ) {
-                try {
-                    botIterator.advance();
-
-                    if (botIterator.value().getRoomUnit().getCurrentLocation().equals(tile)) {
-                        bots.add(botIterator.value());
-                    }
-                } catch (Exception e) {
-                    break;
+            for (Bot bot : this.currentBots.values()) {
+                if (bot.getRoomUnit().getCurrentLocation().equals(tile)) {
+                    bots.add(bot);
                 }
             }
         }
@@ -739,8 +695,8 @@ public class RoomUnitManager {
     /**
      * Gets all Bots on a specific item.
      */
-    public THashSet<Bot> getBotsOnItem(HabboItem item) {
-        THashSet<Bot> bots = new THashSet<>();
+    public Set<Bot> getBotsOnItem(HabboItem item) {
+        Set<Bot> bots = new HashSet<>();
         for (short x = item.getX(); x < item.getX() + item.getBaseItem().getLength(); x++) {
             for (short y = item.getY(); y < item.getY() + item.getBaseItem().getWidth(); y++) {
                 bots.addAll(this.getBotsAt(this.room.getLayout().getTile(x, y)));
@@ -760,7 +716,7 @@ public class RoomUnitManager {
             return;
         }
 
-        THashSet<Bot> bots = this.getBotsAt(tile);
+        Set<Bot> bots = this.getBotsAt(tile);
         HabboItem topItem = this.room.getTopItemAt(x, y);
 
         for (Bot bot : bots) {
@@ -798,7 +754,7 @@ public class RoomUnitManager {
 
         if (!bots.isEmpty()) {
             this.room.sendComposer(new RoomUserStatusComposer(
-                    bots.stream().map(Bot::getRoomUnit).collect(Collectors.toCollection(THashSet::new)),
+                    bots.stream().map(Bot::getRoomUnit).collect(Collectors.toCollection(HashSet::new)),
                     true).compose());
         }
     }
@@ -851,18 +807,11 @@ public class RoomUnitManager {
      * Gets a Pet by RoomUnit.
      */
     public Pet getPet(RoomUnit roomUnit) {
-        TIntObjectIterator<Pet> petIterator = this.currentPets.iterator();
-
-        for (int i = this.currentPets.size(); i-- > 0; ) {
-            try {
-                petIterator.advance();
-            } catch (NoSuchElementException e) {
-                LOGGER.error("Caught exception", e);
-                break;
-            }
-
-            if (petIterator.value().getRoomUnit() == roomUnit) {
-                return petIterator.value();
+        synchronized (this.currentPets) {
+            for (Pet pet : this.currentPets.values()) {
+                if (pet.getRoomUnit() == roomUnit) {
+                    return pet;
+                }
             }
         }
 
@@ -873,13 +822,13 @@ public class RoomUnitManager {
      * Gets all Pets in the room.
      */
     public Collection<Pet> getPets() {
-        return this.currentPets.valueCollection();
+        return this.currentPets.values();
     }
 
     /**
      * Gets the Pet map.
      */
-    public TIntObjectMap<Pet> getCurrentPets() {
+    public Int2ObjectMap<Pet> getCurrentPets() {
         return this.currentPets;
     }
 
@@ -956,18 +905,8 @@ public class RoomUnitManager {
      */
     public boolean hasPetsAt(int x, int y) {
         synchronized (this.currentPets) {
-            TIntObjectIterator<Pet> petIterator = this.currentPets.iterator();
-
-            for (int i = this.currentPets.size(); i-- > 0; ) {
-                try {
-                    petIterator.advance();
-                } catch (NoSuchElementException e) {
-                    LOGGER.error("Caught exception", e);
-                    break;
-                }
-
-                if (petIterator.value().getRoomUnit().getX() == x
-                        && petIterator.value().getRoomUnit().getY() == y) {
+            for (Pet pet : this.currentPets.values()) {
+                if (pet.getRoomUnit().getX() == x && pet.getRoomUnit().getY() == y) {
                     return true;
                 }
             }
@@ -979,20 +918,12 @@ public class RoomUnitManager {
     /**
      * Gets all Pets at a specific tile.
      */
-    public THashSet<Pet> getPetsAt(RoomTile tile) {
-        THashSet<Pet> pets = new THashSet<>();
+    public Set<Pet> getPetsAt(RoomTile tile) {
+        Set<Pet> pets = new HashSet<>();
         synchronized (this.currentPets) {
-            TIntObjectIterator<Pet> petIterator = this.currentPets.iterator();
-
-            for (int i = this.currentPets.size(); i-- > 0; ) {
-                try {
-                    petIterator.advance();
-
-                    if (petIterator.value().getRoomUnit().getCurrentLocation().equals(tile)) {
-                        pets.add(petIterator.value());
-                    }
-                } catch (Exception e) {
-                    break;
+            for (Pet pet : this.currentPets.values()) {
+                if (pet.getRoomUnit().getCurrentLocation().equals(tile)) {
+                    pets.add(pet);
                 }
             }
         }
@@ -1010,7 +941,7 @@ public class RoomUnitManager {
             return;
         }
 
-        THashSet<Pet> pets = this.getPetsAt(tile);
+        Set<Pet> pets = this.getPetsAt(tile);
         HabboItem topItem = this.room.getTopItemAt(x, y);
 
         for (Pet pet : pets) {
@@ -1036,7 +967,7 @@ public class RoomUnitManager {
 
         if (!pets.isEmpty()) {
             this.room.sendComposer(new RoomUserStatusComposer(
-                    pets.stream().map(Pet::getRoomUnit).collect(Collectors.toCollection(THashSet::new)),
+                    pets.stream().map(Pet::getRoomUnit).collect(Collectors.toCollection(HashSet::new)),
                     true).compose());
         }
     }
@@ -1045,21 +976,12 @@ public class RoomUnitManager {
      * Picks up all pets belonging to a Habbo.
      */
     public void pickupPetsForHabbo(Habbo habbo) {
-        THashSet<Pet> pets = new THashSet<>();
+        Set<Pet> pets = new HashSet<>();
 
         synchronized (this.currentPets) {
-            TIntObjectIterator<Pet> petIterator = this.currentPets.iterator();
-
-            for (int i = this.currentPets.size(); i-- > 0; ) {
-                try {
-                    petIterator.advance();
-                } catch (NoSuchElementException e) {
-                    LOGGER.error("Caught exception", e);
-                    break;
-                }
-
-                if (petIterator.value().getUserId() == habbo.getHabboInfo().getId()) {
-                    pets.add(petIterator.value());
+            for (Pet pet : this.currentPets.values()) {
+                if (pet.getUserId() == habbo.getHabboInfo().getId()) {
+                    pets.add(pet);
                 }
             }
         }
@@ -1092,21 +1014,12 @@ public class RoomUnitManager {
      * @param excludeUserId User ID whose pets should NOT be removed, -1 to remove all
      */
     public void removeAllPets(int excludeUserId) {
-        THashSet<Pet> toRemove = new THashSet<>();
+        Set<Pet> toRemove = new HashSet<>();
 
         synchronized (this.currentPets) {
-            TIntObjectIterator<Pet> petIterator = this.currentPets.iterator();
-
-            for (int i = this.currentPets.size(); i-- > 0; ) {
-                try {
-                    petIterator.advance();
-                } catch (NoSuchElementException e) {
-                    LOGGER.error("Caught exception", e);
-                    break;
-                }
-
-                if (petIterator.value().getUserId() != excludeUserId) {
-                    toRemove.add(petIterator.value());
+            for (Pet pet : this.currentPets.values()) {
+                if (pet.getUserId() != excludeUserId) {
+                    toRemove.add(pet);
                 }
             }
         }
@@ -1137,15 +1050,15 @@ public class RoomUnitManager {
     /**
      * Gets all Habbos and Bots at a position.
      */
-    public THashSet<RoomUnit> getHabbosAndBotsAt(short x, short y) {
+    public Set<RoomUnit> getHabbosAndBotsAt(short x, short y) {
         return this.getHabbosAndBotsAt(this.room.getLayout().getTile(x, y));
     }
 
     /**
      * Gets all Habbos and Bots at a tile.
      */
-    public THashSet<RoomUnit> getHabbosAndBotsAt(RoomTile tile) {
-        THashSet<RoomUnit> list = new THashSet<>();
+    public Set<RoomUnit> getHabbosAndBotsAt(RoomTile tile) {
+        Set<RoomUnit> list = new HashSet<>();
 
         for (Bot bot : this.getBotsAt(tile)) {
             list.add(bot.getRoomUnit());
@@ -1161,15 +1074,15 @@ public class RoomUnitManager {
     /**
      * Gets all room units (Habbos, Bots, Pets).
      */
-    public THashSet<RoomUnit> getRoomUnits() {
+    public Set<RoomUnit> getRoomUnits() {
         return getRoomUnits(null);
     }
 
     /**
      * Gets all room units at a specific tile.
      */
-    public THashSet<RoomUnit> getRoomUnits(RoomTile atTile) {
-        THashSet<RoomUnit> units = new THashSet<>();
+    public Set<RoomUnit> getRoomUnits(RoomTile atTile) {
+        Set<RoomUnit> units = new HashSet<>();
 
         for (Habbo habbo : this.currentHabbos.values()) {
             if (habbo != null && habbo.getRoomUnit() != null && habbo.getRoomUnit().getRoom() != null
@@ -1179,7 +1092,7 @@ public class RoomUnitManager {
             }
         }
 
-        for (Pet pet : this.currentPets.valueCollection()) {
+        for (Pet pet : this.currentPets.values()) {
             if (pet != null && pet.getRoomUnit() != null && pet.getRoomUnit().getRoom() != null
                     && pet.getRoomUnit().getRoom().getId() == this.room.getId() && (atTile == null
                     || pet.getRoomUnit().getCurrentLocation() == atTile)) {
@@ -1187,7 +1100,7 @@ public class RoomUnitManager {
             }
         }
 
-        for (Bot bot : this.currentBots.valueCollection()) {
+        for (Bot bot : this.currentBots.values()) {
             if (bot != null && bot.getRoomUnit() != null && bot.getRoomUnit().getRoom() != null
                     && bot.getRoomUnit().getRoom().getId() == this.room.getId() && (atTile == null
                     || bot.getRoomUnit().getCurrentLocation() == atTile)) {
@@ -1202,7 +1115,7 @@ public class RoomUnitManager {
      * Gets room units at a specific tile as a collection.
      */
     public Collection<RoomUnit> getRoomUnitsAt(RoomTile tile) {
-        THashSet<RoomUnit> roomUnits = getRoomUnits();
+        Set<RoomUnit> roomUnits = getRoomUnits();
         return roomUnits.stream().filter(unit -> unit.getCurrentLocation().equals(tile))
                 .collect(Collectors.toSet());
     }
@@ -1240,7 +1153,7 @@ public class RoomUnitManager {
         BedProfile bedProfile = new BedProfile(bed);
         if (!bedProfile.isDouble()) return;
 
-        THashSet<Habbo> habbosOnBed = this.getHabbosOnItem(bed);
+        Set<Habbo> habbosOnBed = this.getHabbosOnItem(bed);
 
         Habbo male = null;
         Habbo female = null;
@@ -1395,18 +1308,11 @@ public class RoomUnitManager {
 
         // Have pets greet their owner
         synchronized (this.currentPets) {
-            TIntObjectIterator<Pet> petIterator = this.currentPets.iterator();
-            for (int i = this.currentPets.size(); i-- > 0; ) {
-                try {
-                    petIterator.advance();
-                    Pet pet = petIterator.value();
-                    if (pet.getUserId() == habbo.getHabboInfo().getId()) {
-                        // Pet sees its owner - greet them!
-                        pet.say(pet.getPetData().randomVocal(PetVocalsType.GREET_OWNER));
-                        pet.addHappiness(10);
-                    }
-                } catch (Exception e) {
-                    break;
+            for (Pet pet : this.currentPets.values()) {
+                if (pet.getUserId() == habbo.getHabboInfo().getId()) {
+                    // Pet sees its owner - greet them!
+                    pet.say(pet.getPetData().randomVocal(PetVocalsType.GREET_OWNER));
+                    pet.addHappiness(10);
                 }
             }
         }
@@ -1415,18 +1321,9 @@ public class RoomUnitManager {
             if (habbo.getHabboInfo().getId() != this.room.getOwnerId()) {
                 return;
             }
-
-            TIntObjectIterator<Bot> botIterator = this.currentBots.iterator();
-
-            for (int i = this.currentBots.size(); i-- > 0; ) {
-                try {
-                    botIterator.advance();
-
-                    if (botIterator.value() instanceof VisitorBot) {
-                        ((VisitorBot) botIterator.value()).onUserEnter(habbo);
-                        break;
-                    }
-                } catch (Exception e) {
+            for (Bot bot : this.currentBots.values()) {
+                if (bot instanceof VisitorBot) {
+                    ((VisitorBot) bot).onUserEnter(habbo);
                     break;
                 }
             }
@@ -1493,13 +1390,13 @@ public class RoomUnitManager {
                 WiredUserMovementHelper.cleanupRoomUnit(habbo.getRoomUnit());
             }
         }
-        for (Bot bot : this.currentBots.valueCollection()) {
+        for (Bot bot : this.currentBots.values()) {
             if (bot.getRoomUnit() != null) {
                 WiredMoveCarryHelper.cleanupRoomUnit(bot.getRoomUnit());
                 WiredUserMovementHelper.cleanupRoomUnit(bot.getRoomUnit());
             }
         }
-        for (Pet pet : this.currentPets.valueCollection()) {
+        for (Pet pet : this.currentPets.values()) {
             if (pet.getRoomUnit() != null) {
                 WiredMoveCarryHelper.cleanupRoomUnit(pet.getRoomUnit());
                 WiredUserMovementHelper.cleanupRoomUnit(pet.getRoomUnit());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitManager.java
@@ -370,7 +370,7 @@ public class RoomUnitManager {
     /**
      * Updates specific Habbos at a position.
      */
-    public void updateHabbosAt(short x, short y, THashSet<Habbo> habbos) {
+    public void updateHabbosAt(short x, short y, Collection<Habbo> habbos) {
         RoomTile tile = this.room.getLayout().getTile(x, y);
 
         if (tile == null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableManager.java
@@ -699,7 +699,7 @@ public class RoomUserVariableManager {
             return Collections.emptyList();
         }
 
-        THashSet<InteractionWiredExtra> extras = this.room.getRoomSpecialTypes().getExtras();
+        Collection<InteractionWiredExtra> extras = this.room.getRoomSpecialTypes().getExtras();
         List<WiredExtraUserVariable> result = new ArrayList<>();
 
         for (InteractionWiredExtra extra : extras) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableManager.java
@@ -12,7 +12,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredVariableLevelSystemSupport;
 import com.eu.habbo.habbohotel.wired.core.WiredVariableTextConnectorSupport;
 import com.eu.habbo.messages.outgoing.wired.WiredUserVariablesDataComposer;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,10 +23,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class RoomUserVariableManager {
@@ -570,7 +571,7 @@ public class RoomUserVariableManager {
         List<UserAssignmentsEntry> users = new ArrayList<>();
         List<WiredExtraVariableReference> userReferences = this.getUserReferences();
         List<WiredExtraVariableEcho> userEchoes = this.getUserEchoes();
-        THashSet<Integer> userIds = new THashSet<>();
+        Set<Integer> userIds = new HashSet<>();
         userIds.addAll(this.activeAssignmentsByUserId.keySet());
 
         for (Habbo habbo : this.room.getCurrentHabbos().values()) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomVariableManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomVariableManager.java
@@ -468,7 +468,7 @@ public class RoomVariableManager {
             return Collections.emptyList();
         }
 
-        THashSet<InteractionWiredExtra> extras = this.room.getRoomSpecialTypes().getExtras();
+        Collection<InteractionWiredExtra> extras = this.room.getRoomSpecialTypes().getExtras();
         List<WiredExtraRoomVariable> result = new ArrayList<>();
 
         for (InteractionWiredExtra extra : extras) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomVariableManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomVariableManager.java
@@ -12,7 +12,6 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredVariableLevelSystemSupport;
 import com.eu.habbo.habbohotel.wired.core.WiredVariableTextConnectorSupport;
 import com.eu.habbo.messages.outgoing.wired.WiredUserVariablesDataComposer;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/TraxManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/TraxManager.java
@@ -366,7 +366,7 @@ public class TraxManager implements Disposable {
     }
 
     public List<InteractionMusicDisc> myList(Habbo habbo) {
-        return habbo.getInventory().getItemsComponent().getItems().valueCollection().stream()
+        return habbo.getInventory().getItemsComponent().getItems().values().stream()
                 .filter(i -> i instanceof InteractionMusicDisc && i.getRoomId() == 0)
                 .map(i -> (InteractionMusicDisc) i)
                 .collect(Collectors.toList());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -20,7 +20,6 @@ import com.eu.habbo.plugin.events.users.UserDisconnectEvent;
 import com.eu.habbo.plugin.events.users.UserGetIPAddressEvent;
 import com.eu.habbo.plugin.events.users.UserPointsEvent;
 import it.unimi.dsi.fastutil.ints.IntCollection;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -355,7 +355,7 @@ public class Habbo implements Runnable {
     }
 
 
-    public void addFurniture(THashSet<HabboItem> items) {
+    public void addFurniture(Collection<HabboItem> items) {
         this.habboInventory.getItemsComponent().addItems(items);
         this.client.sendResponse(new AddHabboItemComposer(items));
         this.client.sendResponse(new InventoryRefreshComposer());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -468,7 +468,7 @@ public class Habbo implements Runnable {
         int currentTimestamp = Emulator.getIntUnixTimestamp();
         int twentyFourHoursInSeconds = 24 * 60 * 60; // 24 hours in seconds
 
-        THashMap<Integer, List<Integer>> newLog = new THashMap<>();
+        Map<Integer, List<Integer>> newLog = new HashMap<>();
 
         for (Map.Entry<Integer, List<Integer>> ltdLog : this.habboStats.ltdPurchaseLog.entrySet()) {
             List<Integer> filteredTimestamps = new ArrayList<>();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -20,7 +20,6 @@ import com.eu.habbo.plugin.events.users.UserDisconnectEvent;
 import com.eu.habbo.plugin.events.users.UserGetIPAddressEvent;
 import com.eu.habbo.plugin.events.users.UserPointsEvent;
 import it.unimi.dsi.fastutil.ints.IntCollection;
-import gnu.trove.map.hash.THashMap;
 import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -410,7 +409,7 @@ public class Habbo implements Runnable {
             this.client.sendResponse(new AddUserBadgeComposer(badge, senderName));
             this.client.sendResponse(new AddHabboItemComposer(badge.getId(), AddHabboItemComposer.AddHabboItemCategory.BADGE));
 
-            THashMap<String, String> keys = new THashMap<>();
+            Map<String, String> keys = new HashMap<>();
             keys.put("display", "BUBBLE");
             keys.put("image", "${image.library.url}album1584/" + badge.getCode() + ".gif");
             keys.put("message", Emulator.getTexts().getValue("commands.generic.cmd_badge.received"));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -19,7 +19,7 @@ import com.eu.habbo.plugin.events.users.UserCreditsEvent;
 import com.eu.habbo.plugin.events.users.UserDisconnectEvent;
 import com.eu.habbo.plugin.events.users.UserGetIPAddressEvent;
 import com.eu.habbo.plugin.events.users.UserPointsEvent;
-import gnu.trove.TIntCollection;
+import it.unimi.dsi.fastutil.ints.IntCollection;
 import gnu.trove.map.hash.THashMap;
 import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
@@ -505,7 +505,7 @@ public class Habbo implements Runnable {
     }
 
     public Set<Integer> getForbiddenClothing() {
-        TIntCollection clothingIDs = this.getInventory().getWardrobeComponent().getClothing();
+        IntCollection clothingIDs = this.getInventory().getWardrobeComponent().getClothing();
 
         return Emulator.getGameEnvironment().getCatalogManager().clothing.values().stream()
                 .filter(c -> !clothingIDs.contains(c.id))

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInfo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInfo.java
@@ -14,7 +14,8 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
-import gnu.trove.map.hash.TIntIntHashMap;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +55,7 @@ public class HabboInfo implements Runnable {
     private int roomQueueId;
     private RideablePet riding;
     private Class<? extends Game> currentGame;
-    private TIntIntHashMap currencies;
+    private Int2IntOpenHashMap currencies;
     // Serializes credits + currencies read-modify-write and the saveCurrencies
     // snapshot so the credit-roller thread and purchase/trade handler threads
     // can't lose updates or rehash the Trove map mid-iteration. Never held
@@ -115,7 +116,7 @@ public class HabboInfo implements Runnable {
     }
 
     private void loadCurrencies() {
-        this.currencies = new TIntIntHashMap();
+        this.currencies = new Int2IntOpenHashMap();
 
         try {
             SqlQueries.forEach(
@@ -133,10 +134,9 @@ public class HabboInfo implements Runnable {
         List<int[]> entries;
         synchronized (this.currencyLock) {
             entries = new ArrayList<>(this.currencies.size());
-            this.currencies.forEachEntry((type, amount) -> {
-                entries.add(new int[]{type, amount});
-                return true;
-            });
+            for (Int2IntMap.Entry entry : this.currencies.int2IntEntrySet()) {
+                entries.add(new int[]{entry.getIntKey(), entry.getIntValue()});
+            }
         }
 
         try {
@@ -253,17 +253,17 @@ public class HabboInfo implements Runnable {
         }
     }
 
-    public TIntIntHashMap getCurrencies() {
+    public Int2IntOpenHashMap getCurrencies() {
         // Return a snapshot under the lock: callers iterate this map, which would
-        // otherwise corrupt during a concurrent adjustOrPutValue rehash.
+        // otherwise corrupt during a concurrent addTo/put rehash.
         synchronized (this.currencyLock) {
-            return new TIntIntHashMap(this.currencies);
+            return new Int2IntOpenHashMap(this.currencies);
         }
     }
 
     public void addCurrencyAmount(int type, int amount) {
         synchronized (this.currencyLock) {
-            this.currencies.adjustOrPutValue(type, amount, amount);
+            this.currencies.addTo(type, amount);
         }
         this.run();
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInventory.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInventory.java
@@ -4,9 +4,10 @@ import com.eu.habbo.habbohotel.catalog.marketplace.MarketPlace;
 import com.eu.habbo.habbohotel.catalog.marketplace.MarketPlaceOffer;
 import com.eu.habbo.habbohotel.catalog.marketplace.MarketPlaceState;
 import com.eu.habbo.habbohotel.users.inventory.*;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
 
 public class HabboInventory {
 
@@ -14,7 +15,7 @@ public class HabboInventory {
 
     //Configuration. Loaded from database & updated accordingly.
     public static int MAXIMUM_ITEMS = 10000;
-    private final THashSet<MarketPlaceOffer> items;
+    private final Set<MarketPlaceOffer> items;
     private final Habbo habbo;
     private WardrobeComponent wardrobeComponent;
     private BadgesComponent badgesComponent;
@@ -187,7 +188,7 @@ public class HabboInventory {
         this.items.remove(marketPlaceOffer);
     }
 
-    public THashSet<MarketPlaceOffer> getMarketplaceItems() {
+    public Set<MarketPlaceOffer> getMarketplaceItems() {
         return this.items;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboItem.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboItem.java
@@ -17,7 +17,6 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserDanceComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserDataComposer;
 import com.eu.habbo.messages.outgoing.users.UpdateUserLookComposer;
-import gnu.trove.set.hash.THashSet;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.math3.util.Pair;
 import org.slf4j.Logger;
@@ -31,6 +30,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 public abstract class HabboItem implements Runnable, IEventTriggers {
 
@@ -527,7 +527,7 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
         return this.baseItem.getStateCount() > 1;
     }
 
-    public boolean canStackAt(Room room, List<Pair<RoomTile, THashSet<HabboItem>>> itemsAtLocation) {
+    public boolean canStackAt(Room room, List<Pair<RoomTile, Set<HabboItem>>> itemsAtLocation) {
         return true;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboNavigatorWindowSettings.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboNavigatorWindowSettings.java
@@ -3,7 +3,6 @@ package com.eu.habbo.habbohotel.users;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.navigation.DisplayMode;
 import com.eu.habbo.habbohotel.navigation.ListMode;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,11 +10,12 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Map;
 
 public class HabboNavigatorWindowSettings {
     private static final Logger LOGGER = LoggerFactory.getLogger(HabboNavigatorWindowSettings.class);
-    public final THashMap<String, HabboNavigatorPersonalDisplayMode> displayModes = new THashMap<>(2);
+    public final Map<String, HabboNavigatorPersonalDisplayMode> displayModes = new HashMap<>(2);
     private final int userId;
     public int x = 100;
     public int y = 100;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
@@ -104,7 +104,7 @@ public class HabboStats implements Runnable {
     public int hcGiftsClaimed;
     public int buildersClubBonusFurni;
     public int hcMessageLastModified = Emulator.getIntUnixTimestamp();
-    public THashSet<Subscription> subscriptions;
+    public Set<Subscription> subscriptions;
 
     private HabboStats(ResultSet set, HabboInfo habboInfo) throws SQLException {
         this.cache = new THashMap<>(1000);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
@@ -14,12 +14,9 @@ import com.eu.habbo.habbohotel.users.cache.HabboOfferPurchase;
 import com.eu.habbo.habbohotel.users.subscriptions.Subscription;
 import com.eu.habbo.plugin.events.users.subscriptions.UserSubscriptionCreatedEvent;
 import com.eu.habbo.plugin.events.users.subscriptions.UserSubscriptionExtendedEvent;
-import gnu.trove.list.array.TIntArrayList;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
-import gnu.trove.set.hash.THashSet;
-import gnu.trove.stack.array.TIntArrayStack;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,18 +29,18 @@ public class HabboStats implements Runnable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HabboStats.class);
 
-    public final TIntArrayList secretRecipes;
+    public final IntArrayList secretRecipes;
     public final HabboNavigatorWindowSettings navigatorWindowSettings;
-    public final THashMap<String, Object> cache;
+    public final Map<String, Object> cache;
     public final ArrayList<CalendarRewardClaimed> calendarRewardsClaimed;
-    public final TIntObjectMap<HabboOfferPurchase> offerCache = new TIntObjectHashMap<>();
+    public final Int2ObjectMap<HabboOfferPurchase> offerCache = new Int2ObjectOpenHashMap<>();
     private final AtomicInteger lastOnlineTime = new AtomicInteger(Emulator.getIntUnixTimestamp());
-    private final THashMap<Achievement, Integer> achievementProgress;
-    private final THashMap<Achievement, Integer> achievementCache;
-    private final THashMap<Integer, CatalogItem> recentPurchases;
-    private final TIntArrayList favoriteRooms;
-    private final TIntArrayList ignoredUsers;
-    private TIntArrayList roomsVists;
+    private final Map<Achievement, Integer> achievementProgress;
+    private final Map<Achievement, Integer> achievementCache;
+    private final Map<Integer, CatalogItem> recentPurchases;
+    private final IntArrayList favoriteRooms;
+    private final IntArrayList ignoredUsers;
+    private IntArrayList roomsVists;
     public int achievementScore;
     public int respectPointsReceived;
     public int respectPointsGiven;
@@ -62,7 +59,7 @@ public class HabboStats implements Runnable {
     public int guild;
     public List<Integer> guilds;
     public String[] tags;
-    public TIntArrayStack votedRooms;
+    public IntArrayList votedRooms;
     public int loginStreak;
     public int rentedItemId;
     public int rentedTimeEnd;
@@ -85,7 +82,7 @@ public class HabboStats implements Runnable {
     public boolean allowNameChange;
     public boolean isPurchasingFurniture = false;
     public int forumPostsCount;
-    public THashMap<Integer, List<Integer>> ltdPurchaseLog = new THashMap<>(0);
+    public Map<Integer, List<Integer>> ltdPurchaseLog = new HashMap<>(0);
     public long lastTradeTimestamp = Emulator.getIntUnixTimestamp();
     public long lastGiftTimestamp = Emulator.getIntUnixTimestamp();
     public long lastPurchaseTimestamp = Emulator.getIntUnixTimestamp();
@@ -107,14 +104,14 @@ public class HabboStats implements Runnable {
     public Set<Subscription> subscriptions;
 
     private HabboStats(ResultSet set, HabboInfo habboInfo) throws SQLException {
-        this.cache = new THashMap<>(1000);
-        this.achievementProgress = new THashMap<>(0);
-        this.achievementCache = new THashMap<>(0);
-        this.recentPurchases = new THashMap<>(0);
-        this.favoriteRooms = new TIntArrayList(0);
-        this.ignoredUsers = new TIntArrayList(0);
-        this.roomsVists = new TIntArrayList(0);
-        this.secretRecipes = new TIntArrayList(0);
+        this.cache = new HashMap<>(1000);
+        this.achievementProgress = new HashMap<>(0);
+        this.achievementCache = new HashMap<>(0);
+        this.recentPurchases = new HashMap<>(0);
+        this.favoriteRooms = new IntArrayList(0);
+        this.ignoredUsers = new IntArrayList(0);
+        this.roomsVists = new IntArrayList(0);
+        this.secretRecipes = new IntArrayList(0);
         this.calendarRewardsClaimed = new ArrayList<>();
 
         this.habboInfo = habboInfo;
@@ -135,7 +132,7 @@ public class HabboStats implements Runnable {
         this.allowTrade = set.getString("can_trade").equals("1");
         this.mentionsEnabled = "1".equals(safeColumnString(set, "mentions_enabled", "1"));
         this.massMentionsEnabled = "1".equals(safeColumnString(set, "mass_mentions_enabled", "1"));
-        this.votedRooms = new TIntArrayStack();
+        this.votedRooms = new IntArrayList();
         this.clubExpireTimestamp = set.getInt("club_expire_timestamp");
         this.loginStreak = set.getInt("login_streak");
         this.rentedItemId = set.getInt("rent_space_id");
@@ -302,7 +299,7 @@ public class HabboStats implements Runnable {
                     statement.setInt(1, habboInfo.getId());
                     try (ResultSet set = statement.executeQuery()) {
                         while (set.next()) {
-                            stats.votedRooms.push(set.getInt("room_id"));
+                            stats.votedRooms.add(set.getInt("room_id"));
                         }
                     }
                 }
@@ -391,7 +388,7 @@ public class HabboStats implements Runnable {
 
             if (!this.offerCache.isEmpty()) {
                 try (PreparedStatement statement = connection.prepareStatement("UPDATE users_target_offer_purchases SET state = ?, amount = ?, last_purchase = ? WHERE user_id = ? AND offer_id = ?")) {
-                    for (HabboOfferPurchase purchase : this.offerCache.valueCollection()) {
+                    for (HabboOfferPurchase purchase : this.offerCache.values()) {
                         if (!purchase.needsUpdate()) continue;
 
                         statement.setInt(1, purchase.getState());
@@ -611,11 +608,11 @@ public class HabboStats implements Runnable {
         this.buildersClubBonusFurni += amount;
     }
 
-    public THashMap<Achievement, Integer> getAchievementProgress() {
+    public Map<Achievement, Integer> getAchievementProgress() {
         return this.achievementProgress;
     }
 
-    public THashMap<Achievement, Integer> getAchievementCache() {
+    public Map<Achievement, Integer> getAchievementCache() {
         return this.achievementCache;
     }
 
@@ -625,7 +622,7 @@ public class HabboStats implements Runnable {
         }
     }
 
-    public THashMap<Integer, CatalogItem> getRecentPurchases() {
+    public Map<Integer, CatalogItem> getRecentPurchases() {
         return this.recentPurchases;
     }
 
@@ -653,7 +650,9 @@ public class HabboStats implements Runnable {
     }
 
     public void removeFavoriteRoom(int roomId) {
-        if (this.favoriteRooms.remove(roomId)) {
+        int index = this.favoriteRooms.indexOf(roomId);
+        if (index >= 0) {
+            this.favoriteRooms.removeInt(index);
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("DELETE FROM users_favorite_rooms WHERE user_id = ? AND room_id = ? LIMIT 1")) {
                 statement.setInt(1, this.habboInfo.getId());
                 statement.setInt(2, roomId);
@@ -672,7 +671,7 @@ public class HabboStats implements Runnable {
 
     public void addVisitRoom(int roomId) { this.roomsVists.add(roomId); }
 
-    public TIntArrayList getFavoriteRooms() {
+    public IntArrayList getFavoriteRooms() {
         return this.favoriteRooms;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/clothingvalidation/ClothingValidationManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/clothingvalidation/ClothingValidationManager.java
@@ -1,13 +1,14 @@
 package com.eu.habbo.habbohotel.users.clothingvalidation;
 
 import com.eu.habbo.habbohotel.users.Habbo;
-import gnu.trove.map.hash.THashMap;
 import it.unimi.dsi.fastutil.ints.IntCollection;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 public class ClothingValidationManager {
@@ -98,7 +99,7 @@ public class ClothingValidationManager {
         String[] newLookParts = look.split(Pattern.quote("."));
         ArrayList<String> lookParts = new ArrayList<>();
 
-        THashMap<String, String[]> parts = new THashMap<>();
+        Map<String, String[]> parts = new HashMap<>();
 
         // add mandatory settypes
         for(String lookpart : newLookParts) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/clothingvalidation/ClothingValidationManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/clothingvalidation/ClothingValidationManager.java
@@ -1,9 +1,9 @@
 package com.eu.habbo.habbohotel.users.clothingvalidation;
 
 import com.eu.habbo.habbohotel.users.Habbo;
-import gnu.trove.TIntCollection;
 import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.TIntHashSet;
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +69,7 @@ public class ClothingValidationManager {
      * @return Cleaned figure string
      */
     public static String validateLook(String look, String gender) {
-        return validateLook(look, gender, false, new TIntHashSet());
+        return validateLook(look, gender, false, new IntOpenHashSet());
     }
 
     /**
@@ -80,7 +80,7 @@ public class ClothingValidationManager {
      * @return Cleaned figure string
      */
     public static String validateLook(String look, String gender, boolean isHC) {
-        return validateLook(look, gender, isHC, new TIntHashSet());
+        return validateLook(look, gender, isHC, new IntOpenHashSet());
     }
 
     /**
@@ -91,7 +91,7 @@ public class ClothingValidationManager {
      * @param ownedClothing Array of owned clothing set IDs. If sellable and setId not in this array clothing will be removed
      * @return Cleaned figure string
      */
-    public static String validateLook(String look, String gender, boolean isHC, TIntCollection ownedClothing) {
+    public static String validateLook(String look, String gender, boolean isHC, IntCollection ownedClothing) {
         if(FIGUREDATA.palettes.size() == 0 || FIGUREDATA.settypes.size() == 0)
             return look;
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/BadgesComponent.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/BadgesComponent.java
@@ -4,7 +4,6 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.permissions.Rank;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboBadge;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,19 +13,20 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Set;
 
 public class BadgesComponent {
     private static final Logger LOGGER = LoggerFactory.getLogger(BadgesComponent.class);
 
-    private final THashSet<HabboBadge> badges = new THashSet<>();
+    private final Set<HabboBadge> badges = new HashSet<>();
 
     public BadgesComponent(Habbo habbo) {
         this.badges.addAll(loadBadges(habbo));
     }
 
-    private static THashSet<HabboBadge> loadBadges(Habbo habbo) {
-        THashSet<HabboBadge> badgesList = new THashSet<>();
+    private static Set<HabboBadge> loadBadges(Habbo habbo) {
+        Set<HabboBadge> badgesList = new HashSet<>();
         Set<String> staffBadges = Emulator.getGameEnvironment().getPermissionsManager().getStaffBadges();
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM users_badges WHERE user_id = ?")) {
             statement.setInt(1, habbo.getHabboInfo().getId());
@@ -124,7 +124,7 @@ public class BadgesComponent {
         }
     }
 
-    public THashSet<HabboBadge> getBadges() {
+    public Set<HabboBadge> getBadges() {
         return this.badges;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/BotsComponent.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/BotsComponent.java
@@ -3,7 +3,6 @@ package com.eu.habbo.habbohotel.users.inventory;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.bots.Bot;
 import com.eu.habbo.habbohotel.users.Habbo;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,12 +10,13 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Map;
 
 public class BotsComponent {
     private static final Logger LOGGER = LoggerFactory.getLogger(BotsComponent.class);
 
-    private final THashMap<Integer, Bot> bots = new THashMap<>();
+    private final Map<Integer, Bot> bots = new HashMap<>();
 
     public BotsComponent(Habbo habbo) {
         this.loadBots(habbo);
@@ -56,7 +56,7 @@ public class BotsComponent {
         }
     }
 
-    public THashMap<Integer, Bot> getBots() {
+    public Map<Integer, Bot> getBots() {
         return this.bots;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/EffectsComponent.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/EffectsComponent.java
@@ -5,7 +5,8 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.inventory.EffectsListAddComposer;
 import com.eu.habbo.messages.outgoing.inventory.EffectsListEffectEnableComposer;
 import com.eu.habbo.messages.outgoing.inventory.EffectsListRemoveComposer;
-import gnu.trove.map.hash.THashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +18,7 @@ import java.sql.SQLException;
 public class EffectsComponent {
     private static final Logger LOGGER = LoggerFactory.getLogger(EffectsComponent.class);
 
-    public final THashMap<Integer, HabboEffect> effects = new THashMap<>();
+    public final Int2ObjectMap<HabboEffect> effects = new Int2ObjectOpenHashMap<>();
     public final Habbo habbo;
     public int activatedEffect = 0;
 
@@ -82,7 +83,7 @@ public class EffectsComponent {
     public void dispose() {
         synchronized (this.effects) {
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE users_effects SET duration = ?, activation_timestamp = ?, total = ? WHERE user_id = ? AND effect = ?")) {
-                this.effects.forEachValue(effect -> {
+                for (HabboEffect effect : this.effects.values()) {
                     if(!effect.isRankEnable) {
                         try {
                             statement.setInt(1, effect.duration);
@@ -95,8 +96,7 @@ public class EffectsComponent {
                             LOGGER.error("Caught SQL exception", e);
                         }
                     }
-                    return true;
-                });
+                }
 
                 statement.executeBatch();
             } catch (SQLException e) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/ItemsComponent.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/ItemsComponent.java
@@ -8,13 +8,10 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.plugin.events.inventory.InventoryItemAddedEvent;
 import com.eu.habbo.plugin.events.inventory.InventoryItemRemovedEvent;
 import com.eu.habbo.plugin.events.inventory.InventoryItemsAddedEvent;
-import gnu.trove.TCollections;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
-import gnu.trove.procedure.TObjectProcedure;
 import gnu.trove.set.hash.THashSet;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,12 +20,13 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.NoSuchElementException;
+import java.util.HashSet;
+import java.util.Set;
 
 public class ItemsComponent {
     private static final Logger LOGGER = LoggerFactory.getLogger(ItemsComponent.class);
 
-    private final TIntObjectMap<HabboItem> items = TCollections.synchronizedMap(new TIntObjectHashMap<>());
+    private final Int2ObjectMap<HabboItem> items = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
 
     private final HabboInventory inventory;
 
@@ -37,8 +35,8 @@ public class ItemsComponent {
         this.items.putAll(loadItems(habbo));
     }
 
-    public static THashMap<Integer, HabboItem> loadItems(Habbo habbo) {
-        THashMap<Integer, HabboItem> itemsList = new THashMap<>();
+    public static Int2ObjectMap<HabboItem> loadItems(Habbo habbo) {
+        Int2ObjectMap<HabboItem> itemsList = new Int2ObjectOpenHashMap<>();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT items.* FROM items LEFT JOIN builders_club_items ON builders_club_items.item_id = items.id WHERE items.room_id = ? AND items.user_id = ? AND builders_club_items.item_id IS NULL")) {
             statement.setInt(1, 0);
@@ -104,17 +102,12 @@ public class ItemsComponent {
     public HabboItem getAndRemoveHabboItem(final Item item) {
         final HabboItem[] habboItem = {null};
         synchronized (this.items) {
-            this.items.forEachValue(new TObjectProcedure<HabboItem>() {
-                @Override
-                public boolean execute(HabboItem object) {
-                    if (object.getBaseItem() == item) {
-                        habboItem[0] = object;
-                        return false;
-                    }
-
-                    return true;
+            for (HabboItem object : this.items.values()) {
+                if (object.getBaseItem() == item) {
+                    habboItem[0] = object;
+                    break;
                 }
-            });
+            }
         }
         this.removeHabboItem(habboItem[0]);
         return habboItem[0];
@@ -135,15 +128,12 @@ public class ItemsComponent {
         }
     }
 
-    public TIntObjectMap<HabboItem> getItems() {
+    public Int2ObjectMap<HabboItem> getItems() {
         return this.items;
     }
 
-    public THashSet<HabboItem> getItemsAsValueCollection() {
-        THashSet<HabboItem> items = new THashSet<>();
-        items.addAll(this.items.valueCollection());
-
-        return items;
+    public Set<HabboItem> getItemsAsValueCollection() {
+        return new HashSet<>(this.items.values());
     }
 
     public int itemCount() {
@@ -152,13 +142,6 @@ public class ItemsComponent {
 
     public void dispose() {
         synchronized (this.items) {
-            TIntObjectIterator<HabboItem> items = this.items.iterator();
-
-            if (items == null) {
-                LOGGER.error("Items is NULL!");
-                return;
-            }
-
             if (!this.items.isEmpty()) {
                 try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
                     try (PreparedStatement updateStmt = connection.prepareStatement(
@@ -169,14 +152,7 @@ public class ItemsComponent {
                             int updateCount = 0;
                             int deleteCount = 0;
 
-                            for (int i = this.items.size(); i-- > 0; ) {
-                                try {
-                                    items.advance();
-                                } catch (NoSuchElementException e) {
-                                    break;
-                                }
-
-                                HabboItem item = items.value();
+                            for (HabboItem item : this.items.values()) {
                                 if (item.needsDelete()) {
                                     deleteStmt.setInt(1, item.getId());
                                     deleteStmt.addBatch();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/ItemsComponent.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/ItemsComponent.java
@@ -22,6 +22,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.NoSuchElementException;
 
 public class ItemsComponent {
@@ -79,8 +80,8 @@ public class ItemsComponent {
         }
     }
 
-    public void addItems(THashSet<HabboItem> items) {
-        InventoryItemsAddedEvent event = new InventoryItemsAddedEvent(this.inventory, items);
+    public void addItems(Collection<HabboItem> items) {
+        InventoryItemsAddedEvent event = new InventoryItemsAddedEvent(this.inventory, new THashSet<>(items));
         if (Emulator.getPluginManager().fireEvent(event).isCancelled()) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/ItemsComponent.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/ItemsComponent.java
@@ -8,7 +8,6 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.plugin.events.inventory.InventoryItemAddedEvent;
 import com.eu.habbo.plugin.events.inventory.InventoryItemRemovedEvent;
 import com.eu.habbo.plugin.events.inventory.InventoryItemsAddedEvent;
-import gnu.trove.set.hash.THashSet;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -79,7 +78,7 @@ public class ItemsComponent {
     }
 
     public void addItems(Collection<HabboItem> items) {
-        InventoryItemsAddedEvent event = new InventoryItemsAddedEvent(this.inventory, new THashSet<>(items));
+        InventoryItemsAddedEvent event = new InventoryItemsAddedEvent(this.inventory, new HashSet<>(items));
         if (Emulator.getPluginManager().fireEvent(event).isCancelled()) {
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/PetsComponent.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/PetsComponent.java
@@ -4,10 +4,9 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.pets.Pet;
 import com.eu.habbo.habbohotel.pets.PetManager;
 import com.eu.habbo.habbohotel.users.Habbo;
-import gnu.trove.TCollections;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,12 +14,11 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.NoSuchElementException;
 import java.util.Set;
 
 public class PetsComponent {
     private static final Logger LOGGER = LoggerFactory.getLogger(PetsComponent.class);
-    private final TIntObjectMap<Pet> pets = TCollections.synchronizedMap(new TIntObjectHashMap<>());
+    private final Int2ObjectMap<Pet> pets = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
 
     public PetsComponent(Habbo habbo) {
         this.loadPets(habbo);
@@ -66,7 +64,7 @@ public class PetsComponent {
         }
     }
 
-    public TIntObjectMap<Pet> getPets() {
+    public Int2ObjectMap<Pet> getPets() {
         return this.pets;
     }
 
@@ -76,16 +74,9 @@ public class PetsComponent {
 
     public void dispose() {
         synchronized (this.pets) {
-            TIntObjectIterator<Pet> petIterator = this.pets.iterator();
-
-            for (int i = this.pets.size(); i-- > 0; ) {
-                try {
-                    petIterator.advance();
-                } catch (NoSuchElementException e) {
-                    break;
-                }
-                if (petIterator.value().needsUpdate)
-                    Emulator.getThreading().run(petIterator.value());
+            for (Pet pet : this.pets.values()) {
+                if (pet.needsUpdate)
+                    Emulator.getThreading().run(pet);
             }
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/WardrobeComponent.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/WardrobeComponent.java
@@ -3,10 +3,9 @@ package com.eu.habbo.habbohotel.users.inventory;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboGender;
-import gnu.trove.TIntCollection;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.TIntSet;
-import gnu.trove.set.hash.TIntHashSet;
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,18 +13,20 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 public class WardrobeComponent {
     private static final Logger LOGGER = LoggerFactory.getLogger(WardrobeComponent.class);
-    private final THashMap<Integer, WardrobeItem> looks;
-    private final TIntSet clothing;
-    private final TIntSet clothingSets;
+    private final Map<Integer, WardrobeItem> looks;
+    private final IntSet clothing;
+    private final IntSet clothingSets;
 
     public WardrobeComponent(Habbo habbo) {
-        this.looks = new THashMap<>();
-        this.clothing = new TIntHashSet();
-        this.clothingSets = new TIntHashSet();
+        this.looks = new HashMap<>();
+        this.clothing = new IntOpenHashSet();
+        this.clothingSets = new IntOpenHashSet();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement("SELECT * FROM users_wardrobe WHERE user_id = ?")) {
@@ -62,15 +63,15 @@ public class WardrobeComponent {
         return new WardrobeItem(habbo.getHabboInfo().getGender(), look, slotId, habbo);
     }
 
-    public THashMap<Integer, WardrobeItem> getLooks() {
+    public Map<Integer, WardrobeItem> getLooks() {
         return this.looks;
     }
 
-    public TIntCollection getClothing() {
+    public IntCollection getClothing() {
         return this.clothing;
     }
 
-    public TIntCollection getClothingSets() {
+    public IntCollection getClothingSets() {
         return this.clothingSets;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/SubscriptionManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/SubscriptionManager.java
@@ -1,8 +1,6 @@
 package com.eu.habbo.habbohotel.users.subscriptions;
 
 import com.eu.habbo.Emulator;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,6 +10,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Beny
@@ -20,10 +22,10 @@ public class SubscriptionManager {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionManager.class);
 
-    public THashMap<String, Class<? extends Subscription>> types;
+    public Map<String, Class<? extends Subscription>> types;
 
     public SubscriptionManager() {
-        this.types = new THashMap<>();
+        this.types = new HashMap<>();
     }
 
     public void init() {
@@ -56,8 +58,8 @@ public class SubscriptionManager {
         this.types.clear();
     }
 
-    public THashSet<Subscription> getSubscriptionsForUser(int userId) {
-        THashSet<Subscription> subscriptions = new THashSet<>();
+    public Set<Subscription> getSubscriptionsForUser(int userId) {
+        Set<Subscription> subscriptions = new HashSet<>();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
              PreparedStatement statement = connection.prepareStatement("SELECT * FROM users_subscriptions WHERE user_id = ?")) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wheel/WheelManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wheel/WheelManager.java
@@ -4,7 +4,6 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,6 +13,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -243,7 +243,7 @@ public class WheelManager {
         Item base = Emulator.getGameEnvironment().getItemManager().getItem(baseId);
         if (base == null) return;
 
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
         for (int i = 0; i < quantity; i++) {
             HabboItem item = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getHabboInfo().getId(), base, 0, 0, "");
             if (item != null) items.add(item);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredHandler.java
@@ -33,7 +33,6 @@ import com.eu.habbo.plugin.events.furniture.wired.WiredStackTriggeredEvent;
 import com.eu.habbo.plugin.events.users.UserWiredRewardReceived;
 import com.eu.habbo.habbohotel.wired.core.WiredExecutionOrderUtil;
 import com.google.gson.GsonBuilder;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +47,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.HashSet;
 import java.util.Set;
 
 public class WiredHandler {
@@ -241,8 +241,8 @@ public class WiredHandler {
                 return false;
             }
 
-            THashSet<InteractionWiredEffect> legacyEffects = new THashSet<>(effects);
-            THashSet<InteractionWiredCondition> legacyConditions = new THashSet<>(conditions);
+            Set<InteractionWiredEffect> legacyEffects = new HashSet<>(effects);
+            Set<InteractionWiredCondition> legacyConditions = new HashSet<>(conditions);
 
             if (Emulator.getPluginManager().fireEvent(new WiredStackTriggeredEvent(room, roomUnit, trigger, legacyEffects, legacyConditions)).isCancelled())
                 return false;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredHandler.java
@@ -42,6 +42,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -447,7 +448,7 @@ public class WiredHandler {
         return (((long) x) << 32) | (y & 0xffffffffL);
     }
 
-    public static boolean executeEffectsAtTiles(THashSet<RoomTile> tiles, final RoomUnit roomUnit, final Room room, final Object[] stuff) {
+    public static boolean executeEffectsAtTiles(Collection<RoomTile> tiles, final RoomUnit roomUnit, final Room room, final Object[] stuff) {
         for (RoomTile tile : tiles) {
             if (room != null) {
                 THashSet<HabboItem> items = room.getItemsAt(tile);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredHandler.java
@@ -83,7 +83,7 @@ public class WiredHandler {
         if (room.getRoomSpecialTypes() == null)
             return false;
 
-        THashSet<InteractionWiredTrigger> triggers = room.getRoomSpecialTypes().getTriggers(triggerType);
+        Collection<InteractionWiredTrigger> triggers = room.getRoomSpecialTypes().getTriggers(triggerType);
 
         if (triggers == null || triggers.isEmpty())
             return false;
@@ -131,7 +131,7 @@ public class WiredHandler {
         if (room.getRoomSpecialTypes() == null)
             return false;
 
-        THashSet<InteractionWiredTrigger> triggers = room.getRoomSpecialTypes().getTriggers(WiredTriggerType.CUSTOM);
+        Collection<InteractionWiredTrigger> triggers = room.getRoomSpecialTypes().getTriggers(WiredTriggerType.CUSTOM);
 
         if (triggers == null || triggers.isEmpty())
             return false;
@@ -189,9 +189,9 @@ public class WiredHandler {
 
         try {
         if (Emulator.isReady && ((Emulator.getConfig().getBoolean("wired.custom.enabled", false) && (trigger.canExecute(millis) || roomUnitId > -1) && trigger.userCanExecute(roomUnitId, millis)) || (!Emulator.getConfig().getBoolean("wired.custom.enabled", false) && trigger.canExecute(millis))) && trigger.execute(roomUnit, room, stuff)) {
-            THashSet<InteractionWiredCondition> conditions = room.getRoomSpecialTypes().getConditions(trigger.getX(), trigger.getY());
-            THashSet<InteractionWiredEffect> effects = room.getRoomSpecialTypes().getEffects(trigger.getX(), trigger.getY());
-            THashSet<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(trigger.getX(), trigger.getY());
+            Collection<InteractionWiredCondition> conditions = room.getRoomSpecialTypes().getConditions(trigger.getX(), trigger.getY());
+            Collection<InteractionWiredEffect> effects = room.getRoomSpecialTypes().getEffects(trigger.getX(), trigger.getY());
+            Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(trigger.getX(), trigger.getY());
             WiredExtraExecutionLimit executionLimitExtra = null;
             WiredExtraRandom randomExtra = null;
 
@@ -240,7 +240,10 @@ public class WiredHandler {
                 return false;
             }
 
-            if (Emulator.getPluginManager().fireEvent(new WiredStackTriggeredEvent(room, roomUnit, trigger, effects, conditions)).isCancelled())
+            THashSet<InteractionWiredEffect> legacyEffects = new THashSet<>(effects);
+            THashSet<InteractionWiredCondition> legacyConditions = new THashSet<>(conditions);
+
+            if (Emulator.getPluginManager().fireEvent(new WiredStackTriggeredEvent(room, roomUnit, trigger, legacyEffects, legacyConditions)).isCancelled())
                 return false;
 
             trigger.activateBox(room, roomUnit, millis);
@@ -278,7 +281,7 @@ public class WiredHandler {
                 }
             }
 
-            return !Emulator.getPluginManager().fireEvent(new WiredStackExecutedEvent(room, roomUnit, trigger, effects, conditions)).isCancelled();
+            return !Emulator.getPluginManager().fireEvent(new WiredStackExecutedEvent(room, roomUnit, trigger, legacyEffects, legacyConditions)).isCancelled();
         }
 
         return false;
@@ -287,7 +290,7 @@ public class WiredHandler {
         }
     }
 
-    private static boolean evaluateConditions(THashSet<InteractionWiredCondition> conditions, RoomUnit roomUnit, Room room, Object[] stuff, int evaluationMode, int evaluationValue) {
+    private static boolean evaluateConditions(Collection<InteractionWiredCondition> conditions, RoomUnit roomUnit, Room room, Object[] stuff, int evaluationMode, int evaluationValue) {
         if (conditions == null || conditions.isEmpty()) {
             return true;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredHandler.java
@@ -48,6 +48,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class WiredHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(WiredHandler.class);
@@ -454,7 +455,7 @@ public class WiredHandler {
     public static boolean executeEffectsAtTiles(Collection<RoomTile> tiles, final RoomUnit roomUnit, final Room room, final Object[] stuff) {
         for (RoomTile tile : tiles) {
             if (room != null) {
-                THashSet<HabboItem> items = room.getItemsAt(tile);
+                Set<HabboItem> items = room.getItemsAt(tile);
 
                 long millis = room.getCycleTimestamp();
                 for (final HabboItem item : items) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/RoomWiredStackIndex.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/RoomWiredStackIndex.java
@@ -16,7 +16,6 @@ import com.eu.habbo.habbohotel.wired.api.IWiredCondition;
 import com.eu.habbo.habbohotel.wired.api.IWiredEffect;
 import com.eu.habbo.habbohotel.wired.api.IWiredTrigger;
 import com.eu.habbo.habbohotel.wired.api.WiredStack;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -120,7 +119,7 @@ public final class RoomWiredStackIndex implements WiredStackIndex {
         }
 
         // Get all triggers of this type
-        THashSet<InteractionWiredTrigger> triggers = specialTypes.getTriggers(legacyType);
+        Collection<InteractionWiredTrigger> triggers = specialTypes.getTriggers(legacyType);
         if (triggers == null || triggers.isEmpty()) {
             return Collections.emptyList();
         }
@@ -149,7 +148,7 @@ public final class RoomWiredStackIndex implements WiredStackIndex {
         }
 
         RoomSpecialTypes specialTypes = room.getRoomSpecialTypes();
-        THashSet<InteractionWiredTrigger> triggers = specialTypes.getTriggers(tile.x, tile.y);
+        Collection<InteractionWiredTrigger> triggers = specialTypes.getTriggers(tile.x, tile.y);
 
         if (triggers == null || triggers.isEmpty()) {
             return Collections.emptyList();
@@ -180,15 +179,15 @@ public final class RoomWiredStackIndex implements WiredStackIndex {
         IWiredTrigger wrappedTrigger = trigger;
 
         // Get conditions at this location
-        THashSet<InteractionWiredCondition> rawConditions = specialTypes.getConditions(x, y);
+        Collection<InteractionWiredCondition> rawConditions = specialTypes.getConditions(x, y);
         List<IWiredCondition> conditions = collectConditions(rawConditions);
 
         // Get effects at this location
-        THashSet<InteractionWiredEffect> rawEffects = specialTypes.getEffects(x, y);
+        Collection<InteractionWiredEffect> rawEffects = specialTypes.getEffects(x, y);
         List<IWiredEffect> effects = collectEffects(rawEffects);
 
         // Check for extras
-        THashSet<InteractionWiredExtra> extras = specialTypes.getExtras(x, y);
+        Collection<InteractionWiredExtra> extras = specialTypes.getExtras(x, y);
         int conditionEvaluationMode = WiredExtraOrEval.MODE_ALL;
         int conditionEvaluationValue = 1;
         boolean useRandom = false;
@@ -232,7 +231,7 @@ public final class RoomWiredStackIndex implements WiredStackIndex {
     /**
      * Collect conditions into a list (they already implement IWiredCondition).
      */
-    private List<IWiredCondition> collectConditions(THashSet<InteractionWiredCondition> rawConditions) {
+    private List<IWiredCondition> collectConditions(Collection<InteractionWiredCondition> rawConditions) {
         if (rawConditions == null || rawConditions.isEmpty()) {
             return Collections.emptyList();
         }
@@ -247,7 +246,7 @@ public final class RoomWiredStackIndex implements WiredStackIndex {
     /**
      * Collect effects into a list (they already implement IWiredEffect).
      */
-    private List<IWiredEffect> collectEffects(THashSet<InteractionWiredEffect> rawEffects) {
+    private List<IWiredEffect> collectEffects(Collection<InteractionWiredEffect> rawEffects) {
         if (rawEffects == null || rawEffects.isEmpty()) {
             return Collections.emptyList();
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredContextVariableSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredContextVariableSupport.java
@@ -5,9 +5,9 @@ import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraContextV
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.WiredVariableDefinitionInfo;
 import com.eu.habbo.messages.outgoing.wired.WiredUserVariablesDataComposer;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
@@ -22,7 +22,7 @@ public final class WiredContextVariableSupport {
             return definitions;
         }
 
-        THashSet<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras();
+        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras();
         if (extras == null || extras.isEmpty()) {
             return definitions;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEngine.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEngine.java
@@ -29,7 +29,6 @@ import com.eu.habbo.messages.outgoing.generic.alerts.GenericAlertComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.ItemStateComposer;
 import com.eu.habbo.plugin.events.furniture.wired.WiredStackExecutedEvent;
 import com.eu.habbo.plugin.events.furniture.wired.WiredStackTriggeredEvent;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1380,8 +1379,8 @@ public final class WiredEngine {
         // Build legacy collections for event
         if (stack.triggerItem() instanceof InteractionWiredTrigger) {
             // This event is checked for cancellation
-            THashSet<InteractionWiredEffect> legacyEffects = new THashSet<>();
-            THashSet<InteractionWiredCondition> legacyConditions = new THashSet<>();
+            Set<InteractionWiredEffect> legacyEffects = new HashSet<>();
+            Set<InteractionWiredCondition> legacyConditions = new HashSet<>();
 
             // Extract effects (all effects should now implement both interfaces)
             for (IWiredEffect eff : stack.effects()) {
@@ -1413,8 +1412,8 @@ public final class WiredEngine {
      */
     private void fireExecutedEvent(WiredStack stack, WiredEvent event) {
         if (stack.triggerItem() instanceof InteractionWiredTrigger) {
-            THashSet<InteractionWiredEffect> legacyEffects = new THashSet<>();
-            THashSet<InteractionWiredCondition> legacyConditions = new THashSet<>();
+            Set<InteractionWiredEffect> legacyEffects = new HashSet<>();
+            Set<InteractionWiredCondition> legacyConditions = new HashSet<>();
 
             for (IWiredEffect eff : stack.effects()) {
                 if (eff instanceof InteractionWiredEffect) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEngine.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEngine.java
@@ -29,7 +29,6 @@ import com.eu.habbo.messages.outgoing.generic.alerts.GenericAlertComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.ItemStateComposer;
 import com.eu.habbo.plugin.events.furniture.wired.WiredStackExecutedEvent;
 import com.eu.habbo.plugin.events.furniture.wired.WiredStackTriggeredEvent;
-import gnu.trove.map.hash.THashMap;
 import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1462,7 +1461,7 @@ public final class WiredEngine {
             return;
         }
 
-        THashSet<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(
+        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(
                 triggerItem.getX(), triggerItem.getY());
 
         if (extras != null) {
@@ -1495,7 +1494,7 @@ public final class WiredEngine {
             return null;
         }
 
-        THashSet<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(
+        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(
                 stack.triggerItem().getX(),
                 stack.triggerItem().getY());
 
@@ -1709,7 +1708,7 @@ public final class WiredEngine {
             room.sendComposer(new GenericAlertComposer(roomAlertMessage).compose());
 
             // Send scripter bubble alert to staff with room link
-            THashMap<String, String> keys = new THashMap<>();
+            Map<String, String> keys = new HashMap<>();
             keys.put("title", Emulator.getTexts().getValue("wired.abuse.staff.title"));
             keys.put("message", Emulator.getTexts().getValue("wired.abuse.staff.message")
                     .replace("%roomname%", room.getName())

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredManager.java
@@ -41,9 +41,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayDeque;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.Set;
 
 /**
@@ -984,7 +984,7 @@ public final class WiredManager {
      * @param callStackDepth current recursion depth for trigger stacks
      * @return true if any effects were executed
      */
-    public static boolean executeEffectsAtTiles(THashSet<RoomTile> tiles, final RoomUnit roomUnit, final Room room, final int callStackDepth) {
+    public static boolean executeEffectsAtTiles(Collection<RoomTile> tiles, final RoomUnit roomUnit, final Room room, final int callStackDepth) {
         if (tiles == null || tiles.isEmpty() || room == null || engine == null || stackIndex == null) {
             return false;
         }
@@ -1012,7 +1012,7 @@ public final class WiredManager {
         return true;
     }
 
-    public static boolean executeNegatedStacksAtTiles(THashSet<RoomTile> tiles, final RoomUnit roomUnit, final Room room, final int callStackDepth) {
+    public static boolean executeNegatedStacksAtTiles(Collection<RoomTile> tiles, final RoomUnit roomUnit, final Room room, final int callStackDepth) {
         if (tiles == null || tiles.isEmpty() || room == null || engine == null || stackIndex == null) {
             return false;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredManager.java
@@ -32,7 +32,6 @@ import com.eu.habbo.plugin.events.emulator.EmulatorLoadedEvent;
 import com.eu.habbo.plugin.events.users.UserWiredRewardReceived;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -937,7 +936,7 @@ public final class WiredManager {
             return null;
         }
 
-        THashSet<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(
+        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(
                 triggerItem.getX(),
                 triggerItem.getY());
 
@@ -991,7 +990,7 @@ public final class WiredManager {
 
         for (RoomTile tile : tiles) {
             if (room != null) {
-                THashSet<HabboItem> items = room.getItemsAt(tile);
+                Collection<HabboItem> items = room.getItemsAt(tile);
 
                 long millis = room.getCycleTimestamp();
                 for (final HabboItem item : items) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredMoveCarryHelper.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredMoveCarryHelper.java
@@ -452,7 +452,7 @@ public final class WiredMoveCarryHelper {
         }
 
         double targetZ = room.getStackHeight(targetTile.x, targetTile.y, false, movingItem);
-        THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(
+        Collection<RoomTile> occupiedTiles = room.getLayout().getTilesAt(
                 targetTile,
                 movingItem.getBaseItem().getWidth(),
                 movingItem.getBaseItem().getLength(),
@@ -565,7 +565,7 @@ public final class WiredMoveCarryHelper {
     }
 
     private static boolean hasMovementBehaviorExtra(Room room, HabboItem stackItem) {
-        THashSet<InteractionWiredExtra> extras = getMovementExtras(room, stackItem);
+        Collection<InteractionWiredExtra> extras = getMovementExtras(room, stackItem);
         if (extras == null || extras.isEmpty()) {
             return false;
         }
@@ -594,7 +594,7 @@ public final class WiredMoveCarryHelper {
             return CarryContext.disabled();
         }
 
-        THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(
+        Collection<RoomTile> occupiedTiles = room.getLayout().getTilesAt(
                 anchorTile,
                 movingItem.getBaseItem().getWidth(),
                 movingItem.getBaseItem().getLength(),
@@ -644,7 +644,7 @@ public final class WiredMoveCarryHelper {
         return WiredSourceUtil.resolveUsers(ctx, userSource);
     }
 
-    private static boolean isEligibleUser(Room room, HabboItem movingItem, RoomUnit roomUnit, THashSet<RoomTile> occupiedTiles, int carryMode) {
+    private static boolean isEligibleUser(Room room, HabboItem movingItem, RoomUnit roomUnit, Collection<RoomTile> occupiedTiles, int carryMode) {
         if (roomUnit == null
                 || roomUnit.getRoomUnitType() != RoomUnitType.USER
                 || roomUnit.getCurrentLocation() == null
@@ -679,7 +679,7 @@ public final class WiredMoveCarryHelper {
         return Math.abs(roomUnit.getZ() - carrySurfaceZ) <= DIRECT_HEIGHT_TOLERANCE;
     }
 
-    private static boolean occupiesMovingFurni(THashSet<RoomTile> occupiedTiles, RoomUnit roomUnit) {
+    private static boolean occupiesMovingFurni(Collection<RoomTile> occupiedTiles, RoomUnit roomUnit) {
         for (RoomTile occupiedTile : occupiedTiles) {
             if (occupiedTile != null
                     && occupiedTile.x == roomUnit.getX()
@@ -692,7 +692,7 @@ public final class WiredMoveCarryHelper {
     }
 
     private static FurnitureMovementError getBlockingUnitError(Room room, HabboItem movingItem, RoomTile targetTile, int rotation, CarryContext carryContext, WiredMovementPhysics movementPhysics) {
-        THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(
+        Collection<RoomTile> occupiedTiles = room.getLayout().getTilesAt(
                 targetTile,
                 movingItem.getBaseItem().getWidth(),
                 movingItem.getBaseItem().getLength(),
@@ -800,7 +800,7 @@ public final class WiredMoveCarryHelper {
             return carriedMoves;
         }
 
-        THashSet<RoomTile> occupiedTiles = room.getLayout().getTilesAt(
+        Collection<RoomTile> occupiedTiles = room.getLayout().getTilesAt(
                 targetTile,
                 movingItem.getBaseItem().getWidth(),
                 movingItem.getBaseItem().getLength(),
@@ -887,7 +887,7 @@ public final class WiredMoveCarryHelper {
     }
 
     private static WiredExtraMoveCarryUsers getActiveExtra(Room room, HabboItem stackItem) {
-        THashSet<InteractionWiredExtra> extras = getMovementExtras(room, stackItem);
+        Collection<InteractionWiredExtra> extras = getMovementExtras(room, stackItem);
         if (extras == null || extras.isEmpty()) {
             return null;
         }
@@ -902,7 +902,7 @@ public final class WiredMoveCarryHelper {
     }
 
     private static WiredExtraMoveNoAnimation getNoAnimationExtra(Room room, HabboItem stackItem) {
-        THashSet<InteractionWiredExtra> extras = getMovementExtras(room, stackItem);
+        Collection<InteractionWiredExtra> extras = getMovementExtras(room, stackItem);
         if (extras == null || extras.isEmpty()) {
             return null;
         }
@@ -917,7 +917,7 @@ public final class WiredMoveCarryHelper {
     }
 
     private static WiredExtraAnimationTime getAnimationTimeExtra(Room room, HabboItem stackItem) {
-        THashSet<InteractionWiredExtra> extras = getMovementExtras(room, stackItem);
+        Collection<InteractionWiredExtra> extras = getMovementExtras(room, stackItem);
         if (extras == null || extras.isEmpty()) {
             return null;
         }
@@ -1001,7 +1001,7 @@ public final class WiredMoveCarryHelper {
     }
 
     private static WiredExtraMovePhysics getMovementPhysicsExtra(Room room, HabboItem stackItem) {
-        THashSet<InteractionWiredExtra> extras = getMovementExtras(room, stackItem);
+        Collection<InteractionWiredExtra> extras = getMovementExtras(room, stackItem);
         if (extras == null || extras.isEmpty()) {
             return null;
         }
@@ -1015,12 +1015,12 @@ public final class WiredMoveCarryHelper {
         return null;
     }
 
-    private static THashSet<InteractionWiredExtra> getMovementExtras(Room room, HabboItem stackItem) {
+    private static Collection<InteractionWiredExtra> getMovementExtras(Room room, HabboItem stackItem) {
         if (room == null || stackItem == null || room.getRoomSpecialTypes() == null) {
             return null;
         }
 
-        THashSet<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(stackItem.getX(), stackItem.getY());
+        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(stackItem.getX(), stackItem.getY());
         if (extras == null || extras.isEmpty()) {
             return null;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredMoveCarryHelper.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredMoveCarryHelper.java
@@ -18,7 +18,6 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.rooms.WiredMovementsComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.FloorItemOnRollerComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -784,7 +783,7 @@ public final class WiredMoveCarryHelper {
 
             Habbo habbo = room.getHabbo(carriedMove.roomUnit);
             if (habbo != null && shouldRefreshPostureWithTileUpdate(carriedMove.roomUnit)) {
-                THashSet<Habbo> movedHabbos = new THashSet<>();
+                Set<Habbo> movedHabbos = new HashSet<>();
                 movedHabbos.add(habbo);
                 room.updateHabbosAt(carriedMove.destinationTile.x, carriedMove.destinationTile.y, movedHabbos);
             }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredSelectionFilterSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredSelectionFilterSupport.java
@@ -9,9 +9,9 @@ import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraFilterUs
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -42,7 +42,7 @@ final class WiredSelectionFilterSupport {
             return items;
         }
 
-        THashSet<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(triggerItem.getX(), triggerItem.getY());
+        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(triggerItem.getX(), triggerItem.getY());
         if (extras == null || extras.isEmpty()) {
             return items;
         }
@@ -86,7 +86,7 @@ final class WiredSelectionFilterSupport {
             return users;
         }
 
-        THashSet<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(triggerItem.getX(), triggerItem.getY());
+        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(triggerItem.getX(), triggerItem.getY());
         if (extras == null || extras.isEmpty()) {
             return users;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredSourceUtil.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredSourceUtil.java
@@ -11,7 +11,6 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.api.IWiredEffect;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -209,7 +208,7 @@ public final class WiredSourceUtil {
             }
         }
 
-        THashSet<InteractionWiredEffect> roomEffects = room.getRoomSpecialTypes().getEffects(triggerItem.getX(), triggerItem.getY());
+        Collection<InteractionWiredEffect> roomEffects = room.getRoomSpecialTypes().getEffects(triggerItem.getX(), triggerItem.getY());
         for (InteractionWiredEffect effect : WiredExecutionOrderUtil.sort(roomEffects)) {
             if (effect != null && effect.isSelector()) {
                 selectorEffects.add(effect);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredTextInputCaptureSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredTextInputCaptureSupport.java
@@ -7,9 +7,9 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.wired.api.WiredStack;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -119,7 +119,7 @@ public final class WiredTextInputCaptureSupport {
             return capturers;
         }
 
-        THashSet<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(trigger.getX(), trigger.getY());
+        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(trigger.getX(), trigger.getY());
         if (extras == null || extras.isEmpty()) {
             return capturers;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredTextPlaceholderUtil.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredTextPlaceholderUtil.java
@@ -22,11 +22,11 @@ import com.eu.habbo.habbohotel.rooms.RoomUnitType;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.util.HotelDateTimeUtil;
-import gnu.trove.set.hash.THashSet;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.WeekFields;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -51,7 +51,7 @@ public final class WiredTextPlaceholderUtil {
             return text;
         }
 
-        THashSet<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(triggerItem.getX(), triggerItem.getY());
+        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(triggerItem.getX(), triggerItem.getY());
         if (extras == null || extras.isEmpty()) {
             return text;
         }
@@ -205,7 +205,7 @@ public final class WiredTextPlaceholderUtil {
             return false;
         }
 
-        THashSet<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(stackItem.getX(), stackItem.getY());
+        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(stackItem.getX(), stackItem.getY());
         if (extras == null || extras.isEmpty()) {
             return false;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredTriggerSourceUtil.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredTriggerSourceUtil.java
@@ -10,7 +10,6 @@ import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraFilterUs
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -149,7 +148,7 @@ public final class WiredTriggerSourceUtil {
             return Collections.emptyList();
         }
 
-        THashSet<InteractionWiredEffect> effects = room.getRoomSpecialTypes().getEffects(trigger.getX(), trigger.getY());
+        Collection<InteractionWiredEffect> effects = room.getRoomSpecialTypes().getEffects(trigger.getX(), trigger.getY());
         List<InteractionWiredEffect> selectorEffects = new ArrayList<>();
 
         for (InteractionWiredEffect effect : WiredExecutionOrderUtil.sort(effects)) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredUserMovementHelper.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredUserMovementHelper.java
@@ -16,7 +16,6 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.outgoing.rooms.WiredMovementsComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,7 +102,7 @@ public final class WiredUserMovementHelper {
             roomUnit.resetIdleTimer();
 
             if (habbo != null) {
-                THashSet<Habbo> movedHabbos = new THashSet<>();
+                Set<Habbo> movedHabbos = new HashSet<>();
                 movedHabbos.add(habbo);
                 room.updateHabbosAt(targetTile.x, targetTile.y, movedHabbos);
             }
@@ -171,7 +170,7 @@ public final class WiredUserMovementHelper {
         roomUnit.statusUpdate(true);
 
         if (habbo != null) {
-            THashSet<Habbo> movedHabbos = new THashSet<>();
+            Set<Habbo> movedHabbos = new HashSet<>();
             movedHabbos.add(habbo);
             room.updateHabbosAt(targetTile.x, targetTile.y, movedHabbos);
         } else {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredVariableLevelSystemSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredVariableLevelSystemSupport.java
@@ -8,9 +8,9 @@ import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariable
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableReference;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.WiredVariableDefinitionInfo;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -35,7 +35,7 @@ public final class WiredVariableLevelSystemSupport {
             return null;
         }
 
-        THashSet<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(definition.getX(), definition.getY());
+        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(definition.getX(), definition.getY());
         if (extras == null || extras.isEmpty()) {
             return null;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredVariableTextConnectorSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredVariableTextConnectorSupport.java
@@ -3,9 +3,9 @@ package com.eu.habbo.habbohotel.wired.core;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredExtra;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableTextConnector;
 import com.eu.habbo.habbohotel.rooms.Room;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +48,7 @@ public final class WiredVariableTextConnectorSupport {
             return Collections.emptyList();
         }
 
-        THashSet<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(definition.getX(), definition.getY());
+        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(definition.getX(), definition.getY());
         if (extras == null || extras.isEmpty()) {
             return Collections.emptyList();
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/highscores/WiredHighscoreMidnightUpdater.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/highscores/WiredHighscoreMidnightUpdater.java
@@ -5,10 +5,10 @@ import com.eu.habbo.habbohotel.items.interactions.InteractionWiredHighscore;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.util.HotelDateTimeUtil;
-import gnu.trove.set.hash.THashSet;
 
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Set;
 
 public class WiredHighscoreMidnightUpdater implements Runnable {
     @Override
@@ -18,7 +18,7 @@ public class WiredHighscoreMidnightUpdater implements Runnable {
         for (Room room : rooms) {
             if (room == null || room.getRoomSpecialTypes() == null) continue;
 
-            THashSet<HabboItem> items = room.getRoomSpecialTypes().getItemsOfType(InteractionWiredHighscore.class);
+            Set<HabboItem> items = room.getRoomSpecialTypes().getItemsOfType(InteractionWiredHighscore.class);
             for (HabboItem item : items) {
                 ((InteractionWiredHighscore) item).reloadData();
                 room.updateItem(item);

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -83,12 +83,13 @@ import com.eu.habbo.messages.incoming.wired.WiredUserVariablesRequestEvent;
 import com.eu.habbo.messages.incoming.wired.WiredTriggerSaveDataEvent;
 import com.eu.habbo.plugin.EventHandler;
 import com.eu.habbo.plugin.events.emulator.EmulatorConfigUpdatedEvent;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class PacketManager {
 
@@ -97,13 +98,13 @@ public class PacketManager {
     private static final List<Integer> logList = new ArrayList<>();
     public static boolean DEBUG_SHOW_PACKETS = false;
     public static boolean MULTI_THREADED_PACKET_HANDLING = false;
-    private final THashMap<Integer, Class<? extends MessageHandler>> incoming;
-    private final THashMap<Integer, List<ICallable>> callables;
+    private final Map<Integer, Class<? extends MessageHandler>> incoming;
+    private final Map<Integer, List<ICallable>> callables;
     private final PacketNames names;
 
     public PacketManager() throws Exception {
-        this.incoming = new THashMap<>();
-        this.callables = new THashMap<>();
+        this.incoming = new HashMap<>();
+        this.callables = new HashMap<>();
         this.names = new PacketNames();
         this.names.initialize();
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceRoomItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceRoomItemEvent.java
@@ -129,7 +129,7 @@ public class BuildersClubPlaceRoomItemEvent extends MessageHandler {
             return null;
         }
 
-        for (CatalogItem catalogItem : page.getCatalogItems().valueCollection()) {
+        for (CatalogItem catalogItem : page.getCatalogItems().values()) {
             if (catalogItem.getOfferId() == offerId) {
                 return catalogItem;
             }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceWallItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/BuildersClubPlaceWallItemEvent.java
@@ -111,7 +111,7 @@ public class BuildersClubPlaceWallItemEvent extends MessageHandler {
             return null;
         }
 
-        for (CatalogItem catalogItem : page.getCatalogItems().valueCollection()) {
+        for (CatalogItem catalogItem : page.getCatalogItems().values()) {
             if (catalogItem.getOfferId() == offerId) {
                 return catalogItem;
             }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
@@ -180,7 +180,7 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                     // CatalogBuyItemEvent. Fall back to scanning the
                     // page for the matching offer_id.
                     if (item == null) {
-                        for (CatalogItem candidate : page.getCatalogItems().valueCollection()) {
+                        for (CatalogItem candidate : page.getCatalogItems().values()) {
                             if (candidate != null && candidate.getOfferId() == itemId) {
                                 item = candidate;
                                 break;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
@@ -23,13 +23,15 @@ import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.users.UserClubComposer;
 import com.eu.habbo.threading.runnables.ShutdownEmulator;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.*;
 import java.util.Calendar;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class CatalogBuyItemAsGiftEvent extends MessageHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogBuyItemAsGiftEvent.class);
@@ -277,7 +279,7 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                         this.client.getHabbo().getHabboStats().addLtdLog(item.getId(), Emulator.getIntUnixTimestamp());
                     }
 
-                    THashSet<HabboItem> itemsList = new THashSet<>();
+                    Set<HabboItem> itemsList = new HashSet<>();
 
                     boolean badgeFound = false;
                     for (Item baseItem : item.getBaseItems()) {
@@ -545,7 +547,7 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                         habbo.getClient().getHabbo().getInventory().getItemsComponent().addItem(gift);
                         habbo.getClient().sendResponse(new InventoryRefreshComposer());
 
-                        THashMap<String, String> keys = new THashMap<>();
+                        Map<String, String> keys = new HashMap<>();
                         keys.put("display", "BUBBLE");
                         keys.put("image", "${image.library.url}notifications/gift.gif");
                         keys.put("message", Emulator.getTexts().getValue("generic.gift.received.anonymous"));
@@ -697,7 +699,7 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
             String daysWord = Emulator.getTexts().getValue("generic.days", "days");
             String clubLabel = offer.isBuildersClubSubscription() ? "Builders Club" : "HC";
             String giftDescription = clubLabel + " (" + offer.getDays() + " " + daysWord + ")";
-            THashMap<String, String> keys = new THashMap<>();
+            Map<String, String> keys = new HashMap<>();
             keys.put("display", "BUBBLE");
             keys.put("image", "${image.library.url}notifications/gift.gif");
             keys.put("message", prefix + " " + giftDescription);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java
@@ -86,10 +86,10 @@ public class CatalogBuyItemEvent extends MessageHandler {
 
                 if (page instanceof RoomBundleLayout) {
                     final CatalogItem[] item = new CatalogItem[1];
-                    page.getCatalogItems().forEachValue(object -> {
+                    for (CatalogItem object : page.getCatalogItems().values()) {
                         item[0] = object;
-                        return false;
-                    });
+                        break;
+                    }
 
                     CatalogItem roomBundleItem = item[0];
                     if (roomBundleItem == null || roomBundleItem.getCredits() > this.client.getHabbo().getHabboInfo().getCredits() || roomBundleItem.getPoints() > this.client.getHabbo().getHabboInfo().getCurrencyAmount(roomBundleItem.getPointsType())) {
@@ -202,7 +202,7 @@ public class CatalogBuyItemEvent extends MessageHandler {
                 item = page.getCatalogItem(itemId);
 
             if (item == null && !(page instanceof RecentPurchasesLayout)) {
-                for (CatalogItem candidate : page.getCatalogItems().valueCollection()) {
+                for (CatalogItem candidate : page.getCatalogItems().values()) {
                     if (candidate != null && candidate.getOfferId() == itemId) {
                         item = candidate;
                         break;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java
@@ -22,8 +22,10 @@ import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.navigator.CanCreateRoomComposer;
 import com.eu.habbo.messages.outgoing.users.AddUserBadgeComposer;
 import com.eu.habbo.threading.runnables.ShutdownEmulator;
-import gnu.trove.map.hash.THashMap;
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.eu.habbo.messages.incoming.catalog.CheckPetNameEvent.PET_NAME_LENGTH_MAXIMUM;
 import static com.eu.habbo.messages.incoming.catalog.CheckPetNameEvent.PET_NAME_LENGTH_MINIMUM;
@@ -119,7 +121,7 @@ public class CatalogBuyItemEvent extends MessageHandler {
                             Emulator.getThreading().run(badge);
                             this.client.getHabbo().getInventory().getBadgesComponent().addBadge(badge);
                             this.client.sendResponse(new AddUserBadgeComposer(badge));
-                            THashMap<String, String> keys = new THashMap<>();
+                            Map<String, String> keys = new HashMap<>();
                             keys.put("display", "BUBBLE");
                             keys.put("image", "${image.library.url}album1584/" + badge.getCode() + ".gif");
                             keys.put("message", Emulator.getTexts().getValue("commands.generic.cmd_badge.received"));

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogSearchedItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogSearchedItemEvent.java
@@ -5,7 +5,6 @@ import com.eu.habbo.habbohotel.catalog.CatalogItem;
 import com.eu.habbo.habbohotel.catalog.CatalogPage;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.catalog.CatalogSearchResultComposer;
-import gnu.trove.iterator.TIntObjectIterator;
 
 public class CatalogSearchedItemEvent extends MessageHandler {
     @Override
@@ -23,13 +22,7 @@ public class CatalogSearchedItemEvent extends MessageHandler {
             CatalogPage page = Emulator.getGameEnvironment().getCatalogManager().getCatalogPage(requestedItem.getPageId());
 
             if (page != null) {
-                TIntObjectIterator<CatalogItem> iterator = page.getCatalogItems().iterator();
-
-                while (iterator.hasNext()) {
-                    iterator.advance();
-
-                    CatalogItem item = iterator.value();
-
+                for (CatalogItem item : page.getCatalogItems().values()) {
                     if (item.getSearchOfferId() == offerId) {
                         this.client.sendResponse(new CatalogSearchResultComposer(item));
                         return;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogSelectClubGiftEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogSelectClubGiftEvent.java
@@ -41,7 +41,7 @@ public class CatalogSelectClubGiftEvent extends MessageHandler {
             return;
         }
 
-        CatalogItem catalogItem = page.getCatalogItems().valueCollection().stream().filter(x -> x.getName().equalsIgnoreCase(itemName)).findAny().orElse(null);
+        CatalogItem catalogItem = page.getCatalogItems().values().stream().filter(x -> x.getName().equalsIgnoreCase(itemName)).findAny().orElse(null);
 
         if(catalogItem == null) {
             LOGGER.error("Catalog item not found");

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogSelectClubGiftEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogSelectClubGiftEvent.java
@@ -8,9 +8,11 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.catalog.*;
 import com.eu.habbo.messages.outgoing.users.ClubGiftReceivedComposer;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class CatalogSelectClubGiftEvent extends MessageHandler {
 
@@ -61,7 +63,7 @@ public class CatalogSelectClubGiftEvent extends MessageHandler {
             return;
         }
 
-        THashSet<Item> itemsGiven = new THashSet<>();
+        Set<Item> itemsGiven = new HashSet<>();
         for(Item item : catalogItem.getBaseItems()) {
             if(Emulator.getGameEnvironment().getItemManager().createGift(this.client.getHabbo().getHabboInfo().getId(), item, "", 0, 0) != null) {
                 itemsGiven.add(item);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/recycler/RecycleEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/recycler/RecycleEvent.java
@@ -13,7 +13,9 @@ import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.inventory.RemoveHabboItemComposer;
 import com.eu.habbo.threading.runnables.QueryDeleteHabboItem;
 import com.eu.habbo.threading.runnables.ShutdownEmulator;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class RecycleEvent extends MessageHandler {
     @Override
@@ -24,7 +26,7 @@ public class RecycleEvent extends MessageHandler {
         }
 
         if (Emulator.getGameEnvironment().getCatalogManager().ecotronItem != null && ItemManager.RECYCLER_ENABLED) {
-            THashSet<HabboItem> items = new THashSet<>();
+            Set<HabboItem> items = new HashSet<>();
 
             int count = this.packet.readInt();
             if (count != Emulator.getConfig().getInt("recycler.value", 8)) return;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftItemEvent.java
@@ -13,8 +13,8 @@ import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.inventory.RemoveHabboItemComposer;
 import com.eu.habbo.threading.runnables.QueryDeleteHabboItems;
-import gnu.trove.map.hash.TIntObjectHashMap;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class CraftingCraftItemEvent extends MessageHandler {
@@ -31,7 +31,7 @@ public class CraftingCraftItemEvent extends MessageHandler {
                 return;
             }
 
-            TIntObjectHashMap<HabboItem> toRemove = new TIntObjectHashMap<>();
+            Map<Integer, HabboItem> toRemove = new HashMap<>();
             for (Map.Entry<Item, Integer> set : recipe.getIngredients().entrySet()) {
                 for (int i = 0; i < set.getValue(); i++) {
                     HabboItem habboItem = this.client.getHabbo().getInventory().getItemsComponent().getAndRemoveHabboItem(set.getKey());
@@ -62,13 +62,12 @@ public class CraftingCraftItemEvent extends MessageHandler {
                 this.client.getHabbo().getInventory().getItemsComponent().addItem(rewardItem);
                 this.client.sendResponse(new AddHabboItemComposer(rewardItem));
                 AchievementManager.progressAchievement(this.client.getHabbo(), Emulator.getGameEnvironment().getAchievementManager().getAchievement("Atcg"));
-                toRemove.forEachValue(object -> {
+                toRemove.values().forEach(object -> {
                     CraftingCraftItemEvent.this.client.sendResponse(new RemoveHabboItemComposer(object.getGiftAdjustedId()));
-                    return true;
                 });
                 this.client.sendResponse(new InventoryRefreshComposer());
 
-                Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove));
+                Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove.values()));
                 return;
             }
 
@@ -80,14 +79,13 @@ public class CraftingCraftItemEvent extends MessageHandler {
         this.client.sendResponse(new CraftingResultComposer(null));
     }
 
-    private void restoreItems(TIntObjectHashMap<HabboItem> items) {
+    private void restoreItems(Map<Integer, HabboItem> items) {
         if (items.isEmpty()) {
             return;
         }
-        items.forEachValue(item -> {
+        items.values().forEach(item -> {
             this.client.getHabbo().getInventory().getItemsComponent().addItem(item);
             this.client.sendResponse(new AddHabboItemComposer(item));
-            return true;
         });
         this.client.sendResponse(new InventoryRefreshComposer());
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftSecretEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftSecretEvent.java
@@ -13,10 +13,11 @@ import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.inventory.RemoveHabboItemComposer;
 import com.eu.habbo.threading.runnables.QueryDeleteHabboItem;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 
+import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
+import java.util.IdentityHashMap;
 import java.util.Set;
 
 public class CraftingCraftSecretEvent extends MessageHandler {
@@ -38,8 +39,8 @@ public class CraftingCraftSecretEvent extends MessageHandler {
             CraftingAltar altar = Emulator.getGameEnvironment().getCraftingManager().getAltar(craftingAltar.getBaseItem());
 
             if (altar != null) {
-                Set<HabboItem> habboItems = new THashSet<>();
-                Map<Item, Integer> items = new THashMap<>();
+                Set<HabboItem> habboItems = Collections.newSetFromMap(new IdentityHashMap<>());
+                Map<Item, Integer> items = new HashMap<>();
 
                 for (int i = 0; i < count; i++) {
                     int itemId = this.packet.readInt();

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/RequestCraftingRecipesAvailableEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/RequestCraftingRecipesAvailableEvent.java
@@ -7,8 +7,8 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.crafting.CraftingRecipesAvailableComposer;
-import gnu.trove.map.hash.THashMap;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class RequestCraftingRecipesAvailableEvent extends MessageHandler {
@@ -21,7 +21,7 @@ public class RequestCraftingRecipesAvailableEvent extends MessageHandler {
         CraftingAltar altar = Emulator.getGameEnvironment().getCraftingManager().getAltar(item.getBaseItem());
 
         if (altar != null) {
-            Map<Item, Integer> items = new THashMap<>();
+            Map<Item, Integer> items = new HashMap<>();
 
             int count = this.packet.readInt();
             for (int i = 0; i < count; i++) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/floorplaneditor/FloorPlanEditorSaveEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/floorplaneditor/FloorPlanEditorSaveEvent.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
 
@@ -159,7 +160,7 @@ public class FloorPlanEditorSaveEvent extends MessageHandler {
 
                 if (square.equalsIgnoreCase("x") && room.getTopItemAt(x, y) != null) {
                     if (autoPickup) {
-                        THashSet<HabboItem> here = room.getItemsAt(x, y);
+                        Set<HabboItem> here = room.getItemsAt(x, y);
                         if (here != null) itemsToPickup.addAll(here);
                         continue;
                     }
@@ -186,7 +187,7 @@ public class FloorPlanEditorSaveEvent extends MessageHandler {
 
                 if (tile != null && tile.state != RoomTileState.INVALID && height != tile.z && room.getTopItemAt(x, y) != null) {
                     if (autoPickup) {
-                        THashSet<HabboItem> here = room.getItemsAt(x, y);
+                        Set<HabboItem> here = room.getItemsAt(x, y);
                         if (here != null) itemsToPickup.addAll(here);
                         continue;
                     }
@@ -202,7 +203,7 @@ public class FloorPlanEditorSaveEvent extends MessageHandler {
             if (!locked_tileList.isEmpty()) {
                 if (autoPickup) {
                     for (RoomTile lt : locked_tileList) {
-                        THashSet<HabboItem> here = room.getItemsAt(lt.x, lt.y);
+                        Set<HabboItem> here = room.getItemsAt(lt.x, lt.y);
                         if (here != null) itemsToPickup.addAll(here);
                     }
                 } else {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/floorplaneditor/FloorPlanEditorSaveEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/floorplaneditor/FloorPlanEditorSaveEvent.java
@@ -13,13 +13,13 @@ import com.eu.habbo.messages.outgoing.generic.alerts.GenericAlertComposer;
 import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.rooms.ForwardToRoomComposer;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -144,9 +144,9 @@ public class FloorPlanEditorSaveEvent extends MessageHandler {
             return;
         }
 
-        THashSet<RoomTile> locked_tileList = room.getLockedTiles();
-        THashSet<RoomTile> new_tileList = new THashSet<>();
-        THashSet<HabboItem> itemsToPickup = new THashSet<>();
+        Set<RoomTile> locked_tileList = room.getLockedTiles();
+        Set<RoomTile> new_tileList = new HashSet<>();
+        Set<HabboItem> itemsToPickup = new HashSet<>();
         int blockedX = -1;
         int blockedY = -1;
         blockingRoomItemScan:

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RemoveFriendEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RemoveFriendEvent.java
@@ -5,15 +5,15 @@ import com.eu.habbo.habbohotel.messenger.Messenger;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.friends.RemoveFriendComposer;
-import gnu.trove.list.array.TIntArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 public class RemoveFriendEvent extends MessageHandler {
     private static final int MAX_BATCH_SIZE = 100;
 
-    private final TIntArrayList removedFriends;
+    private final IntArrayList removedFriends;
 
     public RemoveFriendEvent() {
-        this.removedFriends = new TIntArrayList();
+        this.removedFriends = new IntArrayList();
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/SearchUserEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/SearchUserEvent.java
@@ -4,14 +4,14 @@ import com.eu.habbo.habbohotel.messenger.Messenger;
 import com.eu.habbo.habbohotel.messenger.MessengerBuddy;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.friends.UserSearchResultComposer;
-import gnu.trove.set.hash.THashSet;
 
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class SearchUserEvent extends MessageHandler {
     private static final long CACHE_TTL_MS = 30_000; // 30 second TTL
     private static final ConcurrentHashMap<String, Long> cacheTimestamps = new ConcurrentHashMap<>();
-    public static final ConcurrentHashMap<String, THashSet<MessengerBuddy>> cachedResults = new ConcurrentHashMap<>();
+    public static final ConcurrentHashMap<String, Set<MessengerBuddy>> cachedResults = new ConcurrentHashMap<>();
 
     public static void cleanExpiredCache() {
         long now = System.currentTimeMillis();
@@ -39,7 +39,7 @@ public class SearchUserEvent extends MessageHandler {
         }
 
         if (this.client.getHabbo().getMessenger() != null) {
-            THashSet<MessengerBuddy> buddies = cachedResults.get(username);
+            Set<MessengerBuddy> buddies = cachedResults.get(username);
 
             if (buddies == null) {
                 buddies = Messenger.searchUsers(username);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildDeleteEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildDeleteEvent.java
@@ -9,7 +9,8 @@ import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.guilds.GuildFavoriteRoomUserUpdateComposer;
 import com.eu.habbo.messages.outgoing.rooms.RoomDataComposer;
 import com.eu.habbo.plugin.events.guilds.GuildDeletedEvent;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class GuildDeleteEvent extends MessageHandler {
     @Override
@@ -26,7 +27,7 @@ public class GuildDeleteEvent extends MessageHandler {
         if (guild != null) {
             if (guild.getOwnerId() == this.client.getHabbo().getHabboInfo().getId() || this.client.getHabbo().hasPermission(Permission.ACC_GUILD_ADMIN))
             {
-                THashSet<GuildMember> members = Emulator.getGameEnvironment().getGuildManager().getGuildMembers(guild.getId());
+                Set<GuildMember> members = Emulator.getGameEnvironment().getGuildManager().getGuildMembers(guild.getId());
 
                 for (GuildMember member : members) {
                     Habbo habbo = Emulator.getGameServer().getGameClientManager().getHabbo(member.getUserId());

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestGuildBuyRoomsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestGuildBuyRoomsEvent.java
@@ -4,8 +4,8 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.guilds.GuildBuyRoomsComposer;
-import gnu.trove.set.hash.THashSet;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class RequestGuildBuyRoomsEvent extends MessageHandler {
@@ -13,7 +13,7 @@ public class RequestGuildBuyRoomsEvent extends MessageHandler {
     public void handle() throws Exception {
         List<Room> rooms = Emulator.getGameEnvironment().getRoomManager().getRoomsForHabbo(this.client.getHabbo());
 
-        THashSet<Room> roomList = new THashSet<Room>();
+        List<Room> roomList = new ArrayList<>();
 
         for (Room room : rooms) {
             if (room.getGuildId() == 0)

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestOwnGuildsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestOwnGuildsEvent.java
@@ -4,7 +4,9 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.guilds.Guild;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.guilds.GuildListComposer;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class RequestOwnGuildsEvent extends MessageHandler {
     @Override
@@ -14,7 +16,7 @@ public class RequestOwnGuildsEvent extends MessageHandler {
 
     @Override
     public void handle() throws Exception {
-        THashSet<Guild> guilds = new THashSet<Guild>();
+        Set<Guild> guilds = new HashSet<Guild>();
 
         for (int i : this.client.getHabbo().getHabboStats().guilds) {
             if (i == 0)

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumListEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/forums/GuildForumListEvent.java
@@ -5,7 +5,6 @@ import com.eu.habbo.habbohotel.guilds.Guild;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.guilds.forums.GuildForumListComposer;
 import com.eu.habbo.messages.outgoing.handshake.ConnectionErrorComposer;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,6 +12,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -25,13 +25,13 @@ public class GuildForumListEvent extends MessageHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(GuildForumListEvent.class);
 
     // Cache for active forums list (shared across all users)
-    private static volatile THashSet<Guild> activeForumsCache = null;
+    private static volatile Set<Guild> activeForumsCache = null;
     private static volatile long activeForumsCachedAt = 0;
     private static final long ACTIVE_FORUMS_TTL = 30 * 60 * 1000; // 30 minutes
 
     // Cache for user's forum list
     private static final ConcurrentHashMap<Integer, long[]> myForumsCache = new ConcurrentHashMap<>(); // userId -> {cachedAt}
-    private static final ConcurrentHashMap<Integer, THashSet<Guild>> myForumsData = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<Integer, Set<Guild>> myForumsData = new ConcurrentHashMap<>();
     private static final long MY_FORUMS_TTL = 10 * 60 * 1000; // 10 minutes
 
     public static void invalidateActiveForumsCache() {
@@ -70,14 +70,14 @@ public class GuildForumListEvent extends MessageHandler {
         }
     }
 
-    private THashSet<Guild> getActiveForums() {
+    private Set<Guild> getActiveForums() {
         long now = System.currentTimeMillis();
 
         if (activeForumsCache != null && (now - activeForumsCachedAt) < ACTIVE_FORUMS_TTL) {
             return activeForumsCache;
         }
 
-        THashSet<Guild> guilds = new THashSet<Guild>();
+        Set<Guild> guilds = new HashSet<Guild>();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT `guilds`.`id`, SUM(`guilds_forums_threads`.`posts_count`) AS `post_count` " +
                 "FROM `guilds_forums_threads` " +
@@ -106,16 +106,16 @@ public class GuildForumListEvent extends MessageHandler {
         return guilds;
     }
 
-    private THashSet<Guild> getMyForums(int userId) {
+    private Set<Guild> getMyForums(int userId) {
         long now = System.currentTimeMillis();
 
         long[] cached = myForumsCache.get(userId);
         if (cached != null && (now - cached[0]) < MY_FORUMS_TTL) {
-            THashSet<Guild> data = myForumsData.get(userId);
+            Set<Guild> data = myForumsData.get(userId);
             if (data != null) return data;
         }
 
-        THashSet<Guild> guilds = new THashSet<Guild>();
+        Set<Guild> guilds = new HashSet<Guild>();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT `guilds`.`id` FROM `guilds_members` " +
                 "LEFT JOIN `guilds` ON `guilds`.`id` = `guilds_members`.`guild_id` " +

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java
@@ -40,12 +40,12 @@ import com.eu.habbo.messages.outgoing.navigator.NewNavigatorSavedSearchesCompose
 import com.eu.habbo.messages.outgoing.users.*;
 import com.eu.habbo.plugin.events.emulator.SSOAuthenticationEvent;
 import com.eu.habbo.plugin.events.users.UserLoginEvent;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Map;
 
 @NoAuthMessage
 public class SecureLoginEvent extends MessageHandler {
@@ -271,7 +271,7 @@ public class SecureLoginEvent extends MessageHandler {
                 ModToolSanctions modToolSanctions = Emulator.getGameEnvironment().getModToolSanctions();
 
                 if (Emulator.getConfig().getBoolean("hotel.sanctions.enabled")) {
-                    THashMap<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(habbo.getHabboInfo().getId());
+                    Map<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(habbo.getHabboInfo().getId());
                     ArrayList<ModToolSanctionItem> modToolSanctionItems = modToolSanctionItemsHashMap.get(habbo.getHabboInfo().getId());
 
                     if (modToolSanctionItems != null && !modToolSanctionItems.isEmpty()) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/inventory/RequestInventoryItemsDelete.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/inventory/RequestInventoryItemsDelete.java
@@ -8,8 +8,9 @@ import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.inventory.RemoveHabboItemComposer;
 import com.eu.habbo.threading.runnables.QueryDeleteHabboItems;
-import gnu.trove.iterator.hash.TObjectHashIterator;
-import gnu.trove.map.hash.TIntObjectHashMap;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class RequestInventoryItemsDelete extends MessageHandler {
     private static final int MAX_DELETE_AMOUNT = 1000;
@@ -36,24 +37,22 @@ public class RequestInventoryItemsDelete extends MessageHandler {
         final Habbo habbo = this.client.getHabbo();
         if (habbo == null)
             return;
-        TIntObjectHashMap<HabboItem> toRemove = new TIntObjectHashMap<>();
+        Map<Integer, HabboItem> toRemove = new HashMap<>();
         for (int i = 0; i < amount; i++) {
             HabboItem habboInventoryItem = habbo.getInventory().getItemsComponent().getAndRemoveHabboItem(item);
             if (habboInventoryItem != null)
                 toRemove.put(habboInventoryItem.getId(), habboInventoryItem);
         }
-        toRemove.forEachValue(object -> {
+        toRemove.values().forEach(object -> {
             habbo.getClient().sendResponse(new RemoveHabboItemComposer(object.getGiftAdjustedId()));
-            return true;
         });
         habbo.getClient().sendResponse(new InventoryRefreshComposer());
-        Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove));
+        Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove.values()));
     }
 
     private boolean hasFurnitureInInventory(Habbo habbo, Item item, Integer amount) {
         int count = 0;
-        for (TObjectHashIterator<HabboItem> tObjectHashIterator = habbo.getInventory().getItemsComponent().getItemsAsValueCollection().iterator(); tObjectHashIterator.hasNext(); ) {
-            HabboItem habboItem = tObjectHashIterator.next();
+        for (HabboItem habboItem : habbo.getInventory().getItemsComponent().getItemsAsValueCollection()) {
             if (habboItem.getBaseItem().getId() == item.getId())
                 count++;
         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/inventory/RequestInventoryItemsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/inventory/RequestInventoryItemsEvent.java
@@ -3,17 +3,10 @@ package com.eu.habbo.messages.incoming.inventory;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.inventory.InventoryItemsComposer;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.NoSuchElementException;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 public class RequestInventoryItemsEvent extends MessageHandler {
-    private static final Logger LOGGER = LoggerFactory.getLogger(RequestInventoryItemsEvent.class);
-
     @Override
     public int getRatelimit() {
         return 500;
@@ -24,10 +17,10 @@ public class RequestInventoryItemsEvent extends MessageHandler {
         int totalItems = this.client.getHabbo().getInventory().getItemsComponent().getItems().size();
 
         if (totalItems == 0) {
-                this.client.sendResponse(new InventoryItemsComposer(0, 1, new TIntObjectHashMap<>()));
-                return;
-            }
-            
+            this.client.sendResponse(new InventoryItemsComposer(0, 1, new Int2ObjectOpenHashMap<>()));
+            return;
+        }
+
         int totalFragments = (int) Math.ceil((double) totalItems / 1000.0);
 
         if (totalFragments == 0) {
@@ -35,36 +28,29 @@ public class RequestInventoryItemsEvent extends MessageHandler {
         }
 
         synchronized (this.client.getHabbo().getInventory().getItemsComponent().getItems()) {
-            TIntObjectMap<HabboItem> items = new TIntObjectHashMap<>();
-
-            TIntObjectIterator<HabboItem> iterator = this.client.getHabbo().getInventory().getItemsComponent().getItems().iterator();
+            Int2ObjectMap<HabboItem> items = new Int2ObjectOpenHashMap<>();
 
             int count = 0;
             int fragmentNumber = 0;
 
-            for (int i = this.client.getHabbo().getInventory().getItemsComponent().getItems().size(); i-- > 0; ) {
-
+            for (Int2ObjectMap.Entry<HabboItem> itemEntry : this.client.getHabbo().getInventory().getItemsComponent().getItems().int2ObjectEntrySet()) {
                 if (count == 0) {
                     fragmentNumber++;
                 }
 
-                try {
-                    iterator.advance();
-                    items.put(iterator.key(), iterator.value());
-                    count++;
-                } catch (NoSuchElementException e) {
-                    LOGGER.error("Caught exception", e);
-                    break;
-                }
+                items.put(itemEntry.getIntKey(), itemEntry.getValue());
+                count++;
 
                 if (count == 1000) {
                     this.client.sendResponse(new InventoryItemsComposer(fragmentNumber, totalFragments, items));
                     count = 0;
-                    items.clear();
+                    items = new Int2ObjectOpenHashMap<>();
                 }
             }
 
-            if(count > 0 && !items.isEmpty()) this.client.sendResponse(new InventoryItemsComposer(fragmentNumber, totalFragments, items));
+            if (count > 0 && !items.isEmpty()) {
+                this.client.sendResponse(new InventoryItemsComposer(fragmentNumber, totalFragments, items));
+            }
         }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionAlertEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionAlertEvent.java
@@ -8,9 +8,9 @@ import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.modtool.ModToolIssueHandledComposer;
-import gnu.trove.map.hash.THashMap;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 public class ModToolSanctionAlertEvent extends MessageHandler {
     @Override
@@ -39,7 +39,7 @@ public class ModToolSanctionAlertEvent extends MessageHandler {
                 ModToolSanctions modToolSanctions = Emulator.getGameEnvironment().getModToolSanctions();
 
                 if (Emulator.getConfig().getBoolean("hotel.sanctions.enabled")) {
-                    THashMap<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(habbo.getHabboInfo().getId());
+                    Map<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(habbo.getHabboInfo().getId());
                     ArrayList<ModToolSanctionItem> modToolSanctionItems = modToolSanctionItemsHashMap.get(habbo.getHabboInfo().getId());
 
                     if (modToolSanctionItems != null && !modToolSanctionItems.isEmpty()) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionBanEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionBanEvent.java
@@ -8,9 +8,9 @@ import com.eu.habbo.habbohotel.modtool.ModToolSanctions;
 import com.eu.habbo.habbohotel.modtool.ScripterManager;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.messages.incoming.MessageHandler;
-import gnu.trove.map.hash.THashMap;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 public class ModToolSanctionBanEvent extends MessageHandler {
     @Override
@@ -60,7 +60,7 @@ public class ModToolSanctionBanEvent extends MessageHandler {
             ModToolSanctions modToolSanctions = Emulator.getGameEnvironment().getModToolSanctions();
 
             if (Emulator.getConfig().getBoolean("hotel.sanctions.enabled")) {
-                THashMap<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(userId);
+                Map<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(userId);
                 ArrayList<ModToolSanctionItem> modToolSanctionItems = modToolSanctionItemsHashMap.get(userId);
 
                 if (modToolSanctionItems != null && !modToolSanctionItemsHashMap.isEmpty()) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionMuteEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionMuteEvent.java
@@ -9,10 +9,10 @@ import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.modtool.ModToolIssueHandledComposer;
-import gnu.trove.map.hash.THashMap;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Map;
 
 public class ModToolSanctionMuteEvent extends MessageHandler {
     @Override
@@ -41,7 +41,7 @@ public class ModToolSanctionMuteEvent extends MessageHandler {
                 ModToolSanctions modToolSanctions = Emulator.getGameEnvironment().getModToolSanctions();
 
                 if (Emulator.getConfig().getBoolean("hotel.sanctions.enabled")) {
-                    THashMap<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(habbo.getHabboInfo().getId());
+                    Map<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(habbo.getHabboInfo().getId());
                     ArrayList<ModToolSanctionItem> modToolSanctionItems = modToolSanctionItemsHashMap.get(habbo.getHabboInfo().getId());
 
                     if (modToolSanctionItems != null && !modToolSanctionItemsHashMap.isEmpty()) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionTradeLockEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolSanctionTradeLockEvent.java
@@ -8,9 +8,9 @@ import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.modtool.ModToolIssueHandledComposer;
-import gnu.trove.map.hash.THashMap;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 public class ModToolSanctionTradeLockEvent extends MessageHandler {
     @Override
@@ -40,7 +40,7 @@ public class ModToolSanctionTradeLockEvent extends MessageHandler {
                 ModToolSanctions modToolSanctions = Emulator.getGameEnvironment().getModToolSanctions();
 
                 if (Emulator.getConfig().getBoolean("hotel.sanctions.enabled")) {
-                    THashMap<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(userId);
+                    Map<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(userId);
                     ArrayList<ModToolSanctionItem> modToolSanctionItems = modToolSanctionItemsHashMap.get(userId);
 
                     if (modToolSanctionItems != null && !modToolSanctionItems.isEmpty()) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/navigator/RequestDeleteRoomEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/navigator/RequestDeleteRoomEvent.java
@@ -47,12 +47,12 @@ public class RequestDeleteRoomEvent extends MessageHandler {
                 room.ejectAll();
                 room.ejectUserFurni(room.getOwnerId());
 
-                List<Bot> bots = new ArrayList<>(room.getCurrentBots().valueCollection());
+                List<Bot> bots = new ArrayList<>(room.getCurrentBots().values());
                 for (Bot bot : bots) {
                     Emulator.getGameEnvironment().getBotManager().pickUpBot(bot, null);
                 }
 
-                List<Pet> pets = new ArrayList<>(room.getCurrentPets().valueCollection());
+                List<Pet> pets = new ArrayList<>(room.getCurrentPets().values());
                 for (Pet pet : pets) {
                     if (pet instanceof RideablePet) {
                         RideablePet rideablePet = (RideablePet) pet;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/navigator/RequestNewNavigatorRoomsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/navigator/RequestNewNavigatorRoomsEvent.java
@@ -7,7 +7,6 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomCategory;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.navigator.NewNavigatorSearchResultsComposer;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,7 +120,7 @@ public class RequestNewNavigatorRoomsEvent extends MessageHandler {
 
     private ArrayList<SearchResultList> toQueryResults(List<SearchResultList> resultLists) {
         ArrayList<SearchResultList> nList = new ArrayList<>();
-        THashMap<Integer, Room> searchRooms = new THashMap<>();
+        Map<Integer, Room> searchRooms = new HashMap<>();
 
         for (SearchResultList li : resultLists) {
             for (Room room : li.rooms) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/RoomRemoveAllRightsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/RoomRemoveAllRightsEvent.java
@@ -18,7 +18,7 @@ public class RoomRemoveAllRightsEvent extends MessageHandler {
             return;
 
         if (room.getOwnerId() == this.client.getHabbo().getHabboInfo().getId() || this.client.getHabbo().hasPermission(Permission.ACC_ANYROOMOWNER)) {
-            for (int value : room.getRights().toArray()) {
+            for (int value : room.getRights().toIntArray()) {
                 Habbo habbo = room.getHabbo(value);
 
                 if (habbo != null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/RoomRemoveAllRightsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/RoomRemoveAllRightsEvent.java
@@ -8,7 +8,6 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.rooms.RoomRightsComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserRemoveRightsComposer;
-import gnu.trove.procedure.TIntProcedure;
 
 public class RoomRemoveAllRightsEvent extends MessageHandler {
     @Override
@@ -19,20 +18,15 @@ public class RoomRemoveAllRightsEvent extends MessageHandler {
             return;
 
         if (room.getOwnerId() == this.client.getHabbo().getHabboInfo().getId() || this.client.getHabbo().hasPermission(Permission.ACC_ANYROOMOWNER)) {
-            room.getRights().forEach(new TIntProcedure() {
-                @Override
-                public boolean execute(int value) {
-                    Habbo habbo = room.getHabbo(value);
+            for (int value : room.getRights().toArray()) {
+                Habbo habbo = room.getHabbo(value);
 
-                    if (habbo != null) {
-                        room.sendComposer(new RoomUserRemoveRightsComposer(room, value).compose());
-                        habbo.getRoomUnit().removeStatus(RoomUnitStatus.FLAT_CONTROL);
-                        habbo.getClient().sendResponse(new RoomRightsComposer(RoomRightLevels.NONE));
-                    }
-
-                    return true;
+                if (habbo != null) {
+                    room.sendComposer(new RoomUserRemoveRightsComposer(room, value).compose());
+                    habbo.getRoomUnit().removeStatus(RoomUnitStatus.FLAT_CONTROL);
+                    habbo.getClient().sendResponse(new RoomRightsComposer(RoomRightLevels.NONE));
                 }
-            });
+            }
 
             room.removeAllRights();
         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/AdvertisingSaveEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/AdvertisingSaveEvent.java
@@ -6,7 +6,9 @@ import com.eu.habbo.habbohotel.items.interactions.InteractionRoomAds;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.incoming.MessageHandler;
-import gnu.trove.map.hash.THashMap;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class AdvertisingSaveEvent extends MessageHandler {
     @Override
@@ -31,7 +33,7 @@ public class AdvertisingSaveEvent extends MessageHandler {
             return;
         }
         if (item instanceof InteractionCustomValues) {
-            THashMap<String, String> oldValues = new THashMap<>(((InteractionCustomValues) item).values);
+            Map<String, String> oldValues = new HashMap<>(((InteractionCustomValues) item).values);
             int count = this.packet.readInt();
             if (!RoomItemInputGuard.isValidCustomValueCount(count))
                 return;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/MoodLightSaveSettingsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/MoodLightSaveSettingsEvent.java
@@ -43,7 +43,7 @@ public class MoodLightSaveSettingsEvent extends MessageHandler {
             return;
         }
 
-        for (RoomMoodlightData data : room.getMoodlightData().valueCollection()) {
+        for (RoomMoodlightData data : room.getMoodlightData().values()) {
             if (data.getId() == id) {
                 data.setBackgroundOnly(backgroundOnly == 2);
                 data.setColor(color);
@@ -62,6 +62,6 @@ public class MoodLightSaveSettingsEvent extends MessageHandler {
         }
 
         room.setNeedsUpdate(true);
-        this.client.sendResponse(new MoodLightDataComposer(room.getMoodlightData().valueCollection()));
+        this.client.sendResponse(new MoodLightDataComposer(room.getMoodlightData().values()));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/MoodLightSaveSettingsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/MoodLightSaveSettingsEvent.java
@@ -62,6 +62,6 @@ public class MoodLightSaveSettingsEvent extends MessageHandler {
         }
 
         room.setNeedsUpdate(true);
-        this.client.sendResponse(new MoodLightDataComposer(room.getMoodlightData()));
+        this.client.sendResponse(new MoodLightDataComposer(room.getMoodlightData().valueCollection()));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/MoodLightSettingsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/MoodLightSettingsEvent.java
@@ -7,6 +7,6 @@ public class MoodLightSettingsEvent extends MessageHandler {
     @Override
     public void handle() throws Exception {
         if (this.client.getHabbo().getHabboInfo().getCurrentRoom() != null)
-            this.client.sendResponse(new MoodLightDataComposer(this.client.getHabbo().getHabboInfo().getCurrentRoom().getMoodlightData().valueCollection()));
+            this.client.sendResponse(new MoodLightDataComposer(this.client.getHabbo().getHabboInfo().getCurrentRoom().getMoodlightData().values()));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/MoodLightSettingsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/MoodLightSettingsEvent.java
@@ -7,6 +7,6 @@ public class MoodLightSettingsEvent extends MessageHandler {
     @Override
     public void handle() throws Exception {
         if (this.client.getHabbo().getHabboInfo().getCurrentRoom() != null)
-            this.client.sendResponse(new MoodLightDataComposer(this.client.getHabbo().getHabboInfo().getCurrentRoom().getMoodlightData()));
+            this.client.sendResponse(new MoodLightDataComposer(this.client.getHabbo().getHabboInfo().getCurrentRoom().getMoodlightData().valueCollection()));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/MoodLightTurnOnEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/MoodLightTurnOnEvent.java
@@ -20,7 +20,7 @@ public class MoodLightTurnOnEvent extends MessageHandler {
             // enabled ? 2 : 1, preset id, background only ? 2 : 1, color, intensity
 
             String extradata = "2,1,2,#FF00FF,255";
-            for (RoomMoodlightData data : room.getMoodlightData().valueCollection()) {
+            for (RoomMoodlightData data : room.getMoodlightData().values()) {
                 if (data.isEnabled()) {
                     extradata = data.toString();
                     break;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemClothingEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemClothingEvent.java
@@ -56,7 +56,9 @@ public class RedeemClothingEvent extends MessageHandler {
                             Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
 
                             this.client.getHabbo().getInventory().getWardrobeComponent().getClothing().add(clothing.id);
-                            this.client.getHabbo().getInventory().getWardrobeComponent().getClothingSets().addAll(clothing.setId);
+                            for (int setId : clothing.setId) {
+                                this.client.getHabbo().getInventory().getWardrobeComponent().getClothingSets().add(setId);
+                            }
                             this.client.sendResponse(new UserClothesComposer(this.client.getHabbo()));
                             this.client.sendResponse(new BubbleAlertComposer(BubbleAlertKeys.FIGURESET_REDEEMED.key));
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/SetStackHelperHeightEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/SetStackHelperHeightEvent.java
@@ -9,7 +9,8 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.rooms.UpdateStackHeightComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.UpdateStackHeightTileHeightComposer;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class SetStackHelperHeightEvent extends MessageHandler {
     @Override
@@ -27,7 +28,7 @@ public class SetStackHelperHeightEvent extends MessageHandler {
                 RoomTile itemTile = room.getLayout().getTile(item.getX(), item.getY());
                 double stackerHeight = this.packet.readInt();
 
-                THashSet<RoomTile> tiles = room.getLayout().getTilesAt(itemTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
+                Set<RoomTile> tiles = room.getLayout().getTilesAt(itemTile, item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
                 if (stackerHeight == -100) {
                     for (RoomTile tile : tiles) {
                         double stackheight = room.getStackHeight(tile.x, tile.y, false, item) * 100;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ToggleFloorItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ToggleFloorItemEvent.java
@@ -59,7 +59,7 @@ public class ToggleFloorItemEvent extends MessageHandler {
 
             /*
             if (item.getBaseItem().getName().equalsIgnoreCase("totem_planet")) {
-                THashSet<HabboItem> items = room.getItemsAt(room.getLayout().getTile(item.getX(), item.getY()));
+                Set<HabboItem> items = room.getItemsAt(room.getLayout().getTile(item.getX(), item.getY()));
                 HabboItem totemLeg = null;
                 HabboItem totemHead = null;
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/users/RoomUserWalkEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/users/RoomUserWalkEvent.java
@@ -17,9 +17,10 @@ import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUnitOnRollerComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
 import com.eu.habbo.plugin.events.users.UserIdleEvent;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
 
 public class RoomUserWalkEvent extends MessageHandler {
 
@@ -139,7 +140,7 @@ public class RoomUserWalkEvent extends MessageHandler {
           return;
         }
 
-        THashSet<HabboItem> items = room.getItemsAt(tile);
+        Set<HabboItem> items = room.getItemsAt(tile);
 
         if (!items.isEmpty()) {
           for (HabboItem item : items) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/trading/TradeOfferMultipleItemsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/trading/TradeOfferMultipleItemsEvent.java
@@ -3,7 +3,9 @@ package com.eu.habbo.messages.incoming.trading;
 import com.eu.habbo.habbohotel.rooms.RoomTrade;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.incoming.MessageHandler;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class TradeOfferMultipleItemsEvent extends MessageHandler {
     @Override
@@ -16,7 +18,7 @@ public class TradeOfferMultipleItemsEvent extends MessageHandler {
         if (trade == null)
             return;
 
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         int count = this.packet.readInt();
         if (count <= 0 || count > RoomTrade.MAX_OFFERED_ITEMS)

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/achievements/talenttrack/TalentTrackComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/achievements/talenttrack/TalentTrackComposer.java
@@ -50,7 +50,9 @@ public class TalentTrackComposer extends MessageComposer {
                     this.response.appendInt(level.achievements.size());
 
                     final TalentTrackState finalState = state;
-                    level.achievements.forEachEntry((achievement, index) -> {
+                    for (Map.Entry<com.eu.habbo.habbohotel.achievements.Achievement, Integer> achievementEntry : level.achievements.entrySet()) {
+                        com.eu.habbo.habbohotel.achievements.Achievement achievement = achievementEntry.getKey();
+                        int index = achievementEntry.getValue();
                         if (achievement != null) {
                             this.response.appendInt(achievement.id);
 
@@ -84,8 +86,7 @@ public class TalentTrackComposer extends MessageComposer {
                             this.response.appendInt(0);
                             this.response.appendInt(0);
                         }
-                        return true;
-                    });
+                    }
 
 
                     if (level.perks != null && level.perks.length > 0) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPageComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPageComposer.java
@@ -45,7 +45,7 @@ public class CatalogPageComposer extends MessageComposer {
             }
         } else {
             this.response.appendInt(this.page.getCatalogItems().size());
-            List<CatalogItem> items = new ArrayList<>(this.page.getCatalogItems().valueCollection());
+            List<CatalogItem> items = new ArrayList<>(this.page.getCatalogItems().values());
             Collections.sort(items);
             for (CatalogItem item : items) {
                 item.serialize(this.response);
@@ -64,7 +64,7 @@ public class CatalogPageComposer extends MessageComposer {
     public void serializeExtra(ServerMessage message) {
         message.appendInt(Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPages().size());
 
-        for (CatalogFeaturedPage page : Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPages().valueCollection()) {
+        for (CatalogFeaturedPage page : Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPages().values()) {
             page.serialize(message);
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListComposer.java
@@ -74,7 +74,7 @@ public class CatalogPagesListComposer extends MessageComposer {
         this.response.appendString(category.getPageName());
         this.response.appendString(category.getCaption() + (this.hasPermission ? " (" + category.getId() + ")" : ""));
 
-        int[] offers = category.getOfferIds().toArray();
+        int[] offers = category.getOfferIds().toIntArray();
         int offerCount = Math.min(offers.length, MAX_OFFERS);
         this.response.appendInt(offerCount);
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/ClubGiftsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/ClubGiftsComposer.java
@@ -34,7 +34,7 @@ public class ClubGiftsComposer extends MessageComposer {
         CatalogPage page = Emulator.getGameEnvironment().getCatalogManager().getCatalogPageByLayout(CatalogPageLayouts.club_gift.name().toLowerCase());
 
         if (page != null) {
-            final List<CatalogItem> items = new ArrayList<>(page.getCatalogItems().valueCollection());
+            final List<CatalogItem> items = new ArrayList<>(page.getCatalogItems().values());
             Collections.sort(items);
 
             this.response.appendInt(items.size());

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/PetBreedsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/PetBreedsComposer.java
@@ -4,13 +4,14 @@ import com.eu.habbo.habbohotel.pets.PetRace;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class PetBreedsComposer extends MessageComposer {
     private final String petName;
-    private final THashSet<PetRace> petRaces;
+    private final Set<PetRace> petRaces;
 
-    public PetBreedsComposer(String petName, THashSet<PetRace> petRaces) {
+    public PetBreedsComposer(String petName, Set<PetRace> petRaces) {
         this.petName = petName;
         this.petRaces = petRaces;
     }
@@ -36,7 +37,7 @@ public class PetBreedsComposer extends MessageComposer {
         return petName;
     }
 
-    public THashSet<PetRace> getPetRaces() {
+    public Set<PetRace> getPetRaces() {
         return petRaces;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/RecyclerLogicComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/RecyclerLogicComposer.java
@@ -5,16 +5,16 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.Map;
+import java.util.Set;
 
 public class RecyclerLogicComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.RecyclerLogicComposer);
         this.response.appendInt(Emulator.getGameEnvironment().getCatalogManager().prizes.size());
-        for (Map.Entry<Integer, THashSet<Item>> map : Emulator.getGameEnvironment().getCatalogManager().prizes.entrySet()) {
+        for (Map.Entry<Integer, Set<Item>> map : Emulator.getGameEnvironment().getCatalogManager().prizes.entrySet()) {
             this.response.appendInt(map.getKey());
             this.response.appendInt(Integer.valueOf(Emulator.getConfig().getValue("hotel.ecotron.rarity.chance." + map.getKey())));
             this.response.appendInt(map.getValue().size());

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/events/calendar/AdventCalendarDataComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/events/calendar/AdventCalendarDataComposer.java
@@ -4,9 +4,10 @@ import com.eu.habbo.habbohotel.campaign.calendar.CalendarRewardClaimed;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.list.array.TIntArrayList;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 public class AdventCalendarDataComposer extends MessageComposer {
     private final String eventName;
@@ -34,7 +35,7 @@ public class AdventCalendarDataComposer extends MessageComposer {
         this.response.appendInt(this.totalDays);
         this.response.appendInt(this.unlocked.size());
 
-        TIntArrayList expired = new TIntArrayList();
+        Set<Integer> expired = new LinkedHashSet<>();
         if (this.lockExpired) { for (int i = 0; i < this.totalDays; i++) {
             expired.add(i);
         }
@@ -51,10 +52,9 @@ public class AdventCalendarDataComposer extends MessageComposer {
 
         if (this.lockExpired) {
             this.response.appendInt(expired.size());
-            expired.forEach(value -> {
-                AdventCalendarDataComposer.this.response.appendInt(value);
-                return true;
-            });
+            for (int day : expired) {
+                this.response.appendInt(day);
+            }
         } else {
             this.response.appendInt(0);
         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/floorplaneditor/FloorPlanEditorBlockedTilesComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/floorplaneditor/FloorPlanEditorBlockedTilesComposer.java
@@ -5,7 +5,8 @@ import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class FloorPlanEditorBlockedTilesComposer extends MessageComposer {
     private final Room room;
@@ -18,7 +19,7 @@ public class FloorPlanEditorBlockedTilesComposer extends MessageComposer {
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.FloorPlanEditorBlockedTilesComposer);
 
-        THashSet<RoomTile> tileList = this.room.getLockedTiles();
+        Set<RoomTile> tileList = this.room.getLockedTiles();
 
         this.response.appendInt(tileList.size());
         for (RoomTile node : tileList) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/FriendsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/FriendsComposer.java
@@ -5,12 +5,13 @@ import com.eu.habbo.habbohotel.users.HabboGender;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 public class FriendsComposer extends MessageComposer {
     private static final Logger LOGGER = LoggerFactory.getLogger(FriendsComposer.class);
@@ -59,7 +60,7 @@ public class FriendsComposer extends MessageComposer {
 
     public static ArrayList<ServerMessage> getMessagesForBuddyList(Collection<MessengerBuddy> buddies) {
         ArrayList<ServerMessage> messages = new ArrayList<ServerMessage>();
-        THashSet<MessengerBuddy> friends = new THashSet<MessengerBuddy>();
+        Set<MessengerBuddy> friends = new HashSet<MessengerBuddy>();
 
         int totalPages = (int)Math.ceil(buddies.size() / 750.0);
         int page = 0;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/RemoveFriendComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/RemoveFriendComposer.java
@@ -3,17 +3,17 @@ package com.eu.habbo.messages.outgoing.friends;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.list.array.TIntArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 public class RemoveFriendComposer extends MessageComposer {
-    private final TIntArrayList unfriendIds;
+    private final IntArrayList unfriendIds;
 
-    public RemoveFriendComposer(TIntArrayList unfriendIds) {
+    public RemoveFriendComposer(IntArrayList unfriendIds) {
         this.unfriendIds = unfriendIds;
     }
 
     public RemoveFriendComposer(int i) {
-        this.unfriendIds = new TIntArrayList();
+        this.unfriendIds = new IntArrayList();
         this.unfriendIds.add(i);
     }
 
@@ -25,13 +25,13 @@ public class RemoveFriendComposer extends MessageComposer {
         this.response.appendInt(this.unfriendIds.size());
         for (int i = 0; i < this.unfriendIds.size(); i++) {
             this.response.appendInt(-1);
-            this.response.appendInt(this.unfriendIds.get(i));
+            this.response.appendInt(this.unfriendIds.getInt(i));
         }
 
         return this.response;
     }
 
-    public TIntArrayList getUnfriendIds() {
+    public IntArrayList getUnfriendIds() {
         return unfriendIds;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/RoomInviteErrorComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/RoomInviteErrorComposer.java
@@ -4,14 +4,14 @@ import com.eu.habbo.habbohotel.messenger.MessengerBuddy;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.procedure.TObjectProcedure;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Collection;
 
 public class RoomInviteErrorComposer extends MessageComposer {
     private final int errorCode;
-    private final THashSet<MessengerBuddy> buddies;
+    private final Collection<MessengerBuddy> buddies;
 
-    public RoomInviteErrorComposer(int errorCode, THashSet<MessengerBuddy> buddies) {
+    public RoomInviteErrorComposer(int errorCode, Collection<MessengerBuddy> buddies) {
         this.errorCode = errorCode;
         this.buddies = buddies;
     }
@@ -21,13 +21,9 @@ public class RoomInviteErrorComposer extends MessageComposer {
         this.response.init(Outgoing.RoomInviteErrorComposer);
         this.response.appendInt(this.errorCode);
         this.response.appendInt(this.buddies.size());
-        this.buddies.forEach(new TObjectProcedure<MessengerBuddy>() {
-            @Override
-            public boolean execute(MessengerBuddy object) {
-                RoomInviteErrorComposer.this.response.appendInt(object.getId());
-                return true;
-            }
-        });
+        for (MessengerBuddy buddy : this.buddies) {
+            this.response.appendInt(buddy.getId());
+        }
         return this.response;
     }
 
@@ -35,7 +31,7 @@ public class RoomInviteErrorComposer extends MessageComposer {
         return errorCode;
     }
 
-    public THashSet<MessengerBuddy> getBuddies() {
+    public Collection<MessengerBuddy> getBuddies() {
         return buddies;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/UserSearchResultComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/UserSearchResultComposer.java
@@ -5,20 +5,20 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 public class UserSearchResultComposer extends MessageComposer {
-    private final THashSet<MessengerBuddy> users;
-    private final THashSet<MessengerBuddy> friends;
+    private final Set<MessengerBuddy> users;
+    private final Set<MessengerBuddy> friends;
     private final Habbo habbo;
 
     private static Comparator<MessengerBuddy> COMPARATOR = Comparator.comparing((MessengerBuddy b) -> b.getUsername().length()).thenComparing((MessengerBuddy b, MessengerBuddy b2) -> b.getUsername().compareToIgnoreCase(b2.getUsername()));
 
-    public UserSearchResultComposer(THashSet<MessengerBuddy> users, THashSet<MessengerBuddy> friends, Habbo habbo) {
+    public UserSearchResultComposer(Set<MessengerBuddy> users, Set<MessengerBuddy> friends, Habbo habbo) {
         this.users = users;
         this.friends = friends;
         this.habbo = habbo;
@@ -78,11 +78,11 @@ public class UserSearchResultComposer extends MessageComposer {
         return false;
     }
 
-    public THashSet<MessengerBuddy> getUsers() {
+    public Set<MessengerBuddy> getUsers() {
         return users;
     }
 
-    public THashSet<MessengerBuddy> getFriends() {
+    public Set<MessengerBuddy> getFriends() {
         return friends;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/generic/alerts/BubbleAlertComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/generic/alerts/BubbleAlertComposer.java
@@ -3,28 +3,28 @@ package com.eu.habbo.messages.outgoing.generic.alerts;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.map.hash.THashMap;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class BubbleAlertComposer extends MessageComposer {
     private final String errorKey;
-    private final THashMap<String, String> keys;
+    private final Map<String, String> keys;
 
-    public BubbleAlertComposer(String errorKey, THashMap<String, String> keys) {
+    public BubbleAlertComposer(String errorKey, Map<String, String> keys) {
         this.errorKey = errorKey;
         this.keys = keys;
     }
 
     public BubbleAlertComposer(String errorKey, String message) {
         this.errorKey = errorKey;
-        this.keys = new THashMap<>();
+        this.keys = new HashMap<>();
         this.keys.put("message", message);
     }
 
     public BubbleAlertComposer(String errorKey) {
         this.errorKey = errorKey;
-        this.keys = new THashMap<>();
+        this.keys = new HashMap<>();
     }
 
     @Override
@@ -43,7 +43,7 @@ public class BubbleAlertComposer extends MessageComposer {
         return errorKey;
     }
 
-    public THashMap<String, String> getKeys() {
+    public Map<String, String> getKeys() {
         return keys;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/guardians/GuardianVotingRequestedComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/guardians/GuardianVotingRequestedComposer.java
@@ -5,7 +5,8 @@ import com.eu.habbo.habbohotel.modtool.ModToolChatLog;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.map.hash.TIntIntHashMap;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 
 import java.util.Calendar;
 
@@ -18,7 +19,7 @@ public class GuardianVotingRequestedComposer extends MessageComposer {
 
     @Override
     protected ServerMessage composeInternal() {
-        TIntIntHashMap mappedUsers = new TIntIntHashMap();
+        Int2IntMap mappedUsers = new Int2IntOpenHashMap();
         mappedUsers.put(this.ticket.getReported().getHabboInfo().getId(), 0);
 
         Calendar c = Calendar.getInstance();

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/guilds/GuildBuyRoomsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/guilds/GuildBuyRoomsComposer.java
@@ -5,12 +5,13 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Collection;
 
 public class GuildBuyRoomsComposer extends MessageComposer {
-    private final THashSet<Room> rooms;
+    private final Collection<Room> rooms;
 
-    public GuildBuyRoomsComposer(THashSet<Room> rooms) {
+    public GuildBuyRoomsComposer(Collection<Room> rooms) {
         this.rooms = rooms;
     }
 
@@ -50,7 +51,7 @@ public class GuildBuyRoomsComposer extends MessageComposer {
         return this.response;
     }
 
-    public THashSet<Room> getRooms() {
+    public Collection<Room> getRooms() {
         return rooms;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/guilds/GuildListComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/guilds/GuildListComposer.java
@@ -6,13 +6,14 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class GuildListComposer extends MessageComposer {
-    private final THashSet<Guild> guilds;
+    private final Set<Guild> guilds;
     private final Habbo habbo;
 
-    public GuildListComposer(THashSet<Guild> guilds, Habbo habbo) {
+    public GuildListComposer(Set<Guild> guilds, Habbo habbo) {
         this.guilds = guilds;
         this.habbo = habbo;
     }
@@ -34,7 +35,7 @@ public class GuildListComposer extends MessageComposer {
         return this.response;
     }
 
-    public THashSet<Guild> getGuilds() {
+    public Set<Guild> getGuilds() {
         return guilds;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/guilds/forums/GuildForumDataComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/guilds/forums/GuildForumDataComposer.java
@@ -12,7 +12,6 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 import com.eu.habbo.messages.outgoing.handshake.ConnectionErrorComposer;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,6 +19,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 
@@ -109,7 +109,7 @@ public class GuildForumDataComposer extends MessageComposer {
 
     public static void serializeForumData(ServerMessage response, Guild guild, Habbo habbo) {
 
-        final THashSet<ForumThread> forumThreads = ForumThread.getByGuildId(guild.getId());
+        final Set<ForumThread> forumThreads = ForumThread.getByGuildId(guild.getId());
         int lastSeenAt = getLastSeenAt(habbo.getHabboInfo().getId(), guild.getId());
 
         int totalComments = 0;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/inventory/AddHabboItemComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/inventory/AddHabboItemComposer.java
@@ -4,19 +4,19 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 public class AddHabboItemComposer extends MessageComposer {
-    private THashSet<HabboItem> itemsList;
+    private Collection<HabboItem> itemsList;
     private HabboItem item;
     private int[] ids;
     private AddHabboItemCategory category;
     private Map<AddHabboItemCategory, List<Integer>> entries;
 
-    public AddHabboItemComposer(THashSet<HabboItem> itemsList) {
+    public AddHabboItemComposer(Collection<HabboItem> itemsList) {
         this.itemsList = itemsList;
         this.category = AddHabboItemCategory.OWNED_FURNI;
     }
@@ -95,7 +95,7 @@ public class AddHabboItemComposer extends MessageComposer {
         }
     }
 
-    public THashSet<HabboItem> getItemsList() {
+    public Collection<HabboItem> getItemsList() {
         return itemsList;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/inventory/InventoryAchievementsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/inventory/InventoryAchievementsComposer.java
@@ -6,8 +6,8 @@ import com.eu.habbo.habbohotel.achievements.AchievementLevel;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.procedure.TObjectProcedure;
+
+import java.util.Map;
 
 public class InventoryAchievementsComposer extends MessageComposer {
     @Override
@@ -15,23 +15,18 @@ public class InventoryAchievementsComposer extends MessageComposer {
         this.response.init(Outgoing.InventoryAchievementsComposer);
 
         synchronized (Emulator.getGameEnvironment().getAchievementManager().getAchievements()) {
-            THashMap<String, Achievement> achievements = Emulator.getGameEnvironment().getAchievementManager().getAchievements();
+            Map<String, Achievement> achievements = Emulator.getGameEnvironment().getAchievementManager().getAchievements();
 
             this.response.appendInt(achievements.size());
-            achievements.forEachValue(new TObjectProcedure<Achievement>() {
-                @Override
-                public boolean execute(Achievement achievement) {
-                    InventoryAchievementsComposer.this.response.appendString((achievement.name.startsWith("ACH_") ? achievement.name.replace("ACH_", "") : achievement.name));
-                    InventoryAchievementsComposer.this.response.appendInt(achievement.levels.size());
+            for (Achievement achievement : achievements.values()) {
+                InventoryAchievementsComposer.this.response.appendString((achievement.name.startsWith("ACH_") ? achievement.name.replace("ACH_", "") : achievement.name));
+                InventoryAchievementsComposer.this.response.appendInt(achievement.levels.size());
 
-                    for (AchievementLevel level : achievement.levels.values()) {
-                        InventoryAchievementsComposer.this.response.appendInt(level.level);
-                        InventoryAchievementsComposer.this.response.appendInt(level.progress);
-                    }
-
-                    return true;
+                for (AchievementLevel level : achievement.levels.values()) {
+                    InventoryAchievementsComposer.this.response.appendInt(level.level);
+                    InventoryAchievementsComposer.this.response.appendInt(level.progress);
                 }
-            });
+            }
         }
         return this.response;
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/inventory/InventoryBadgesComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/inventory/InventoryBadgesComposer.java
@@ -5,7 +5,9 @@ import com.eu.habbo.habbohotel.users.HabboBadge;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class InventoryBadgesComposer extends MessageComposer {
     private final Habbo habbo;
@@ -19,7 +21,7 @@ public class InventoryBadgesComposer extends MessageComposer {
         if (this.habbo == null)
             return null;
 
-        THashSet<HabboBadge> equippedBadges = new THashSet<>();
+        Set<HabboBadge> equippedBadges = new HashSet<>();
 
         this.response.init(Outgoing.InventoryBadgesComposer);
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/inventory/InventoryBotsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/inventory/InventoryBotsComposer.java
@@ -5,7 +5,8 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.map.hash.THashMap;
+
+import java.util.Map;
 
 public class InventoryBotsComposer extends MessageComposer {
     private final Habbo habbo;
@@ -18,7 +19,7 @@ public class InventoryBotsComposer extends MessageComposer {
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.InventoryBotsComposer);
 
-        THashMap<Integer, Bot> userBots = this.habbo.getInventory().getBotsComponent().getBots();
+        Map<Integer, Bot> userBots = this.habbo.getInventory().getBotsComponent().getBots();
         this.response.appendInt(userBots.size());
         for (Bot bot : userBots.values()) {
             this.response.appendInt(bot.getId());

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/inventory/InventoryItemsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/inventory/InventoryItemsComposer.java
@@ -6,22 +6,21 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.procedure.TIntObjectProcedure;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.List;
 
-public class InventoryItemsComposer extends MessageComposer implements TIntObjectProcedure<HabboItem> {
+public class InventoryItemsComposer extends MessageComposer {
     private static final Logger LOGGER = LoggerFactory.getLogger(InventoryItemsComposer.class);
 
     private final int fragmentNumber;
     private final int totalFragments;
-    private final TIntObjectMap<HabboItem> items;
+    private final Int2ObjectMap<HabboItem> items;
 
-    public InventoryItemsComposer(int fragmentNumber, int totalFragments, TIntObjectMap<HabboItem> items) {
+    public InventoryItemsComposer(int fragmentNumber, int totalFragments, Int2ObjectMap<HabboItem> items) {
         this.fragmentNumber = fragmentNumber;
         this.totalFragments = totalFragments;
         this.items = items;
@@ -35,7 +34,9 @@ public class InventoryItemsComposer extends MessageComposer implements TIntObjec
             this.response.appendInt(this.fragmentNumber - 1);
             this.response.appendInt(this.items.size());
 
-            this.items.forEachEntry(this);
+            for (HabboItem habboItem : this.items.values()) {
+                this.serializeItem(habboItem);
+            }
             return this.response;
         } catch (Exception e) {
             LOGGER.error("Caught exception", e);
@@ -44,8 +45,7 @@ public class InventoryItemsComposer extends MessageComposer implements TIntObjec
         return null;
     }
 
-    @Override
-    public boolean execute(int a, HabboItem habboItem) {
+    private void serializeItem(HabboItem habboItem) {
         this.response.appendInt(habboItem.getGiftAdjustedId());
         this.response.appendString(habboItem.getBaseItem().getType().code);
         this.response.appendInt(habboItem.getId());
@@ -92,14 +92,10 @@ public class InventoryItemsComposer extends MessageComposer implements TIntObjec
             if(habboItem.getBaseItem().getName().equals("song_disk")) {
                 List<String> extraDataAsList = Arrays.asList(habboItem.getExtradata().split("\n"));
                 this.response.appendInt(Integer.valueOf(extraDataAsList.get(extraDataAsList.size() - 1)));
-                return true;
+                return;
             }
             this.response.appendInt(habboItem instanceof InteractionGift ? ((((InteractionGift) habboItem).getColorId() * 1000) + ((InteractionGift) habboItem).getRibbonId()) : 1);
         }
-
-
-
-        return true;
     }
 
     public void addExtraDataToResponse(HabboItem habboItem) {
@@ -115,7 +111,7 @@ public class InventoryItemsComposer extends MessageComposer implements TIntObjec
         return totalFragments;
     }
 
-    public TIntObjectMap<HabboItem> getItems() {
+    public Int2ObjectMap<HabboItem> getItems() {
         return items;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/inventory/InventoryPetsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/inventory/InventoryPetsComposer.java
@@ -5,9 +5,6 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.iterator.TIntObjectIterator;
-
-import java.util.NoSuchElementException;
 
 public class InventoryPetsComposer extends MessageComposer {
     private final Habbo habbo;
@@ -24,15 +21,8 @@ public class InventoryPetsComposer extends MessageComposer {
         this.response.appendInt(1);
         this.response.appendInt(this.habbo.getInventory().getPetsComponent().getPetsCount());
 
-        TIntObjectIterator<Pet> petIterator = this.habbo.getInventory().getPetsComponent().getPets().iterator();
-
-        for (int i = this.habbo.getInventory().getPetsComponent().getPets().size(); i-- > 0; ) {
-            try {
-                petIterator.advance();
-            } catch (NoSuchElementException e) {
-                break;
-            }
-            petIterator.value().serialize(this.response);
+        for (Pet pet : this.habbo.getInventory().getPetsComponent().getPets().values()) {
+            pet.serialize(this.response);
         }
 
         return this.response;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/CfhTopicsMessageComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/CfhTopicsMessageComposer.java
@@ -6,32 +6,23 @@ import com.eu.habbo.habbohotel.modtool.CfhTopic;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.procedure.TObjectProcedure;
 
 public class CfhTopicsMessageComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.CfhTopicsMessageComposer);
 
-        this.response.appendInt(Emulator.getGameEnvironment().getModToolManager().getCfhCategories().valueCollection().size());
+        this.response.appendInt(Emulator.getGameEnvironment().getModToolManager().getCfhCategories().values().size());
 
-        Emulator.getGameEnvironment().getModToolManager().getCfhCategories().forEachValue(new TObjectProcedure<CfhCategory>() {
-            @Override
-            public boolean execute(CfhCategory category) {
-                CfhTopicsMessageComposer.this.response.appendString(category.getName());
-                CfhTopicsMessageComposer.this.response.appendInt(category.getTopics().valueCollection().size());
-                category.getTopics().forEachValue(new TObjectProcedure<CfhTopic>() {
-                    @Override
-                    public boolean execute(CfhTopic topic) {
-                        CfhTopicsMessageComposer.this.response.appendString(topic.name);
-                        CfhTopicsMessageComposer.this.response.appendInt(topic.id);
-                        CfhTopicsMessageComposer.this.response.appendString(topic.action.toString());
-                        return true;
-                    }
-                });
-                return true;
+        for (CfhCategory category : Emulator.getGameEnvironment().getModToolManager().getCfhCategories().values()) {
+            this.response.appendString(category.getName());
+            this.response.appendInt(category.getTopics().values().size());
+            for (CfhTopic topic : category.getTopics().values()) {
+                this.response.appendString(topic.name);
+                this.response.appendInt(topic.id);
+                this.response.appendString(topic.action.toString());
             }
-        });
+        }
 
         return this.response;
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolComposer.java
@@ -10,12 +10,11 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 import gnu.trove.map.hash.THashMap;
-import gnu.trove.procedure.TObjectProcedure;
 import gnu.trove.set.hash.THashSet;
 
 import java.util.Iterator;
 
-public class ModToolComposer extends MessageComposer implements TObjectProcedure<ModToolCategory> {
+public class ModToolComposer extends MessageComposer {
     private final Habbo habbo;
 
     public ModToolComposer(Habbo habbo) {
@@ -62,7 +61,9 @@ public class ModToolComposer extends MessageComposer implements TObjectProcedure
 
         this.response.appendInt(Emulator.getGameEnvironment().getModToolManager().getCategory().size());
 
-        Emulator.getGameEnvironment().getModToolManager().getCategory().forEachValue(this);
+        for (ModToolCategory category : Emulator.getGameEnvironment().getModToolManager().getCategory().values()) {
+            this.serializeCategory(category);
+        }
 
         this.response.appendBoolean(this.habbo.hasPermission(Permission.ACC_MODTOOL_TICKET_Q)); //ticketQueueueuhuehuehuehue
         this.response.appendBoolean(this.habbo.hasPermission(Permission.ACC_MODTOOL_USER_LOGS)); //user chatlogs
@@ -82,8 +83,7 @@ public class ModToolComposer extends MessageComposer implements TObjectProcedure
         return this.response;
     }
 
-    @Override
-    public boolean execute(ModToolCategory category) {
+    private void serializeCategory(ModToolCategory category) {
         this.response.appendString(category.getName());
 
 
@@ -91,8 +91,6 @@ public class ModToolComposer extends MessageComposer implements TObjectProcedure
 
 //
 
-
-        return true;
     }
 
     public Habbo getHabbo() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolComposer.java
@@ -9,10 +9,11 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
 
 public class ModToolComposer extends MessageComposer {
     private final Habbo habbo;
@@ -26,9 +27,9 @@ public class ModToolComposer extends MessageComposer {
         this.response.init(Outgoing.ModToolComposer);
 
         if (this.habbo.hasPermission(Permission.ACC_MODTOOL_TICKET_Q)) {
-            THashSet<ModToolIssue> openTickets = new THashSet<>();
+            Set<ModToolIssue> openTickets = new HashSet<>();
 
-            THashMap<Integer, ModToolIssue> tickets = Emulator.getGameEnvironment().getModToolManager().getTickets();
+            Map<Integer, ModToolIssue> tickets = Emulator.getGameEnvironment().getModToolManager().getTickets();
 
             for (ModToolIssue t : tickets.values()) {
                 if (t.state != ModToolTicketState.CLOSED)

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolSanctionInfoComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolSanctionInfoComposer.java
@@ -8,11 +8,11 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.map.hash.THashMap;
 
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Map;
 
 public class ModToolSanctionInfoComposer extends MessageComposer {
 
@@ -30,7 +30,7 @@ public class ModToolSanctionInfoComposer extends MessageComposer {
         Date probationStartTime;
 
         if (Emulator.getConfig().getBoolean("hotel.sanctions.enabled")) {
-            THashMap<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(habbo.getHabboInfo().getId());
+            Map<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(habbo.getHabboInfo().getId());
             ArrayList<ModToolSanctionItem> modToolSanctionItems = modToolSanctionItemsHashMap.get(habbo.getHabboInfo().getId());
 
             if (modToolSanctionItems != null && modToolSanctionItems.size() > 0) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserInfoComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserInfoComposer.java
@@ -7,7 +7,6 @@ import com.eu.habbo.habbohotel.modtool.ModToolSanctions;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,6 +14,7 @@ import java.sql.*;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Map;
 
 public class ModToolUserInfoComposer extends MessageComposer {
     private static final Logger LOGGER = LoggerFactory.getLogger(ModToolUserInfoComposer.class);
@@ -62,7 +62,7 @@ public class ModToolUserInfoComposer extends MessageComposer {
             ModToolSanctions modToolSanctions = Emulator.getGameEnvironment().getModToolSanctions();
 
             if (Emulator.getConfig().getBoolean("hotel.sanctions.enabled")) {
-                THashMap<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(this.set.getInt("user_id"));
+                Map<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(this.set.getInt("user_id"));
                 ArrayList<ModToolSanctionItem> modToolSanctionItems = modToolSanctionItemsHashMap.get(this.set.getInt("user_id"));
 
                 if (modToolSanctionItems != null && modToolSanctionItems.size() > 0) //has sanction

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserRoomVisitsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserRoomVisitsComposer.java
@@ -5,16 +5,16 @@ import com.eu.habbo.habbohotel.users.HabboInfo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.Calendar;
+import java.util.Set;
 import java.util.TimeZone;
 
 public class ModToolUserRoomVisitsComposer extends MessageComposer {
     private final HabboInfo habboInfo;
-    private final THashSet<ModToolRoomVisit> roomVisits;
+    private final Set<ModToolRoomVisit> roomVisits;
 
-    public ModToolUserRoomVisitsComposer(HabboInfo habboInfo, THashSet<ModToolRoomVisit> roomVisits) {
+    public ModToolUserRoomVisitsComposer(HabboInfo habboInfo, Set<ModToolRoomVisit> roomVisits) {
         this.habboInfo = habboInfo;
         this.roomVisits = roomVisits;
     }
@@ -41,7 +41,7 @@ public class ModToolUserRoomVisitsComposer extends MessageComposer {
         return habboInfo;
     }
 
-    public THashSet<ModToolRoomVisit> getRoomVisits() {
+    public Set<ModToolRoomVisit> getRoomVisits() {
         return roomVisits;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rarevalues/RareValuesComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rarevalues/RareValuesComposer.java
@@ -3,11 +3,10 @@ package com.eu.habbo.messages.outgoing.rarevalues;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.TIntObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 
 public class RareValuesComposer extends MessageComposer {
-    private final TIntObjectMap<int[]> values;
+    private final Int2ObjectMap<int[]> values;
     private final byte[] snapshot;
 
     public RareValuesComposer(byte[] snapshot) {
@@ -15,7 +14,7 @@ public class RareValuesComposer extends MessageComposer {
         this.snapshot = snapshot;
     }
 
-    public RareValuesComposer(TIntObjectMap<int[]> values) {
+    public RareValuesComposer(Int2ObjectMap<int[]> values) {
         this.values = values;
         this.snapshot = null;
     }
@@ -31,11 +30,9 @@ public class RareValuesComposer extends MessageComposer {
 
         this.response.appendInt(this.values.size());
 
-        TIntObjectIterator<int[]> iterator = this.values.iterator();
-        while (iterator.hasNext()) {
-            iterator.advance();
-            int[] value = iterator.value();
-            this.response.appendInt(iterator.key()); // spriteId
+        for (Int2ObjectMap.Entry<int[]> entry : this.values.int2ObjectEntrySet()) {
+            int[] value = entry.getValue();
+            this.response.appendInt(entry.getIntKey()); // spriteId
             this.response.appendInt(value[0]);        // credits
             this.response.appendInt(value[1]);        // points
             this.response.appendInt(value[2]);        // pointsType

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/RoomBannedUsersComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/RoomBannedUsersComposer.java
@@ -23,7 +23,7 @@ public class RoomBannedUsersComposer extends MessageComposer {
 
         Set<RoomBan> roomBans = new HashSet<>();
 
-        for (RoomBan ban : this.room.getBannedHabbos().valueCollection()) {
+        for (RoomBan ban : this.room.getBannedHabbos().values()) {
             if (ban.endTimestamp > timeStamp)
                 roomBans.add(ban);
         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/RoomBannedUsersComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/RoomBannedUsersComposer.java
@@ -6,10 +6,9 @@ import com.eu.habbo.habbohotel.rooms.RoomBan;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.set.hash.THashSet;
 
-import java.util.NoSuchElementException;
+import java.util.HashSet;
+import java.util.Set;
 
 public class RoomBannedUsersComposer extends MessageComposer {
     private final Room room;
@@ -22,19 +21,11 @@ public class RoomBannedUsersComposer extends MessageComposer {
     protected ServerMessage composeInternal() {
         int timeStamp = Emulator.getIntUnixTimestamp();
 
-        THashSet<RoomBan> roomBans = new THashSet<>();
+        Set<RoomBan> roomBans = new HashSet<>();
 
-        TIntObjectIterator<RoomBan> iterator = this.room.getBannedHabbos().iterator();
-
-        for (int i = this.room.getBannedHabbos().size(); i-- > 0; ) {
-            try {
-                iterator.advance();
-
-                if (iterator.value().endTimestamp > timeStamp)
-                    roomBans.add(iterator.value());
-            } catch (NoSuchElementException e) {
-                break;
-            }
+        for (RoomBan ban : this.room.getBannedHabbos().valueCollection()) {
+            if (ban.endTimestamp > timeStamp)
+                roomBans.add(ban);
         }
 
         if (roomBans.isEmpty())

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/UpdateStackHeightComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/UpdateStackHeightComposer.java
@@ -6,9 +6,9 @@ import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -18,7 +18,7 @@ public class UpdateStackHeightComposer extends MessageComposer {
     private short z;
     private double height;
 
-    private THashSet<RoomTile> updateTiles;
+    private Collection<RoomTile> updateTiles;
     private Room room;
 
     public UpdateStackHeightComposer(int x, int y, short z, double height) {
@@ -28,7 +28,7 @@ public class UpdateStackHeightComposer extends MessageComposer {
         this.height = height;
     }
 
-    public UpdateStackHeightComposer(Room room, THashSet<RoomTile> updateTiles) {
+    public UpdateStackHeightComposer(Room room, Collection<RoomTile> updateTiles) {
         this.updateTiles = updateTiles;
         this.room = room;
     }
@@ -56,7 +56,7 @@ public class UpdateStackHeightComposer extends MessageComposer {
 
                 List<RoomTile> remainingTiles = tilesCopy.subList(127, tilesCopy.size());
                 if (!remainingTiles.isEmpty()) {
-                    this.room.sendComposer(new UpdateStackHeightComposer(this.room, new THashSet<>(remainingTiles)).compose());
+                    this.room.sendComposer(new UpdateStackHeightComposer(this.room, new ArrayList<>(remainingTiles)).compose());
                 }
 
                 return this.response;
@@ -102,7 +102,7 @@ public class UpdateStackHeightComposer extends MessageComposer {
         return height;
     }
 
-    public THashSet<RoomTile> getUpdateTiles() {
+    public Collection<RoomTile> getUpdateTiles() {
         return updateTiles;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ConfInvisStateComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ConfInvisStateComposer.java
@@ -5,12 +5,13 @@ import com.eu.habbo.habbohotel.rooms.RoomConfInvisSupport;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.list.array.TIntArrayList;
+
+import java.util.List;
 
 public class ConfInvisStateComposer extends MessageComposer {
     private final int roomId;
     private final boolean active;
-    private final TIntArrayList hiddenItemIds;
+    private final List<Integer> hiddenItemIds;
 
     public ConfInvisStateComposer(Room room) {
         this.roomId = (room != null) ? room.getId() : 0;
@@ -25,8 +26,8 @@ public class ConfInvisStateComposer extends MessageComposer {
         this.response.appendBoolean(this.active);
         this.response.appendInt(this.hiddenItemIds.size());
 
-        for (int i = 0; i < this.hiddenItemIds.size(); i++) {
-            this.response.appendInt(this.hiddenItemIds.get(i));
+        for (int itemId : this.hiddenItemIds) {
+            this.response.appendInt(itemId);
         }
 
         return this.response;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/FloorItemOnRollerComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/FloorItemOnRollerComposer.java
@@ -6,7 +6,8 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class FloorItemOnRollerComposer extends MessageComposer {
     private final HabboItem item;
@@ -64,7 +65,7 @@ public class FloorItemOnRollerComposer extends MessageComposer {
             this.item.needsUpdate(true);
 
             // Update affected tiles for both old and new positions
-            THashSet<RoomTile> tiles = this.room.getLayout().getTilesAt(this.room.getLayout().getTile(oldX, oldY), this.item.getBaseItem().getWidth(), this.item.getBaseItem().getLength(), this.item.getRotation());
+            Set<RoomTile> tiles = this.room.getLayout().getTilesAt(this.room.getLayout().getTile(oldX, oldY), this.item.getBaseItem().getWidth(), this.item.getBaseItem().getLength(), this.item.getRotation());
             tiles.addAll(this.room.getLayout().getTilesAt(this.room.getLayout().getTile(this.item.getX(), this.item.getY()), this.item.getBaseItem().getWidth(), this.item.getBaseItem().getLength(), this.item.getRotation()));
             this.room.updateTiles(tiles);
         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/MoodLightDataComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/MoodLightDataComposer.java
@@ -4,12 +4,13 @@ import com.eu.habbo.habbohotel.rooms.RoomMoodlightData;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.map.TIntObjectMap;
+
+import java.util.Collection;
 
 public class MoodLightDataComposer extends MessageComposer {
-    private final TIntObjectMap<RoomMoodlightData> moodLightData;
+    private final Collection<RoomMoodlightData> moodLightData;
 
-    public MoodLightDataComposer(TIntObjectMap<RoomMoodlightData> moodLightData) {
+    public MoodLightDataComposer(Collection<RoomMoodlightData> moodLightData) {
         this.moodLightData = moodLightData;
     }
 
@@ -19,7 +20,7 @@ public class MoodLightDataComposer extends MessageComposer {
         this.response.appendInt(3); //PresetCount
 
         int index = 1;
-        for (RoomMoodlightData data : this.moodLightData.valueCollection()) {
+        for (RoomMoodlightData data : this.moodLightData) {
             if (data.isEnabled()) {
                 this.response.appendInt(data.getId());
                 index = -1;
@@ -33,7 +34,7 @@ public class MoodLightDataComposer extends MessageComposer {
         }
 
         int i = 1;
-        for (RoomMoodlightData data : this.moodLightData.valueCollection()) {
+        for (RoomMoodlightData data : this.moodLightData) {
             this.response.appendInt(data.getId()); //Preset ID
             this.response.appendInt(data.isBackgroundOnly() ? 2 : 1); //Background only ? 2 : 1
             this.response.appendString(data.getColor()); //Color
@@ -53,7 +54,7 @@ public class MoodLightDataComposer extends MessageComposer {
         return this.response;
     }
 
-    public TIntObjectMap<RoomMoodlightData> getMoodLightData() {
+    public Collection<RoomMoodlightData> getMoodLightData() {
         return moodLightData;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/RoomFloorItemsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/RoomFloorItemsComposer.java
@@ -7,15 +7,15 @@ import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 import gnu.trove.iterator.TIntObjectIterator;
 import gnu.trove.map.TIntObjectMap;
-import gnu.trove.set.hash.THashSet;
 
+import java.util.Collection;
 import java.util.NoSuchElementException;
 
 public class RoomFloorItemsComposer extends MessageComposer {
     private final TIntObjectMap<String> furniOwnerNames;
-    private final THashSet<? extends HabboItem> items;
+    private final Collection<? extends HabboItem> items;
 
-    public RoomFloorItemsComposer(TIntObjectMap<String> furniOwnerNames, THashSet<? extends HabboItem> items) {
+    public RoomFloorItemsComposer(TIntObjectMap<String> furniOwnerNames, Collection<? extends HabboItem> items) {
         this.furniOwnerNames = furniOwnerNames;
         this.items = items;
     }
@@ -67,7 +67,7 @@ public class RoomFloorItemsComposer extends MessageComposer {
         return furniOwnerNames;
     }
 
-    public THashSet<? extends HabboItem> getItems() {
+    public Collection<? extends HabboItem> getItems() {
         return items;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/RoomFloorItemsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/RoomFloorItemsComposer.java
@@ -5,17 +5,15 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.TIntObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 
 import java.util.Collection;
-import java.util.NoSuchElementException;
 
 public class RoomFloorItemsComposer extends MessageComposer {
-    private final TIntObjectMap<String> furniOwnerNames;
+    private final Int2ObjectMap<String> furniOwnerNames;
     private final Collection<? extends HabboItem> items;
 
-    public RoomFloorItemsComposer(TIntObjectMap<String> furniOwnerNames, Collection<? extends HabboItem> items) {
+    public RoomFloorItemsComposer(Int2ObjectMap<String> furniOwnerNames, Collection<? extends HabboItem> items) {
         this.furniOwnerNames = furniOwnerNames;
         this.items = items;
     }
@@ -24,17 +22,10 @@ public class RoomFloorItemsComposer extends MessageComposer {
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.RoomFloorItemsComposer);
 
-        TIntObjectIterator<String> iterator = this.furniOwnerNames.iterator();
-
         this.response.appendInt(this.furniOwnerNames.size());
-        for (int i = this.furniOwnerNames.size(); i-- > 0; ) {
-            try {
-                iterator.advance();
-                this.response.appendInt(iterator.key());
-                this.response.appendString(iterator.value());
-            } catch (NoSuchElementException e) {
-                break;
-            }
+        for (Int2ObjectMap.Entry<String> entry : this.furniOwnerNames.int2ObjectEntrySet()) {
+            this.response.appendInt(entry.getIntKey());
+            this.response.appendString(entry.getValue());
         }
 
         this.response.appendInt(this.items.size());
@@ -63,7 +54,7 @@ public class RoomFloorItemsComposer extends MessageComposer {
         return this.response;
     }
 
-    public TIntObjectMap<String> getFurniOwnerNames() {
+    public Int2ObjectMap<String> getFurniOwnerNames() {
         return furniOwnerNames;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/RoomWallItemsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/RoomWallItemsComposer.java
@@ -5,12 +5,8 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.iterator.TIntObjectIterator;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.THashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 
-import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
 
 public class RoomWallItemsComposer extends MessageComposer {
@@ -23,23 +19,11 @@ public class RoomWallItemsComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.RoomWallItemsComposer);
-        THashMap<Integer, String> userNames = new THashMap<>();
-        TIntObjectMap<String> furniOwnerNames = this.room.getFurniOwnerNames();
-        TIntObjectIterator<String> iterator = furniOwnerNames.iterator();
-
-        for (int i = furniOwnerNames.size(); i-- > 0; ) {
-            try {
-                iterator.advance();
-
-                userNames.put(iterator.key(), iterator.value());
-            } catch (NoSuchElementException e) {
-                break;
-            }
-        }
+        Int2ObjectMap<String> userNames = this.room.getFurniOwnerNames();
 
         this.response.appendInt(userNames.size());
-        for (Map.Entry<Integer, String> set : userNames.entrySet()) {
-            this.response.appendInt(set.getKey());
+        for (Int2ObjectMap.Entry<String> set : userNames.int2ObjectEntrySet()) {
+            this.response.appendInt(set.getIntKey());
             this.response.appendString(set.getValue());
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/RoomWallItemsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/RoomWallItemsComposer.java
@@ -8,10 +8,10 @@ import com.eu.habbo.messages.outgoing.Outgoing;
 import gnu.trove.iterator.TIntObjectIterator;
 import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 public class RoomWallItemsComposer extends MessageComposer {
     private final Room room;
@@ -43,7 +43,7 @@ public class RoomWallItemsComposer extends MessageComposer {
             this.response.appendString(set.getValue());
         }
 
-        THashSet<HabboItem> items = this.room.getWallItems();
+        Set<HabboItem> items = this.room.getWallItems();
 
         this.response.appendInt(items.size());
         for (HabboItem item : items) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/jukebox/JukeBoxPlayListUpdatedComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/jukebox/JukeBoxPlayListUpdatedComposer.java
@@ -4,12 +4,13 @@ import com.eu.habbo.habbohotel.items.SoundTrack;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Collection;
 
 public class JukeBoxPlayListUpdatedComposer extends MessageComposer {
-    private final THashSet<SoundTrack> tracks;
+    private final Collection<SoundTrack> tracks;
 
-    public JukeBoxPlayListUpdatedComposer(THashSet<SoundTrack> tracks) {
+    public JukeBoxPlayListUpdatedComposer(Collection<SoundTrack> tracks) {
         this.tracks = tracks;
     }
 
@@ -36,7 +37,7 @@ public class JukeBoxPlayListUpdatedComposer extends MessageComposer {
         return this.response;
     }
 
-    public THashSet<SoundTrack> getTracks() {
+    public Collection<SoundTrack> getTracks() {
         return tracks;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/pets/RoomPetComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/pets/RoomPetComposer.java
@@ -4,19 +4,18 @@ import com.eu.habbo.habbohotel.pets.*;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.map.TIntObjectMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
-import gnu.trove.procedure.TIntObjectProcedure;
 
-public class RoomPetComposer extends MessageComposer implements TIntObjectProcedure<Pet> {
-    private final TIntObjectMap<Pet> pets;
+import java.util.Collection;
+import java.util.Collections;
+
+public class RoomPetComposer extends MessageComposer {
+    private final Collection<Pet> pets;
 
     public RoomPetComposer(Pet pet) {
-        this.pets = new TIntObjectHashMap<>();
-        this.pets.put(pet.getId(), pet);
+        this.pets = Collections.singletonList(pet);
     }
 
-    public RoomPetComposer(TIntObjectMap<Pet> pets) {
+    public RoomPetComposer(Collection<Pet> pets) {
         this.pets = pets;
     }
 
@@ -24,12 +23,13 @@ public class RoomPetComposer extends MessageComposer implements TIntObjectProced
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.RoomUsersComposer);
         this.response.appendInt(this.pets.size());
-        this.pets.forEachEntry(this);
+        for (Pet pet : this.pets) {
+            this.serializePet(pet);
+        }
         return this.response;
     }
 
-    @Override
-    public boolean execute(int a, Pet pet) {
+    private void serializePet(Pet pet) {
         this.response.appendInt(pet.getId());
         this.response.appendString(pet.getName());
         this.response.appendString("");
@@ -63,7 +63,5 @@ public class RoomPetComposer extends MessageComposer implements TIntObjectProced
         this.response.appendString("unknown");
         this.response.appendInt(0);
         this.response.appendInt(0);
-
-        return true;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/pets/breeding/PetBreedingResultComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/pets/breeding/PetBreedingResultComposer.java
@@ -8,7 +8,7 @@ import com.eu.habbo.messages.ISerialize;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.map.hash.TIntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import org.apache.commons.math3.distribution.NormalDistribution;
 
 import java.util.ArrayList;
@@ -37,7 +37,7 @@ public class PetBreedingResultComposer extends MessageComposer {
         NormalDistribution normalDistribution = PetManager.getNormalDistributionForBreeding(avgLevel);
 
 
-        TIntObjectHashMap<ArrayList<PetBreedingReward>> rewardBreeds = Emulator.getGameEnvironment().getPetManager().getBreedingRewards(this.petType);
+        Int2ObjectMap<ArrayList<PetBreedingReward>> rewardBreeds = Emulator.getGameEnvironment().getPetManager().getBreedingRewards(this.petType);
 
         this.response.appendInt(4); //Levels
         {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/users/RoomUserStatusComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/users/RoomUserStatusComposer.java
@@ -8,21 +8,20 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 public class RoomUserStatusComposer extends MessageComposer {
     private Collection<Habbo> habbos;
-    private THashSet<RoomUnit> roomUnits;
+    private Collection<RoomUnit> roomUnits;
     private double overrideZ = -1;
 
     public RoomUserStatusComposer(RoomUnit roomUnit) {
-        this.roomUnits = new THashSet<>();
-        this.roomUnits.add(roomUnit);
+        this.roomUnits = Collections.singletonList(roomUnit);
     }
 
     public RoomUserStatusComposer(RoomUnit roomUnit, double overrideZ) {
@@ -30,7 +29,7 @@ public class RoomUserStatusComposer extends MessageComposer {
         this.overrideZ = overrideZ;
     }
 
-    public RoomUserStatusComposer(THashSet<RoomUnit> roomUnits, boolean value) {
+    public RoomUserStatusComposer(Collection<RoomUnit> roomUnits, boolean value) {
         this.roomUnits = roomUnits;
     }
 
@@ -116,7 +115,7 @@ public class RoomUserStatusComposer extends MessageComposer {
         return habbos;
     }
 
-    public THashSet<RoomUnit> getRoomUnits() {
+    public Collection<RoomUnit> getRoomUnits() {
         return roomUnits;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/users/RoomUsersGuildBadgesComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/users/RoomUsersGuildBadgesComposer.java
@@ -3,13 +3,13 @@ package com.eu.habbo.messages.outgoing.rooms.users;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.procedure.TObjectObjectProcedure;
+
+import java.util.Map;
 
 public class RoomUsersGuildBadgesComposer extends MessageComposer {
-    private final THashMap<Integer, String> guildBadges;
+    private final Map<Integer, String> guildBadges;
 
-    public RoomUsersGuildBadgesComposer(THashMap<Integer, String> guildBadges) {
+    public RoomUsersGuildBadgesComposer(Map<Integer, String> guildBadges) {
         this.guildBadges = guildBadges;
     }
 
@@ -18,18 +18,14 @@ public class RoomUsersGuildBadgesComposer extends MessageComposer {
         this.response.init(Outgoing.RoomUsersGuildBadgesComposer);
         this.response.appendInt(this.guildBadges.size());
 
-        this.guildBadges.forEachEntry(new TObjectObjectProcedure<Integer, String>() {
-            @Override
-            public boolean execute(Integer guildId, String badge) {
-                RoomUsersGuildBadgesComposer.this.response.appendInt(guildId);
-                RoomUsersGuildBadgesComposer.this.response.appendString(badge);
-                return true;
-            }
-        });
+        for (Map.Entry<Integer, String> guildBadge : this.guildBadges.entrySet()) {
+            this.response.appendInt(guildBadge.getKey());
+            this.response.appendString(guildBadge.getValue());
+        }
         return this.response;
     }
 
-    public THashMap<Integer, String> getGuildBadges() {
+    public Map<Integer, String> getGuildBadges() {
         return guildBadges;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/ClubGiftReceivedComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/ClubGiftReceivedComposer.java
@@ -4,14 +4,15 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class ClubGiftReceivedComposer extends MessageComposer {
     //:test 735 s:t i:1 s:s i:230 s:throne i:1 b:1 i:1 i:10;
     private final String name;
-    private final THashSet<Item> items;
+    private final Set<Item> items;
 
-    public ClubGiftReceivedComposer(String name, THashSet<Item> items) {
+    public ClubGiftReceivedComposer(String name, Set<Item> items) {
         this.name = name;
         this.items = items;
     }
@@ -34,7 +35,7 @@ public class ClubGiftReceivedComposer extends MessageComposer {
         return name;
     }
 
-    public THashSet<Item> getItems() {
+    public Set<Item> getItems() {
         return items;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/FavoriteRoomsCountComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/FavoriteRoomsCountComposer.java
@@ -5,7 +5,6 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.procedure.TIntProcedure;
 
 public class FavoriteRoomsCountComposer extends MessageComposer {
     private final Habbo habbo;
@@ -19,13 +18,9 @@ public class FavoriteRoomsCountComposer extends MessageComposer {
         this.response.init(Outgoing.FavoriteRoomsCountComposer);
         this.response.appendInt(Emulator.getConfig().getInt("hotel.rooms.max.favorite"));
         this.response.appendInt(this.habbo.getHabboStats().getFavoriteRooms().size());
-        this.habbo.getHabboStats().getFavoriteRooms().forEach(new TIntProcedure() {
-            @Override
-            public boolean execute(int value) {
-                FavoriteRoomsCountComposer.this.response.appendInt(value);
-                return true;
-            }
-        });
+        for (int roomId : this.habbo.getHabboStats().getFavoriteRooms().toArray()) {
+            this.response.appendInt(roomId);
+        }
         return this.response;
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/FavoriteRoomsCountComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/FavoriteRoomsCountComposer.java
@@ -18,7 +18,7 @@ public class FavoriteRoomsCountComposer extends MessageComposer {
         this.response.init(Outgoing.FavoriteRoomsCountComposer);
         this.response.appendInt(Emulator.getConfig().getInt("hotel.rooms.max.favorite"));
         this.response.appendInt(this.habbo.getHabboStats().getFavoriteRooms().size());
-        for (int roomId : this.habbo.getHabboStats().getFavoriteRooms().toArray()) {
+        for (int roomId : this.habbo.getHabboStats().getFavoriteRooms()) {
             this.response.appendInt(roomId);
         }
         return this.response;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/ProfileFriendsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/ProfileFriendsComposer.java
@@ -5,8 +5,6 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 
 public class ProfileFriendsComposer extends MessageComposer {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProfileFriendsComposer.class);
@@ -23,7 +22,7 @@ public class ProfileFriendsComposer extends MessageComposer {
     private final List<MessengerBuddy> haters = new ArrayList<>();
     private final int userId;
 
-    public ProfileFriendsComposer(THashMap<Integer, THashSet<MessengerBuddy>> map, int userId) {
+    public ProfileFriendsComposer(Map<Integer, Set<MessengerBuddy>> map, int userId) {
         this.lovers.addAll(map.get(1));
         this.friends.addAll(map.get(2));
         this.haters.addAll(map.get(3));

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/UserClothesComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/UserClothesComposer.java
@@ -6,7 +6,6 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.procedure.TIntProcedure;
 
 import java.util.ArrayList;
 
@@ -26,22 +25,17 @@ public class UserClothesComposer extends MessageComposer {
     private final ArrayList<ClothEntry> clothEntries = new ArrayList<>();
 
     public UserClothesComposer(Habbo habbo) {
-        habbo.getInventory().getWardrobeComponent().getClothing().forEach(new TIntProcedure() {
-            @Override
-            public boolean execute(int value) {
-                ClothItem item = Emulator.getGameEnvironment().getCatalogManager().clothing.get(value);
+        for (int value : habbo.getInventory().getWardrobeComponent().getClothing()) {
+            ClothItem item = Emulator.getGameEnvironment().getCatalogManager().clothing.get(value);
 
-                if (item != null) {
-                    for (Integer j : item.setId) {
-                        UserClothesComposer.this.idList.add(j);
-                    }
-
-                    UserClothesComposer.this.nameList.add(item.name);
+            if (item != null) {
+                for (Integer j : item.setId) {
+                    this.idList.add(j);
                 }
 
-                return true;
+                this.nameList.add(item.name);
             }
-        });
+        }
 
         for (ClothItem item : Emulator.getGameEnvironment().getCatalogManager().clothing.values()) {
             if (item != null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/ImageAlertUser.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/ImageAlertUser.java
@@ -4,11 +4,13 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.google.gson.Gson;
-import gnu.trove.map.hash.THashMap;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ImageAlertUser extends RCONMessage<ImageAlertUser.JSON> {
     public ImageAlertUser() {
@@ -24,7 +26,7 @@ public class ImageAlertUser extends RCONMessage<ImageAlertUser.JSON> {
             return;
         }
 
-        THashMap<String, String> keys = new THashMap<>();
+        Map<String, String> keys = new HashMap<>();
 
         if (!json.message.isEmpty()) {
             keys.put("message", json.message);

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/ImageHotelAlert.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/ImageHotelAlert.java
@@ -5,11 +5,11 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.google.gson.Gson;
-import gnu.trove.map.hash.THashMap;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class ImageHotelAlert extends RCONMessage<ImageHotelAlert.JSON> {
@@ -19,7 +19,7 @@ public class ImageHotelAlert extends RCONMessage<ImageHotelAlert.JSON> {
 
     @Override
     public void handle(Gson gson, JSON json) {
-        THashMap<String, String> keys = new THashMap<>();
+        Map<String, String> keys = new HashMap<>();
 
         if (!json.message.isEmpty()) {
             keys.put("message", json.message);

--- a/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServer.java
@@ -7,7 +7,6 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import gnu.trove.map.hash.THashMap;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.netty.channel.ChannelHandlerContext;
@@ -20,14 +19,16 @@ import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class RCONServer extends Server {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RCONServer.class);
 
-    private final THashMap<String, Class<? extends RCONMessage>> messages;
+    private final Map<String, Class<? extends RCONMessage>> messages;
     private final GsonBuilder gsonBuilder;
     private final boolean rateLimitEnabled;
     private final LoadingCache<String, RateLimiter> rateLimiters;
@@ -36,7 +37,7 @@ public class RCONServer extends Server {
     public RCONServer(String host, int port) throws Exception {
         super("RCON Server", host, port, 1, 2);
 
-        this.messages = new THashMap<>();
+        this.messages = new HashMap<>();
 
         this.gsonBuilder = new GsonBuilder();
         this.gsonBuilder.registerTypeAdapter(RCONMessage.class, new RCONMessage.RCONMessageSerializer());

--- a/Emulator/src/main/java/com/eu/habbo/plugin/HabboPlugin.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/HabboPlugin.java
@@ -1,15 +1,17 @@
 package com.eu.habbo.plugin;
 
 import com.eu.habbo.habbohotel.users.Habbo;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
 
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URLClassLoader;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public abstract class HabboPlugin {
-    public final THashMap<Class<? extends Event>, THashSet<Method>> registeredEvents = new THashMap<>();
+    public final Map<Class<? extends Event>, Set<Method>> registeredEvents = new HashMap<>();
 
     public HabboPluginConfiguration configuration;
     public URLClassLoader classLoader;

--- a/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
@@ -45,8 +45,6 @@ import com.eu.habbo.threading.runnables.RoomTrashing;
 import com.eu.habbo.threading.runnables.ShutdownEmulator;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import gnu.trove.iterator.hash.TObjectHashIterator;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,8 +56,9 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
-import java.util.NoSuchElementException;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -71,8 +70,8 @@ public class PluginManager {
     // of building a parser per plugin-config load.
     private static final Gson PLUGIN_GSON = new GsonBuilder().create();
 
-    private final THashSet<HabboPlugin> plugins = new THashSet<>();
-    private final THashSet<Method> methods = new THashSet<>();
+    private final Set<HabboPlugin> plugins = new HashSet<>();
+    private final Set<Method> methods = new HashSet<>();
 
     @EventHandler
     public static void globalOnConfigurationUpdated(EmulatorConfigUpdatedEvent event) {
@@ -313,7 +312,7 @@ public class PluginManager {
                             final Class<?> eventClass = method.getParameterTypes()[0];
 
                             if (!plugin.registeredEvents.containsKey(eventClass.asSubclass(Event.class))) {
-                                plugin.registeredEvents.put(eventClass.asSubclass(Event.class), new THashSet<>());
+                                plugin.registeredEvents.put(eventClass.asSubclass(Event.class), new HashSet<>());
                             }
 
                             plugin.registeredEvents.get(eventClass.asSubclass(Event.class)).add(method);
@@ -336,27 +335,21 @@ public class PluginManager {
             }
         }
 
-        TObjectHashIterator<HabboPlugin> iterator = this.plugins.iterator();
-        while (iterator.hasNext()) {
-            try {
-                HabboPlugin plugin = iterator.next();
+        for (HabboPlugin plugin : this.plugins) {
 
-                if (plugin != null) {
-                    THashSet<Method> methods = plugin.registeredEvents.get(event.getClass().asSubclass(Event.class));
+            if (plugin != null) {
+                Set<Method> methods = plugin.registeredEvents.get(event.getClass().asSubclass(Event.class));
 
-                    if (methods != null) {
-                        for (Method method : methods) {
-                            try {
-                                method.invoke(plugin, event);
-                            } catch (Exception e) {
-                                LOGGER.error("Could not pass event {} to {}", event.getClass().getName(), plugin.configuration.name);
-                                LOGGER.error("Caught exception", e);
-                            }
+                if (methods != null) {
+                    for (Method method : methods) {
+                        try {
+                            method.invoke(plugin, event);
+                        } catch (Exception e) {
+                            LOGGER.error("Could not pass event {} to {}", event.getClass().getName(), plugin.configuration.name);
+                            LOGGER.error("Caught exception", e);
                         }
                     }
                 }
-            } catch (NoSuchElementException e) {
-                break;
             }
         }
 
@@ -364,14 +357,9 @@ public class PluginManager {
     }
 
     public boolean isRegistered(Class<? extends Event> clazz, boolean pluginsOnly) {
-        TObjectHashIterator<HabboPlugin> iterator = this.plugins.iterator();
-        while (iterator.hasNext()) {
-            try {
-                HabboPlugin plugin = iterator.next();
-                if (plugin.isRegistered(clazz))
-                    return true;
-            } catch (NoSuchElementException e) {
-                break;
+        for (HabboPlugin plugin : this.plugins) {
+            if (plugin != null && plugin.isRegistered(clazz)) {
+                return true;
             }
         }
 
@@ -393,25 +381,18 @@ public class PluginManager {
     }
 
     private void disposePlugins() {
-        TObjectHashIterator<HabboPlugin> iterator = this.plugins.iterator();
-        while (iterator.hasNext()) {
-            try {
-                HabboPlugin p = iterator.next();
+        for (HabboPlugin p : this.plugins) {
+            if (p != null) {
 
-                if (p != null) {
-
-                    try {
-                        p.onDisable();
-                        p.stream.close();
-                        p.classLoader.close();
-                    } catch (IOException e) {
-                        LOGGER.error("Caught exception", e);
-                    } catch (Exception ex) {
-                        LOGGER.error("Failed to disable {} because of an exception.", p.configuration.name, ex);
-                    }
+                try {
+                    p.onDisable();
+                    p.stream.close();
+                    p.classLoader.close();
+                } catch (IOException e) {
+                    LOGGER.error("Caught exception", e);
+                } catch (Exception ex) {
+                    LOGGER.error("Failed to disable {} because of an exception.", p.configuration.name, ex);
                 }
-            } catch (NoSuchElementException e) {
-                break;
             }
         }
         this.plugins.clear();
@@ -449,7 +430,7 @@ public class PluginManager {
         }
     }
 
-    public THashSet<HabboPlugin> getPlugins() {
+    public Set<HabboPlugin> getPlugins() {
         return this.plugins;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/plugin/events/furniture/wired/WiredStackExecutedEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/events/furniture/wired/WiredStackExecutedEvent.java
@@ -6,20 +6,21 @@ import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.plugin.events.roomunit.RoomUnitEvent;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class WiredStackExecutedEvent extends RoomUnitEvent {
 
     public final InteractionWiredTrigger trigger;
 
 
-    public final THashSet<InteractionWiredEffect> effects;
+    public final Set<InteractionWiredEffect> effects;
 
 
-    public final THashSet<InteractionWiredCondition> conditions;
+    public final Set<InteractionWiredCondition> conditions;
 
 
-    public WiredStackExecutedEvent(Room room, RoomUnit roomUnit, InteractionWiredTrigger trigger, THashSet<InteractionWiredEffect> effects, THashSet<InteractionWiredCondition> conditions) {
+    public WiredStackExecutedEvent(Room room, RoomUnit roomUnit, InteractionWiredTrigger trigger, Set<InteractionWiredEffect> effects, Set<InteractionWiredCondition> conditions) {
         super(room, roomUnit);
 
         this.trigger = trigger;

--- a/Emulator/src/main/java/com/eu/habbo/plugin/events/furniture/wired/WiredStackTriggeredEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/events/furniture/wired/WiredStackTriggeredEvent.java
@@ -6,20 +6,21 @@ import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.plugin.events.roomunit.RoomUnitEvent;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class WiredStackTriggeredEvent extends RoomUnitEvent {
 
     public final InteractionWiredTrigger trigger;
 
 
-    public final THashSet<InteractionWiredEffect> effects;
+    public final Set<InteractionWiredEffect> effects;
 
 
-    public final THashSet<InteractionWiredCondition> conditions;
+    public final Set<InteractionWiredCondition> conditions;
 
 
-    public WiredStackTriggeredEvent(Room room, RoomUnit roomUnit, InteractionWiredTrigger trigger, THashSet<InteractionWiredEffect> effects, THashSet<InteractionWiredCondition> conditions) {
+    public WiredStackTriggeredEvent(Room room, RoomUnit roomUnit, InteractionWiredTrigger trigger, Set<InteractionWiredEffect> effects, Set<InteractionWiredCondition> conditions) {
         super(room, roomUnit);
 
         this.trigger = trigger;

--- a/Emulator/src/main/java/com/eu/habbo/plugin/events/inventory/InventoryItemsAddedEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/events/inventory/InventoryItemsAddedEvent.java
@@ -2,12 +2,13 @@ package com.eu.habbo.plugin.events.inventory;
 
 import com.eu.habbo.habbohotel.users.HabboInventory;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class InventoryItemsAddedEvent extends InventoryEvent {
-    public final THashSet<HabboItem> items;
+    public final Set<HabboItem> items;
 
-    public InventoryItemsAddedEvent(HabboInventory inventory, THashSet<HabboItem> items) {
+    public InventoryItemsAddedEvent(HabboInventory inventory, Set<HabboItem> items) {
         super(inventory);
         this.items = items;
     }

--- a/Emulator/src/main/java/com/eu/habbo/plugin/events/rooms/RoomFloorItemsLoadEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/events/rooms/RoomFloorItemsLoadEvent.java
@@ -3,19 +3,20 @@ package com.eu.habbo.plugin.events.rooms;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.plugin.events.users.UserEvent;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class RoomFloorItemsLoadEvent extends UserEvent {
-    private THashSet<HabboItem> floorItems;
+    private Set<HabboItem> floorItems;
     private boolean changedFloorItems;
 
-    public RoomFloorItemsLoadEvent(Habbo habbo, THashSet<HabboItem> floorItems) {
+    public RoomFloorItemsLoadEvent(Habbo habbo, Set<HabboItem> floorItems) {
         super(habbo);
         this.floorItems = floorItems;
         this.changedFloorItems = false;
     }
 
-    public void setFloorItems(THashSet<HabboItem> floorItems) {
+    public void setFloorItems(Set<HabboItem> floorItems) {
         this.changedFloorItems = true;
         this.floorItems = floorItems;
     }
@@ -24,7 +25,7 @@ public class RoomFloorItemsLoadEvent extends UserEvent {
         return this.changedFloorItems;
     }
 
-    public THashSet<HabboItem> getFloorItems() {
+    public Set<HabboItem> getFloorItems() {
         return this.floorItems;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/plugin/events/users/catalog/UserCatalogFurnitureBoughtEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/events/users/catalog/UserCatalogFurnitureBoughtEvent.java
@@ -3,14 +3,15 @@ package com.eu.habbo.plugin.events.users.catalog;
 import com.eu.habbo.habbohotel.catalog.CatalogItem;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class UserCatalogFurnitureBoughtEvent extends UserCatalogEvent {
 
-    public final THashSet<HabboItem> furniture;
+    public final Set<HabboItem> furniture;
 
 
-    public UserCatalogFurnitureBoughtEvent(Habbo habbo, CatalogItem catalogItem, THashSet<HabboItem> furniture) {
+    public UserCatalogFurnitureBoughtEvent(Habbo habbo, CatalogItem catalogItem, Set<HabboItem> furniture) {
         super(habbo, catalogItem);
 
         this.furniture = furniture;

--- a/Emulator/src/main/java/com/eu/habbo/plugin/events/users/catalog/UserCatalogItemPurchasedEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/events/users/catalog/UserCatalogItemPurchasedEvent.java
@@ -3,13 +3,13 @@ package com.eu.habbo.plugin.events.users.catalog;
 import com.eu.habbo.habbohotel.catalog.CatalogItem;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
 
 import java.util.List;
+import java.util.Set;
 
 public class UserCatalogItemPurchasedEvent extends UserCatalogEvent {
 
-    public final THashSet<HabboItem> itemsList;
+    public final Set<HabboItem> itemsList;
 
 
     public int totalCredits;
@@ -21,7 +21,7 @@ public class UserCatalogItemPurchasedEvent extends UserCatalogEvent {
     public List<String> badges;
 
 
-    public UserCatalogItemPurchasedEvent(Habbo habbo, CatalogItem catalogItem, THashSet<HabboItem> itemsList, int totalCredits, int totalPoints, List<String> badges) {
+    public UserCatalogItemPurchasedEvent(Habbo habbo, CatalogItem catalogItem, Set<HabboItem> itemsList, int totalCredits, int totalPoints, List<String> badges) {
         super(habbo, catalogItem);
 
         this.itemsList = itemsList;

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/BattleBanzaiTilesFlicker.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/BattleBanzaiTilesFlicker.java
@@ -6,17 +6,18 @@ import com.eu.habbo.habbohotel.items.interactions.games.battlebanzai.Interaction
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.outgoing.rooms.items.ItemsDataUpdateComposer;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class BattleBanzaiTilesFlicker implements Runnable {
-    private final THashSet<HabboItem> items;
+    private final Set<HabboItem> items;
     private final GameTeamColors color;
     private final Room room;
 
     private boolean on = false;
     private int count = 0;
 
-    public BattleBanzaiTilesFlicker(THashSet<HabboItem> items, GameTeamColors color, Room room) {
+    public BattleBanzaiTilesFlicker(Set<HabboItem> items, GameTeamColors color, Room room) {
         this.items = items;
         this.color = color;
         this.room = room;

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/CannonKickAction.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/CannonKickAction.java
@@ -9,9 +9,10 @@ import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
-import gnu.trove.map.hash.THashMap;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class CannonKickAction implements Runnable {
     private final InteractionCannon cannon;
@@ -29,7 +30,7 @@ public class CannonKickAction implements Runnable {
         if (this.client != null) {
             this.client.getHabbo().getRoomUnit().setCanWalk(true);
         }
-        THashMap<String, String> dater = new THashMap<>();
+        Map<String, String> dater = new HashMap<>();
         dater.put("title", "${notification.room.kick.cannonball.title}");
         dater.put("message", "${notification.room.kick.cannonball.message}");
 

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/ClearRentedSpace.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/ClearRentedSpace.java
@@ -7,7 +7,9 @@ import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class ClearRentedSpace implements Runnable {
     private final InteractionRentableSpace item;
@@ -20,7 +22,7 @@ public class ClearRentedSpace implements Runnable {
 
     @Override
     public void run() {
-        THashSet<HabboItem> items = new THashSet<>();
+        Set<HabboItem> items = new HashSet<>();
 
         for (RoomTile t : this.room.getLayout().getTilesAt(this.room.getLayout().getTile(this.item.getX(), this.item.getY()), this.item.getBaseItem().getWidth(), this.item.getBaseItem().getLength(), this.item.getRotation())) {
             for (HabboItem i : this.room.getItemsAt(t)) {

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/OpenGift.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/OpenGift.java
@@ -10,11 +10,11 @@ import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryUpdateItemComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.PresentItemOpenedComposer;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +37,7 @@ public class OpenGift implements Runnable {
         try {
             HabboItem inside = null;
 
-            THashSet<HabboItem> items = ((InteractionGift) this.item).loadItems();
+            Collection<HabboItem> items = ((InteractionGift) this.item).loadItems();
             for (HabboItem i : items) {
                 if (inside == null)
                     inside = i;

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/QueryDeleteHabboItems.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/QueryDeleteHabboItems.java
@@ -2,27 +2,29 @@ package com.eu.habbo.threading.runnables;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.map.TIntObjectMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public class QueryDeleteHabboItems implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(QueryDeleteHabboItems.class);
 
-    private TIntObjectMap<HabboItem> items;
+    private final List<HabboItem> items;
 
-    public QueryDeleteHabboItems(TIntObjectMap<HabboItem> items) {
-        this.items = items;
+    public QueryDeleteHabboItems(Collection<HabboItem> items) {
+        this.items = new ArrayList<>(items);
     }
 
     @Override
     public void run() {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("DELETE FROM items WHERE id = ?")) {
-            for (HabboItem item : this.items.valueCollection()) {
+            for (HabboItem item : this.items) {
                 if (item.getRoomId() > 0)
                     continue;
 

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/RebugKickBallAction.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/RebugKickBallAction.java
@@ -9,7 +9,8 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.outgoing.rooms.items.FloorItemOnRollerComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.ItemStateComposer;
 import com.eu.habbo.util.pathfinding.Direction8;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 public class RebugKickBallAction implements Runnable {
 
@@ -142,7 +143,7 @@ public class RebugKickBallAction implements Runnable {
             }
 
             if (!this.zigzag && this.tilesSinceBounce > 1 && !this.isDribble) {
-                THashSet<Habbo> habbos = this.room.getHabbosAt(nextTile.x, nextTile.y);
+                Set<Habbo> habbos = this.room.getHabbosAt(nextTile.x, nextTile.y);
                 if (!habbos.isEmpty()) {
                     this.direction = this.direction.rotateDirection180Degrees();
                     this.tilesSinceBounce = 0;

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/RoomTrashing.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/RoomTrashing.java
@@ -9,7 +9,9 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.rooms.items.FloorItemOnRollerComposer;
 import com.eu.habbo.plugin.EventHandler;
 import com.eu.habbo.plugin.events.users.UserTakeStepEvent;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class RoomTrashing implements Runnable {
     public static RoomTrashing INSTANCE;
@@ -38,9 +40,9 @@ public class RoomTrashing implements Runnable {
         if (INSTANCE.habbo == event.habbo) {
             if (event.habbo.getHabboInfo().getCurrentRoom() != null) {
                 if (event.habbo.getHabboInfo().getCurrentRoom().equals(INSTANCE.room)) {
-                    THashSet<ServerMessage> messages = new THashSet<>();
+                    Set<ServerMessage> messages = new HashSet<>();
 
-                    THashSet<HabboItem> items = INSTANCE.room.getItemsAt(event.toLocation);
+                    Set<HabboItem> items = INSTANCE.room.getItemsAt(event.toLocation);
 
                     int offset = Emulator.getRandom().nextInt(4) + 2;
 

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/freeze/FreezeHandleSnowballExplosion.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/freeze/FreezeHandleSnowballExplosion.java
@@ -9,9 +9,11 @@ import com.eu.habbo.habbohotel.items.interactions.games.freeze.InteractionFreeze
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
 
 class FreezeHandleSnowballExplosion implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(FreezeHandleSnowballExplosion.class);
@@ -35,7 +37,7 @@ class FreezeHandleSnowballExplosion implements Runnable {
 
             player.addSnowball();
 
-            THashSet<RoomTile> tiles = new THashSet<>();
+            Set<RoomTile> tiles = new HashSet<>();
 
             FreezeGame game = ((FreezeGame) this.thrownData.room.getGame(FreezeGame.class));
 
@@ -51,10 +53,10 @@ class FreezeHandleSnowballExplosion implements Runnable {
                 player.nextDiagonal = false;
             }
 
-            THashSet<InteractionFreezeTile> freezeTiles = new THashSet<>();
+            Set<InteractionFreezeTile> freezeTiles = new HashSet<>();
 
             for (RoomTile roomTile : tiles) {
-                THashSet<HabboItem> items = this.thrownData.room.getItemsAt(roomTile);
+                Set<HabboItem> items = this.thrownData.room.getItemsAt(roomTile);
 
                 // Track if we already processed a block at this tile to prevent stacking exploit
                 boolean blockProcessedAtTile = false;
@@ -74,7 +76,7 @@ class FreezeHandleSnowballExplosion implements Runnable {
                             this.thrownData.room.updateItem(freezeTile);
 
 
-                            THashSet<Habbo> habbos = new THashSet<>();
+                            Set<Habbo> habbos = new HashSet<>();
                             habbos.addAll(this.thrownData.room.getHabbosAt(freezeTile.getX(), freezeTile.getY()));
 
                             for (Habbo habbo : habbos) {

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/freeze/FreezeResetExplosionTiles.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/freeze/FreezeResetExplosionTiles.java
@@ -3,13 +3,14 @@ package com.eu.habbo.threading.runnables.freeze;
 import com.eu.habbo.habbohotel.items.interactions.games.freeze.InteractionFreezeTile;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import gnu.trove.set.hash.THashSet;
+
+import java.util.Set;
 
 class FreezeResetExplosionTiles implements Runnable {
-    private final THashSet<InteractionFreezeTile> tiles;
+    private final Set<InteractionFreezeTile> tiles;
     private final Room room;
 
-    public FreezeResetExplosionTiles(THashSet<InteractionFreezeTile> tiles, Room room) {
+    public FreezeResetExplosionTiles(Set<InteractionFreezeTile> tiles, Room room) {
         this.tiles = tiles;
         this.room = room;
     }

--- a/Emulator/src/main/java/com/eu/habbo/util/figure/FigureUtil.java
+++ b/Emulator/src/main/java/com/eu/habbo/util/figure/FigureUtil.java
@@ -1,14 +1,14 @@
 package com.eu.habbo.util.figure;
 
-import gnu.trove.map.hash.THashMap;
 import org.apache.commons.lang3.ArrayUtils;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 public class FigureUtil {
-    public static THashMap<String, String> getFigureBits(String looks) {
-        THashMap<String, String> bits = new THashMap<>();
+    public static Map<String, String> getFigureBits(String looks) {
+        Map<String, String> bits = new HashMap<>();
         String[] sets = looks.split("\\.");
 
         for (String set : sets) {
@@ -45,8 +45,8 @@ public class FigureUtil {
     }
 
     public static String mergeFigures(String figure1, String figure2, String[] limitFigure1, String[] limitFigure2) {
-        THashMap<String, String> figureBits1 = getFigureBits(figure1);
-        THashMap<String, String> figureBits2 = getFigureBits(figure2);
+        Map<String, String> figureBits1 = getFigureBits(figure1);
+        Map<String, String> figureBits2 = getFigureBits(figure2);
 
         StringBuilder finalLook = new StringBuilder();
 

--- a/Emulator/src/main/java/com/eu/habbo/util/imager/badges/BadgeImager.java
+++ b/Emulator/src/main/java/com/eu/habbo/util/imager/badges/BadgeImager.java
@@ -4,7 +4,6 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.guilds.Guild;
 import com.eu.habbo.habbohotel.guilds.GuildPart;
 import com.eu.habbo.habbohotel.guilds.GuildPartType;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,13 +15,14 @@ import java.awt.image.ColorModel;
 import java.awt.image.WritableRaster;
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 public class BadgeImager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BadgeImager.class);
 
-    final THashMap<String, BufferedImage> cachedImages = new THashMap<>();
+    final Map<String, BufferedImage> cachedImages = new HashMap<>();
 
     public BadgeImager() {
         if (Emulator.getConfig().getBoolean("imager.internal.enabled")) {
@@ -124,7 +124,7 @@ public class BadgeImager {
 
         this.cachedImages.clear();
         try {
-            for (Map.Entry<GuildPartType, THashMap<Integer, GuildPart>> set : Emulator.getGameEnvironment().getGuildManager().getGuildParts().entrySet()) {
+            for (Map.Entry<GuildPartType, ? extends Map<Integer, GuildPart>> set : Emulator.getGameEnvironment().getGuildManager().getGuildParts().entrySet()) {
                 if (set.getKey() == GuildPartType.SYMBOL || set.getKey() == GuildPartType.BASE) {
                     for (Map.Entry<Integer, GuildPart> map : set.getValue().entrySet()) {
                         for (String part : Arrays.asList(map.getValue().valueA, map.getValue().valueB)) {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/commands/RedeemCommandValueGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/commands/RedeemCommandValueGuardTest.java
@@ -1,7 +1,9 @@
 package com.eu.habbo.habbohotel.commands;
 
-import gnu.trove.map.hash.TIntIntHashMap;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -27,7 +29,7 @@ class RedeemCommandValueGuardTest {
 
     @Test
     void rejectsOverflowingPointTotalsWithoutChangingTheMap() {
-        TIntIntHashMap points = new TIntIntHashMap();
+        Map<Integer, Integer> points = new HashMap<>();
         points.put(5, Integer.MAX_VALUE);
 
         assertFalse(RedeemCommand.addRedeemPoints(points, 5, 1));

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomTradeSafetyContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomTradeSafetyContractTest.java
@@ -17,7 +17,7 @@ class RoomTradeSafetyContractTest {
     void sqlFailureStopsBeforeInventoryTransfer() throws Exception {
         String source = roomTradeSource();
         int catchIndex = source.indexOf("catch (SQLException e)");
-        int inventoryTransferIndex = source.indexOf("THashSet<HabboItem> itemsUserOne");
+        int inventoryTransferIndex = source.indexOf("Set<HabboItem> itemsUserOne");
 
         assertTrue(catchIndex > -1, "RoomTrade must handle SQL failures explicitly");
         assertTrue(inventoryTransferIndex > catchIndex, "Inventory transfer should happen after SQL ownership updates");

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftSecretContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftSecretContractTest.java
@@ -29,7 +29,7 @@ class CraftingCraftSecretContractTest {
     void rejectsDuplicateIngredientItemsBeforeRecipeLookup() throws Exception {
         String source = source();
 
-        int setDeclaration = source.indexOf("Set<HabboItem> habboItems = new THashSet<>()");
+        int setDeclaration = source.indexOf("Set<HabboItem> habboItems = Collections.newSetFromMap(new IdentityHashMap<>())");
         int duplicateGuard = source.indexOf("habboItem == null || !habboItems.add(habboItem)", setDeclaration);
         int recipeLookup = source.indexOf("CraftingRecipe recipe = altar.getRecipe(items)", duplicateGuard);
 


### PR DESCRIPTION
## Summary
- Keeps the Trove4j -> fastutil/java.util modernization in one consolidated PR.
- Adds `fastutil` alongside the existing Trove dependency.
- Migrates modtool primitive int-to-object maps from Trove `TIntObjectMap` to fastutil `Int2ObjectMap`.
- Removes Trove object collections from modtool, core console/config, achievements/talent-track, and campaign calendar by using Java `Map` / `Set` interfaces with `HashMap` / `HashSet` implementations.
- Rewrites affected Trove callback iterations (`forEachValue`, `forEachEntry`, `valueCollection`) to normal Java loops while preserving packet serialization order and business logic.

## Scope and risk notes
This is the single PR for the Trove4j modernization effort. Trove4j is intentionally not removed yet: large gameplay areas such as rooms, items, catalog, wired, users, guilds and inventory still contain Trove usage and will be migrated into this same branch step by step.

The approach is conservative: package-level slices, compile/package after each meaningful step, and no public plugin/API removal unless we have a compatibility-safe replacement.

This branch is stacked on PR #273 while the upstream dev package repair is pending. Rebase/recheck after #273 lands.

## Verification
- `mvn compile`
- `mvn -Dtest=ModTool*Test,Housekeeping*Test test` (43 tests)
- `mvn -Dtest=*Achievement*,EarningsCenterManagerTest test` (11 tests)
- `mvn package` (376 tests)