### PR TITLE
fix(build): keep Flyway MariaDB support in the uber jar; upgrade Flyway for MariaDB 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Minimum-supported and recommended MariaDB releases.
+        # Minimum-supported, recommended LTS, and current MariaDB releases.
         mariadb:
           - "mariadb:10.11.14@sha256:dbe56e20372fc6d6b8e0e396866ba89c4c7f128c38c4f59aaa54d957db95790c"
           - "mariadb:11.4.12@sha256:a794d9eb009e20de605858a11f32f63b4075cbd197c650436f0e3b457e4caed7"
+          - "mariadb:12.3@sha256:628f228f0fd5913a220438693576b29b6fe4dc1fa0a1298c0e98579fae28635f"
     defaults:
       run:
         working-directory: Emulator

--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -30,7 +30,7 @@
         <jakarta-mail.version>2.0.5</jakarta-mail.version>
         <junit.version>6.1.2</junit.version>
         <javaparser.version>3.27.1</javaparser.version>
-        <flyway.version>11.10.0</flyway.version>
+        <flyway.version>12.11.0</flyway.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <mockito.version>5.14.2</mockito.version>
         <datafaker.version>2.4.2</datafaker.version>

--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -94,6 +94,11 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.eu.habbo.Emulator</mainClass>
+                                    <manifestEntries>
+                                        <Implementation-Title>${project.name}</Implementation-Title>
+                                        <Implementation-Version>${project.version}</Implementation-Version>
+                                        <Java-Version>${maven.compiler.release}</Java-Version>
+                                    </manifestEntries>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -60,7 +60,8 @@ public final class Emulator {
     public final static String PREVIEW = "";
 
     // Tied to the Maven project version: read from the jar manifest
-    // (Implementation-Version = ${project.version}, see pom assembly plugin).
+    // (Implementation-Version = ${project.version}, see the shade plugin's
+    // ManifestResourceTransformer in the pom).
     private static String resolveVersionNumber() {
         String implementation = Emulator.class.getPackage().getImplementationVersion();
         if (implementation != null && !implementation.isEmpty()) return implementation;

--- a/Emulator/src/test/java/com/eu/habbo/packaging/PackagedJarContractIT.java
+++ b/Emulator/src/test/java/com/eu/habbo/packaging/PackagedJarContractIT.java
@@ -1,0 +1,60 @@
+package com.eu.habbo.packaging;
+
+import com.eu.habbo.packaging.probe.PackagedJarProbe;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PackagedJarContractIT {
+
+    @Test
+    void executableJarPreservesVersionAndFlywayServiceDiscovery() throws Exception {
+        Path jar = packagedJar();
+        try (JarFile archive = new JarFile(jar.toFile())) {
+            assertEquals(
+                    "com.eu.habbo.Emulator",
+                    archive.getManifest().getMainAttributes().getValue(Attributes.Name.MAIN_CLASS));
+        }
+
+        Path java = Path.of(
+                System.getProperty("java.home"),
+                "bin",
+                System.getProperty("os.name", "").startsWith("Windows") ? "java.exe" : "java");
+        String classpath = String.join(
+                File.pathSeparator,
+                Path.of("target", "test-classes").toAbsolutePath().toString(),
+                jar.toAbsolutePath().toString());
+        Process process = new ProcessBuilder(
+                java.toString(),
+                "-cp",
+                classpath,
+                PackagedJarProbe.class.getName())
+                .redirectErrorStream(true)
+                .start();
+
+        assertTrue(process.waitFor(30, TimeUnit.SECONDS), "Packaged JAR probe timed out");
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertEquals(0, process.exitValue(), output);
+        assertTrue(output.contains("Packaged JAR contract verified"), output);
+    }
+
+    private static Path packagedJar() throws Exception {
+        try (var files = Files.list(Path.of("target"))) {
+            List<Path> jars = files
+                    .filter(path -> path.getFileName().toString().matches("Polaris-.+-jar-with-dependencies\\.jar"))
+                    .toList();
+            assertEquals(1, jars.size(), "Expected one packaged Polaris executable JAR");
+            return jars.getFirst();
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/packaging/probe/PackagedJarProbe.java
+++ b/Emulator/src/test/java/com/eu/habbo/packaging/probe/PackagedJarProbe.java
@@ -1,0 +1,45 @@
+package com.eu.habbo.packaging.probe;
+
+import com.eu.habbo.Emulator;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.internal.database.DatabaseTypeRegister;
+
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Properties;
+
+public final class PackagedJarProbe {
+
+    private PackagedJarProbe() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        Properties project = new Properties();
+        try (InputStream pom = PackagedJarProbe.class.getResourceAsStream(
+                "/META-INF/maven/com.eu.habbo/Polaris/pom.properties")) {
+            require(pom != null, "Packaged JAR is missing its Maven project metadata");
+            project.load(pom);
+        }
+
+        Package emulatorPackage = Emulator.class.getPackage();
+        require(
+                Objects.equals(project.getProperty("version"), emulatorPackage.getImplementationVersion()),
+                "Implementation-Version does not match the Maven project version");
+        require(
+                Objects.equals(project.getProperty("artifactId"), emulatorPackage.getImplementationTitle()),
+                "Implementation-Title does not match the Maven artifact name");
+
+        String databaseType = DatabaseTypeRegister
+                .getDatabaseTypeForUrl("jdbc:mariadb://localhost/polaris", Flyway.configure())
+                .getName();
+        require("MariaDB".equals(databaseType), "Flyway MariaDB service provider was not discovered");
+
+        System.out.println("Packaged JAR contract verified");
+    }
+
+    private static void require(boolean condition, String message) {
+        if (!condition) {
+            throw new IllegalStateException(message);
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/packaging/probe/PackagedJarProbe.java
+++ b/Emulator/src/test/java/com/eu/habbo/packaging/probe/PackagedJarProbe.java
@@ -1,12 +1,12 @@
 package com.eu.habbo.packaging.probe;
 
 import com.eu.habbo.Emulator;
-import org.flywaydb.core.Flyway;
-import org.flywaydb.core.internal.database.DatabaseTypeRegister;
+import org.flywaydb.core.extensibility.Plugin;
 
 import java.io.InputStream;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.ServiceLoader;
 
 public final class PackagedJarProbe {
 
@@ -29,10 +29,11 @@ public final class PackagedJarProbe {
                 Objects.equals(project.getProperty("artifactId"), emulatorPackage.getImplementationTitle()),
                 "Implementation-Title does not match the Maven artifact name");
 
-        String databaseType = DatabaseTypeRegister
-                .getDatabaseTypeForUrl("jdbc:mariadb://localhost/polaris", Flyway.configure())
-                .getName();
-        require("MariaDB".equals(databaseType), "Flyway MariaDB service provider was not discovered");
+        boolean mariaDbProviderDiscovered = ServiceLoader.load(Plugin.class).stream()
+                .map(ServiceLoader.Provider::type)
+                .map(Class::getName)
+                .anyMatch("org.flywaydb.database.mysql.mariadb.MariaDBDatabaseType"::equals);
+        require(mariaDbProviderDiscovered, "Flyway MariaDB service provider was not discovered");
 
         System.out.println("Packaged JAR contract verified");
     }


### PR DESCRIPTION
## Problem

Startup aborted with:

```
org.flywaydb.core.api.FlywayException: Unsupported Database: MariaDB 12.3
```

and the same error persisted after downgrading to MariaDB 10.11 — proving the database version was not the root cause. The uber jar was being built with the assembly plugin, which does not merge colliding `META-INF/services` files: `flyway-core` and `flyway-mysql` both ship `org.flywaydb.core.extensibility.Plugin`, and losing `flyway-mysql`'s copy silently drops all MariaDB/MySQL support from the packaged jar.

## Fix

Builds on the assembly→shade switch (4d633995, keeping the shade + `ServicesResourceTransformer` approach) and hardens it:

- **Restore jar manifest metadata.** The shade switch dropped assembly's `addDefaultImplementationEntries`, so `Emulator.resolveVersionNumber()` (which reads `Implementation-Version` from the manifest) fell back to the hardcoded 4.1.0 version. Explicit `manifestEntries` bring `Implementation-Title`/`Implementation-Version` back.
- **Upgrade Flyway 11.10.0 → 12.11.0** for genuine MariaDB 12.x support.
- **`PackagedJarContractIT`** — a packaging regression test that spawns a fresh JVM against the real shaded jar and fails if the Flyway MariaDB service provider is ever lost again, or if the manifest version/title stop matching the Maven project.
- **CI matrix gains MariaDB 12.3** (digest-pinned) alongside 10.11 and 11.4, so migrations are continuously verified on the current series.

## Validation

- `mvn verify` with `POLARIS_TEST_MARIADB_IMAGE=mariadb:12.3@sha256:628f22…`: 683 unit tests and all integration tests green, including `MigrationRunnerIT` (7 tests) applying the full migration chain on MariaDB 12.3 via Flyway 12.11.0 — the exact scenario from the bug report.
- Shaded jar inspected: merged `META-INF/services/org.flywaydb.core.extensibility.Plugin` contains `MariaDBDatabaseType`; manifest carries `Main-Class`, `Implementation-Title: Polaris`, `Implementation-Version: 4.2.60`.
- Probe run against the real jar prints `Packaged JAR contract verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhnUNL6jivdT612t3XFvGE