### PR TITLE
fix: retain failed earnings claim markers

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/earnings/EarningsCenterManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/earnings/EarningsCenterManager.java
@@ -6,6 +6,8 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboBadge;
 import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionHabboClub;
 import com.eu.habbo.messages.outgoing.users.AddUserBadgeComposer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -18,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class EarningsCenterManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EarningsCenterManager.class);
     public static final String CONFIG_PREFIX = "earnings.";
     private static final int DEFAULT_COOLDOWN_SECONDS = 86400;
     private static final int DEFAULT_POINTS_TYPE = 5;
@@ -109,10 +112,12 @@ public class EarningsCenterManager {
             this.rewards.grant(habbo, definition.rewards());
             return new EarningsClaimResult(category, EarningsClaimResult.Status.SUCCESS, buildEntry(habbo, userId, category, now));
         } catch (SQLException e) {
-            try {
-                this.claims.removeClaim(userId, category.getKey(), periodKey);
-            } catch (SQLException ignored) {
-            }
+            // A reward applier may have completed earlier grants before a later
+            // database-backed reward failed. Keep the unique claim marker so a
+            // retry cannot duplicate the already-applied portion. Operators can
+            // reconcile the retained claim and missing reward from this log.
+            LOGGER.error("Earnings grant failed after claim marker was recorded; retaining claim userId={} category={} period={}",
+                    userId, category.getKey(), periodKey, e);
             return new EarningsClaimResult(category, EarningsClaimResult.Status.ERROR, buildEntry(habbo, userId, category, now));
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/earnings/EarningsCenterManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/earnings/EarningsCenterManager.java
@@ -104,11 +104,22 @@ public class EarningsCenterManager {
 
         String periodKey = periodKey(habbo, category, now, definition.cooldownSeconds());
 
+        boolean claimRecorded;
         try {
-            if (!this.claims.recordClaim(userId, category.getKey(), periodKey, now)) {
-                return new EarningsClaimResult(category, EarningsClaimResult.Status.ALREADY_CLAIMED, buildEntry(habbo, userId, category, now));
-            }
+            claimRecorded = this.claims.recordClaim(userId, category.getKey(), periodKey, now);
+        } catch (SQLException e) {
+            // The claim marker was never written and no reward was applied, so a
+            // retry is safe and cannot duplicate anything.
+            LOGGER.error("Earnings claim marker could not be recorded; no reward granted, retry is safe userId={} category={} period={}",
+                    userId, category.getKey(), periodKey, e);
+            return new EarningsClaimResult(category, EarningsClaimResult.Status.ERROR, buildEntry(habbo, userId, category, now));
+        }
 
+        if (!claimRecorded) {
+            return new EarningsClaimResult(category, EarningsClaimResult.Status.ALREADY_CLAIMED, buildEntry(habbo, userId, category, now));
+        }
+
+        try {
             this.rewards.grant(habbo, definition.rewards());
             return new EarningsClaimResult(category, EarningsClaimResult.Status.SUCCESS, buildEntry(habbo, userId, category, now));
         } catch (SQLException e) {
@@ -296,8 +307,6 @@ public class EarningsCenterManager {
         boolean hasClaim(int userId, String category, String periodKey) throws SQLException;
 
         boolean recordClaim(int userId, String category, String periodKey, int claimedAt) throws SQLException;
-
-        void removeClaim(int userId, String category, String periodKey) throws SQLException;
     }
 
     public interface RewardApplier {
@@ -354,17 +363,6 @@ public class EarningsCenterManager {
                 return statement.executeUpdate() == 1;
             } catch (SQLIntegrityConstraintViolationException duplicate) {
                 return false;
-            }
-        }
-
-        @Override
-        public void removeClaim(int userId, String category, String periodKey) throws SQLException {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                 PreparedStatement statement = connection.prepareStatement("DELETE FROM users_earnings_claims WHERE user_id = ? AND category = ? AND period_key = ? LIMIT 1")) {
-                statement.setInt(1, userId);
-                statement.setString(2, category);
-                statement.setString(3, periodKey);
-                statement.executeUpdate();
             }
         }
     }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/earnings/EarningsCenterManagerTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/earnings/EarningsCenterManagerTest.java
@@ -106,10 +106,14 @@ class EarningsCenterManagerTest {
     }
 
     @Test
-    void failedRewardGrantRollsBackClaimRecord() {
-        TestConfig config = enabledConfig().with("earnings.daily_gift.credits", "10");
+    void failedRewardGrantRetainsClaimToPreventPartialRewardReplay() {
+        TestConfig config = enabledConfig()
+                .with("earnings.daily_gift.credits", "10")
+                .with("earnings.daily_gift.points", "5");
         TestClaims claims = new TestClaims();
+        List<EarningsReward> partiallyGranted = new ArrayList<>();
         EarningsCenterManager manager = new EarningsCenterManager(config, claims, (habbo, rewards) -> {
+            partiallyGranted.add(rewards.getFirst());
             throw new SQLException("grant failed");
         }, FIXED_CLOCK);
 
@@ -118,7 +122,8 @@ class EarningsCenterManagerTest {
                 .claim(null, "daily_gift");
 
         assertEquals(EarningsClaimResult.Status.ERROR, failed.getStatus());
-        assertEquals(EarningsClaimResult.Status.SUCCESS, retried.getStatus());
+        assertEquals(1, partiallyGranted.size());
+        assertEquals(EarningsClaimResult.Status.ALREADY_CLAIMED, retried.getStatus());
     }
 
     @Test

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/earnings/EarningsCenterManagerTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/earnings/EarningsCenterManagerTest.java
@@ -127,6 +127,34 @@ class EarningsCenterManagerTest {
     }
 
     @Test
+    void failedClaimMarkerRecordingGrantsNothingAndAllowsRetry() {
+        TestConfig config = enabledConfig().with("earnings.daily_gift.credits", "10");
+        ClaimRepository throwingClaims = new ClaimRepository() {
+            @Override
+            public boolean hasClaim(int userId, String category, String periodKey) {
+                return false;
+            }
+
+            @Override
+            public boolean recordClaim(int userId, String category, String periodKey, int claimedAt) throws SQLException {
+                throw new SQLException("record failed");
+            }
+        };
+        TestRewards rewards = new TestRewards();
+
+        EarningsClaimResult failed = new EarningsCenterManager(config, throwingClaims, rewards, FIXED_CLOCK)
+                .claim(null, "daily_gift");
+
+        assertEquals(EarningsClaimResult.Status.ERROR, failed.getStatus());
+        assertEquals(0, rewards.granted.size());
+
+        TestClaims claims = new TestClaims();
+        EarningsClaimResult retried = new EarningsCenterManager(config, claims, new TestRewards(), FIXED_CLOCK)
+                .claim(null, "daily_gift");
+        assertEquals(EarningsClaimResult.Status.SUCCESS, retried.getStatus());
+    }
+
+    @Test
     void nativeMarketplaceRowsUseNativeClaimInsteadOfPeriodicClaimLedger() {
         TestConfig config = enabledConfig().with("earnings.marketplace.native.enabled", "1");
         TestClaims claims = new TestClaims();
@@ -222,11 +250,6 @@ class EarningsCenterManagerTest {
         @Override
         public boolean recordClaim(int userId, String category, String periodKey, int claimedAt) {
             return this.claims.add(key(userId, category, periodKey));
-        }
-
-        @Override
-        public void removeClaim(int userId, String category, String periodKey) {
-            this.claims.remove(key(userId, category, periodKey));
         }
 
         private String key(int userId, String category, String periodKey) {


### PR DESCRIPTION
Finding and fix produced by OpenAI Codex.

## Finding

The earnings center recorded a unique claim marker and then granted a list of rewards sequentially. If an early reward succeeded but a later database-backed badge, item, or club reward threw `SQLException`, the catch path deleted the claim marker. The client could then retry the same period and receive the already-successful prefix again.

The shipped earnings feature is disabled and its configured rewards are zero, so this is dormant in the default configuration. It becomes reachable when an operator enables a mixed reward set containing both an immediately applied reward and a later fallible reward.

## Impact

- Replay duplication of credits, points, badges, or items already granted before a later failure
- Repeated partial claims amplifying configured earnings rewards
- Database-persistent economy inflation when the feature is enabled with a vulnerable reward order

## Fix

Keep the unique claim marker when reward application fails. The failed claim is logged with user, category, and period for operator reconciliation, but it cannot be retried automatically and duplicate the already-applied portion.

This is deliberately fail-closed. A fully atomic multi-reward transaction would require all inventory, subscription, badge, and in-memory wallet mutations to share one transaction boundary; the current architecture does not provide that boundary. Retaining the marker prevents duplication without pretending the partial operation was rolled back.
