### PR TITLE
fix: restrict custom badge CORS origins

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/badges/BadgeHttpHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/badges/BadgeHttpHandler.java
@@ -7,6 +7,7 @@ import com.eu.habbo.habbohotel.users.custombadge.CustomBadgeManager;
 import com.eu.habbo.networking.gameserver.GameServerAttributes;
 import com.eu.habbo.networking.gameserver.auth.AccessTokenService;
 import com.eu.habbo.networking.gameserver.auth.AuthRateLimiter;
+import com.eu.habbo.networking.gameserver.auth.CorsOriginGate;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -342,11 +343,11 @@ public class BadgeHttpHandler extends ChannelInboundHandlerAdapter {
 
     private static void applyCors(FullHttpRequest req, FullHttpResponse response) {
         String origin = req.headers().get(HttpHeaderNames.ORIGIN);
-        if (origin != null && !origin.isEmpty()) {
+        if (origin != null && !origin.isEmpty() && CorsOriginGate.isAllowed(req)) {
             response.headers().set("Access-Control-Allow-Origin", origin);
-            response.headers().set("Vary", "Origin");
             response.headers().set("Access-Control-Allow-Credentials", "true");
         }
+        response.headers().set("Vary", "Origin");
         response.headers().set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, OPTIONS");
         response.headers().set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With");
     }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/badges/BadgeHttpHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/badges/BadgeHttpHandler.java
@@ -342,14 +342,17 @@ public class BadgeHttpHandler extends ChannelInboundHandlerAdapter {
     }
 
     private static void applyCors(FullHttpRequest req, FullHttpResponse response) {
+        // Vary is emitted for every response so shared caches never serve a
+        // CORS-approved response body to a request with a different Origin.
+        response.headers().set("Vary", "Origin");
+
         String origin = req.headers().get(HttpHeaderNames.ORIGIN);
         if (origin != null && !origin.isEmpty() && CorsOriginGate.isAllowed(req)) {
             response.headers().set("Access-Control-Allow-Origin", origin);
             response.headers().set("Access-Control-Allow-Credentials", "true");
+            response.headers().set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, OPTIONS");
+            response.headers().set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With");
         }
-        response.headers().set("Vary", "Origin");
-        response.headers().set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, OPTIONS");
-        response.headers().set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With");
     }
 
     private static boolean isKeepAlive(FullHttpRequest req) {

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/badges/BadgeCorsContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/badges/BadgeCorsContractTest.java
@@ -1,0 +1,30 @@
+package com.eu.habbo.networking.gameserver.badges;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BadgeCorsContractTest {
+    @Test
+    void customBadgeApiDoesNotReflectUnapprovedOrigins() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/networking/gameserver/badges/BadgeHttpHandler.java"));
+
+        int applyCors = source.indexOf("private static void applyCors");
+        int originRead = source.indexOf("get(HttpHeaderNames.ORIGIN)", applyCors);
+        int allowlist = source.indexOf("CorsOriginGate.isAllowed(req)", originRead);
+        int reflection = source.indexOf("set(\"Access-Control-Allow-Origin\", origin)", allowlist);
+
+        assertTrue(originRead > applyCors);
+        assertTrue(allowlist > originRead, "badge CORS must consult the configured origin gate");
+        assertTrue(reflection > allowlist, "origin may only be reflected after allowlist approval");
+
+        String corsMethod = source.substring(applyCors, source.indexOf("private static boolean isKeepAlive", applyCors));
+        assertFalse(corsMethod.contains("if (origin != null && !origin.isEmpty()) {"),
+                "non-empty Origin alone must not authorize credentialed CORS");
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/badges/BadgeCorsContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/badges/BadgeCorsContractTest.java
@@ -18,10 +18,12 @@ class BadgeCorsContractTest {
         int originRead = source.indexOf("get(HttpHeaderNames.ORIGIN)", applyCors);
         int allowlist = source.indexOf("CorsOriginGate.isAllowed(req)", originRead);
         int reflection = source.indexOf("set(\"Access-Control-Allow-Origin\", origin)", allowlist);
+        int allowMethods = source.indexOf("set(\"Access-Control-Allow-Methods\"", allowlist);
 
         assertTrue(originRead > applyCors);
         assertTrue(allowlist > originRead, "badge CORS must consult the configured origin gate");
         assertTrue(reflection > allowlist, "origin may only be reflected after allowlist approval");
+        assertTrue(allowMethods > allowlist, "credentialed CORS method/header grants must be gated by the origin allowlist");
 
         String corsMethod = source.substring(applyCors, source.indexOf("private static boolean isKeepAlive", applyCors));
         assertFalse(corsMethod.contains("if (origin != null && !origin.isEmpty()) {"),


### PR DESCRIPTION
Finding and fix produced by OpenAI Codex.

## Finding

The custom badge API reflected every non-empty request `Origin` into `Access-Control-Allow-Origin` and enabled credentialed CORS. That made the badge mutation endpoint an exception to the rest of the authenticated HTTP surface, which already uses the configured `CorsOriginGate`.

The current endpoint requires an explicit bearer header, so this was not demonstrated as a standalone CSRF exploit: browsers do not automatically attach that token to an attacker origin. It was still an unnecessary cross-origin trust expansion and would become directly dangerous if authentication moved to cookies or a frontend exposed the bearer token.

## Impact

- Arbitrary websites received browser permission to call authenticated badge routes when they could obtain a bearer token
- Future cookie-based authentication would turn the policy into a direct credentialed cross-origin risk
- Badge mutations had a weaker origin policy than adjacent authenticated endpoints

## Fix

Require `CorsOriginGate.isAllowed(req)` before reflecting the origin or enabling credentials. The gate uses the existing `ws.whitelist` configuration, matching the leaderboard and authentication HTTP handlers. Disallowed origins receive no `Access-Control-Allow-Origin` header and are blocked by the browser.
