### PR TITLE
🆙 Create and helper for chests

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniWithdrawHelper.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniWithdrawHelper.java
@@ -1,0 +1,37 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+import java.util.List;
+
+public final class ChestFurniWithdrawHelper {
+    private ChestFurniWithdrawHelper() {
+    }
+
+    public static int completeWithdraw(GameClient client, InteractionWiredChest chest, List<ChestFurniStoredItem> removedItems) {
+        if (client == null || chest == null || removedItems == null || removedItems.isEmpty()) {
+            return 0;
+        }
+
+        Habbo habbo = client.getHabbo();
+        if (habbo == null) {
+            return 0;
+        }
+
+        int delivered = ChestWiredFurniUtil.giveStoredItemsToInventory(habbo, removedItems);
+        client.sendResponse(new InventoryRefreshComposer());
+        int withdrawn = removedItems.size();
+        chest.getContents().addLog(new ChestStorage.LogEntry(
+                "withdraw", System.currentTimeMillis(), habbo.getHabboInfo().getUsername(), withdrawn, 0));
+        chest.persistContents();
+
+        client.sendResponse(new ChestDataComposer(chest));
+        ChestFurniPackets.sendDelta(client, chest.getId(),
+                removedItems.stream().map(row -> row.inventoryId).toList(), List.of());
+
+        return delivered;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestWiredFurniUtil.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestWiredFurniUtil.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-/** Chest ↔ inventory furni helpers for wired effects and contract transactions. */
 public final class ChestWiredFurniUtil {
     private ChestWiredFurniUtil() {
     }
@@ -29,7 +28,7 @@ public final class ChestWiredFurniUtil {
         }
 
         List<ChestFurniStoredItem> removed = chest.getContents().removeFurniByType(wallItem, baseItemId, legacyPosterId, amount);
-        int given = deliverStoredItems(habbo, removed);
+        int given = giveStoredItemsToInventory(habbo, removed);
         if (given > 0) {
             chest.persistContents();
         }
@@ -127,7 +126,10 @@ public final class ChestWiredFurniUtil {
         chest.persistContents();
     }
 
-    private static int deliverStoredItems(Habbo habbo, List<ChestFurniStoredItem> removed) {
+    public static int giveStoredItemsToInventory(Habbo habbo, List<ChestFurniStoredItem> removed) {
+        if (habbo == null || habbo.getClient() == null || removed == null || removed.isEmpty()) {
+            return 0;
+        }
         int given = 0;
         for (ChestFurniStoredItem stored : removed) {
             Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(stored.baseItemId);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawAllFurniEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawAllFurniEvent.java
@@ -1,25 +1,15 @@
 package com.eu.habbo.messages.incoming.rooms.items;
 
-import com.eu.habbo.Emulator;
-import com.eu.habbo.habbohotel.items.Item;
-import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniPackets;
 import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniStoredItem;
-import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniWithdrawHelper;
 import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.incoming.MessageHandler;
-import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
-import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
-import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
 
 import java.util.List;
 
-/**
- * Withdraw all stored furni from a wired furni chest (official Vefehonuj wire shape):
- * {@code int chestItemId} only. Header 9326.
- */
 public class ChestWithdrawAllFurniEvent extends MessageHandler {
     @Override
     public int getRatelimit() {
@@ -41,33 +31,8 @@ public class ChestWithdrawAllFurniEvent extends MessageHandler {
 
         if (!room.hasRights(habbo)) return;
 
-        ChestStorage contents = chest.getContents();
-        List<ChestFurniStoredItem> removedItems = contents.removeAllFurniItems();
-        if (removedItems.isEmpty()) return;
+        List<ChestFurniStoredItem> removedItems = chest.getContents().removeAllFurniItems();
 
-        int taken = 0;
-        for (ChestFurniStoredItem stored : removedItems) {
-            Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(stored.baseItemId);
-            if (baseItem == null) continue;
-
-            HabboItem created = Emulator.getGameEnvironment().getItemManager().createItem(
-                    habbo.getHabboInfo().getId(), baseItem, stored.limitedStack, stored.limitedSells, stored.extradata);
-            if (created == null) continue;
-
-            this.client.sendResponse(new AddHabboItemComposer(created));
-            habbo.getInventory().getItemsComponent().addItem(created);
-            taken++;
-        }
-
-        if (taken <= 0) return;
-
-        this.client.sendResponse(new InventoryRefreshComposer());
-
-        contents.addLog(new ChestStorage.LogEntry("withdraw", System.currentTimeMillis(), habbo.getHabboInfo().getUsername(), taken, 0));
-        chest.persistContents();
-
-        this.client.sendResponse(new ChestDataComposer(chest));
-        ChestFurniPackets.sendDelta(this.client, chest.getId(),
-                removedItems.stream().map(i -> i.inventoryId).toList(), List.of());
+        ChestFurniWithdrawHelper.completeWithdraw(this.client, chest, removedItems);
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawFurniEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawFurniEvent.java
@@ -1,26 +1,15 @@
 package com.eu.habbo.messages.incoming.rooms.items;
 
-import com.eu.habbo.Emulator;
-import com.eu.habbo.habbohotel.items.Item;
-import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniPackets;
 import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniStoredItem;
-import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniWithdrawHelper;
 import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.incoming.MessageHandler;
-import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
-import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
-import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
 
 import java.util.List;
 
-/**
- * Player withdraws stored furni from a wired furni chest (official Dul wire shape):
- * {@code int chestItemId, bool isWall, int typeId, string legacyPosterId, int amount}.
- * amount {@code < 0} = withdraw all matching rows.
- */
 public class ChestWithdrawFurniEvent extends MessageHandler {
     private static final int MAX_WITHDRAW_AMOUNT = 1000;
 
@@ -48,35 +37,12 @@ public class ChestWithdrawFurniEvent extends MessageHandler {
 
         if (!room.hasRights(habbo)) return;
 
-        // typeId is the CLIENT-facing type (sprite id) echoed back from what we sent on the wire.
-        // amount < 0 = withdraw all matching rows; a positive amount is capped so a spoofed huge
-        // value can't force an oversized allocation. removeFurniByWireType is atomic and caps at
-        // whatever is actually present, so it can never over-withdraw or duplicate.
-        ChestStorage contents = chest.getContents();
         int requested = (amount < 0) ? Integer.MAX_VALUE : Math.min(amount, MAX_WITHDRAW_AMOUNT);
         if (requested <= 0) return;
 
-        var removedItems = contents.removeFurniByWireType(wallItem, typeId, legacyPosterId, requested);
-        int taken = removedItems.size();
-        if (taken <= 0) return;
+        List<ChestFurniStoredItem> removedItems =
+                chest.getContents().removeFurniByWireType(wallItem, typeId, legacyPosterId, requested);
 
-        for (ChestFurniStoredItem stored : removedItems) {
-            Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(stored.baseItemId);
-            if (baseItem == null) continue;
-
-            HabboItem created = Emulator.getGameEnvironment().getItemManager().createItem(
-                    habbo.getHabboInfo().getId(), baseItem, stored.limitedStack, stored.limitedSells, stored.extradata);
-            if (created == null) continue;
-            this.client.sendResponse(new AddHabboItemComposer(created));
-            habbo.getInventory().getItemsComponent().addItem(created);
-        }
-        this.client.sendResponse(new InventoryRefreshComposer());
-
-        contents.addLog(new ChestStorage.LogEntry("withdraw", System.currentTimeMillis(), habbo.getHabboInfo().getUsername(), taken, 0));
-        chest.persistContents();
-
-        this.client.sendResponse(new ChestDataComposer(chest));
-        ChestFurniPackets.sendDelta(this.client, chest.getId(),
-                removedItems.stream().map(i -> i.inventoryId).toList(), List.of());
+        ChestFurniWithdrawHelper.completeWithdraw(this.client, chest, removedItems);
     }
 }


### PR DESCRIPTION
ChestWiredFurniUtil.giveStoredItemsToInventory — the single method that recreates stored rows as inventory items, preserving each row's limited-edition data and extradata. Every withdraw path (player subset, player all, wired give) now routes through it.

ChestFurniWithdrawHelper.completeWithdraw — deliver + log + persist + push chest state and delta, in one place. It always persists once rows have left storage, so the memory/DB divergence is gone and the two handlers can't drift again.