### PR TITLE
fix(core): stop console loop on EOF

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -282,10 +282,11 @@ public final class Emulator {
             PrintStream output) throws IOException {
         String line = reader.readLine();
 
-        if (line != null) {
-            commandHandler.accept(line);
+        if (line == null) {
+            return false;
         }
 
+        commandHandler.accept(line);
         output.println("Waiting for command: ");
         return true;
     }

--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -37,6 +37,7 @@ import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -249,12 +250,9 @@ public final class Emulator {
 
                 while (!isShuttingDown && isReady) {
                     try {
-                        String line = reader.readLine();
-
-                        if (line != null) {
-                            ConsoleCommand.handle(line);
+                        if (!processConsoleInput(reader, ConsoleCommand::handle, System.out)) {
+                            break;
                         }
-                        System.out.println("Waiting for command: ");
                     } catch (Exception e) {
                         if (!(e instanceof IOException && e.getMessage().equals("Bad file descriptor"))) {
                             LOGGER.error("Error while reading command", e);
@@ -276,6 +274,20 @@ public final class Emulator {
             LOGGER.error("Caught exception", e);
             throw e;
         }
+    }
+
+    static boolean processConsoleInput(
+            BufferedReader reader,
+            Consumer<String> commandHandler,
+            PrintStream output) throws IOException {
+        String line = reader.readLine();
+
+        if (line != null) {
+            commandHandler.accept(line);
+        }
+
+        output.println("Waiting for command: ");
+        return true;
     }
 
     private static void setBuild() {

--- a/Emulator/src/test/java/com/eu/habbo/EmulatorStartupConsoleTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorStartupConsoleTest.java
@@ -19,6 +19,22 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EmulatorStartupConsoleTest {
     @Test
+    void consoleInputStopsCleanlyAtEndOfFile() throws Exception {
+        List<String> commands = new ArrayList<>();
+        ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
+
+        boolean keepRunning;
+        try (BufferedReader reader = new BufferedReader(new StringReader(""));
+             PrintStream output = new PrintStream(outputBytes, true, StandardCharsets.UTF_8)) {
+            keepRunning = Emulator.processConsoleInput(reader, commands::add, output);
+        }
+
+        assertFalse(keepRunning);
+        assertTrue(commands.isEmpty());
+        assertEquals("", outputBytes.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
     void consoleInputDispatchesCommandAndKeepsLoopRunning() throws Exception {
         List<String> commands = new ArrayList<>();
         ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();

--- a/Emulator/src/test/java/com/eu/habbo/EmulatorStartupConsoleTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorStartupConsoleTest.java
@@ -2,14 +2,39 @@ package com.eu.habbo;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EmulatorStartupConsoleTest {
+    @Test
+    void consoleInputDispatchesCommandAndKeepsLoopRunning() throws Exception {
+        List<String> commands = new ArrayList<>();
+        ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
+
+        boolean keepRunning;
+        try (BufferedReader reader = new BufferedReader(new StringReader("status\n"));
+             PrintStream output = new PrintStream(outputBytes, true, StandardCharsets.UTF_8)) {
+            keepRunning = Emulator.processConsoleInput(reader, commands::add, output);
+        }
+
+        assertTrue(keepRunning);
+        assertEquals(List.of("status"), commands);
+        assertEquals("Waiting for command: " + System.lineSeparator(),
+                outputBytes.toString(StandardCharsets.UTF_8));
+    }
+
     @Test
     void startupHeroUsesUniversalAsciiLayout() {
         String hero = Emulator.startupHero();


### PR DESCRIPTION
Stops the headless console loop when standard input reaches EOF.

Existing command dispatch and prompt behavior remain unchanged for real console input.
