### PR TITLE
fix(build): align java release configuration

### DIFF
--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -10,8 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
     </properties>
 
     <build>
@@ -21,9 +20,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
                 <configuration>
-                    <source>19</source>
-                    <target>19</target>
-                    <release>21</release>
+                    <release>${maven.compiler.release}</release>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
## Summary
- replace conflicting Java source/target/release settings with one maven.compiler.release property
- keep the effective compiler release at Java 21
- reduce build ambiguity for local and CI environments

## Tests
- mvn compile
- mvn package