### PR TITLE
fix(core): report periodic task failures

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/threading/HabboExecutorService.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/HabboExecutorService.java
@@ -3,7 +3,6 @@ package com.eu.habbo.threading;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -17,7 +16,7 @@ public class HabboExecutorService extends ScheduledThreadPoolExecutor {
     private static final Logger LOGGER = LoggerFactory.getLogger(HabboExecutorService.class);
 
     public HabboExecutorService(int corePoolSize, ThreadFactory threadFactory) {
-        super(corePoolSize, threadFactory);
+        super(corePoolSize, threadFactory, RejectedExecutionHandlerImpl.aborting());
     }
 
     @Override
@@ -65,8 +64,6 @@ public class HabboExecutorService extends ScheduledThreadPoolExecutor {
     }
 
     private void logFailure(Throwable failure) {
-        if (!(failure instanceof IOException)) {
-            LOGGER.error("Error in HabboExecutorService", failure);
-        }
+        LOGGER.error("Error in HabboExecutorService", failure);
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/threading/RejectedExecutionHandlerImpl.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/RejectedExecutionHandlerImpl.java
@@ -8,9 +8,27 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 public class RejectedExecutionHandlerImpl implements RejectedExecutionHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(RejectedExecutionHandlerImpl.class);
+    private final RejectedExecutionHandler terminalHandler;
+
+    public RejectedExecutionHandlerImpl() {
+        this((runnable, executor) -> {
+        });
+    }
+
+    private RejectedExecutionHandlerImpl(RejectedExecutionHandler terminalHandler) {
+        this.terminalHandler = terminalHandler;
+    }
+
+    static RejectedExecutionHandlerImpl aborting() {
+        return new RejectedExecutionHandlerImpl(new ThreadPoolExecutor.AbortPolicy());
+    }
 
     @Override
     public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
-        LOGGER.error("{} is rejected", r.toString());
+        try {
+            LOGGER.error("{} is rejected", r);
+        } finally {
+            this.terminalHandler.rejectedExecution(r, executor);
+        }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/threading/HabboExecutorServicePeriodicTaskTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/threading/HabboExecutorServicePeriodicTaskTest.java
@@ -1,7 +1,14 @@
 package com.eu.habbo.threading;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -29,5 +36,63 @@ class HabboExecutorServicePeriodicTaskTest {
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    @Test
+    void periodicIoFailureIsReportedWhenAFileAppenderFails() throws Exception {
+        Logger logger = (Logger) LoggerFactory.getLogger(HabboExecutorService.class);
+        Level previousLevel = logger.getLevel();
+        boolean previousAdditivity = logger.isAdditive();
+        ListAppender<ILoggingEvent> observedEvents = new ListAppender<>();
+        AppenderBase<ILoggingEvent> failingFileAppender = new AppenderBase<>() {
+            @Override
+            protected void append(ILoggingEvent eventObject) {
+                throw new IllegalStateException("runtime error file is unavailable");
+            }
+        };
+        observedEvents.setContext(logger.getLoggerContext());
+        failingFileAppender.setContext(logger.getLoggerContext());
+        observedEvents.start();
+        failingFileAppender.start();
+        logger.setLevel(Level.ERROR);
+        logger.setAdditive(false);
+        logger.addAppender(failingFileAppender);
+        logger.addAppender(observedEvents);
+
+        HabboExecutorService executor = new HabboExecutorService(
+                1,
+                Executors.defaultThreadFactory());
+        AtomicInteger executions = new AtomicInteger();
+        CountDownLatch recoveredExecution = new CountDownLatch(1);
+
+        try {
+            executor.scheduleAtFixedRate(() -> {
+                if (executions.incrementAndGet() == 1) {
+                    throwUnchecked(new IOException("periodic I/O failed"));
+                }
+                recoveredExecution.countDown();
+            }, 0, 10, TimeUnit.MILLISECONDS);
+
+            assertTrue(recoveredExecution.await(2, TimeUnit.SECONDS),
+                    "a recoverable I/O exception must not cancel later executions");
+            assertTrue(observedEvents.list.stream().anyMatch(event ->
+                            event.getThrowableProxy() != null
+                                    && IOException.class.getName().equals(
+                                    event.getThrowableProxy().getClassName())),
+                    "the I/O failure must reach an observable logger even if a file appender fails");
+        } finally {
+            executor.shutdownNow();
+            logger.detachAppender(failingFileAppender);
+            logger.detachAppender(observedEvents);
+            logger.setAdditive(previousAdditivity);
+            logger.setLevel(previousLevel);
+            failingFileAppender.stop();
+            observedEvents.stop();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E extends Throwable> void throwUnchecked(Throwable failure) throws E {
+        throw (E) failure;
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/threading/HabboExecutorServiceRejectionTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/threading/HabboExecutorServiceRejectionTest.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -23,5 +25,15 @@ class HabboExecutorServiceRejectionTest {
 
         assertThrows(RejectedExecutionException.class, () -> executor.execute(() -> {
         }));
+    }
+
+    @Test
+    void publicStandaloneHandlerPreservesItsLoggingOnlyBehavior() {
+        RejectedExecutionHandlerImpl handler = new RejectedExecutionHandlerImpl();
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+        executor.shutdownNow();
+
+        assertDoesNotThrow(() -> handler.rejectedExecution(() -> {
+        }, executor));
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/threading/HabboExecutorServiceRejectionTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/threading/HabboExecutorServiceRejectionTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class HabboExecutorServiceRejectionTest {
@@ -14,6 +15,10 @@ class HabboExecutorServiceRejectionTest {
         HabboExecutorService executor = new HabboExecutorService(
                 1,
                 Executors.defaultThreadFactory());
+        assertInstanceOf(
+                RejectedExecutionHandlerImpl.class,
+                executor.getRejectedExecutionHandler(),
+                "the project rejection handler must be installed");
         executor.shutdownNow();
 
         assertThrows(RejectedExecutionException.class, () -> executor.execute(() -> {

--- a/Emulator/src/test/java/com/eu/habbo/threading/HabboExecutorServiceRejectionTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/threading/HabboExecutorServiceRejectionTest.java
@@ -1,0 +1,22 @@
+package com.eu.habbo.threading;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class HabboExecutorServiceRejectionTest {
+
+    @Test
+    void rejectedTaskRemainsExplicitToTheCaller() {
+        HabboExecutorService executor = new HabboExecutorService(
+                1,
+                Executors.defaultThreadFactory());
+        executor.shutdownNow();
+
+        assertThrows(RejectedExecutionException.class, () -> executor.execute(() -> {
+        }));
+    }
+}


### PR DESCRIPTION
Reports recoverable periodic-task exceptions, including I/O failures, while keeping later executions scheduled.

The project rejection handler is now installed with an abort terminal policy, preserving caller-visible rejection and its public standalone logging behavior.
