### PR TITLE
fix(net): fail startup when ports cannot bind

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/networking/Server.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/Server.java
@@ -82,21 +82,26 @@ public abstract class Server {
     }
 
     public void connect() {
-        ChannelFuture channelFuture = this.serverBootstrap.bind(this.host, this.port);
+        this.listening = false;
+        ChannelFuture channelFuture = this.bind(this.serverBootstrap, this.name, this.host, this.port);
+        this.serverChannel = channelFuture.channel();
+        this.listening = true;
+        channelFuture.channel().closeFuture().addListener(ignored -> this.listening = false);
+        LOGGER.info("Started {} on {}:{}", this.name, this.host, this.port);
+    }
 
-        while (!channelFuture.isDone()) {
-        }
+    protected final ChannelFuture bind(
+            ServerBootstrap bootstrap,
+            String serverName,
+            String host,
+            int port) {
+        ChannelFuture channelFuture = bootstrap.bind(host, port).awaitUninterruptibly();
 
         if (!channelFuture.isSuccess()) {
-            this.listening = false;
-            LOGGER.info("Failed to start {} on {}:{}", this.name, this.host, this.port);
-            System.exit(0);
-        } else {
-            this.serverChannel = channelFuture.channel();
-            this.listening = true;
-            channelFuture.channel().closeFuture().addListener(ignored -> this.listening = false);
-            LOGGER.info("Started {} on {}:{}", this.name, this.host, this.port);
+            throw new ServerBindException(serverName, host, port, channelFuture.cause());
         }
+
+        return channelFuture;
     }
 
     public void stop() {

--- a/Emulator/src/main/java/com/eu/habbo/networking/ServerBindException.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/ServerBindException.java
@@ -1,0 +1,7 @@
+package com.eu.habbo.networking;
+
+public final class ServerBindException extends IllegalStateException {
+    public ServerBindException(String serverName, String host, int port, Throwable cause) {
+        super("Failed to start " + serverName + " on " + host + ":" + port, cause);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
@@ -10,7 +10,6 @@ import com.eu.habbo.networking.gameserver.encoders.GameServerMessageEncoder;
 import com.eu.habbo.networking.gameserver.encoders.GameServerMessageLogger;
 import com.eu.habbo.networking.gameserver.handlers.IdleTimeoutHandler;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
@@ -94,27 +93,23 @@ public class GameServer extends Server {
         this.webSocketBootstrap.childOption(ChannelOption.ALLOCATOR, allocator());
         this.webSocketBootstrap.childHandler(wsInitializer);
 
-        ChannelFuture wsFuture = this.webSocketBootstrap.bind(wsHost, wsPort);
+        ChannelFuture wsFuture = this.bind(
+                this.webSocketBootstrap,
+                "WebSocket Server",
+                wsHost,
+                wsPort);
+        this.webSocketChannel = wsFuture.channel();
+        this.webSocketListening = true;
+        wsFuture.channel().closeFuture().addListener(ignored -> this.webSocketListening = false);
+        LOGGER.info("WebSocket server started on {}:{} (SSL: {})", wsHost, wsPort, wsInitializer.isSslEnabled());
 
-        while (!wsFuture.isDone()) {
-        }
-
-        if (!wsFuture.isSuccess()) {
-            LOGGER.error("Failed to start WebSocket server on {}:{}", wsHost, wsPort);
-        } else {
-            this.webSocketChannel = wsFuture.channel();
-            this.webSocketListening = true;
-            wsFuture.channel().closeFuture().addListener(ignored -> this.webSocketListening = false);
-            LOGGER.info("WebSocket server started on {}:{} (SSL: {})", wsHost, wsPort, wsInitializer.isSslEnabled());
-
-            if (com.eu.habbo.Emulator.getConfig().getBoolean("crypto.ws.signing.enabled", false)) {
-                try {
-                    com.eu.habbo.networking.gameserver.crypto.CryptoSigningKeyManager.get();
-                    LOGGER.info("[ws-crypto] signing public key ready: {}",
-                            com.eu.habbo.networking.gameserver.crypto.CryptoSigningKeyManager.publicKeyBase64());
-                } catch (Exception e) {
-                    LOGGER.error("[ws-crypto] failed to warm signing keypair", e);
-                }
+        if (com.eu.habbo.Emulator.getConfig().getBoolean("crypto.ws.signing.enabled", false)) {
+            try {
+                com.eu.habbo.networking.gameserver.crypto.CryptoSigningKeyManager.get();
+                LOGGER.info("[ws-crypto] signing public key ready: {}",
+                        com.eu.habbo.networking.gameserver.crypto.CryptoSigningKeyManager.publicKeyBase64());
+            } catch (Exception e) {
+                LOGGER.error("[ws-crypto] failed to warm signing keypair", e);
             }
         }
     }

--- a/Emulator/src/test/java/com/eu/habbo/networking/ServerBindFailureProbe.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/ServerBindFailureProbe.java
@@ -1,0 +1,48 @@
+package com.eu.habbo.networking;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.socket.SocketChannel;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+
+public final class ServerBindFailureProbe {
+    private ServerBindFailureProbe() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        try (ServerSocket occupiedPort = new ServerSocket()) {
+            occupiedPort.setReuseAddress(false);
+            occupiedPort.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+
+            ProbeServer server = new ProbeServer(
+                    InetAddress.getLoopbackAddress().getHostAddress(),
+                    occupiedPort.getLocalPort());
+            server.initializePipeline();
+
+            try {
+                server.connect();
+            } finally {
+                server.stop();
+            }
+        }
+    }
+
+    private static final class ProbeServer extends Server {
+        private ProbeServer(String host, int port) throws Exception {
+            super("Bind Failure Probe", host, port, 1, 1);
+        }
+
+        @Override
+        public void initializePipeline() {
+            super.initializePipeline();
+            this.serverBootstrap.childHandler(new ChannelInitializer<SocketChannel>() {
+                @Override
+                protected void initChannel(SocketChannel channel) {
+                    // No handlers are required to reproduce a bind collision.
+                }
+            });
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/ServerBindLifecycleTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/ServerBindLifecycleTest.java
@@ -49,6 +49,8 @@ class ServerBindLifecycleTest {
 
         String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
         assertTrue(finished, () -> "bind-failure probe did not terminate:\n" + output);
+        assertTrue(output.contains("ServerBindException"),
+                () -> "bind failure must surface a typed startup exception:\n" + output);
         assertNotEquals(0, process.exitValue(),
                 () -> "bind failure must terminate startup unsuccessfully:\n" + output);
     }

--- a/Emulator/src/test/java/com/eu/habbo/networking/ServerBindLifecycleTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/ServerBindLifecycleTest.java
@@ -1,0 +1,72 @@
+package com.eu.habbo.networking;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.socket.SocketChannel;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServerBindLifecycleTest {
+    @Test
+    void connectMarksServerListeningUntilStop() throws Exception {
+        TestServer server = new TestServer("127.0.0.1", 0);
+        server.initializePipeline();
+
+        try {
+            server.connect();
+            assertTrue(server.isListening());
+        } finally {
+            server.stop();
+        }
+
+        assertFalse(server.isListening());
+    }
+
+    @Test
+    void occupiedPortCausesStartupFailure() throws Exception {
+        String javaExecutable = Path.of(
+                System.getProperty("java.home"),
+                "bin",
+                "java").toString();
+        Process process = new ProcessBuilder(
+                javaExecutable,
+                "-cp",
+                System.getProperty("surefire.test.class.path"),
+                ServerBindFailureProbe.class.getName())
+                .redirectErrorStream(true)
+                .start();
+
+        boolean finished = process.waitFor(10, TimeUnit.SECONDS);
+        if (!finished) {
+            process.destroyForcibly();
+        }
+
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertTrue(finished, () -> "bind-failure probe did not terminate:\n" + output);
+        assertNotEquals(0, process.exitValue(),
+                () -> "bind failure must terminate startup unsuccessfully:\n" + output);
+    }
+
+    private static final class TestServer extends Server {
+        private TestServer(String host, int port) throws Exception {
+            super("Test Server", host, port, 1, 1);
+        }
+
+        @Override
+        public void initializePipeline() {
+            super.initializePipeline();
+            this.serverBootstrap.childHandler(new ChannelInitializer<SocketChannel>() {
+                @Override
+                protected void initChannel(SocketChannel channel) {
+                    // No handlers are required for a bind lifecycle test.
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Replaces busy-wait bind loops with a shared completed-future path for TCP, RCON, and WebSocket listeners.

Port collisions now surface as a typed startup failure with a non-zero process exit instead of terminating successfully or leaving an enabled listener unavailable.
