### PR TITLE
fix(runtime): validate packet startup contracts

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -132,6 +132,9 @@ public class PacketManager {
         this.registerCamera();
         this.registerGameCenter();
         this.registerEarnings();
+
+        RuntimeValidationReport report = PacketRuntimeValidator.validateHandlers(this.incoming);
+        report.logErrors(LOGGER, "Incoming packet handler validation");
     }
 
     public PacketNames getNames() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketNames.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketNames.java
@@ -22,6 +22,11 @@ public class PacketNames {
     }
 
     public void initialize() {
+        RuntimeValidationReport report = new RuntimeValidationReport();
+        report.merge(PacketRuntimeValidator.validatePacketNameClass("Incoming", Incoming.class));
+        report.merge(PacketRuntimeValidator.validatePacketNameClass("Outgoing", Outgoing.class));
+        report.logErrors(LOGGER, "Packet name validation");
+
         PacketNames.getNames(Incoming.class, this.incoming);
         PacketNames.getNames(Outgoing.class, this.outgoing);
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketRuntimeValidator.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketRuntimeValidator.java
@@ -1,0 +1,76 @@
+package com.eu.habbo.messages;
+
+import com.eu.habbo.messages.incoming.MessageHandler;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class PacketRuntimeValidator {
+
+    private PacketRuntimeValidator() {
+    }
+
+    public static RuntimeValidationReport validatePacketNameClass(String direction, Class<?> packetClass) {
+        RuntimeValidationReport report = new RuntimeValidationReport();
+        Map<Integer, String> packetNames = new HashMap<>();
+
+        for (Field field : packetClass.getFields()) {
+            int modifiers = field.getModifiers();
+
+            if (!Modifier.isPublic(modifiers) || !Modifier.isStatic(modifiers) || !Modifier.isFinal(modifiers) || field.getType() != int.class) {
+                continue;
+            }
+
+            try {
+                int packetId = field.getInt(null);
+
+                if (packetId <= 0) {
+                    continue;
+                }
+
+                String existingName = packetNames.putIfAbsent(packetId, field.getName());
+
+                if (existingName != null) {
+                    report.addError("Duplicate " + direction + " packet id " + packetId + " for " + existingName + " and " + field.getName());
+                }
+            } catch (IllegalAccessException e) {
+                report.addError("Unable to read " + direction + " packet id field " + packetClass.getName() + "." + field.getName());
+            }
+        }
+
+        return report;
+    }
+
+    public static RuntimeValidationReport validateHandlers(Map<Integer, Class<? extends MessageHandler>> handlers) {
+        RuntimeValidationReport report = new RuntimeValidationReport();
+
+        for (Map.Entry<Integer, Class<? extends MessageHandler>> entry : handlers.entrySet()) {
+            Integer packetId = entry.getKey();
+            Class<? extends MessageHandler> handlerClass = entry.getValue();
+
+            if (packetId == null || packetId < 0) {
+                report.addError("Incoming handler " + handlerClass + " is registered with invalid packet id " + packetId);
+                continue;
+            }
+
+            if (handlerClass == null) {
+                report.addError("Incoming packet id " + packetId + " is registered with a null handler");
+                continue;
+            }
+
+            try {
+                handlerClass.getDeclaredConstructor();
+            } catch (NoSuchMethodException e) {
+                report.addError("Incoming packet id " + packetId + " uses " + handlerClass.getName() + " without a no-argument constructor");
+            } catch (NoClassDefFoundError e) {
+                report.addError("Incoming packet id " + packetId + " uses " + handlerClass.getName() + " but dependency " + e.getMessage() + " is missing");
+            } catch (LinkageError e) {
+                report.addError("Incoming packet id " + packetId + " uses " + handlerClass.getName() + " but linkage failed: " + e.getMessage());
+            }
+        }
+
+        return report;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/RuntimeValidationIssue.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/RuntimeValidationIssue.java
@@ -1,0 +1,4 @@
+package com.eu.habbo.messages;
+
+public record RuntimeValidationIssue(String message) {
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/RuntimeValidationReport.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/RuntimeValidationReport.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.messages;
+
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class RuntimeValidationReport {
+
+    private final List<RuntimeValidationIssue> errors = new ArrayList<>();
+
+    public void addError(String message) {
+        this.errors.add(new RuntimeValidationIssue(message));
+    }
+
+    public void merge(RuntimeValidationReport report) {
+        this.errors.addAll(report.errors);
+    }
+
+    public boolean hasErrors() {
+        return !this.errors.isEmpty();
+    }
+
+    public List<RuntimeValidationIssue> errors() {
+        return Collections.unmodifiableList(this.errors);
+    }
+
+    public void logErrors(Logger logger, String label) {
+        if (!this.hasErrors()) {
+            return;
+        }
+
+        logger.error("{} failed with {} error(s):", label, this.errors.size());
+
+        for (RuntimeValidationIssue issue : this.errors) {
+            logger.error(" - {}", issue.message());
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
@@ -265,8 +265,10 @@ public class PluginManager {
         }
 
         for (File file : Objects.requireNonNull(loc.listFiles(file -> file.getPath().toLowerCase().endsWith(".jar")))) {
-            URLClassLoader urlClassLoader;
-            InputStream stream;
+            URLClassLoader urlClassLoader = null;
+            InputStream stream = null;
+            boolean retainPluginResources = false;
+
             try {
                 urlClassLoader = URLClassLoader.newInstance(new URL[]{file.toURI().toURL()});
                 stream = urlClassLoader.getResourceAsStream("plugin.json");
@@ -297,6 +299,7 @@ public class PluginManager {
                         plugin.classLoader = urlClassLoader;
                         plugin.stream = stream;
                         this.plugins.add(plugin);
+                        retainPluginResources = true;
                         plugin.onEnable();
                     } catch (Exception e) {
                         LOGGER.error("Could not load plugin {}!", pluginConfigurtion.name);
@@ -305,6 +308,28 @@ public class PluginManager {
                 }
             } catch (Exception e) {
                 LOGGER.error("Caught exception", e);
+            } finally {
+                if (!retainPluginResources) {
+                    closeRejectedPluginResources(stream, urlClassLoader, file.getName());
+                }
+            }
+        }
+    }
+
+    private static void closeRejectedPluginResources(InputStream stream, URLClassLoader classLoader, String jarName) {
+        if (stream != null) {
+            try {
+                stream.close();
+            } catch (IOException e) {
+                LOGGER.warn("Failed to close plugin.json stream for rejected plugin {}.", jarName, e);
+            }
+        }
+
+        if (classLoader != null) {
+            try {
+                classLoader.close();
+            } catch (IOException e) {
+                LOGGER.warn("Failed to close classloader for rejected plugin {}.", jarName, e);
             }
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
@@ -29,6 +29,7 @@ import com.eu.habbo.habbohotel.wired.core.WiredEngine;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.highscores.WiredHighscoreManager;
 import com.eu.habbo.messages.PacketManager;
+import com.eu.habbo.messages.RuntimeValidationReport;
 import com.eu.habbo.messages.incoming.catalog.CheckPetNameEvent;
 import com.eu.habbo.messages.incoming.floorplaneditor.FloorPlanEditorSaveEvent;
 import com.eu.habbo.messages.incoming.hotelview.HotelViewRequestLTDAvailabilityEvent;
@@ -280,6 +281,12 @@ public class PluginManager {
                     String body = new String(content, java.nio.charset.StandardCharsets.UTF_8);
 
                     HabboPluginConfiguration pluginConfigurtion = PLUGIN_GSON.fromJson(body, HabboPluginConfiguration.class);
+                    RuntimeValidationReport validationReport = PluginRuntimeValidator.validatePluginClass(file.getName(), pluginConfigurtion, urlClassLoader);
+
+                    if (validationReport.hasErrors()) {
+                        validationReport.logErrors(LOGGER, "Plugin validation");
+                        continue;
+                    }
 
                     try {
                         Class<?> clazz = urlClassLoader.loadClass(pluginConfigurtion.main);

--- a/Emulator/src/main/java/com/eu/habbo/plugin/PluginRuntimeValidator.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/PluginRuntimeValidator.java
@@ -1,0 +1,69 @@
+package com.eu.habbo.plugin;
+
+import com.eu.habbo.messages.RuntimeValidationReport;
+
+public final class PluginRuntimeValidator {
+
+    private PluginRuntimeValidator() {
+    }
+
+    public static RuntimeValidationReport validateConfiguration(String jarName, HabboPluginConfiguration configuration) {
+        RuntimeValidationReport report = new RuntimeValidationReport();
+
+        if (configuration == null) {
+            report.addError("Plugin " + jarName + " has an invalid plugin.json");
+            return report;
+        }
+
+        if (isBlank(configuration.name)) {
+            report.addError("Plugin " + jarName + " is missing required plugin.json field name");
+        }
+
+        if (isBlank(configuration.main)) {
+            report.addError("Plugin " + jarName + " is missing required plugin.json field main");
+        }
+
+        return report;
+    }
+
+    public static RuntimeValidationReport validatePluginClass(String jarName, HabboPluginConfiguration configuration, ClassLoader classLoader) {
+        RuntimeValidationReport report = validateConfiguration(jarName, configuration);
+
+        if (report.hasErrors()) {
+            return report;
+        }
+
+        try {
+            Class<?> clazz = classLoader.loadClass(configuration.main);
+
+            if (!HabboPlugin.class.isAssignableFrom(clazz)) {
+                report.addError("Plugin " + pluginLabel(jarName, configuration) + " main class " + configuration.main + " must extend HabboPlugin");
+                return report;
+            }
+
+            clazz.asSubclass(HabboPlugin.class).getConstructor();
+        } catch (ClassNotFoundException e) {
+            report.addError("Plugin " + pluginLabel(jarName, configuration) + " main class " + configuration.main + " was not found");
+        } catch (NoSuchMethodException e) {
+            report.addError("Plugin " + pluginLabel(jarName, configuration) + " main class " + configuration.main + " must expose a public no-argument constructor");
+        } catch (NoClassDefFoundError e) {
+            report.addError("Plugin " + pluginLabel(jarName, configuration) + " main class " + configuration.main + " is missing dependency " + e.getMessage());
+        } catch (LinkageError e) {
+            report.addError("Plugin " + pluginLabel(jarName, configuration) + " main class " + configuration.main + " linkage failed: " + e.getMessage());
+        }
+
+        return report;
+    }
+
+    private static String pluginLabel(String jarName, HabboPluginConfiguration configuration) {
+        if (configuration == null || isBlank(configuration.name)) {
+            return jarName;
+        }
+
+        return configuration.name + " (" + jarName + ")";
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/PacketRuntimeValidatorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/PacketRuntimeValidatorTest.java
@@ -1,0 +1,70 @@
+package com.eu.habbo.messages;
+
+import com.eu.habbo.messages.incoming.MessageHandler;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PacketRuntimeValidatorTest {
+    @Test
+    void reportsDuplicatePacketNamesWithBothAliases() {
+        RuntimeValidationReport report = PacketRuntimeValidator.validatePacketNameClass("Incoming", DuplicateIds.class);
+
+        assertTrue(report.hasErrors());
+        assertEquals(1, report.errors().size());
+        assertTrue(report.errors().get(0).message().contains("Duplicate Incoming packet id 100"));
+        assertTrue(report.errors().get(0).message().contains("FIRST"));
+        assertTrue(report.errors().get(0).message().contains("SECOND"));
+    }
+
+    @Test
+    void reportsHandlersThatCannotBeInstantiatedAtStartup() {
+        RuntimeValidationReport report = PacketRuntimeValidator.validateHandlers(Map.of(
+                1, ValidHandler.class,
+                2, MissingDefaultConstructorHandler.class
+        ));
+
+        assertTrue(report.hasErrors());
+        assertEquals(1, report.errors().size());
+        assertTrue(report.errors().get(0).message().contains("2"));
+        assertTrue(report.errors().get(0).message().contains(MissingDefaultConstructorHandler.class.getName()));
+    }
+
+    @Test
+    void acceptsUniquePacketNamesAndDefaultConstructibleHandlers() {
+        RuntimeValidationReport names = PacketRuntimeValidator.validatePacketNameClass("Outgoing", UniqueIds.class);
+        RuntimeValidationReport handlers = PacketRuntimeValidator.validateHandlers(Map.of(1, ValidHandler.class));
+
+        assertFalse(names.hasErrors());
+        assertFalse(handlers.hasErrors());
+    }
+
+    public static final class DuplicateIds {
+        public static final int FIRST = 100;
+        public static final int SECOND = 100;
+    }
+
+    public static final class UniqueIds {
+        public static final int FIRST = 100;
+        public static final int SECOND = 101;
+    }
+
+    public static final class ValidHandler extends MessageHandler {
+        @Override
+        public void handle() {
+        }
+    }
+
+    public static final class MissingDefaultConstructorHandler extends MessageHandler {
+        public MissingDefaultConstructorHandler(String value) {
+        }
+
+        @Override
+        public void handle() {
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/plugin/PluginRuntimeValidatorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/plugin/PluginRuntimeValidatorTest.java
@@ -1,0 +1,102 @@
+package com.eu.habbo.plugin;
+
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.messages.RuntimeValidationReport;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PluginRuntimeValidatorTest {
+
+    @Test
+    void reportsMissingPluginConfigurationFields() {
+        RuntimeValidationReport report = PluginRuntimeValidator.validateConfiguration("broken.jar", new HabboPluginConfiguration());
+
+        assertTrue(report.hasErrors());
+        assertTrue(report.errors().stream().anyMatch(issue -> issue.message().contains("broken.jar")));
+        assertTrue(report.errors().stream().anyMatch(issue -> issue.message().contains("main")));
+    }
+
+    @Test
+    void reportsMissingPluginMainClass() {
+        HabboPluginConfiguration configuration = configuration("Missing", "com.eu.habbo.plugin.DoesNotExist");
+
+        RuntimeValidationReport report = PluginRuntimeValidator.validatePluginClass("missing.jar", configuration, getClass().getClassLoader());
+
+        assertTrue(report.hasErrors());
+        assertTrue(report.errors().get(0).message().contains("DoesNotExist"));
+    }
+
+    @Test
+    void reportsClassThatIsNotAHabboPlugin() {
+        HabboPluginConfiguration configuration = configuration("WrongType", NotAPlugin.class.getName());
+
+        RuntimeValidationReport report = PluginRuntimeValidator.validatePluginClass("wrong.jar", configuration, getClass().getClassLoader());
+
+        assertTrue(report.hasErrors());
+        assertTrue(report.errors().get(0).message().contains("HabboPlugin"));
+    }
+
+    @Test
+    void reportsPluginWithoutPublicNoArgumentConstructor() {
+        HabboPluginConfiguration configuration = configuration("NoCtor", MissingPublicConstructorPlugin.class.getName());
+
+        RuntimeValidationReport report = PluginRuntimeValidator.validatePluginClass("ctor.jar", configuration, getClass().getClassLoader());
+
+        assertTrue(report.hasErrors());
+        assertTrue(report.errors().get(0).message().contains("public no-argument constructor"));
+    }
+
+    @Test
+    void acceptsValidPluginClass() {
+        HabboPluginConfiguration configuration = configuration("Valid", ValidPlugin.class.getName());
+
+        RuntimeValidationReport report = PluginRuntimeValidator.validatePluginClass("valid.jar", configuration, getClass().getClassLoader());
+
+        assertFalse(report.hasErrors());
+    }
+
+    private static HabboPluginConfiguration configuration(String name, String main) {
+        HabboPluginConfiguration configuration = new HabboPluginConfiguration();
+        configuration.name = name;
+        configuration.main = main;
+        return configuration;
+    }
+
+    public static final class ValidPlugin extends HabboPlugin {
+        @Override
+        public void onEnable() {
+        }
+
+        @Override
+        public void onDisable() {
+        }
+
+        @Override
+        public boolean hasPermission(Habbo habbo, String key) {
+            return false;
+        }
+    }
+
+    public static final class MissingPublicConstructorPlugin extends HabboPlugin {
+        private MissingPublicConstructorPlugin() {
+        }
+
+        @Override
+        public void onEnable() {
+        }
+
+        @Override
+        public void onDisable() {
+        }
+
+        @Override
+        public boolean hasPermission(Habbo habbo, String key) {
+            return false;
+        }
+    }
+
+    public static final class NotAPlugin {
+    }
+}


### PR DESCRIPTION
## Summary
- add a small runtime validation report for startup checks
- report duplicate Incoming/Outgoing packet ids with both aliases before the packet name cache is built
- validate registered incoming handlers for missing no-argument constructors or linkage failures during PacketManager startup
- validate plugin.json metadata and plugin main classes before plugin instantiation
- close plugin streams/classloaders when a plugin is rejected during startup validation

## Why
This turns packet and plugin registration problems into clear startup logs instead of delayed client disconnects or generic plugin loading stack traces. Rejected plugin jars no longer leave open resources after validation fails.

## Tests
- mvn -Dtest=PacketRuntimeValidatorTest,PacketNamesContractTest test
- mvn -Dtest=PluginRuntimeValidatorTest,PacketRuntimeValidatorTest,PacketNamesContractTest test
- mvn -Dtest=PluginRuntimeValidatorTest test
- mvn package