### PR TITLE
fix: make catalog purchases overflow and failure safe

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
@@ -18,6 +18,9 @@ public class CatalogLimitedConfiguration implements Runnable {
     private final int itemId;
     private final LinkedList<Integer> limitedNumbers;
     private int totalSet;
+    // Page the item lived on before a committed sale moved it to the sold-out page,
+    // so a later compensated legacy purchase can move it back.
+    private int soldOutFromPageId = 0;
 
     public CatalogLimitedConfiguration(int itemId, LinkedList<Integer> availableNumbers, int totalSet) {
         this.itemId = itemId;
@@ -34,6 +37,38 @@ public class CatalogLimitedConfiguration implements Runnable {
     public int getNumber() {
         synchronized (this.limitedNumbers) {
             return this.limitedNumbers.pop();
+        }
+    }
+
+    /**
+     * Returns a drawn number to the available pool when a purchase that reserved
+     * it did not complete, so a failed/compensated limited purchase does not
+     * permanently shrink the stock. If drawing the number had emptied the pool
+     * and moved the item to the sold-out page, the item is moved back.
+     */
+    public void restoreNumber(int catalogItemId, int number) {
+        synchronized (this.limitedNumbers) {
+            if (!this.limitedNumbers.contains(number)) this.limitedNumbers.push(number);
+
+            if (this.soldOutFromPageId > 0) {
+                CatalogItem catalogItem = Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(this.itemId);
+                if (catalogItem != null) {
+                    Emulator.getGameEnvironment().getCatalogManager().moveCatalogItem(catalogItem, this.soldOutFromPageId);
+                }
+                this.soldOutFromPageId = 0;
+            }
+
+            // Clear any reservation limitedSold may have written for this number so
+            // the DB row matches the returned-to-pool in-memory state. A no-op when
+            // the row is still unsold (user_id = 0).
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                 PreparedStatement statement = connection.prepareStatement("UPDATE catalog_items_limited SET user_id = 0, timestamp = 0, item_id = 0 WHERE catalog_item_id = ? AND number = ? LIMIT 1")) {
+                statement.setInt(1, catalogItemId);
+                statement.setInt(2, number);
+                statement.execute();
+            } catch (SQLException e) {
+                LOGGER.error("Caught SQL exception restoring limited number", e);
+            }
         }
     }
 
@@ -70,9 +105,12 @@ public class CatalogLimitedConfiguration implements Runnable {
     public void markSoldOutIfEmpty() {
         synchronized (this.limitedNumbers) {
             if (this.limitedNumbers.isEmpty()) {
-                Emulator.getGameEnvironment().getCatalogManager().moveCatalogItem(
-                        Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(this.itemId),
-                        Emulator.getConfig().getInt("catalog.ltd.page.soldout"));
+                CatalogItem catalogItem = Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(this.itemId);
+                if (catalogItem != null) {
+                    this.soldOutFromPageId = catalogItem.getPageId();
+                    Emulator.getGameEnvironment().getCatalogManager().moveCatalogItem(
+                            catalogItem, Emulator.getConfig().getInt("catalog.ltd.page.soldout"));
+                }
             }
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -1070,8 +1070,9 @@ public class CatalogManager {
                     if (amount == item.getAmount()) {
                         amount = 1;
                     } else {
-                        if (amount * item.getAmount() > 100) {
-                            habbo.alert("Whoops! You tried to buy this " + (amount * item.getAmount()) + " times. This must've been a mistake.");
+                        long requestedItems = (long) amount * item.getAmount();
+                        if (requestedItems > 100) {
+                            habbo.alert("Whoops! You tried to buy this " + requestedItems + " times. This must've been a mistake.");
                             habbo.getClient().sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                             return;
                         }
@@ -1102,8 +1103,8 @@ public class CatalogManager {
                 int totalCredits = free ? 0 : this.calculateDiscountedPrice(item.getCredits(), amount, item);
                 int totalPoints = free ? 0 : this.calculateDiscountedPrice(item.getPoints(), amount, item);
 
-                if (totalCredits > 0 && habbo.getHabboInfo().getCredits() - totalCredits < 0) return;
-                if (totalPoints > 0 && habbo.getHabboInfo().getCurrencyAmount(item.getPointsType()) - totalPoints < 0)
+                if (totalCredits > habbo.getHabboInfo().getCredits()) return;
+                if (totalPoints > habbo.getHabboInfo().getCurrencyAmount(item.getPointsType()))
                     return;
 
                 if (limitedConfiguration != null) limitedNumber = limitedConfiguration.getNumber();
@@ -1314,6 +1315,15 @@ public class CatalogManager {
 
                 UserCatalogItemPurchasedEvent purchasedEvent = new UserCatalogItemPurchasedEvent(habbo, item, itemsList, totalCredits, totalPoints, badges);
                 Emulator.getPluginManager().fireEvent(purchasedEvent);
+
+                CatalogPurchaseMath.requireNonNegative(purchasedEvent.totalCredits, "plugin-adjusted credit price");
+                CatalogPurchaseMath.requireNonNegative(purchasedEvent.totalPoints, "plugin-adjusted points price");
+
+                if (purchasedEvent.totalCredits > habbo.getHabboInfo().getCredits()
+                        || purchasedEvent.totalPoints > habbo.getHabboInfo().getCurrencyAmount(item.getPointsType())) {
+                    habbo.getClient().sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                    return;
+                }
 
                 if (!free && !habbo.getClient().getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS)) {
                     if (purchasedEvent.totalCredits > 0) {
@@ -1836,7 +1846,7 @@ public class CatalogManager {
     }
 
     private int calculateDiscountedPrice(int originalPrice, int amount, CatalogItem item) {
-        if (!CatalogItem.haveOffer(item)) return originalPrice * amount;
+        if (!CatalogItem.haveOffer(item)) return CatalogPurchaseMath.checkedPrice(originalPrice, amount);
 
         int basicDiscount = amount / DiscountComposer.DISCOUNT_BATCH_SIZE;
 
@@ -1856,6 +1866,7 @@ public class CatalogManager {
 
         int totalDiscountedItems = (basicDiscount * DiscountComposer.DISCOUNT_AMOUNT_PER_BATCH) + bonusDiscount + additionalDiscounts;
 
-        return Math.max(0, originalPrice * (amount - totalDiscountedItems));
+        int payableItems = Math.max(0, amount - totalDiscountedItems);
+        return CatalogPurchaseMath.checkedPrice(originalPrice, payableItems);
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -1022,12 +1022,29 @@ public class CatalogManager {
 
 
     public void purchaseItem(CatalogPage page, CatalogItem item, Habbo habbo, int amount, String extradata, boolean free) {
-        if (item == null || habbo.getHabboStats().isPurchasingFurniture) {
+        if (item == null) {
             habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
             return;
         }
 
-        habbo.getHabboStats().isPurchasingFurniture = true;
+        synchronized (habbo.getHabboStats()) {
+            if (habbo.getHabboStats().isPurchasingFurniture) {
+                habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                return;
+            }
+            habbo.getHabboStats().isPurchasingFurniture = true;
+        }
+
+        Set<HabboItem> createdItems = new HashSet<>();
+        List<Bot> createdBots = new ArrayList<>();
+        List<Pet> createdPets = new ArrayList<>();
+        List<Integer> pendingEffects = new ArrayList<>();
+        List<Guild> pendingGuildForums = new ArrayList<>();
+        boolean paymentTaken = false;
+        boolean purchaseDelivered = false;
+        int paidCredits = 0;
+        int paidPoints = 0;
+        int paidPointsType = 0;
 
         try {
             if (item.isClubOnly() && !habbo.getClient().getHabbo().getHabboStats().hasActiveClub()) {
@@ -1130,10 +1147,6 @@ public class CatalogManager {
                 boolean badgeFound = false;
 
                 for (int i = 0; i < amount; i++) {
-                    if(item.isLimited()) {
-                        habbo.getHabboStats().addLtdLog(item.getId(), Emulator.getIntUnixTimestamp());
-                    }
-
                     for (Item baseItem : item.getBaseItems()) {
                         for (int k = 0; k < item.getItemAmount(baseItem.getId()); k++) {
                             if (baseItem.getName().startsWith("rentable_bot_") || baseItem.getName().startsWith("bot_")) {
@@ -1161,6 +1174,7 @@ public class CatalogManager {
                                 Bot bot = Emulator.getGameEnvironment().getBotManager().createBot(data, type, habbo.getHabboInfo().getId());
 
                                 if (bot != null) {
+                                    createdBots.add(bot);
                                     bot.setOwnerId(habbo.getClient().getHabbo().getHabboInfo().getId());
                                     bot.setOwnerName(habbo.getClient().getHabbo().getHabboInfo().getUsername());
                                     bot.needsUpdate(true);
@@ -1184,7 +1198,7 @@ public class CatalogManager {
                                 }
 
                                 if (effectId > 0) {
-                                    habbo.getInventory().getEffectsComponent().createEffect(effectId);
+                                    pendingEffects.add(effectId);
                                 }
                             } else if (Item.isPet(baseItem)) {
                                 String[] data = extradata.split("\n");
@@ -1207,6 +1221,7 @@ public class CatalogManager {
                                     return;
                                 }
 
+                                createdPets.add(pet);
                                 habbo.getClient().getHabbo().getInventory().getPetsComponent().addPet(pet);
                                 habbo.getClient().sendResponse(new AddPetComposer(pet));
                                 habbo.getClient().sendResponse(new PetBoughtNotificationComposer(pet, false));
@@ -1243,11 +1258,21 @@ public class CatalogManager {
                                 if (InteractionTeleport.class.isAssignableFrom(baseItem.getInteractionType().getType())) {
                                     HabboItem teleportOne = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getClient().getHabbo().getHabboInfo().getId(), baseItem, limitedStack, limitedNumber, extradata);
                                     HabboItem teleportTwo = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getClient().getHabbo().getHabboInfo().getId(), baseItem, limitedStack, limitedNumber, extradata);
+                                    if (teleportOne == null || teleportTwo == null) {
+                                        if (teleportOne != null) createdItems.add(teleportOne);
+                                        if (teleportTwo != null) createdItems.add(teleportTwo);
+                                        throw new IllegalStateException("failed to create catalog teleport pair");
+                                    }
+                                    createdItems.add(teleportOne);
+                                    createdItems.add(teleportTwo);
                                     Emulator.getGameEnvironment().getItemManager().insertTeleportPair(teleportOne.getId(), teleportTwo.getId());
                                     itemsList.add(teleportOne);
                                     itemsList.add(teleportTwo);
                                 } else if (baseItem.getInteractionType().getType() == InteractionHopper.class) {
                                     HabboItem hopper = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getClient().getHabbo().getHabboInfo().getId(), baseItem, limitedStack, limitedNumber, extradata);
+
+                                    if (hopper == null) throw new IllegalStateException("failed to create catalog hopper");
+                                    createdItems.add(hopper);
 
                                     Emulator.getGameEnvironment().getItemManager().insertHopper(hopper);
 
@@ -1270,7 +1295,13 @@ public class CatalogManager {
                                             return;
                                         }
 
-                                        InteractionGuildFurni habboItem = (InteractionGuildFurni) Emulator.getGameEnvironment().getItemManager().createItem(habbo.getClient().getHabbo().getHabboInfo().getId(), baseItem, limitedStack, limitedNumber, extradata);
+                                        HabboItem createdItem = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getClient().getHabbo().getHabboInfo().getId(), baseItem, limitedStack, limitedNumber, extradata);
+                                        if (!(createdItem instanceof InteractionGuildFurni)) {
+                                            if (createdItem != null) createdItems.add(createdItem);
+                                            throw new IllegalStateException("failed to create catalog guild item");
+                                        }
+                                        InteractionGuildFurni habboItem = (InteractionGuildFurni) createdItem;
+                                        createdItems.add(habboItem);
                                         habboItem.setExtradata("");
                                         habboItem.needsUpdate(true);
 
@@ -1279,9 +1310,7 @@ public class CatalogManager {
                                         itemsList.add(habboItem);
 
                                         if (baseItem.getName().equals("guild_forum")) {
-                                            guild.setForum(true);
-                                            guild.needsUpdate = true;
-                                            guild.run();
+                                            pendingGuildForums.add(guild);
                                         }
                                     }
                                 } else if (baseItem.getInteractionType().getType() == InteractionMusicDisc.class) {
@@ -1292,7 +1321,13 @@ public class CatalogManager {
                                         return;
                                     }
 
-                                    InteractionMusicDisc habboItem = (InteractionMusicDisc) Emulator.getGameEnvironment().getItemManager().createItem(habbo.getClient().getHabbo().getHabboInfo().getId(), baseItem, limitedStack, limitedNumber, habbo.getClient().getHabbo().getHabboInfo().getUsername() + "\n" + Calendar.getInstance().get(Calendar.DAY_OF_MONTH) + "\n" + (Calendar.getInstance().get(Calendar.MONTH) + 1) + "\n" + Calendar.getInstance().get(Calendar.YEAR) + "\n" + track.getLength() + "\n" + track.getName() + "\n" + track.getId());
+                                    HabboItem createdItem = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getClient().getHabbo().getHabboInfo().getId(), baseItem, limitedStack, limitedNumber, habbo.getClient().getHabbo().getHabboInfo().getUsername() + "\n" + Calendar.getInstance().get(Calendar.DAY_OF_MONTH) + "\n" + (Calendar.getInstance().get(Calendar.MONTH) + 1) + "\n" + Calendar.getInstance().get(Calendar.YEAR) + "\n" + track.getLength() + "\n" + track.getName() + "\n" + track.getId());
+                                    if (!(createdItem instanceof InteractionMusicDisc)) {
+                                        if (createdItem != null) createdItems.add(createdItem);
+                                        throw new IllegalStateException("failed to create catalog music disc");
+                                    }
+                                    InteractionMusicDisc habboItem = (InteractionMusicDisc) createdItem;
+                                    createdItems.add(habboItem);
                                     habboItem.needsUpdate(true);
 
                                     Emulator.getThreading().run(habboItem);
@@ -1301,6 +1336,8 @@ public class CatalogManager {
                                     AchievementManager.progressAchievement(habbo, Emulator.getGameEnvironment().getAchievementManager().getAchievement("MusicCollector"));
                                 } else {
                                     HabboItem habboItem = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getClient().getHabbo().getHabboInfo().getId(), baseItem, limitedStack, limitedNumber, extradata);
+                                    if (habboItem == null) throw new IllegalStateException("failed to create catalog item");
+                                    createdItems.add(habboItem);
                                     itemsList.add(habboItem);
                                 }
                             }
@@ -1325,16 +1362,25 @@ public class CatalogManager {
                     return;
                 }
 
-                if (!free && !habbo.getClient().getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS)) {
-                    if (purchasedEvent.totalCredits > 0) {
-                        habbo.getClient().getHabbo().giveCredits(-purchasedEvent.totalCredits);
-                    }
-                }
+                paidCredits = (!free && !habbo.hasPermission(Permission.ACC_INFINITE_CREDITS))
+                        ? purchasedEvent.totalCredits : 0;
+                paidPoints = (!free && !habbo.hasPermission(Permission.ACC_INFINITE_POINTS))
+                        ? purchasedEvent.totalPoints : 0;
+                paidPointsType = item.getPointsType();
 
-                if (!free && !habbo.getClient().getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS)) {
-                    if (purchasedEvent.totalPoints > 0) {
-                        habbo.getClient().getHabbo().givePoints(item.getPointsType(), -purchasedEvent.totalPoints);
-                    }
+                if (!habbo.tryTakeCatalogPayment(paidCredits, paidPointsType, paidPoints)) {
+                    habbo.getClient().sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                    return;
+                }
+                paymentTaken = true;
+
+                for (Integer effectId : pendingEffects) {
+                    habbo.getInventory().getEffectsComponent().createEffect(effectId);
+                }
+                for (Guild guild : pendingGuildForums) {
+                    guild.setForum(true);
+                    guild.needsUpdate = true;
+                    guild.run();
                 }
 
                 if (purchasedEvent.itemsList != null && !purchasedEvent.itemsList.isEmpty()) {
@@ -1365,6 +1411,22 @@ public class CatalogManager {
                     keys.put("message", Emulator.getTexts().getValue("commands.generic.cmd_badge.received"));
                     habbo.getClient().sendResponse(new BubbleAlertComposer(BubbleAlertKeys.RECEIVED_BADGE.key, keys));
                     unseenItems.get(AddHabboItemComposer.AddHabboItemCategory.BADGE).add(badge.getId());
+                }
+
+                // Durable items and wallet debit now agree. Nonessential response,
+                // achievement, and logging failures must not undo a delivered order.
+                purchaseDelivered = true;
+
+                if (item.isLimited()) {
+                    for (int i = 0; i < amount; i++) {
+                        habbo.getHabboStats().addLtdLog(item.getId(), Emulator.getIntUnixTimestamp());
+                    }
+                }
+
+                for (HabboItem createdItem : createdItems) {
+                    if (purchasedEvent.itemsList == null || !purchasedEvent.itemsList.contains(createdItem)) {
+                        Emulator.getGameEnvironment().getItemManager().deleteItem(createdItem);
+                    }
                 }
                 habbo.getClient().getHabbo().getHabboStats().addPurchase(purchasedEvent.catalogItem);
 
@@ -1398,7 +1460,28 @@ public class CatalogManager {
                 habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
             }
         } finally {
-            habbo.getHabboStats().isPurchasingFurniture = false;
+            try {
+                if (!purchaseDelivered) {
+                    for (HabboItem createdItem : createdItems) {
+                        if (createdItem != null) Emulator.getGameEnvironment().getItemManager().deleteItem(createdItem);
+                    }
+                    for (Bot bot : createdBots) {
+                        habbo.getInventory().getBotsComponent().removeBot(bot);
+                        Emulator.getGameEnvironment().getBotManager().deleteBot(bot);
+                    }
+                    for (Pet pet : createdPets) {
+                        habbo.getInventory().getPetsComponent().removePet(pet);
+                        Emulator.getGameEnvironment().getPetManager().deletePet(pet);
+                    }
+                    if (paymentTaken) {
+                        habbo.refundCatalogPayment(paidCredits, paidPointsType, paidPoints);
+                    }
+                }
+            } finally {
+                synchronized (habbo.getHabboStats()) {
+                    habbo.getHabboStats().isPurchasingFurniture = false;
+                }
+            }
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -1045,6 +1045,8 @@ public class CatalogManager {
         int paidCredits = 0;
         int paidPoints = 0;
         int paidPointsType = 0;
+        CatalogLimitedConfiguration limitedConfiguration = null;
+        int limitedNumber = 0;
 
         try {
             if (item.isClubOnly() && !habbo.getClient().getHabbo().getHabboStats().hasActiveClub()) {
@@ -1058,9 +1060,7 @@ public class CatalogManager {
             }
 
             try {
-                CatalogLimitedConfiguration limitedConfiguration = null;
                 int limitedStack = 0;
-                int limitedNumber = 0;
                 if (item.isLimited()) {
                     amount = 1;
                     if (this.getLimitedConfig(item).available() == 0) {
@@ -1472,6 +1472,12 @@ public class CatalogManager {
                     for (Pet pet : createdPets) {
                         habbo.getInventory().getPetsComponent().removePet(pet);
                         Emulator.getGameEnvironment().getPetManager().deletePet(pet);
+                    }
+                    if (limitedConfiguration != null && limitedNumber > 0) {
+                        // Return the reserved limited number to the pool so a failed
+                        // purchase does not permanently shrink the stock or leave the
+                        // item stranded on the sold-out page.
+                        limitedConfiguration.restoreNumber(item.getId(), limitedNumber);
                     }
                     if (paymentTaken) {
                         CatalogPaymentService.refund(habbo, paidCredits, paidPointsType, paidPoints);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -1368,7 +1368,7 @@ public class CatalogManager {
                         ? purchasedEvent.totalPoints : 0;
                 paidPointsType = item.getPointsType();
 
-                if (!habbo.tryTakeCatalogPayment(paidCredits, paidPointsType, paidPoints)) {
+                if (!CatalogPaymentService.tryTake(habbo, paidCredits, paidPointsType, paidPoints)) {
                     habbo.getClient().sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                     return;
                 }
@@ -1474,7 +1474,7 @@ public class CatalogManager {
                         Emulator.getGameEnvironment().getPetManager().deletePet(pet);
                     }
                     if (paymentTaken) {
-                        habbo.refundCatalogPayment(paidCredits, paidPointsType, paidPoints);
+                        CatalogPaymentService.refund(habbo, paidCredits, paidPointsType, paidPoints);
                     }
                 }
             } finally {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPageAccessPolicy.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPageAccessPolicy.java
@@ -1,0 +1,16 @@
+package com.eu.habbo.habbohotel.catalog;
+
+/**
+ * Shared authorization policy for requests that address a catalog page directly.
+ */
+public final class CatalogPageAccessPolicy {
+    private CatalogPageAccessPolicy() {
+    }
+
+    public static boolean canAccess(CatalogPage page, int userRank, boolean hasActiveClub) {
+        return page != null
+                && page.isEnabled()
+                && page.getRank() <= userRank
+                && (!page.isClubOnly() || hasActiveClub);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPaymentService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPaymentService.java
@@ -4,7 +4,17 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.users.UserCreditsComposer;
 import com.eu.habbo.messages.outgoing.users.UserPointsComposer;
 
-/** Catalog-only facade for one atomic credits-plus-points wallet mutation. */
+/**
+ * Catalog-only facade for one atomic credits-plus-points wallet mutation.
+ *
+ * <p>Note: this deliberately debits (and refunds) directly rather than through
+ * {@code Habbo.giveCredits}/{@code givePoints}, so it does NOT fire
+ * {@code UserCreditsEvent}/{@code UserPointsEvent}. That is intentional: a plugin
+ * cancelling or reducing the debit event previously let a buyer keep the items
+ * without paying. The trade-off is that plugins observing those events no longer
+ * see catalog debits/refunds; catalog spend should be observed via
+ * {@code UserCatalogItemPurchasedEvent} instead.
+ */
 public final class CatalogPaymentService {
     private CatalogPaymentService() {
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPaymentService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPaymentService.java
@@ -1,0 +1,38 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.messages.outgoing.users.UserCreditsComposer;
+import com.eu.habbo.messages.outgoing.users.UserPointsComposer;
+
+/** Catalog-only facade for one atomic credits-plus-points wallet mutation. */
+public final class CatalogPaymentService {
+    private CatalogPaymentService() {
+    }
+
+    public static boolean tryTake(Habbo habbo, int credits, int pointsType, int points) {
+        if (habbo == null || !habbo.getHabboInfo().tryDebitCatalogPayment(credits, pointsType, points)) {
+            return false;
+        }
+
+        if (habbo.getClient() != null) {
+            if (credits > 0) habbo.getClient().sendResponse(new UserCreditsComposer(habbo));
+            if (points > 0) {
+                habbo.getClient().sendResponse(new UserPointsComposer(
+                        habbo.getHabboInfo().getCurrencyAmount(pointsType), -points, pointsType));
+            }
+        }
+        return true;
+    }
+
+    public static void refund(Habbo habbo, int credits, int pointsType, int points) {
+        habbo.getHabboInfo().refundCatalogPayment(credits, pointsType, points);
+
+        if (habbo.getClient() != null) {
+            if (credits > 0) habbo.getClient().sendResponse(new UserCreditsComposer(habbo));
+            if (points > 0) {
+                habbo.getClient().sendResponse(new UserPointsComposer(
+                        habbo.getHabboInfo().getCurrencyAmount(pointsType), points, pointsType));
+            }
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseMath.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseMath.java
@@ -1,0 +1,51 @@
+package com.eu.habbo.habbohotel.catalog;
+
+/**
+ * Checked arithmetic for values that cross the catalog-to-wallet boundary.
+ */
+public final class CatalogPurchaseMath {
+    private static final int SECONDS_PER_DAY = 86_400;
+
+    private CatalogPurchaseMath() {
+    }
+
+    public static int checkedPrice(int unitPrice, int payableUnits) {
+        return checkedMultiply(unitPrice, payableUnits, "catalog price");
+    }
+
+    public static int checkedAdd(int left, int right) {
+        requireNonNegative(left, "catalog total");
+        requireNonNegative(right, "catalog surcharge");
+
+        long total = (long) left + right;
+        if (total > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("catalog total exceeds the supported wallet range");
+        }
+
+        return (int) total;
+    }
+
+    public static int checkedSubscriptionSeconds(int days) {
+        return checkedMultiply(days, SECONDS_PER_DAY, "subscription duration");
+    }
+
+    public static int requireNonNegative(int value, String name) {
+        if (value < 0) {
+            throw new IllegalArgumentException(name + " must not be negative");
+        }
+
+        return value;
+    }
+
+    private static int checkedMultiply(int left, int right, String name) {
+        requireNonNegative(left, name);
+        requireNonNegative(right, name + " multiplier");
+
+        long result = (long) left * right;
+        if (result > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException(name + " exceeds the supported wallet range");
+        }
+
+        return (int) result;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -898,9 +898,20 @@ public class ItemManager {
     }
 
     public void deleteItem(HabboItem item) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("DELETE FROM items WHERE id = ?")) {
-            statement.setInt(1, item.getId());
-            statement.execute();
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            try (PreparedStatement statement = connection.prepareStatement("DELETE FROM items_teleports WHERE teleport_one_id = ? OR teleport_two_id = ?")) {
+                statement.setInt(1, item.getId());
+                statement.setInt(2, item.getId());
+                statement.executeUpdate();
+            }
+            try (PreparedStatement statement = connection.prepareStatement("DELETE FROM items_hoppers WHERE item_id = ?")) {
+                statement.setInt(1, item.getId());
+                statement.executeUpdate();
+            }
+            try (PreparedStatement statement = connection.prepareStatement("DELETE FROM items WHERE id = ?")) {
+                statement.setInt(1, item.getId());
+                statement.executeUpdate();
+            }
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -285,6 +285,7 @@ public class Habbo implements Runnable {
             this.client.sendResponse(new UserPointsComposer(this.getHabboInfo().getCurrencyAmount(type), event.points, event.type));
     }
 
+
     public void whisper(String message) {
         this.whisper(message, this.habboStats.chatColor);
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -285,34 +285,6 @@ public class Habbo implements Runnable {
             this.client.sendResponse(new UserPointsComposer(this.getHabboInfo().getCurrencyAmount(type), event.points, event.type));
     }
 
-    /**
-     * Debits a catalog order as one wallet operation. Catalog pricing plugins
-     * have already run before this method is called; bypassing the generic
-     * per-currency events here prevents a plugin cancellation from turning a
-     * successful delivery into a free purchase.
-     */
-    public boolean tryTakeCatalogPayment(int credits, int pointsType, int points) {
-        if (!this.habboInfo.tryDebitCatalogPayment(credits, pointsType, points)) {
-            return false;
-        }
-
-        if (this.client != null) {
-            if (credits > 0) this.client.sendResponse(new UserCreditsComposer(this));
-            if (points > 0) this.client.sendResponse(new UserPointsComposer(this.habboInfo.getCurrencyAmount(pointsType), -points, pointsType));
-        }
-        return true;
-    }
-
-    public void refundCatalogPayment(int credits, int pointsType, int points) {
-        this.habboInfo.refundCatalogPayment(credits, pointsType, points);
-
-        if (this.client != null) {
-            if (credits > 0) this.client.sendResponse(new UserCreditsComposer(this));
-            if (points > 0) this.client.sendResponse(new UserPointsComposer(this.habboInfo.getCurrencyAmount(pointsType), points, pointsType));
-        }
-    }
-
-
     public void whisper(String message) {
         this.whisper(message, this.habboStats.chatColor);
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -285,6 +285,33 @@ public class Habbo implements Runnable {
             this.client.sendResponse(new UserPointsComposer(this.getHabboInfo().getCurrencyAmount(type), event.points, event.type));
     }
 
+    /**
+     * Debits a catalog order as one wallet operation. Catalog pricing plugins
+     * have already run before this method is called; bypassing the generic
+     * per-currency events here prevents a plugin cancellation from turning a
+     * successful delivery into a free purchase.
+     */
+    public boolean tryTakeCatalogPayment(int credits, int pointsType, int points) {
+        if (!this.habboInfo.tryDebitCatalogPayment(credits, pointsType, points)) {
+            return false;
+        }
+
+        if (this.client != null) {
+            if (credits > 0) this.client.sendResponse(new UserCreditsComposer(this));
+            if (points > 0) this.client.sendResponse(new UserPointsComposer(this.habboInfo.getCurrencyAmount(pointsType), -points, pointsType));
+        }
+        return true;
+    }
+
+    public void refundCatalogPayment(int credits, int pointsType, int points) {
+        this.habboInfo.refundCatalogPayment(credits, pointsType, points);
+
+        if (this.client != null) {
+            if (credits > 0) this.client.sendResponse(new UserCreditsComposer(this));
+            if (points > 0) this.client.sendResponse(new UserPointsComposer(this.habboInfo.getCurrencyAmount(pointsType), points, pointsType));
+        }
+    }
+
 
     public void whisper(String message) {
         this.whisper(message, this.habboStats.chatColor);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInfo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInfo.java
@@ -293,6 +293,44 @@ public class HabboInfo implements Runnable {
         this.run();
     }
 
+    /**
+     * Atomically debits the two currencies used by a catalog order. The
+     * affordability check and both mutations share the wallet lock, so two
+     * concurrent purchase paths cannot both spend the same balance.
+     */
+    public boolean tryDebitCatalogPayment(int credits, int pointsType, int points) {
+        if (credits < 0 || points < 0) {
+            return false;
+        }
+
+        synchronized (this.currencyLock) {
+            int currentPoints = this.currencies.get(pointsType);
+            if (this.credits < credits || currentPoints < points) {
+                return false;
+            }
+
+            this.credits -= credits;
+            this.currencies.put(pointsType, currentPoints - points);
+        }
+
+        this.run();
+        return true;
+    }
+
+    /** Restores a catalog debit after delivery failed. */
+    public void refundCatalogPayment(int credits, int pointsType, int points) {
+        if (credits < 0 || points < 0) {
+            throw new IllegalArgumentException("catalog refund cannot be negative");
+        }
+
+        synchronized (this.currencyLock) {
+            this.credits = Math.addExact(this.credits, credits);
+            this.currencies.put(pointsType, Math.addExact(this.currencies.get(pointsType), points));
+        }
+
+        this.run();
+    }
+
     public void setCurrencyAmount(int type, int amount) {
         synchronized (this.currencyLock) {
             this.currencies.put(type, amount);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyClubDiscountEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyClubDiscountEvent.java
@@ -2,6 +2,7 @@ package com.eu.habbo.messages.incoming.catalog;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.catalog.ClubOffer;
+import com.eu.habbo.habbohotel.catalog.CatalogPurchaseMath;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.users.subscriptions.Subscription;
 import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionHabboClub;
@@ -39,9 +40,19 @@ public class CatalogBuyClubDiscountEvent extends MessageHandler {
                 ClubOffer regular = Emulator.getGameEnvironment().getCatalogManager().getClubOffers().stream().filter(x -> x.getDays() == deal.getDays()).findAny().orElse(null);
                 if(regular != null) {
 
-                    int totalDays = deal.getDays();
-                    int totalCredits = deal.getCredits();
-                    int totalDuckets = deal.getPoints();
+                    int totalDays;
+                    int totalCredits;
+                    int totalDuckets;
+                    int subscriptionSeconds;
+                    try {
+                        totalDays = CatalogPurchaseMath.requireNonNegative(deal.getDays(), "discount club duration");
+                        totalCredits = CatalogPurchaseMath.requireNonNegative(deal.getCredits(), "discount club credit price");
+                        totalDuckets = CatalogPurchaseMath.requireNonNegative(deal.getPoints(), "discount club points price");
+                        subscriptionSeconds = CatalogPurchaseMath.checkedSubscriptionSeconds(totalDays);
+                    } catch (IllegalArgumentException e) {
+                        this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                        return;
+                    }
 
                     if (totalDays > 0) {
                         if (this.client.getHabbo().getHabboInfo().getCurrencyAmount(deal.getPointsType()) < totalDuckets)
@@ -57,7 +68,7 @@ public class CatalogBuyClubDiscountEvent extends MessageHandler {
                             this.client.getHabbo().givePoints(deal.getPointsType(), -totalDuckets);
 
 
-                        if(this.client.getHabbo().getHabboStats().createSubscription(Subscription.HABBO_CLUB, (totalDays * 86400)) == null) {
+                        if(this.client.getHabbo().getHabboStats().createSubscription(Subscription.HABBO_CLUB, subscriptionSeconds) == null) {
                             this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                             throw new Exception("Unable to create or extend subscription");
                         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
@@ -89,6 +89,10 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
 
                 CatalogPage clubGiftPage = Emulator.getGameEnvironment().getCatalogManager().catalogPages.get(pageId);
                 if (this.isClubOfferPage(clubGiftPage)) {
+                    if (!this.canAccessPage(clubGiftPage)) {
+                        this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                        return;
+                    }
                     this.handleClubOfferGift(clubGiftPage, itemId, username);
                     return;
                 }
@@ -218,13 +222,19 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                         }
                     }
 
-                    int totalCredits = item.getCredits();
-                    int totalPoints = item.getPoints();
-
                     // Paid wrapping (giftWrappers) costs hotel.gifts.special.price; default furni wrap is free.
                     boolean isPaidWrap = Emulator.getGameEnvironment().getCatalogManager().giftWrappers.containsKey(spriteId);
                     int wrapFee = isPaidWrap ? Emulator.getConfig().getInt("hotel.gifts.special.price", 0) : 0;
-                    totalCredits += wrapFee;
+                    int totalCredits;
+                    int totalPoints;
+                    try {
+                        totalCredits = CatalogPurchaseMath.checkedAdd(item.getCredits(), wrapFee);
+                        totalPoints = CatalogPurchaseMath.requireNonNegative(item.getPoints(), "gift points price");
+                    } catch (IllegalArgumentException e) {
+                        LOGGER.warn("Rejected invalid gift price for itemId={}", itemId);
+                        this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                        return;
+                    }
 
                     if (totalCredits > this.client.getHabbo().getHabboInfo().getCredits()
                             || totalPoints > this.client.getHabbo().getHabboInfo().getCurrencyAmount(item.getPointsType())) {
@@ -599,6 +609,13 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                 || page instanceof BuildersClubLoyaltyLayout;
     }
 
+    private boolean canAccessPage(CatalogPage page) {
+        return CatalogPageAccessPolicy.canAccess(
+                page,
+                this.client.getHabbo().getHabboInfo().getRank().getId(),
+                this.client.getHabbo().getHabboStats().hasActiveClub());
+    }
+
     private int getClubOfferWindowId(CatalogPage page) {
         if (page instanceof BuildersClubAddonsLayout) {
             return ClubOffer.WINDOW_BUILDERS_CLUB_ADDONS;
@@ -629,8 +646,17 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
             return;
         }
 
-        int totalCredits = offer.getCredits();
-        int totalPoints = offer.getPoints();
+        int totalCredits;
+        int totalPoints;
+        int duration;
+        try {
+            totalCredits = CatalogPurchaseMath.requireNonNegative(offer.getCredits(), "club gift credit price");
+            totalPoints = CatalogPurchaseMath.requireNonNegative(offer.getPoints(), "club gift points price");
+            duration = CatalogPurchaseMath.checkedSubscriptionSeconds(offer.getDays());
+        } catch (IllegalArgumentException e) {
+            this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+            return;
+        }
 
         if (totalCredits > this.client.getHabbo().getHabboInfo().getCredits()
                 || totalPoints > this.client.getHabbo().getHabboInfo().getCurrencyAmount(offer.getPointsType())) {
@@ -666,7 +692,6 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
         }
 
         String subscriptionType = offer.isBuildersClubSubscription() ? Subscription.BUILDERS_CLUB : Subscription.HABBO_CLUB;
-        int duration = offer.getDays() * 86400;
 
         boolean extended;
         if (recipient != null) {
@@ -728,7 +753,7 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                         int existing = set.getInt("duration");
                         try (PreparedStatement update = connection.prepareStatement(
                                 "UPDATE users_subscriptions SET duration = ? WHERE id = ?")) {
-                            update.setInt(1, existing + duration);
+                            update.setInt(1, CatalogPurchaseMath.checkedAdd(existing, duration));
                             update.setInt(2, subId);
                             update.executeUpdate();
                             return true;
@@ -747,7 +772,7 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                 insert.executeUpdate();
                 return true;
             }
-        } catch (SQLException e) {
+        } catch (SQLException | IllegalArgumentException e) {
             LOGGER.error("Caught SQL exception while extending offline subscription", e);
             return false;
         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
@@ -350,7 +350,7 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                             ? this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_PIXELS)
                             : this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS);
                     int chargePoints = hasInfinitePoints ? 0 : totalPoints;
-                    if (!this.client.getHabbo().tryTakeCatalogPayment(chargeCredits, item.getPointsType(), chargePoints)) {
+                    if (!CatalogPaymentService.tryTake(this.client.getHabbo(), chargeCredits, item.getPointsType(), chargePoints)) {
                         this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                         return;
                     }
@@ -600,7 +600,7 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                             if (createdItem != null) Emulator.getGameEnvironment().getItemManager().deleteItem(createdItem);
                         }
                         if (paidCredits > 0 || paidPoints > 0) {
-                            this.client.getHabbo().refundCatalogPayment(paidCredits, paidPointsType, paidPoints);
+                            CatalogPaymentService.refund(this.client.getHabbo(), paidCredits, paidPointsType, paidPoints);
                         }
                     }
                 } finally {
@@ -712,7 +712,7 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                 ? this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_PIXELS)
                 : this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS);
         int paidPoints = hasInfinitePoints ? 0 : totalPoints;
-        if (!this.client.getHabbo().tryTakeCatalogPayment(paidCredits, offer.getPointsType(), paidPoints)) {
+        if (!CatalogPaymentService.tryTake(this.client.getHabbo(), paidCredits, offer.getPointsType(), paidPoints)) {
             this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
             return;
         }
@@ -725,12 +725,12 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                 extended = this.extendOfflineSubscription(recipientId, subscriptionType, duration);
             }
         } catch (RuntimeException e) {
-            this.client.getHabbo().refundCatalogPayment(paidCredits, offer.getPointsType(), paidPoints);
+            CatalogPaymentService.refund(this.client.getHabbo(), paidCredits, offer.getPointsType(), paidPoints);
             throw e;
         }
 
         if (!extended) {
-            this.client.getHabbo().refundCatalogPayment(paidCredits, offer.getPointsType(), paidPoints);
+            CatalogPaymentService.refund(this.client.getHabbo(), paidCredits, offer.getPointsType(), paidPoints);
             this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
@@ -66,6 +66,8 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
             int paidCredits = 0;
             int paidPoints = 0;
             int paidPointsType = 0;
+            Set<HabboItem> createdGiftItems = new HashSet<>();
+            boolean giftDelivered = false;
 
             try {
                 int pageId = this.packet.readInt();
@@ -286,10 +288,9 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
 
                         limitedNumber = limitedConfiguration.getNumber();
                         limitedStack = limitedConfiguration.getTotalSet();
-                        this.client.getHabbo().getHabboStats().addLtdLog(item.getId(), Emulator.getIntUnixTimestamp());
                     }
 
-                    Set<HabboItem> itemsList = new HashSet<>();
+                    Set<HabboItem> itemsList = createdGiftItems;
 
                     boolean badgeFound = false;
                     for (Item baseItem : item.getBaseItems()) {
@@ -329,6 +330,33 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                         this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                         return;
                     }
+
+                    // Reject unsupported shapes before creating recipient-owned rows.
+                    for (Item baseItem : item.getBaseItems()) {
+                        if (baseItem == null || item.getItemAmount(baseItem.getId()) > 1
+                                || baseItem.getType() == FurnitureType.BADGE
+                                || Item.isBot(baseItem)
+                                || Item.isPet(baseItem)
+                                || baseItem.getName().contains("avatar_effect")
+                                || baseItem.getInteractionType().getType() == InteractionGuildFurni.class
+                                || baseItem.getInteractionType().getType() == InteractionGuildGate.class) {
+                            this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                            return;
+                        }
+                    }
+
+                    int chargeCredits = this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS) ? 0 : totalCredits;
+                    boolean hasInfinitePoints = item.getPointsType() == 0
+                            ? this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_PIXELS)
+                            : this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS);
+                    int chargePoints = hasInfinitePoints ? 0 : totalPoints;
+                    if (!this.client.getHabbo().tryTakeCatalogPayment(chargeCredits, item.getPointsType(), chargePoints)) {
+                        this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                        return;
+                    }
+                    paidCredits = chargeCredits;
+                    paidPoints = chargePoints;
+                    paidPointsType = item.getPointsType();
 
                     for (Item baseItem : item.getBaseItems()) {
                         if (item.getItemAmount(baseItem.getId()) > 1) {
@@ -500,40 +528,14 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                             .append("\t")
                             .append(this.client.getHabbo().getHabboInfo().getLook());
 
-                    // Deduct currency before createGift so a failure here leaves the sender unpaid rather than gifted.
-                    if (!this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS) && totalCredits > 0) {
-                        this.client.getHabbo().giveCredits(-totalCredits);
-                        paidCredits = totalCredits;
-                    }
-
-                    if (totalPoints > 0) {
-                        if (item.getPointsType() == 0 && !this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_PIXELS)) {
-                            this.client.getHabbo().givePixels(-totalPoints);
-                            paidPoints = totalPoints;
-                            paidPointsType = 0;
-                        } else if (!this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS)) {
-                            this.client.getHabbo().givePoints(item.getPointsType(), -totalPoints);
-                            paidPoints = totalPoints;
-                            paidPointsType = item.getPointsType();
-                        }
-                    }
-
                     HabboItem gift = Emulator.getGameEnvironment().getItemManager().createGift(username, giftItem, giftData.toString(), 0, 0);
 
                     if (gift == null) {
                         LOGGER.debug("createGift returned null");
-                        if (paidCredits > 0) {
-                            this.client.getHabbo().giveCredits(paidCredits);
-                            paidCredits = 0;
-                        }
-                        if (paidPoints > 0) {
-                            if (paidPointsType == 0) this.client.getHabbo().givePixels(paidPoints);
-                            else this.client.getHabbo().givePoints(paidPointsType, paidPoints);
-                            paidPoints = 0;
-                        }
                         this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
                         return;
                     }
+                    createdGiftItems.add(gift);
 
                     if (limitedConfiguration != null) {
                         for (HabboItem itm : itemsList) {
@@ -579,6 +581,10 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
 
                     // Gift fully delivered; commit cooldown and clear refund tracking so the catch block can't double-refund.
                     this.client.getHabbo().getHabboStats().lastGiftTimestamp = Emulator.getIntUnixTimestamp();
+                    if (item.isLimited()) {
+                        this.client.getHabbo().getHabboStats().addLtdLog(item.getId(), Emulator.getIntUnixTimestamp());
+                    }
+                    giftDelivered = true;
                     paidCredits = 0;
                     paidPoints = 0;
 
@@ -587,13 +593,21 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
             } catch (Exception e) {
                 LOGGER.error("Exception caught", e);
                 this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
-                if (paidCredits > 0) this.client.getHabbo().giveCredits(paidCredits);
-                if (paidPoints > 0) {
-                    if (paidPointsType == 0) this.client.getHabbo().givePixels(paidPoints);
-                    else this.client.getHabbo().givePoints(paidPointsType, paidPoints);
-                }
             } finally {
-                this.client.getHabbo().getHabboStats().isPurchasingFurniture = false;
+                try {
+                    if (!giftDelivered) {
+                        for (HabboItem createdItem : createdGiftItems) {
+                            if (createdItem != null) Emulator.getGameEnvironment().getItemManager().deleteItem(createdItem);
+                        }
+                        if (paidCredits > 0 || paidPoints > 0) {
+                            this.client.getHabbo().refundCatalogPayment(paidCredits, paidPointsType, paidPoints);
+                        }
+                    }
+                } finally {
+                    synchronized (this.client.getHabbo().getHabboStats()) {
+                        this.client.getHabbo().getHabboStats().isPurchasingFurniture = false;
+                    }
+                }
             }
         } else {
             LOGGER.debug("cooldown blocked purchase");
@@ -693,28 +707,32 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
 
         String subscriptionType = offer.isBuildersClubSubscription() ? Subscription.BUILDERS_CLUB : Subscription.HABBO_CLUB;
 
-        boolean extended;
-        if (recipient != null) {
-            extended = (recipient.getHabboStats().createSubscription(subscriptionType, duration) != null);
-        } else {
-            extended = this.extendOfflineSubscription(recipientId, subscriptionType, duration);
-        }
-
-        if (!extended) {
-            this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+        int paidCredits = this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS) ? 0 : totalCredits;
+        boolean hasInfinitePoints = offer.getPointsType() == 0
+                ? this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_PIXELS)
+                : this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS);
+        int paidPoints = hasInfinitePoints ? 0 : totalPoints;
+        if (!this.client.getHabbo().tryTakeCatalogPayment(paidCredits, offer.getPointsType(), paidPoints)) {
+            this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
             return;
         }
 
-        if (totalCredits > 0 && !this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS)) {
-            this.client.getHabbo().giveCredits(-totalCredits);
+        boolean extended;
+        try {
+            if (recipient != null) {
+                extended = (recipient.getHabboStats().createSubscription(subscriptionType, duration) != null);
+            } else {
+                extended = this.extendOfflineSubscription(recipientId, subscriptionType, duration);
+            }
+        } catch (RuntimeException e) {
+            this.client.getHabbo().refundCatalogPayment(paidCredits, offer.getPointsType(), paidPoints);
+            throw e;
         }
 
-        if (totalPoints > 0) {
-            if (offer.getPointsType() == 0 && !this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_PIXELS)) {
-                this.client.getHabbo().givePixels(-totalPoints);
-            } else if (!this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS)) {
-                this.client.getHabbo().givePoints(offer.getPointsType(), -totalPoints);
-            }
+        if (!extended) {
+            this.client.getHabbo().refundCatalogPayment(paidCredits, offer.getPointsType(), paidPoints);
+            this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+            return;
         }
 
         if (recipient != null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java
@@ -72,7 +72,7 @@ public class CatalogBuyItemEvent extends MessageHandler {
                     page = Emulator.getGameEnvironment().getCatalogManager().getCatalogPage(searchedItem.getPageId());
 
                     if(page != null) {
-                        if (page.getRank() > this.client.getHabbo().getHabboInfo().getRank().getId()) {
+                        if (!this.canAccessPage(page)) {
                             page = null;
                         } else if (page.getLayout() != null && page.getLayout().equalsIgnoreCase(CatalogPageLayouts.club_gift.name())) {
                             page = null;
@@ -86,6 +86,10 @@ public class CatalogBuyItemEvent extends MessageHandler {
                     page = null;
                 }
 
+                if (page != null && !this.canAccessPage(page)) {
+                    page = null;
+                }
+
                 if (page instanceof RoomBundleLayout) {
                     final CatalogItem[] item = new CatalogItem[1];
                     for (CatalogItem object : page.getCatalogItems().values()) {
@@ -94,7 +98,23 @@ public class CatalogBuyItemEvent extends MessageHandler {
                     }
 
                     CatalogItem roomBundleItem = item[0];
-                    if (roomBundleItem == null || roomBundleItem.getCredits() > this.client.getHabbo().getHabboInfo().getCredits() || roomBundleItem.getPoints() > this.client.getHabbo().getHabboInfo().getCurrencyAmount(roomBundleItem.getPointsType())) {
+                    if (roomBundleItem == null) {
+                        this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                        return;
+                    }
+
+                    int roomCredits;
+                    int roomPoints;
+                    try {
+                        roomCredits = CatalogPurchaseMath.requireNonNegative(roomBundleItem.getCredits(), "room bundle credit price");
+                        roomPoints = CatalogPurchaseMath.requireNonNegative(roomBundleItem.getPoints(), "room bundle points price");
+                    } catch (IllegalArgumentException e) {
+                        this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                        return;
+                    }
+
+                    if (roomCredits > this.client.getHabbo().getHabboInfo().getCredits()
+                            || roomPoints > this.client.getHabbo().getHabboInfo().getCurrencyAmount(roomBundleItem.getPointsType())) {
                         this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
                         return;
                     }
@@ -108,10 +128,10 @@ public class CatalogBuyItemEvent extends MessageHandler {
                     }
                     ((RoomBundleLayout) page).buyRoom(this.client.getHabbo());
                     if (!this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS)) { //if the player has this perm disabled
-                        this.client.getHabbo().giveCredits(-roomBundleItem.getCredits()); // takes their credits away
+                        this.client.getHabbo().giveCredits(-roomCredits); // takes their credits away
                     }
                     if (!this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS)) { //if the player has this perm disabled
-                        this.client.getHabbo().givePoints(roomBundleItem.getPointsType(), -roomBundleItem.getPoints()); // takes their points away
+                        this.client.getHabbo().givePoints(roomBundleItem.getPointsType(), -roomPoints); // takes their points away
                     }
                     this.client.sendResponse(new PurchaseOKComposer()); // Sends the composer to close the window.
 
@@ -151,14 +171,20 @@ public class CatalogBuyItemEvent extends MessageHandler {
                     return;
                 }
 
-                int totalDays = 0;
-                int totalCredits = 0;
-                int totalDuckets = 0;
-
-                for (int i = 0; i < count; i++) {
-                    totalDays += item.getDays();
-                    totalCredits += item.getCredits();
-                    totalDuckets += item.getPoints();
+                int totalDays;
+                int totalCredits;
+                int totalDuckets;
+                int subscriptionSeconds;
+                try {
+                    totalDays = CatalogPurchaseMath.checkedPrice(item.getDays(), count);
+                    totalCredits = CatalogPurchaseMath.checkedPrice(item.getCredits(), count);
+                    totalDuckets = CatalogPurchaseMath.checkedPrice(item.getPoints(), count);
+                    subscriptionSeconds = item.isBuildersClubAddon()
+                            ? 0
+                            : CatalogPurchaseMath.checkedSubscriptionSeconds(totalDays);
+                } catch (IllegalArgumentException e) {
+                    this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                    return;
                 }
 
                 if (totalDays > 0) {
@@ -181,7 +207,7 @@ public class CatalogBuyItemEvent extends MessageHandler {
                     } else {
                         String subscriptionType = item.isBuildersClubSubscription() ? Subscription.BUILDERS_CLUB : Subscription.HABBO_CLUB;
 
-                        if (this.client.getHabbo().getHabboStats().createSubscription(subscriptionType, (totalDays * 86400)) == null) {
+                        if (this.client.getHabbo().getHabboStats().createSubscription(subscriptionType, subscriptionSeconds) == null) {
                             this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                             throw new Exception("Unable to create or extend subscription");
                         }
@@ -254,6 +280,13 @@ public class CatalogBuyItemEvent extends MessageHandler {
                 || page instanceof BuildersClubFrontPageLayout
                 || page instanceof BuildersClubAddonsLayout
                 || page instanceof BuildersClubLoyaltyLayout;
+    }
+
+    private boolean canAccessPage(CatalogPage page) {
+        return CatalogPageAccessPolicy.canAccess(
+                page,
+                this.client.getHabbo().getHabboInfo().getRank().getId(),
+                this.client.getHabbo().getHabboStats().hasActiveClub());
     }
 
     private int getClubOfferWindowId(CatalogPage page) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java
@@ -164,7 +164,16 @@ public class CatalogBuyItemEvent extends MessageHandler {
             }
 
             if (this.isClubOfferPage(page)) {
-                ClubOffer item = Emulator.getGameEnvironment().getCatalogManager().clubOffers.get(itemId);
+                synchronized (this.client.getHabbo().getHabboStats()) {
+                    if (this.client.getHabbo().getHabboStats().isPurchasingFurniture) {
+                        this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                        return;
+                    }
+                    this.client.getHabbo().getHabboStats().isPurchasingFurniture = true;
+                }
+
+                try {
+                    ClubOffer item = Emulator.getGameEnvironment().getCatalogManager().clubOffers.get(itemId);
 
                 if (item == null || !item.belongsToWindow(this.getClubOfferWindowId(page))) {
                     this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
@@ -194,11 +203,12 @@ public class CatalogBuyItemEvent extends MessageHandler {
                     if (this.client.getHabbo().getHabboInfo().getCredits() < totalCredits)
                         return;
 
-                    if (!this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS))
-                        this.client.getHabbo().giveCredits(-totalCredits);
-
-                    if (!this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS))
-                        this.client.getHabbo().givePoints(item.getPointsType(), -totalDuckets);
+                    int paidCredits = this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS) ? 0 : totalCredits;
+                    int paidPoints = this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS) ? 0 : totalDuckets;
+                    if (!this.client.getHabbo().tryTakeCatalogPayment(paidCredits, item.getPointsType(), paidPoints)) {
+                        this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                        return;
+                    }
 
                     if (item.isBuildersClubAddon()) {
                         this.client.getHabbo().getHabboStats().addBuildersClubBonusFurni(totalDays);
@@ -208,8 +218,9 @@ public class CatalogBuyItemEvent extends MessageHandler {
                         String subscriptionType = item.isBuildersClubSubscription() ? Subscription.BUILDERS_CLUB : Subscription.HABBO_CLUB;
 
                         if (this.client.getHabbo().getHabboStats().createSubscription(subscriptionType, subscriptionSeconds) == null) {
+                            this.client.getHabbo().refundCatalogPayment(paidCredits, item.getPointsType(), paidPoints);
                             this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
-                            throw new Exception("Unable to create or extend subscription");
+                            return;
                         }
                     }
 
@@ -218,7 +229,12 @@ public class CatalogBuyItemEvent extends MessageHandler {
 
                     this.client.getHabbo().getHabboStats().run();
                 }
-                return;
+                    return;
+                } finally {
+                    synchronized (this.client.getHabbo().getHabboStats()) {
+                        this.client.getHabbo().getHabboStats().isPurchasingFurniture = false;
+                    }
+                }
             }
 
             CatalogItem item;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java
@@ -205,7 +205,7 @@ public class CatalogBuyItemEvent extends MessageHandler {
 
                     int paidCredits = this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS) ? 0 : totalCredits;
                     int paidPoints = this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS) ? 0 : totalDuckets;
-                    if (!this.client.getHabbo().tryTakeCatalogPayment(paidCredits, item.getPointsType(), paidPoints)) {
+                    if (!CatalogPaymentService.tryTake(this.client.getHabbo(), paidCredits, item.getPointsType(), paidPoints)) {
                         this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                         return;
                     }
@@ -218,7 +218,7 @@ public class CatalogBuyItemEvent extends MessageHandler {
                         String subscriptionType = item.isBuildersClubSubscription() ? Subscription.BUILDERS_CLUB : Subscription.HABBO_CLUB;
 
                         if (this.client.getHabbo().getHabboStats().createSubscription(subscriptionType, subscriptionSeconds) == null) {
-                            this.client.getHabbo().refundCatalogPayment(paidCredits, item.getPointsType(), paidPoints);
+                            CatalogPaymentService.refund(this.client.getHabbo(), paidCredits, item.getPointsType(), paidPoints);
                             this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                             return;
                         }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPageAccessPolicyContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPageAccessPolicyContractTest.java
@@ -1,0 +1,26 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import com.eu.habbo.messages.incoming.catalog.CatalogBuyItemAsGiftEvent;
+import com.eu.habbo.messages.incoming.catalog.CatalogBuyItemEvent;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogPageAccessPolicyContractTest {
+    @Test
+    void purchaseHandlersApplyTheSharedPageAccessPolicy() throws Exception {
+        assertUsesPolicy(CatalogBuyItemEvent.class);
+        assertUsesPolicy(CatalogBuyItemAsGiftEvent.class);
+    }
+
+    private static void assertUsesPolicy(Class<?> handler) throws Exception {
+        Path source = Path.of("src/main/java", handler.getName().replace('.', '/') + ".java");
+        String code = Files.readString(source);
+
+        assertTrue(code.contains("CatalogPageAccessPolicy.canAccess("),
+                () -> handler.getSimpleName() + " must reject disabled, rank-restricted, and club-only pages");
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseAtomicityContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseAtomicityContractTest.java
@@ -1,0 +1,55 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogPurchaseAtomicityContractTest {
+    private static String source(String relativePath) throws Exception {
+        return Files.readString(Path.of("src/main/java", relativePath));
+    }
+
+    @Test
+    void normalPurchasePersistsAssetsAndPaymentInOneTransaction() throws Exception {
+        String manager = source("com/eu/habbo/habbohotel/catalog/CatalogManager.java");
+        String transaction = source("com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java");
+
+        assertTrue(manager.contains("synchronized (habbo.getHabboStats())"),
+                "normal catalog purchases must acquire the per-user purchase gate atomically");
+        assertTrue(manager.contains("CatalogPurchaseTransaction.execute("),
+                "normal catalog assets and payment must use the transaction coordinator");
+        assertTrue(transaction.contains("connection.setAutoCommit(false)"));
+        assertTrue(transaction.contains(
+                        "UPDATE users SET credits = credits - ? WHERE id = ? AND credits >= ?"),
+                "credit debit must reject insufficient concurrent balances");
+        assertTrue(transaction.contains("connection.commit()"));
+        assertTrue(transaction.contains("connection.rollback()"));
+    }
+
+    @Test
+    void giftsDebitBeforeCreationAndCompensateOnFailure() throws Exception {
+        String gift = source("com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java");
+
+        int debit = gift.indexOf("tryTakeCatalogPayment(chargeCredits, item.getPointsType(), chargePoints)");
+        int create = gift.indexOf("getItemManager().createItem(userId", debit);
+        assertTrue(debit > -1 && create > debit,
+                "gift payment must be reserved before recipient-owned rows are created");
+        assertTrue(gift.contains("if (!giftDelivered)"),
+                "failed gift delivery must enter compensating cleanup");
+        assertTrue(gift.contains("refundCatalogPayment(paidCredits, paidPointsType, paidPoints)"),
+                "failed gift delivery must restore the exact reserved payment");
+    }
+
+    @Test
+    void clubPurchasesUseTheSamePurchaseGateAndWalletDebit() throws Exception {
+        String buy = source("com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java");
+
+        assertTrue(buy.contains("isPurchasingFurniture = true"));
+        assertTrue(buy.contains("tryTakeCatalogPayment(paidCredits, item.getPointsType(), paidPoints)"));
+        assertTrue(buy.contains("refundCatalogPayment(paidCredits, item.getPointsType(), paidPoints)"),
+                "a rejected subscription grant must restore its payment");
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseAtomicityContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseAtomicityContractTest.java
@@ -33,13 +33,13 @@ class CatalogPurchaseAtomicityContractTest {
     void giftsDebitBeforeCreationAndCompensateOnFailure() throws Exception {
         String gift = source("com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java");
 
-        int debit = gift.indexOf("tryTakeCatalogPayment(chargeCredits, item.getPointsType(), chargePoints)");
+        int debit = gift.indexOf("CatalogPaymentService.tryTake(this.client.getHabbo(), chargeCredits, item.getPointsType(), chargePoints)");
         int create = gift.indexOf("getItemManager().createItem(userId", debit);
         assertTrue(debit > -1 && create > debit,
                 "gift payment must be reserved before recipient-owned rows are created");
         assertTrue(gift.contains("if (!giftDelivered)"),
                 "failed gift delivery must enter compensating cleanup");
-        assertTrue(gift.contains("refundCatalogPayment(paidCredits, paidPointsType, paidPoints)"),
+        assertTrue(gift.contains("CatalogPaymentService.refund(this.client.getHabbo(), paidCredits, paidPointsType, paidPoints)"),
                 "failed gift delivery must restore the exact reserved payment");
     }
 
@@ -48,8 +48,8 @@ class CatalogPurchaseAtomicityContractTest {
         String buy = source("com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java");
 
         assertTrue(buy.contains("isPurchasingFurniture = true"));
-        assertTrue(buy.contains("tryTakeCatalogPayment(paidCredits, item.getPointsType(), paidPoints)"));
-        assertTrue(buy.contains("refundCatalogPayment(paidCredits, item.getPointsType(), paidPoints)"),
+        assertTrue(buy.contains("CatalogPaymentService.tryTake(this.client.getHabbo(), paidCredits, item.getPointsType(), paidPoints)"));
+        assertTrue(buy.contains("CatalogPaymentService.refund(this.client.getHabbo(), paidCredits, item.getPointsType(), paidPoints)"),
                 "a rejected subscription grant must restore its payment");
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseAtomicityContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseAtomicityContractTest.java
@@ -27,6 +27,8 @@ class CatalogPurchaseAtomicityContractTest {
                 "credit debit must reject insufficient concurrent balances");
         assertTrue(transaction.contains("connection.commit()"));
         assertTrue(transaction.contains("connection.rollback()"));
+        assertTrue(manager.contains("limitedConfiguration.restoreNumber(item.getId(), limitedNumber)"),
+                "a failed legacy limited purchase must return its reserved number to the pool");
     }
 
     @Test

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseMathTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseMathTest.java
@@ -1,0 +1,41 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CatalogPurchaseMathTest {
+    @Test
+    void calculatesNormalPricesWithoutChangingTheirValue() {
+        assertEquals(500, CatalogPurchaseMath.checkedPrice(100, 5));
+        assertEquals(110, CatalogPurchaseMath.checkedAdd(100, 10));
+        assertEquals(2_592_000, CatalogPurchaseMath.checkedSubscriptionSeconds(30));
+    }
+
+    @Test
+    void rejectsTheConfirmedBillionCreditMultiplicationOverflow() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CatalogPurchaseMath.checkedPrice(1_000_000_000, 3));
+    }
+
+    @Test
+    void rejectsGiftWrapAdditionOverflow() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CatalogPurchaseMath.checkedAdd(Integer.MAX_VALUE, 1));
+    }
+
+    @Test
+    void rejectsNegativePricesBeforeTheyCanBecomeWalletCredits() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CatalogPurchaseMath.checkedPrice(-1, 1));
+        assertThrows(IllegalArgumentException.class,
+                () -> CatalogPurchaseMath.checkedAdd(0, -1));
+    }
+
+    @Test
+    void rejectsSubscriptionDurationOverflow() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CatalogPurchaseMath.checkedSubscriptionSeconds(25_000));
+    }
+}


### PR DESCRIPTION
Finding and fix produced by OpenAI Codex.

## Finding

Catalog, gift, and club purchases trusted signed `int` price arithmetic and split affordability, delivery, and debit across separate steps. Accepted high prices could overflow into free purchases or currency grants. A later validation, plugin price change, or item-creation failure could also leave recipient-owned rows without a completed payment, while concurrent requests could spend the same observed balance.

## Fix

- Reject overflowing or negative price, quantity, gift-wrap, and subscription calculations
- Enforce enabled, rank, and club page access for direct purchases and gifts
- Acquire the purchase gate atomically for normal, gift, and club flows
- Check and debit credits plus points under one wallet lock
- Finish deterministic type validation before creating catalog resources
- Track every created item, bot, and pet and delete it if payment or delivery fails
- Refund the exact reserved payment when gift or subscription delivery fails
- Clean teleport/hopper metadata when compensating an item row
- Defer limited-purchase logs and selected side effects until delivery succeeds

