### PR TITLE
fix(achievements): use standard collections

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/Achievement.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/Achievement.java
@@ -1,9 +1,9 @@
 package com.eu.habbo.habbohotel.achievements;
 
-import gnu.trove.map.hash.THashMap;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class Achievement {
 
@@ -16,11 +16,11 @@ public class Achievement {
     public final AchievementCategories category;
 
 
-    public final THashMap<Integer, AchievementLevel> levels;
+    public final Map<Integer, AchievementLevel> levels;
 
 
     public Achievement(ResultSet set) throws SQLException {
-        this.levels = new THashMap<>();
+        this.levels = new HashMap<>();
 
         this.id = set.getInt("id");
         this.name = set.getString("name");

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/AchievementManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/AchievementManager.java
@@ -16,12 +16,11 @@ import com.eu.habbo.messages.outgoing.users.UserBadgesComposer;
 import com.eu.habbo.plugin.Event;
 import com.eu.habbo.plugin.events.users.achievements.UserAchievementLeveledEvent;
 import com.eu.habbo.plugin.events.users.achievements.UserAchievementProgressEvent;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.procedure.TObjectIntProcedure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.*;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -30,12 +29,12 @@ public class AchievementManager {
 
     public static boolean TALENTTRACK_ENABLED = false;
 
-    private final THashMap<String, Achievement> achievements;
-    private final THashMap<TalentTrackType, LinkedHashMap<Integer, TalentTrackLevel>> talentTrackLevels;
+    private final Map<String, Achievement> achievements;
+    private final Map<TalentTrackType, LinkedHashMap<Integer, TalentTrackLevel>> talentTrackLevels;
 
     public AchievementManager() {
-        this.achievements = new THashMap<>();
-        this.talentTrackLevels = new THashMap<>();
+        this.achievements = new HashMap<>();
+        this.talentTrackLevels = new HashMap<>();
     }
 
     public static void progressAchievement(int habboId, Achievement achievement) {
@@ -311,7 +310,7 @@ public class AchievementManager {
         return null;
     }
 
-    public THashMap<String, Achievement> getAchievements() {
+    public Map<String, Achievement> getAchievements() {
         return this.achievements;
     }
 
@@ -324,16 +323,12 @@ public class AchievementManager {
 
         for (Map.Entry<Integer, TalentTrackLevel> entry : this.talentTrackLevels.get(type).entrySet()) {
             final boolean[] allCompleted = {true};
-            entry.getValue().achievements.forEachEntry(new TObjectIntProcedure<Achievement>() {
-                @Override
-                public boolean execute(Achievement a, int b) {
-                    if (habbo.getHabboStats().getAchievementProgress(a) < b) {
-                        allCompleted[0] = false;
-                    }
-
-                    return allCompleted[0];
+            for (Map.Entry<Achievement, Integer> achievementEntry : entry.getValue().achievements.entrySet()) {
+                if (habbo.getHabboStats().getAchievementProgress(achievementEntry.getKey()) < achievementEntry.getValue()) {
+                    allCompleted[0] = false;
+                    break;
                 }
-            });
+            }
 
             if (allCompleted[0]) {
                 if (level == null || level.level < entry.getValue().level) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/TalentTrackLevel.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/TalentTrackLevel.java
@@ -2,30 +2,31 @@ package com.eu.habbo.habbohotel.achievements;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.items.Item;
-import gnu.trove.map.TObjectIntMap;
-import gnu.trove.map.hash.TObjectIntHashMap;
-import gnu.trove.set.hash.THashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class TalentTrackLevel {
     private static final Logger LOGGER = LoggerFactory.getLogger(TalentTrackLevel.class);
 
     public TalentTrackType type;
     public int level;
-    public TObjectIntMap<Achievement> achievements;
-    public THashSet<Item> items;
+    public Map<Achievement, Integer> achievements;
+    public Set<Item> items;
     public String[] perks;
     public String[] badges;
 
     public TalentTrackLevel(ResultSet set) throws SQLException {
         this.type = TalentTrackType.valueOf(set.getString("type").toUpperCase());
         this.level = set.getInt("level");
-        this.achievements = new TObjectIntHashMap<>();
-        this.items = new THashSet<>();
+        this.achievements = new HashMap<>();
+        this.items = new HashSet<>();
 
         String[] achievements = set.getString("achievement_ids").split(",");
         String[] achievementLevels = set.getString("achievement_levels").split(",");

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/achievements/talenttrack/TalentTrackComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/achievements/talenttrack/TalentTrackComposer.java
@@ -50,7 +50,9 @@ public class TalentTrackComposer extends MessageComposer {
                     this.response.appendInt(level.achievements.size());
 
                     final TalentTrackState finalState = state;
-                    level.achievements.forEachEntry((achievement, index) -> {
+                    for (Map.Entry<com.eu.habbo.habbohotel.achievements.Achievement, Integer> achievementEntry : level.achievements.entrySet()) {
+                        com.eu.habbo.habbohotel.achievements.Achievement achievement = achievementEntry.getKey();
+                        int index = achievementEntry.getValue();
                         if (achievement != null) {
                             this.response.appendInt(achievement.id);
 
@@ -84,8 +86,7 @@ public class TalentTrackComposer extends MessageComposer {
                             this.response.appendInt(0);
                             this.response.appendInt(0);
                         }
-                        return true;
-                    });
+                    }
 
 
                     if (level.perks != null && level.perks.length > 0) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/inventory/InventoryAchievementsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/inventory/InventoryAchievementsComposer.java
@@ -6,8 +6,8 @@ import com.eu.habbo.habbohotel.achievements.AchievementLevel;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.procedure.TObjectProcedure;
+
+import java.util.Map;
 
 public class InventoryAchievementsComposer extends MessageComposer {
     @Override
@@ -15,23 +15,18 @@ public class InventoryAchievementsComposer extends MessageComposer {
         this.response.init(Outgoing.InventoryAchievementsComposer);
 
         synchronized (Emulator.getGameEnvironment().getAchievementManager().getAchievements()) {
-            THashMap<String, Achievement> achievements = Emulator.getGameEnvironment().getAchievementManager().getAchievements();
+            Map<String, Achievement> achievements = Emulator.getGameEnvironment().getAchievementManager().getAchievements();
 
             this.response.appendInt(achievements.size());
-            achievements.forEachValue(new TObjectProcedure<Achievement>() {
-                @Override
-                public boolean execute(Achievement achievement) {
-                    InventoryAchievementsComposer.this.response.appendString((achievement.name.startsWith("ACH_") ? achievement.name.replace("ACH_", "") : achievement.name));
-                    InventoryAchievementsComposer.this.response.appendInt(achievement.levels.size());
+            for (Achievement achievement : achievements.values()) {
+                InventoryAchievementsComposer.this.response.appendString((achievement.name.startsWith("ACH_") ? achievement.name.replace("ACH_", "") : achievement.name));
+                InventoryAchievementsComposer.this.response.appendInt(achievement.levels.size());
 
-                    for (AchievementLevel level : achievement.levels.values()) {
-                        InventoryAchievementsComposer.this.response.appendInt(level.level);
-                        InventoryAchievementsComposer.this.response.appendInt(level.progress);
-                    }
-
-                    return true;
+                for (AchievementLevel level : achievement.levels.values()) {
+                    InventoryAchievementsComposer.this.response.appendInt(level.level);
+                    InventoryAchievementsComposer.this.response.appendInt(level.progress);
                 }
-            });
+            }
         }
         return this.response;
     }


### PR DESCRIPTION
## Summary
- Replaces Trove object maps/sets in the achievements domain with Java collection interfaces and `HashMap` / `HashSet` implementations.
- Converts talent-track requirements from `TObjectIntMap` to `Map<Achievement, Integer>`.
- Rewrites Trove callback iteration in achievement/talent-track composers to normal Java loops while preserving packet field order.

## Scope and compatibility
This PR is limited to achievements/talent-track serialization and the inventory achievements composer. It does not change achievement progress rules, reward creation, badge naming, packet ids, or database schema.

This branch is stacked on PR #273 while the upstream dev package repair is pending. Rebase/recheck after #273 lands.

## Verification
- `mvn compile`
- `mvn -Dtest=*Achievement*,EarningsCenterManagerTest test` (11 tests)
- `mvn package` (376 tests)