### PR TITLE
fix(db): preserve configured pool sizing

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -181,8 +181,9 @@ public final class Emulator {
             Emulator.databaseLogger = new DatabaseLogger();
             Emulator.config.loaded = true;
             Emulator.config.loadFromDatabase();
-            Emulator.threading = new ThreadPooling(Emulator.getConfig().getInt("runtime.threads"));
-            Emulator.getDatabase().getDataSource().setMaximumPoolSize(Emulator.getConfig().getInt("runtime.threads") * 2);
+            int runtimeThreads = runtimeThreadCount(Emulator.getConfig());
+            Emulator.threading = new ThreadPooling(runtimeThreads);
+            Emulator.getDatabase().getDataSource().setMaximumPoolSize(runtimeThreads * 2);
             Emulator.getDatabase().getDataSource().setMinimumIdle(10);
             registerStartupConfigDefaults();
             Emulator.pluginManager = new PluginManager();
@@ -233,9 +234,9 @@ public final class Emulator {
                 EmulatorDashboard.launch();
             }
 
-            if (Emulator.getConfig().getInt("runtime.threads") < (Runtime.getRuntime().availableProcessors() * 2)) {
+            if (runtimeThreads < (Runtime.getRuntime().availableProcessors() * 2)) {
                 LOGGER.warn("Emulator settings runtime.threads ({}) can be increased to ({}) to possibly increase performance.",
-                        Emulator.getConfig().getInt("runtime.threads"),
+                        runtimeThreads,
                         Runtime.getRuntime().availableProcessors() * 2);
             }
 
@@ -431,6 +432,10 @@ public final class Emulator {
 
     static boolean shouldLaunchGui() {
         return Emulator.getConfig() != null && Emulator.getConfig().getBoolean("gui.autostart.enabled", false);
+    }
+
+    static int runtimeThreadCount(ConfigurationManager config) {
+        return config.getInt("runtime.threads");
     }
 
     private static void registerStartupConfigDefaults() {

--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -51,6 +51,7 @@ public final class Emulator {
     private static final String ANSI_GREEN = "\u001B[32m";
     private static final String ANSI_YELLOW = "\u001B[33m";
     private static final String ANSI_DIM = "\u001B[2m";
+    private static final int DEFAULT_RUNTIME_THREADS = 8;
 
     // Fallback version, only used when running outside a packaged jar (e.g. from
     // the IDE). In production the version comes from the jar manifest below.
@@ -181,11 +182,9 @@ public final class Emulator {
             Emulator.databaseLogger = new DatabaseLogger();
             Emulator.config.loaded = true;
             Emulator.config.loadFromDatabase();
+            registerStartupConfigDefaults();
             int runtimeThreads = runtimeThreadCount(Emulator.getConfig());
             Emulator.threading = new ThreadPooling(runtimeThreads);
-            Emulator.getDatabase().getDataSource().setMaximumPoolSize(runtimeThreads * 2);
-            Emulator.getDatabase().getDataSource().setMinimumIdle(10);
-            registerStartupConfigDefaults();
             Emulator.pluginManager = new PluginManager();
             Emulator.pluginManager.reload();
             Emulator.getPluginManager().fireEvent(new EmulatorConfigUpdatedEvent());
@@ -435,10 +434,17 @@ public final class Emulator {
     }
 
     static int runtimeThreadCount(ConfigurationManager config) {
-        return config.getInt("runtime.threads");
+        int configuredThreads = config.getInt("runtime.threads", DEFAULT_RUNTIME_THREADS);
+        if (configuredThreads > 0) {
+            return configuredThreads;
+        }
+
+        LOGGER.warn("Invalid runtime.threads value {}; using {}.", configuredThreads, DEFAULT_RUNTIME_THREADS);
+        return DEFAULT_RUNTIME_THREADS;
     }
 
     private static void registerStartupConfigDefaults() {
+        Emulator.config.register("runtime.threads", Integer.toString(DEFAULT_RUNTIME_THREADS));
         Emulator.config.register("camera.url", "http://localhost/camera/");
         Emulator.config.register("imager.location.output.camera", "/public/camera/");
         Emulator.config.register("imager.location.output.thumbnail", "/public/camera/thumbnails/");

--- a/Emulator/src/main/java/com/eu/habbo/database/DatabasePool.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/DatabasePool.java
@@ -41,8 +41,7 @@ class DatabasePool {
             HikariConfig databaseConfiguration = new HikariConfig();
 
             // Pool sizing
-            databaseConfiguration.setMaximumPoolSize(config.getInt(DB_POOL_MAX_SIZE, 50));
-            databaseConfiguration.setMinimumIdle(config.getInt(DB_POOL_MIN_SIZE, 10));
+            applyPoolSizing(databaseConfiguration, config);
 
             // Pool timeouts (milliseconds)
             databaseConfiguration.setConnectionTimeout(config.getInt(DB_POOL_CONNECTION_TIMEOUT, 10_000));
@@ -114,6 +113,11 @@ class DatabasePool {
             return false;
         }
         return true;
+    }
+
+    static void applyPoolSizing(HikariConfig databaseConfiguration, ConfigurationManager config) {
+        databaseConfiguration.setMaximumPoolSize(config.getInt(DB_POOL_MAX_SIZE, 50));
+        databaseConfiguration.setMinimumIdle(config.getInt(DB_POOL_MIN_SIZE, 10));
     }
 
     public HikariDataSource getDatabase() {

--- a/Emulator/src/test/java/com/eu/habbo/EmulatorDatabasePoolOwnershipTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorDatabasePoolOwnershipTest.java
@@ -1,0 +1,24 @@
+package com.eu.habbo;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class EmulatorDatabasePoolOwnershipTest {
+
+    @Test
+    void startupDoesNotOverwriteDatabasePoolSizing() throws Exception {
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/Emulator.java"));
+        int databaseConfigLoaded = source.indexOf("Emulator.config.loadFromDatabase();");
+        int startupDefaults = source.indexOf("registerStartupConfigDefaults();");
+        String runtimeInitialization = source.substring(databaseConfigLoaded, startupDefaults);
+
+        assertFalse(runtimeInitialization.contains("setMaximumPoolSize"),
+                "DatabasePool must remain the sole owner of db.pool.maxsize");
+        assertFalse(runtimeInitialization.contains("setMinimumIdle"),
+                "DatabasePool must remain the sole owner of db.pool.minsize");
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/EmulatorRuntimeThreadCountTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorRuntimeThreadCountTest.java
@@ -1,0 +1,25 @@
+package com.eu.habbo;
+
+import com.eu.habbo.core.ConfigurationManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EmulatorRuntimeThreadCountTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void usesConfiguredRuntimeThreadCount() throws Exception {
+        Path configFile = tempDir.resolve("config.ini");
+        Files.writeString(configFile, "runtime.threads=12");
+        ConfigurationManager config = new ConfigurationManager(configFile.toString());
+
+        assertEquals(12, Emulator.runtimeThreadCount(config));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/EmulatorRuntimeThreadCountTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorRuntimeThreadCountTest.java
@@ -22,4 +22,31 @@ class EmulatorRuntimeThreadCountTest {
 
         assertEquals(12, Emulator.runtimeThreadCount(config));
     }
+
+    @Test
+    void fallsBackWhenRuntimeThreadCountIsMissing() throws Exception {
+        Path configFile = tempDir.resolve("missing.ini");
+        Files.writeString(configFile, "");
+        ConfigurationManager config = new ConfigurationManager(configFile.toString());
+
+        assertEquals(8, Emulator.runtimeThreadCount(config));
+    }
+
+    @Test
+    void fallsBackWhenRuntimeThreadCountIsMalformed() throws Exception {
+        Path configFile = tempDir.resolve("malformed.ini");
+        Files.writeString(configFile, "runtime.threads=not-a-number");
+        ConfigurationManager config = new ConfigurationManager(configFile.toString());
+
+        assertEquals(8, Emulator.runtimeThreadCount(config));
+    }
+
+    @Test
+    void fallsBackWhenRuntimeThreadCountIsNotPositive() throws Exception {
+        Path configFile = tempDir.resolve("zero.ini");
+        Files.writeString(configFile, "runtime.threads=0");
+        ConfigurationManager config = new ConfigurationManager(configFile.toString());
+
+        assertEquals(8, Emulator.runtimeThreadCount(config));
+    }
 }

--- a/Emulator/src/test/java/com/eu/habbo/ExampleConfigurationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/ExampleConfigurationTest.java
@@ -1,0 +1,37 @@
+package com.eu.habbo;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExampleConfigurationTest {
+
+    @Test
+    void databaseLeakThresholdIsParseable() throws Exception {
+        Properties properties = loadExample();
+
+        assertEquals("20000", properties.getProperty("db.pool.leak_detection_ms"));
+    }
+
+    @Test
+    void rememberJwtPlaceholderUsesTheDocumentedChangeMePrefix() throws Exception {
+        Properties properties = loadExample();
+
+        assertEquals("change-me-to-a-long-random-secret",
+                properties.getProperty("login.remember.jwt.secret"));
+    }
+
+    private static Properties loadExample() throws Exception {
+        Properties properties = new Properties();
+        Path example = Path.of("..", "config example", "config.ini.example");
+        try (InputStream input = Files.newInputStream(example)) {
+            properties.load(input);
+        }
+        return properties;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/DatabasePoolSizingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/DatabasePoolSizingTest.java
@@ -1,0 +1,46 @@
+package com.eu.habbo.database;
+
+import com.eu.habbo.core.ConfigurationManager;
+import com.zaxxer.hikari.HikariConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DatabasePoolSizingTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void appliesConfiguredPoolSizes() throws Exception {
+        Path configFile = tempDir.resolve("config.ini");
+        Files.writeString(configFile, """
+                db.pool.maxsize=37
+                db.pool.minsize=7
+                """);
+        ConfigurationManager config = new ConfigurationManager(configFile.toString());
+        HikariConfig hikariConfig = new HikariConfig();
+
+        DatabasePool.applyPoolSizing(hikariConfig, config);
+
+        assertEquals(37, hikariConfig.getMaximumPoolSize());
+        assertEquals(7, hikariConfig.getMinimumIdle());
+    }
+
+    @Test
+    void appliesDocumentedPoolDefaultsWhenSizesAreAbsent() throws Exception {
+        Path configFile = tempDir.resolve("config.ini");
+        Files.writeString(configFile, "");
+        ConfigurationManager config = new ConfigurationManager(configFile.toString());
+        HikariConfig hikariConfig = new HikariConfig();
+
+        DatabasePool.applyPoolSizing(hikariConfig, config);
+
+        assertEquals(50, hikariConfig.getMaximumPoolSize());
+        assertEquals(10, hikariConfig.getMinimumIdle());
+    }
+}

--- a/config example/config.ini.example
+++ b/config example/config.ini.example
@@ -43,7 +43,7 @@ db.pool.idle_timeout_ms       = 600000
 db.pool.max_lifetime_ms       = 1800000
 db.pool.validation_timeout_ms = 5000
 # set db.pool.leak_detection_ms to 0 to disable
-db.pool.leak_detection_ms     = 20000 set to 0 to disable
+db.pool.leak_detection_ms     = 20000
 
 enc.enabled=false
 enc.e=3
@@ -68,7 +68,7 @@ nitro.secure.master_key=change-me-to-a-long-random-secret
 login.remember.enabled=true
 login.remember.duration.days=30
 # Optional: set a persistent remember-me JWT secret here, otherwise one is generated and stored in emulator_settings.
-login.remember.jwt.secret=hange-me-to-a-long-random-secret
+login.remember.jwt.secret=change-me-to-a-long-random-secret
 # Lifetime for SSO tickets minted by Polaris's built-in password/remember endpoints.
 login.sso.ticket.ttl.seconds=60
 
@@ -76,6 +76,7 @@ login.sso.ticket.ttl.seconds=60
 login.news.limit=5
 
 #Performance / concurrency (optional — sensible defaults apply if unset; adjust in the Database).
+runtime.threads=8
 ## io.packet.handler.threads=24 #Game packet-handler pool size; runs game handlers OFF the Netty I/O loop. Default max(16, 2 x CPU cores).
 ## auth.http.pool.size=16 #Dedicated worker pool for the /api/auth/* HTTP endpoints (BCrypt/JDBC/Turnstile/SMTP run off the event loop). Default 16.
 ## io.netty.allocator.pooled=false #Set true to opt into Netty's pooled ByteBuf allocator. Default false (unpooled-heap).


### PR DESCRIPTION
Restores `db.pool.maxsize` and `db.pool.minsize` as the authoritative Hikari settings instead of replacing them with runtime thread geometry.

Startup now uses eight runtime threads when the setting is missing, malformed, or non-positive. The shipped example also includes the default and corrects its leak-threshold and JWT placeholder values.
