### PR TITLE
fix(campaign): use standard collection maps

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/campaign/calendar/CalendarCampaign.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/campaign/calendar/CalendarCampaign.java
@@ -1,16 +1,15 @@
 package com.eu.habbo.habbohotel.campaign.calendar;
 
-import gnu.trove.map.hash.THashMap;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Map;
 
 public class CalendarCampaign {
     private int id;
     private final String name;
     private final String image;
-    private Map<Integer , CalendarRewardObject> rewards = new THashMap<>();
+    private Map<Integer , CalendarRewardObject> rewards = new HashMap<>();
     private final Integer start_timestamp;
     private final int total_days;
     private final boolean lock_expired;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/campaign/calendar/CalendarManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/campaign/calendar/CalendarManager.java
@@ -5,7 +5,6 @@ import com.eu.habbo.database.SqlQueries;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.events.calendar.AdventCalendarProductComposer;
 import com.eu.habbo.plugin.events.users.calendar.UserClaimRewardEvent;
-import gnu.trove.map.hash.THashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,7 +18,7 @@ import static java.time.temporal.ChronoUnit.DAYS;
 public class CalendarManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(CalendarCampaign.class);
 
-    final private static Map<Integer, CalendarCampaign> calendarCampaigns = new THashMap<>();
+    final private static Map<Integer, CalendarCampaign> calendarCampaigns = new HashMap<>();
     public static double HC_MODIFIER;
 
     public CalendarManager() {
@@ -116,7 +115,7 @@ public class CalendarManager {
         if (habbo.getHabboStats().calendarRewardsClaimed.stream().noneMatch(claimed -> claimed.getCampaignId() == campaign.getId() && claimed.getDay() == day)) {
 
             Set<Integer> keys = campaign.getRewards().keySet();
-            Map<Integer, Integer> rewards = new THashMap<>();
+            Map<Integer, Integer> rewards = new HashMap<>();
             if(keys.isEmpty()) return;
             keys.forEach(key -> rewards.put(rewards.size() + 1, key));
             int rand = Emulator.getRandom().nextInt(rewards.size() - 1 + 1) + 1;


### PR DESCRIPTION
## Summary
- Replaces Trove `THashMap` usage in calendar campaign storage with Java `HashMap` behind existing `Map` types.
- Keeps campaign loading, reward lookup, random reward selection and claim persistence behavior unchanged.

## Scope and compatibility
This PR is limited to the campaign calendar package. It does not change packet payloads, database schema, reward selection rules, or claim validation.

This branch is stacked on PR #273 while the upstream dev package repair is pending. Rebase/recheck after #273 lands.

## Verification
- `mvn compile`
- `mvn package` (376 tests)