### PR TITLE
fix(rooms): publish promotion after loading

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -540,7 +540,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     }
 
     // Perform loading WITHOUT holding the lock to avoid deadlocks
-    try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+    try {
       synchronized (this.roomUnitLock) {
         this.unitManager.clear();
       }
@@ -554,20 +554,13 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
         LOGGER.error("Caught exception loading layout", e);
       }
 
+      CompletableFuture<Void> promotionFuture = CompletableFuture.completedFuture(null);
       if (this.promoted) {
-        CompletableFuture.runAsync(() -> {
-          try (Connection promoConnection = Emulator.getDatabase().getDataSource().getConnection();
-               PreparedStatement stmt = promoConnection.prepareStatement(
-                       "SELECT * FROM room_promotions WHERE room_id = ? AND end_timestamp > ? LIMIT 1")) {
-            stmt.setInt(1, this.id);
-            stmt.setInt(2, Emulator.getIntUnixTimestamp());
-            try (ResultSet promoSet = stmt.executeQuery()) {
-              this.promoted = false;
-              if (promoSet.next()) {
-                this.promoted = true;
-                this.promotion = new RoomPromotion(this, promoSet);
-              }
-            }
+        promotionFuture = CompletableFuture.runAsync(() -> {
+          try (Connection promoConnection = Emulator.getDatabase().getDataSource().getConnection()) {
+            this.promotionManager.loadPromotion(true, promoConnection);
+            this.promotion = this.promotionManager.getPromotion();
+            this.promoted = this.promotionManager.getPromotedFlag();
           } catch (Exception e) {
             LOGGER.error("Caught exception loading promotion", e);
           }
@@ -641,7 +634,8 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
       // Wait for all remaining operations
       try {
-        CompletableFuture.allOf(rightsFuture, wordFilterFuture, botsFuture, petsFuture, heightmapFuture, wiredFuture).join();
+        CompletableFuture.allOf(promotionFuture, rightsFuture, wordFilterFuture,
+                botsFuture, petsFuture, heightmapFuture, wiredFuture).join();
       } catch (Exception e) {
         LOGGER.error("Error waiting for parallel room data loading", e);
       }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomPromotionManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomPromotionManager.java
@@ -8,6 +8,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.function.IntSupplier;
 
 /**
  * Manages room promotions.
@@ -16,11 +17,17 @@ public class RoomPromotionManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(RoomPromotionManager.class);
 
     private final Room room;
+    private final IntSupplier roomId;
     private RoomPromotion promotion;
     private volatile boolean promoted;
 
     public RoomPromotionManager(Room room) {
+        this(room, room::getId);
+    }
+
+    RoomPromotionManager(Room room, IntSupplier roomId) {
         this.room = room;
+        this.roomId = roomId;
         this.promoted = false;
         this.promotion = null;
     }
@@ -34,7 +41,7 @@ public class RoomPromotionManager {
         if (this.promoted) {
             try (PreparedStatement statement = connection.prepareStatement(
                 "SELECT * FROM room_promotions WHERE room_id = ? AND end_timestamp > ? LIMIT 1")) {
-                statement.setInt(1, this.room.getId());
+                statement.setInt(1, this.roomId.getAsInt());
                 statement.setInt(2, Emulator.getIntUnixTimestamp());
 
                 try (ResultSet promotionSet = statement.executeQuery()) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomPromotionManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomPromotionManager.java
@@ -37,20 +37,22 @@ public class RoomPromotionManager {
      */
     public void loadPromotion(boolean isPromoted, Connection connection) throws SQLException {
         this.promoted = isPromoted;
-        
-        if (this.promoted) {
-            try (PreparedStatement statement = connection.prepareStatement(
-                "SELECT * FROM room_promotions WHERE room_id = ? AND end_timestamp > ? LIMIT 1")) {
-                statement.setInt(1, this.roomId.getAsInt());
-                statement.setInt(2, Emulator.getIntUnixTimestamp());
 
-                try (ResultSet promotionSet = statement.executeQuery()) {
-                    this.promoted = false;
-                    if (promotionSet.next()) {
-                        this.promoted = true;
-                        this.promotion = new RoomPromotion(this.room, promotionSet);
-                    }
-                }
+        if (!isPromoted) {
+            return;
+        }
+
+        try (PreparedStatement statement = connection.prepareStatement(
+            "SELECT * FROM room_promotions WHERE room_id = ? AND end_timestamp > ? LIMIT 1")) {
+            statement.setInt(1, this.roomId.getAsInt());
+            statement.setInt(2, Emulator.getIntUnixTimestamp());
+
+            try (ResultSet promotionSet = statement.executeQuery()) {
+                RoomPromotion loadedPromotion = promotionSet.next()
+                        ? new RoomPromotion(this.room, promotionSet)
+                        : null;
+                this.promotion = loadedPromotion;
+                this.promoted = loadedPromotion != null;
             }
         }
     }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomLoadPublicationContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomLoadPublicationContractTest.java
@@ -1,0 +1,41 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoomLoadPublicationContractTest {
+
+    @Test
+    void roomLoadDoesNotHoldAnUnusedOuterConnection() throws Exception {
+        String loadMethod = loadDataInternalSource();
+
+        assertFalse(loadMethod.contains(
+                "try (Connection connection = Emulator.getDatabase().getDataSource().getConnection())"),
+                "loadDataInternal must not reserve a connection that its child loads never use");
+    }
+
+    @Test
+    void promotionLoadPublishesOnceAndCompletesWithTheRoomLoad() throws Exception {
+        String loadMethod = loadDataInternalSource();
+
+        assertFalse(loadMethod.contains("this.promoted = false;"),
+                "promotion state must not publish a transient false value");
+        assertTrue(loadMethod.contains("promotionFuture"),
+                "promotion loading must have an explicit completion future");
+        assertTrue(loadMethod.contains("CompletableFuture.allOf(promotionFuture,"),
+                "room loading must wait for promotion state before publishing loaded");
+    }
+
+    private static String loadDataInternalSource() throws Exception {
+        String source = Files.readString(
+                Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/Room.java"));
+        int start = source.indexOf("private void loadDataInternal()");
+        int end = source.indexOf("private synchronized void loadLayout()", start);
+        return source.substring(start, end);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomPromotionManagerPublicationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomPromotionManagerPublicationTest.java
@@ -1,0 +1,95 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoomPromotionManagerPublicationTest {
+
+    @Test
+    void keepsExistingPromotionVisibleUntilReplacementQueryCompletes() throws Exception {
+        CountDownLatch queryReached = new CountDownLatch(1);
+        CountDownLatch allowQueryToComplete = new CountDownLatch(1);
+
+        ResultSet resultSet = proxy(ResultSet.class, (method, arguments) -> {
+            if (method.getName().equals("next")) {
+                queryReached.countDown();
+                assertTrue(allowQueryToComplete.await(5, TimeUnit.SECONDS));
+                return false;
+            }
+            return defaultValue(method.getReturnType());
+        });
+        PreparedStatement statement = proxy(PreparedStatement.class, (method, arguments) -> {
+            if (method.getName().equals("executeQuery")) {
+                return resultSet;
+            }
+            return defaultValue(method.getReturnType());
+        });
+        Connection connection = proxy(Connection.class, (method, arguments) -> {
+            if (method.getName().equals("prepareStatement")) {
+                return statement;
+            }
+            return defaultValue(method.getReturnType());
+        });
+
+        RoomPromotionManager manager = new RoomPromotionManager(null, () -> 42);
+        manager.setPromoted(true);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> load = executor.submit(() -> {
+                manager.loadPromotion(true, connection);
+                return null;
+            });
+
+            assertTrue(queryReached.await(5, TimeUnit.SECONDS));
+            assertTrue(manager.getPromotedFlag(),
+                    "the existing promotion must remain visible while its replacement is loading");
+
+            allowQueryToComplete.countDown();
+            load.get(5, TimeUnit.SECONDS);
+
+            assertFalse(manager.getPromotedFlag());
+        } finally {
+            allowQueryToComplete.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, JdbcInvocation invocation) {
+        return (T) Proxy.newProxyInstance(
+                type.getClassLoader(),
+                new Class<?>[]{type},
+                (proxy, method, arguments) -> invocation.invoke(method, arguments));
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive() || type == void.class) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return 0;
+    }
+
+    @FunctionalInterface
+    private interface JdbcInvocation {
+        Object invoke(java.lang.reflect.Method method, Object[] arguments) throws Throwable;
+    }
+}


### PR DESCRIPTION
Stops room loading from reserving a database connection while each child phase opens its own.

Promotion loading now completes with the room load and publishes its result once, keeping the existing state visible while the query is in progress.
