### PR TITLE
fix(config): register startup defaults before plugin events

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -142,35 +142,12 @@ public final class Emulator {
             Emulator.threading = new ThreadPooling(Emulator.getConfig().getInt("runtime.threads"));
             Emulator.getDatabase().getDataSource().setMaximumPoolSize(Emulator.getConfig().getInt("runtime.threads") * 2);
             Emulator.getDatabase().getDataSource().setMinimumIdle(10);
+            registerStartupConfigDefaults();
             Emulator.pluginManager = new PluginManager();
             Emulator.pluginManager.reload();
             Emulator.getPluginManager().fireEvent(new EmulatorConfigUpdatedEvent());
             Emulator.texts = new TextsManager();
 
-            Emulator.config.register("camera.url", "http://localhost/camera/");
-            Emulator.config.register("imager.location.output.camera", "/public/camera/");
-            Emulator.config.register("imager.location.output.thumbnail", "/public/camera/thumbnails/");
-            Emulator.config.register("camera.price.points.publish", "1");
-            Emulator.config.register("camera.price.points.publish.type", "5");
-            Emulator.config.register("camera.publish.delay", "180");
-            Emulator.config.register("camera.price.credits", "2");
-            Emulator.config.register("camera.price.points", "0");
-            Emulator.config.register("camera.price.points.type", "5");
-            Emulator.config.register("camera.render.delay", "5");
-            Emulator.config.register("hotel.timezone", java.time.ZoneId.systemDefault().getId());
-            Emulator.config.register("gui.enabled", "0");
-            Emulator.config.register("gui.autostart.enabled", "0");
-            Emulator.config.register("rcon.rate_limit.enabled", "1");
-            Emulator.config.register("rcon.rate_limit.limit_for_period", "60");
-            Emulator.config.register("rcon.rate_limit.refresh_period_ms", "1000");
-            Emulator.config.register("rcon.rate_limit.timeout_ms", "0");
-            Emulator.config.register("rcon.execute_command.denied_permissions", "cmd_shutdown;cmd_give_rank");
-            Emulator.config.register("rcon.execute_command.allowed_permissions", "");
-            Emulator.config.register("rcon.max_payload_bytes", "65536");
-            Emulator.config.register("nitro.secure.api.max_payload_bytes", "65536");
-            Emulator.config.register("nitro.secure.config.max_file_bytes", "2097152");
-            Emulator.config.register("nitro.secure.gamedata.max_file_bytes", "16777216");
-            registerEarningsSettings();
             String hotelTimezoneId = Emulator.getConfig().getValue("hotel.timezone", java.time.ZoneId.systemDefault().getId());
             System.out.println(startupCard(hotelTimezoneId));
             Emulator.texts.register("camera.permission", "You don't have permission to use the camera!");
@@ -402,6 +379,33 @@ public final class Emulator {
 
     static boolean shouldLaunchGui() {
         return Emulator.getConfig() != null && Emulator.getConfig().getBoolean("gui.autostart.enabled", false);
+    }
+
+    private static void registerStartupConfigDefaults() {
+        Emulator.config.register("camera.url", "http://localhost/camera/");
+        Emulator.config.register("imager.location.output.camera", "/public/camera/");
+        Emulator.config.register("imager.location.output.thumbnail", "/public/camera/thumbnails/");
+        Emulator.config.register("camera.price.points.publish", "1");
+        Emulator.config.register("camera.price.points.publish.type", "5");
+        Emulator.config.register("camera.publish.delay", "180");
+        Emulator.config.register("camera.price.credits", "2");
+        Emulator.config.register("camera.price.points", "0");
+        Emulator.config.register("camera.price.points.type", "5");
+        Emulator.config.register("camera.render.delay", "5");
+        Emulator.config.register("hotel.timezone", java.time.ZoneId.systemDefault().getId());
+        Emulator.config.register("gui.enabled", "0");
+        Emulator.config.register("gui.autostart.enabled", "0");
+        Emulator.config.register("rcon.rate_limit.enabled", "1");
+        Emulator.config.register("rcon.rate_limit.limit_for_period", "60");
+        Emulator.config.register("rcon.rate_limit.refresh_period_ms", "1000");
+        Emulator.config.register("rcon.rate_limit.timeout_ms", "0");
+        Emulator.config.register("rcon.execute_command.denied_permissions", "cmd_shutdown;cmd_give_rank");
+        Emulator.config.register("rcon.execute_command.allowed_permissions", "");
+        Emulator.config.register("rcon.max_payload_bytes", "65536");
+        Emulator.config.register("nitro.secure.api.max_payload_bytes", "65536");
+        Emulator.config.register("nitro.secure.config.max_file_bytes", "2097152");
+        Emulator.config.register("nitro.secure.gamedata.max_file_bytes", "16777216");
+        registerEarningsSettings();
     }
 
     private static String fit(String value, int width) {

--- a/Emulator/src/test/java/com/eu/habbo/EmulatorStartupConfigDefaultsTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorStartupConfigDefaultsTest.java
@@ -1,0 +1,36 @@
+package com.eu.habbo;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EmulatorStartupConfigDefaultsTest {
+
+    @Test
+    void registersStartupConfigDefaultsBeforePluginConfigEvent() throws Exception {
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/Emulator.java"));
+
+        int defaults = source.indexOf("registerStartupConfigDefaults();");
+        int plugins = source.indexOf("Emulator.pluginManager = new PluginManager();");
+
+        assertTrue(defaults > 0, "Emulator must register startup config defaults explicitly");
+        assertTrue(plugins > 0, "Emulator must initialize the plugin manager explicitly");
+        assertTrue(defaults < plugins, "startup config defaults must exist before plugin reload/config events");
+    }
+
+    @Test
+    void guiDefaultsArePartOfStartupDefaults() throws Exception {
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/Emulator.java"));
+
+        int defaultsMethod = source.indexOf("private static void registerStartupConfigDefaults()");
+        int guiEnabled = source.indexOf("Emulator.config.register(\"gui.enabled\", \"0\")");
+        int guiAutostart = source.indexOf("Emulator.config.register(\"gui.autostart.enabled\", \"0\")");
+
+        assertTrue(defaultsMethod > 0, "startup defaults helper must exist");
+        assertTrue(guiEnabled > defaultsMethod, "gui.enabled must be registered by startup defaults");
+        assertTrue(guiAutostart > defaultsMethod, "gui.autostart.enabled must be registered by startup defaults");
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/EmulatorStartupConsoleTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorStartupConsoleTest.java
@@ -78,7 +78,7 @@ class EmulatorStartupConsoleTest {
                 "gui.enabled must be registered disabled by default so it does not log missing config errors or start the UI unexpectedly");
         assertTrue(source.contains("register(\"gui.autostart.enabled\", \"0\")"),
                 "GUI autostart must use a new disabled-by-default key so old gui.enabled=1 settings do not launch the current UI");
-        assertTrue(source.indexOf("register(\"gui.autostart.enabled\", \"0\")") < source.indexOf("shouldLaunchGui()"),
+        assertTrue(source.indexOf("registerStartupConfigDefaults();") < source.indexOf("shouldLaunchGui()"),
                 "GUI autostart must be registered before the launch decision");
         assertFalse(source.contains("getBoolean(\"gui.enabled\", true)"),
                 "GUI must not use a true fallback");

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerContractTest.java
@@ -37,7 +37,7 @@ class RCONServerHandlerContractTest {
     @Test
     void rconRateLimitDefaultsAreRegisteredBeforeServerStarts() throws Exception {
         String source = emulatorSource();
-        int registerIndex = source.indexOf("register(\"rcon.rate_limit.enabled\", \"1\")");
+        int registerIndex = source.indexOf("registerStartupConfigDefaults();");
         int serverIndex = source.indexOf("new RCONServer");
 
         assertTrue(registerIndex >= 0, "RCON rate limiting must have a registered default toggle");


### PR DESCRIPTION
## Summary
- register emulator startup defaults before the plugin manager reloads and before the first EmulatorConfigUpdatedEvent
- keep gui.enabled/gui.autostart.enabled disabled by default before any launch decision
- keep RCON payload/rate-limit defaults available before RCON server construction
- update contract tests so future startup ordering regressions are caught

## Why
Modern optional settings were being registered after early startup listeners could read them, which produced noisy `Config key not found` logs such as `gui.enabled` during boot. Defaults now exist before plugin config events while preserving the same values.

## Tests
- mvn -Dtest=EmulatorStartupConfigDefaultsTest test
- mvn -Dtest=EmulatorStartupConfigDefaultsTest,EmulatorStartupConsoleTest,RCONServerHandlerContractTest test
- mvn package