### PR TITLE
feat: add optional signed RCON requests

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -405,6 +405,8 @@ public final class Emulator {
         Emulator.config.register("rcon.execute_command.denied_permissions", "cmd_shutdown;cmd_give_rank");
         Emulator.config.register("rcon.execute_command.allowed_permissions", "");
         Emulator.config.register("rcon.max_payload_bytes", "65536");
+        Emulator.config.register("rcon.auth.secret", "");
+        Emulator.config.register("rcon.auth.max_clock_skew_seconds", "60");
         Emulator.config.register("nitro.secure.api.max_payload_bytes", "65536");
         Emulator.config.register("nitro.secure.config.max_file_bytes", "2097152");
         Emulator.config.register("nitro.secure.gamedata.max_file_bytes", "16777216");

--- a/Emulator/src/main/java/com/eu/habbo/core/ConfigurationManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/ConfigurationManager.java
@@ -87,6 +87,7 @@ public class ConfigurationManager {
             envMapping.put("rcon.host", "RCON_HOST");
             envMapping.put("rcon.port", "RCON_PORT");
             envMapping.put("rcon.allowed", "RCON_ALLOWED");
+            envMapping.put("rcon.auth.secret", "RCON_AUTH_SECRET");
 
             // Runtime
             envMapping.put("runtime.threads", "RT_THREADS");

--- a/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServer.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.SocketAddress;
+import java.net.InetAddress;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -88,6 +89,11 @@ public class RCONServer extends Server {
         this.addRCONMessage("updateitems", UpdateItems.class);
 
         Collections.addAll(this.allowedAdresses, Emulator.getConfig().getValue("rcon.allowed", "127.0.0.1").split(";"));
+
+        if (!isLoopbackHost(host) && !RconRequestAuthenticator.enabled()) {
+            LOGGER.warn("RCON is bound to non-loopback host {} without rcon.auth.secret; "
+                    + "legacy IP allowlisting remains active, but signed request authentication is disabled", host);
+        }
     }
 
     @Override
@@ -157,5 +163,13 @@ public class RCONServer extends Server {
 
         SocketAddress address = ctx.channel().remoteAddress();
         return address == null ? "unknown" : address.toString();
+    }
+
+    private static boolean isLoopbackHost(String host) {
+        try {
+            return InetAddress.getByName(host).isLoopbackAddress();
+        } catch (Exception ignored) {
+            return false;
+        }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
@@ -64,12 +64,17 @@ public class RCONServerHandler extends ChannelInboundHandlerAdapter {
             try {
                 JsonObject object = gson.fromJson(message, JsonObject.class);
                 key = object.get("key").getAsString();
+                if (!RconRequestAuthenticator.verify(object, key, object.get("data"))) {
+                    LOGGER.warn("Rejected unauthenticated RCON request from {}", remoteAddress(ctx));
+                    writeAndClose(ctx, "UNAUTHORIZED");
+                    return;
+                }
                 response = Emulator.getRconServer().handle(ctx, key, object.get("data").toString());
             } catch (ArrayIndexOutOfBoundsException e) {
                 LOGGER.error("Unknown RCON Message: {}", key);
             } catch (Exception e) {
-                LOGGER.error("Invalid RCON Message: {}", message);
-            LOGGER.error("Caught exception", e);
+                LOGGER.error("Invalid RCON message from {}", remoteAddress(ctx));
+                LOGGER.error("Caught exception", e);
             }
 
             writeAndClose(ctx, response);

--- a/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RconRequestAuthenticator.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RconRequestAuthenticator.java
@@ -1,0 +1,85 @@
+package com.eu.habbo.networking.rconserver;
+
+import com.eu.habbo.Emulator;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HexFormat;
+
+final class RconRequestAuthenticator {
+    static final int DEFAULT_MAX_CLOCK_SKEW_SECONDS = 60;
+    private static final int MAX_NONCE_LENGTH = 128;
+    private static final Cache<String, Boolean> SEEN_NONCES = Caffeine.newBuilder()
+            .maximumSize(10_000)
+            .expireAfterWrite(Duration.ofMinutes(5))
+            .build();
+
+    private RconRequestAuthenticator() {
+    }
+
+    static boolean enabled() {
+        return !secret().isBlank();
+    }
+
+    static boolean verify(JsonObject request, String key, JsonElement data) {
+        String secret = secret();
+        int maxSkew = Emulator.getConfig() == null
+                ? DEFAULT_MAX_CLOCK_SKEW_SECONDS
+                : Math.max(1, Emulator.getConfig().getInt(
+                        "rcon.auth.max_clock_skew_seconds", DEFAULT_MAX_CLOCK_SKEW_SECONDS));
+        return verify(secret, Instant.now().getEpochSecond(), maxSkew, request, key, data);
+    }
+
+    static boolean verify(String secret, long now, int maxSkew, JsonObject request,
+                          String key, JsonElement data) {
+        if (secret.isBlank()) {
+            return true;
+        }
+
+        try {
+            long timestamp = request.get("timestamp").getAsLong();
+            String nonce = request.get("nonce").getAsString();
+            String signature = request.get("signature").getAsString();
+
+            if (nonce.isBlank() || nonce.length() > MAX_NONCE_LENGTH
+                    || Math.abs(now - timestamp) > maxSkew) {
+                return false;
+            }
+
+            String expected = sign(secret, timestamp, nonce, key, data);
+            if (!MessageDigest.isEqual(expected.getBytes(StandardCharsets.US_ASCII),
+                    signature.toLowerCase().getBytes(StandardCharsets.US_ASCII))) {
+                return false;
+            }
+
+            return SEEN_NONCES.asMap().putIfAbsent(timestamp + ":" + nonce, Boolean.TRUE) == null;
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    static String sign(String secret, long timestamp, String nonce, String key, JsonElement data) {
+        String canonical = timestamp + "\n" + nonce + "\n" + key + "\n" + data;
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return HexFormat.of().formatHex(mac.doFinal(canonical.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException("HmacSHA256 unavailable", e);
+        }
+    }
+
+    private static String secret() {
+        return Emulator.getConfig() == null
+                ? ""
+                : Emulator.getConfig().getValue("rcon.auth.secret", "").trim();
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RconAuthenticationContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RconAuthenticationContractTest.java
@@ -1,0 +1,30 @@
+package com.eu.habbo.networking.rconserver;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RconAuthenticationContractTest {
+    @Test
+    void authenticationRunsBeforeCommandDispatchAndLegacyModeIsExplicit() throws Exception {
+        String handler = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java"));
+        String authenticator = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/networking/rconserver/RconRequestAuthenticator.java"));
+
+        int verify = handler.indexOf("RconRequestAuthenticator.verify(");
+        int dispatch = handler.indexOf("getRconServer().handle(", verify);
+
+        assertTrue(verify > -1 && dispatch > verify,
+                "signed request verification must occur before privileged command dispatch");
+        assertTrue(authenticator.contains("if (secret.isBlank())"),
+                "an empty secret must retain legacy request compatibility");
+        assertTrue(authenticator.contains("SEEN_NONCES.asMap().putIfAbsent"),
+                "authenticated mode must reject nonce replay");
+        assertTrue(authenticator.contains("MessageDigest.isEqual"),
+                "signature comparison must be constant time");
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RconRequestAuthenticatorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RconRequestAuthenticatorTest.java
@@ -1,0 +1,74 @@
+package com.eu.habbo.networking.rconserver;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RconRequestAuthenticatorTest {
+    @Test
+    void signatureBindsTimestampNonceCommandAndPayload() {
+        JsonObject first = new JsonObject();
+        first.addProperty("user_id", 42);
+        JsonObject second = new JsonObject();
+        second.addProperty("user_id", 43);
+
+        String signature = RconRequestAuthenticator.sign("secret", 1234, "nonce", "givecredits", first);
+
+        assertEquals(signature,
+                RconRequestAuthenticator.sign("secret", 1234, "nonce", "givecredits", first));
+        assertNotEquals(signature,
+                RconRequestAuthenticator.sign("secret", 1235, "nonce", "givecredits", first));
+        assertNotEquals(signature,
+                RconRequestAuthenticator.sign("secret", 1234, "different", "givecredits", first));
+        assertNotEquals(signature,
+                RconRequestAuthenticator.sign("secret", 1234, "nonce", "setrank", first));
+        assertNotEquals(signature,
+                RconRequestAuthenticator.sign("secret", 1234, "nonce", "givecredits", second));
+    }
+
+    @Test
+    void verificationRejectsBadStaleAndReplayedRequests() {
+        long now = 10_000;
+        String nonce = UUID.randomUUID().toString();
+        JsonObject data = new JsonObject();
+        data.addProperty("user_id", 42);
+        JsonObject request = signedRequest("secret", now, nonce, "givecredits", data);
+
+        assertTrue(RconRequestAuthenticator.verify("secret", now, 60,
+                request, "givecredits", data));
+        assertFalse(RconRequestAuthenticator.verify("secret", now, 60,
+                request, "givecredits", data), "the same nonce must not be accepted twice");
+
+        JsonObject stale = signedRequest("secret", now - 61, UUID.randomUUID().toString(),
+                "givecredits", data);
+        assertFalse(RconRequestAuthenticator.verify("secret", now, 60,
+                stale, "givecredits", data));
+
+        JsonObject bad = signedRequest("different-secret", now, UUID.randomUUID().toString(),
+                "givecredits", data);
+        assertFalse(RconRequestAuthenticator.verify("secret", now, 60,
+                bad, "givecredits", data));
+    }
+
+    @Test
+    void blankSecretPreservesLegacyRequests() {
+        assertTrue(RconRequestAuthenticator.verify("", 1, 60,
+                new JsonObject(), "legacy", new JsonObject()));
+    }
+
+    private static JsonObject signedRequest(String secret, long timestamp, String nonce,
+                                            String key, JsonObject data) {
+        JsonObject request = new JsonObject();
+        request.addProperty("timestamp", timestamp);
+        request.addProperty("nonce", nonce);
+        request.addProperty("signature",
+                RconRequestAuthenticator.sign(secret, timestamp, nonce, key, data));
+        return request;
+    }
+}

--- a/config example/config.ini.example
+++ b/config example/config.ini.example
@@ -18,6 +18,9 @@ game.port=3000
 rcon.host=127.0.0.1
 rcon.port=3001
 rcon.allowed=127.0.0.1;127.0.0.2
+# Optional backward-compatible signed-request mode. Leave empty for legacy CMS requests.
+rcon.auth.secret=
+rcon.auth.max_clock_skew_seconds=60
 
 # Databse configuration
 db.pool.connection_timeout_ms = 10000


### PR DESCRIPTION
Finding and fix produced by OpenAI Codex.

## Finding

RCON authorizes requests only through the source-IP allowlist. That is safe by default when bound to loopback, but a deployment that exposes the port trusts every process capable of originating traffic from an allowed address. RCON includes currency, rank, moderation, and command-execution operations.

## Compatibility constraint

Making a new signature mandatory would break existing CMS/RCON consumers. This PR therefore adds authenticated mode as an emulator-side opt-in and keeps the established request format unchanged when no secret is configured.

## Fix

- Add optional HMAC-SHA256 request authentication through `rcon.auth.secret`
- Bind the signature to timestamp, nonce, command key, and the JSON data element
- Enforce configurable clock skew, constant-time comparison, and one-use nonce replay protection
- Reject authentication before privileged command dispatch
- Warn prominently when RCON binds beyond loopback without authenticated mode
- Stop logging entire malformed RCON payloads
- Support `RCON_AUTH_SECRET` without changing existing environment variables

Signed requests add top-level `timestamp`, `nonce`, and lowercase hex `signature` fields. The canonical signed value is:

`timestamp + "\\n" + nonce + "\\n" + key + "\\n" + data.toString()`

Leaving `rcon.auth.secret` empty preserves all existing CMS requests exactly as they work today. No external change is required to upgrade Polaris.

## Verification

The complete Maven test suite passes. Tests cover signature binding, altered fields, bad signatures, stale timestamps, nonce replay, constant-time comparison, pre-dispatch enforcement, and explicit legacy compatibility.
