### PR TITLE
fix: recheck bans on session resume

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/SessionResumeManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/SessionResumeManager.java
@@ -109,6 +109,27 @@ public class SessionResumeManager {
         return ghostSessions.containsKey(userId);
     }
 
+    /**
+     * Evicts a parked session immediately, cancelling its scheduled disposal and
+     * fully disconnecting the Habbo. Used when an external decision (such as a ban)
+     * must take effect during the reconnect grace window rather than waiting for a
+     * resume attempt to re-run its checks. Returns true if a ghost was evicted.
+     */
+    public boolean disposeGhostSession(int userId) {
+        GhostSession ghost = ghostSessions.remove(userId);
+        if (ghost == null) {
+            return false;
+        }
+
+        if (ghost.disposeFuture != null) {
+            ghost.disposeFuture.cancel(false);
+        }
+
+        LOGGER.info("[SessionResume] Evicting parked session for user {} (forced disposal)", userId);
+        performFullDisconnect(ghost.habbo);
+        return true;
+    }
+
     public void disposeAll() {
         for (GhostSession ghost : ghostSessions.values()) {
             if (ghost.disposeFuture != null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolManager.java
@@ -2,6 +2,7 @@ package com.eu.habbo.habbohotel.modtool;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.gameclients.SessionResumeManager;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.permissions.Rank;
 import com.eu.habbo.habbohotel.rooms.Room;
@@ -469,6 +470,12 @@ public class ModToolManager {
         if (target != null) {
             Emulator.getGameServer().getGameClientManager().forceDisposeClient(target.getClient());
         }
+
+        // A parked/ghost session keeps the Habbo resumable during the reconnect
+        // grace window, and its client was already detached so forceDisposeClient
+        // above is a no-op for it. Evict it explicitly so a ban applied while the
+        // target is parked cannot be resumed.
+        SessionResumeManager.getInstance().disposeGhostSession(targetUserId);
 
         if ((type == ModToolBanType.IP || type == ModToolBanType.SUPER) && target != null && !ban.ip.equals("offline")) {
             for (Habbo h : Emulator.getGameServer().getGameClientManager().getHabbosWithIP(ban.ip)) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -129,7 +129,14 @@ public class Habbo implements Runnable {
         return true;
     }
 
-    /** Re-evaluates identity bans without replaying normal-login side effects. */
+    /**
+     * Re-evaluates account, IP, and machine bans for the current connection,
+     * used when resuming a parked session that skips the normal login path.
+     * This resolves and records the resuming connection's IP (and fires
+     * {@link com.eu.habbo.plugin.events.users.UserGetIPAddressEvent}) exactly
+     * as {@link #connect()} does, but does not bring the Habbo online or load
+     * rooms. Returns true when the connection is allowed to proceed.
+     */
     public boolean passesConnectionSecurityChecks() {
         return this.checkConnectionSecurity().allowed();
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -116,21 +116,41 @@ public class Habbo implements Runnable {
 
 
     public boolean connect() {
+        ConnectionSecurityResult security = this.checkConnectionSecurity();
+        if (!security.allowed()) {
+            return false;
+        }
+
+        this.isOnline(true);
+        this.messenger.connectionChanged(this, true, false);
+        Emulator.getGameEnvironment().getRoomManager().loadRoomsForHabbo(this);
+        LOGGER.info("{} logged in from IP {} using proxyserver {}", this.habboInfo.getUsername(), this.habboInfo.getIpLogin(), security.proxyInfo());
+        LOGGER.info("{} client MachineId = {}", this.habboInfo.getUsername(), this.client.getMachineId());
+        return true;
+    }
+
+    /** Re-evaluates identity bans without replaying normal-login side effects. */
+    public boolean passesConnectionSecurityChecks() {
+        return this.checkConnectionSecurity().allowed();
+    }
+
+    private ConnectionSecurityResult checkConnectionSecurity() {
+        if (this.client == null || this.client.getChannel() == null) {
+            return new ConnectionSecurityResult(false, "missing client channel");
+        }
+
         String ip = "";
         String proxyInfo = "";
 
         String wsIp = this.client.getChannel().attr(GameServerAttributes.WS_IP).get();
         if (wsIp != null && !wsIp.isEmpty()) {
             ip = wsIp;
-            SocketAddress address = this.client.getChannel().remoteAddress();
-            proxyInfo = ((InetSocketAddress) address).getAddress().getHostAddress();
+            proxyInfo = remoteIp(this.client.getChannel().remoteAddress());
         } else if (!Emulator.getConfig().getBoolean("networking.tcp.proxy") && this.client.getChannel().remoteAddress() != null) {
-            SocketAddress address = this.client.getChannel().remoteAddress();
-            ip = ((InetSocketAddress) address).getAddress().getHostAddress();
+            ip = remoteIp(this.client.getChannel().remoteAddress());
             proxyInfo = "- no proxy server used";
         } else {
-            SocketAddress address = this.client.getChannel().remoteAddress();
-            proxyInfo = ((InetSocketAddress) address).getAddress().getHostAddress();
+            proxyInfo = remoteIp(this.client.getChannel().remoteAddress());
         }
 
         if (Emulator.getPluginManager().isRegistered(UserGetIPAddressEvent.class, true)) {
@@ -144,31 +164,35 @@ public class Habbo implements Runnable {
             this.habboInfo.setIpLogin(ip);
         }
 
-        // The Nitro client sends the UniqueID (machine fingerprint) packet right
-        // AFTER the SSO ticket, so client.getMachineId() may still be null here.
-        // Do NOT reject the login for a missing machineId — MachineIDEvent sets it
-        // and enforces the MAC ban as soon as the UniqueID packet arrives. Only
-        // MAC-ban check here when the fingerprint is already available.
+        if (Emulator.getGameEnvironment().getModToolManager().checkForBan(this.habboInfo.getId()) != null) {
+            return new ConnectionSecurityResult(false, proxyInfo);
+        }
+
+        // Nitro sends its machine fingerprint after SSO. Check it here only when
+        // already available; MachineIDEvent enforces a later-arriving fingerprint.
         String machineId = this.client.getMachineId();
         if (machineId != null && !machineId.isEmpty()) {
             this.habboInfo.setMachineID(machineId);
-
             if (Emulator.getGameEnvironment().getModToolManager().hasMACBan(this.client)) {
-                return false;
+                return new ConnectionSecurityResult(false, proxyInfo);
             }
         }
 
         if (Emulator.getGameEnvironment().getModToolManager().hasIPBan(this.habboInfo.getIpLogin())) {
-            return false;
+            return new ConnectionSecurityResult(false, proxyInfo);
         }
-        this.isOnline(true);
 
-        this.messenger.connectionChanged(this, true, false);
+        return new ConnectionSecurityResult(true, proxyInfo);
+    }
 
-        Emulator.getGameEnvironment().getRoomManager().loadRoomsForHabbo(this);
-        LOGGER.info("{} logged in from IP {} using proxyserver {}", this.habboInfo.getUsername(), this.habboInfo.getIpLogin(), proxyInfo);
-        LOGGER.info("{} client MachineId = {}", this.habboInfo.getUsername(), this.client.getMachineId());
-        return true;
+    private static String remoteIp(SocketAddress address) {
+        if (address instanceof InetSocketAddress inetAddress && inetAddress.getAddress() != null) {
+            return inetAddress.getAddress().getHostAddress();
+        }
+        return "";
+    }
+
+    private record ConnectionSecurityResult(boolean allowed, String proxyInfo) {
     }
 
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java
@@ -145,6 +145,13 @@ public class SecureLoginEvent extends MessageHandler {
                 this.client.setHabbo(habbo);
                 this.client.setMachineId(habbo.getHabboInfo().getMachineID());
 
+                if (!habbo.passesConnectionSecurityChecks()) {
+                    LOGGER.warn("[SessionResume] Rejected resumed session for banned identity id={}",
+                            habbo.getHabboInfo().getId());
+                    Emulator.getGameServer().getGameClientManager().forceDisposeClient(this.client);
+                    return;
+                }
+
                 // NB: NON svuotiamo il ticket SSO qui (vedi HabboManager.loadHabbo):
                 // dietro Cloudflare il client ritenta la connessione con lo stesso
                 // ticket, quindi deve restare valido fino alla scadenza TTL. Consumarlo

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/handshake/SessionResumeSecurityContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/handshake/SessionResumeSecurityContractTest.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.messages.incoming.handshake;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SessionResumeSecurityContractTest {
+    @Test
+    void resumedSessionRechecksBansBeforeLoginContinues() throws Exception {
+        String login = Files.readString(
+                Path.of("src/main/java/com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java"));
+
+        int resume = login.indexOf("resumeSession(lookupUserId)");
+        int securityCheck = login.indexOf("habbo.passesConnectionSecurityChecks()", resume);
+        int loginResponse = login.indexOf("new SecureLoginOKComposer()", securityCheck);
+
+        assertTrue(resume > -1);
+        assertTrue(securityCheck > resume, "resumed Habbo must recheck account, IP, and machine bans");
+        assertTrue(loginResponse > securityCheck, "ban checks must run before successful-login responses");
+    }
+
+    @Test
+    void normalAndResumedConnectionsShareTheSameSecurityChecks() throws Exception {
+        String habbo = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/users/Habbo.java"));
+
+        int connect = habbo.indexOf("public boolean connect()");
+        int sharedCheck = habbo.indexOf("this.checkConnectionSecurity()", connect);
+        int accountBan = habbo.indexOf("checkForBan(this.habboInfo.getId())", sharedCheck);
+        int macBan = habbo.indexOf("hasMACBan(this.client)", accountBan);
+        int ipBan = habbo.indexOf("hasIPBan(this.habboInfo.getIpLogin())", macBan);
+
+        assertTrue(sharedCheck > connect, "normal login must use the shared check");
+        assertTrue(accountBan > sharedCheck, "shared check must revalidate account bans");
+        assertTrue(macBan > accountBan, "shared check must revalidate machine bans");
+        assertTrue(ipBan > macBan, "shared check must revalidate IP bans");
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/handshake/SessionResumeSecurityContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/handshake/SessionResumeSecurityContractTest.java
@@ -15,7 +15,7 @@ class SessionResumeSecurityContractTest {
 
         int resume = login.indexOf("resumeSession(lookupUserId)");
         int securityCheck = login.indexOf("habbo.passesConnectionSecurityChecks()", resume);
-        int loginResponse = login.indexOf("new SecureLoginOKComposer()", securityCheck);
+        int loginResponse = login.indexOf("new SecureLoginOKComposer(", securityCheck);
 
         assertTrue(resume > -1);
         assertTrue(securityCheck > resume, "resumed Habbo must recheck account, IP, and machine bans");


### PR DESCRIPTION
Finding and fix produced by OpenAI Codex.

## Finding

A parked Habbo could be reattached during the reconnect grace window without repeating the account, IP, and available machine-ID ban checks used by a fresh connection. A ban applied after parking but before resume could therefore be skipped until the resumable session expired.

## Fix

- Extract the existing fresh-connection identity checks into one side-effect-free method
- Keep normal login using that same method
- Re-run account, IP, and available machine-ID checks after attaching the new transport but before sending any successful-login response
- Fully dispose a rejected resumed connection
- Safely handle missing/non-INET remote addresses while evaluating the connection
