### PR TITLE
fix(build): restore java release property

### DIFF
--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -10,8 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
 
         <netty.version>4.2.15.Final</netty.version>
         <gson.version>2.14.0</gson.version>


### PR DESCRIPTION
## Summary
- replace the invalid Java 25 source/target properties with maven.compiler.release=21
- keep the compiler plugin using the release property introduced by #285

## Verification
- mvn -q -f Emulator/pom.xml verify