### PR TITLE
fix(core): publish lifecycle field changes

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -83,9 +83,9 @@ public final class Emulator {
     public static long buildTimestamp = -1L;
 
 
-    public static boolean isReady = false;
-    public static boolean isShuttingDown = false;
-    public static boolean stopped = false;
+    public static volatile boolean isReady = false;
+    public static volatile boolean isShuttingDown = false;
+    public static volatile boolean stopped = false;
     public static boolean debugging = false;
     private static int timeStarted = 0;
     private static Runtime runtime;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -139,7 +139,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   private String ownerName;
   private String name;
   private String description;
-  private RoomLayout layout;
+  private volatile RoomLayout layout;
   private boolean overrideModel;
   private String layoutName;
   private String password;
@@ -189,7 +189,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   private int rollerSpeed;
   private int lastTimerReset = Emulator.getIntUnixTimestamp();
   private volatile boolean muted;
-  private RoomSpecialTypes roomSpecialTypes;
+  private volatile RoomSpecialTypes roomSpecialTypes;
   private TraxManager traxManager;
   private final Object wiredSettingsLock = new Object();
   private volatile boolean wiredSettingsLoaded;

--- a/Emulator/src/test/java/com/eu/habbo/LifecycleFieldCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/LifecycleFieldCompatibilityTest.java
@@ -44,6 +44,15 @@ class LifecycleFieldCompatibilityTest {
         assertPrivateMutableField("roomSpecialTypes", RoomSpecialTypes.class);
     }
 
+    @Test
+    void crossThreadControlFieldsAreVolatile() throws Exception {
+        assertVolatile(Emulator.class.getDeclaredField("isReady"));
+        assertVolatile(Emulator.class.getDeclaredField("isShuttingDown"));
+        assertVolatile(Emulator.class.getDeclaredField("stopped"));
+        assertVolatile(Room.class.getDeclaredField("layout"));
+        assertVolatile(Room.class.getDeclaredField("roomSpecialTypes"));
+    }
+
     private static void assertPublicStaticMutableBoolean(String name) throws Exception {
         Field field = Emulator.class.getDeclaredField(name);
         int modifiers = field.getModifiers();
@@ -62,5 +71,11 @@ class LifecycleFieldCompatibilityTest {
         assertTrue(Modifier.isPrivate(modifiers));
         assertFalse(Modifier.isStatic(modifiers));
         assertFalse(Modifier.isFinal(modifiers));
+    }
+
+    private static void assertVolatile(Field field) {
+        assertTrue(Modifier.isVolatile(field.getModifiers()),
+                () -> field.getDeclaringClass().getSimpleName() + "." + field.getName()
+                        + " must be volatile");
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/LifecycleFieldCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/LifecycleFieldCompatibilityTest.java
@@ -1,0 +1,66 @@
+package com.eu.habbo;
+
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomLayout;
+import com.eu.habbo.habbohotel.rooms.RoomSpecialTypes;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LifecycleFieldCompatibilityTest {
+
+    @Test
+    void lifecycleFieldsRemainPublicStaticAndDirectlyWritable() throws Exception {
+        boolean ready = Emulator.isReady;
+        boolean shuttingDown = Emulator.isShuttingDown;
+        boolean stopped = Emulator.stopped;
+        try {
+            Emulator.isReady = !ready;
+            Emulator.isShuttingDown = !shuttingDown;
+            Emulator.stopped = !stopped;
+
+            assertEquals(!ready, Emulator.isReady);
+            assertEquals(!shuttingDown, Emulator.isShuttingDown);
+            assertEquals(!stopped, Emulator.stopped);
+        } finally {
+            Emulator.isReady = ready;
+            Emulator.isShuttingDown = shuttingDown;
+            Emulator.stopped = stopped;
+        }
+
+        assertPublicStaticMutableBoolean("isReady");
+        assertPublicStaticMutableBoolean("isShuttingDown");
+        assertPublicStaticMutableBoolean("stopped");
+    }
+
+    @Test
+    void roomVisibilityFieldsKeepTheirTypesAndEncapsulation() throws Exception {
+        assertPrivateMutableField("layout", RoomLayout.class);
+        assertPrivateMutableField("roomSpecialTypes", RoomSpecialTypes.class);
+    }
+
+    private static void assertPublicStaticMutableBoolean(String name) throws Exception {
+        Field field = Emulator.class.getDeclaredField(name);
+        int modifiers = field.getModifiers();
+
+        assertEquals(boolean.class, field.getType());
+        assertTrue(Modifier.isPublic(modifiers));
+        assertTrue(Modifier.isStatic(modifiers));
+        assertFalse(Modifier.isFinal(modifiers));
+    }
+
+    private static void assertPrivateMutableField(String name, Class<?> type) throws Exception {
+        Field field = Room.class.getDeclaredField(name);
+        int modifiers = field.getModifiers();
+
+        assertEquals(type, field.getType());
+        assertTrue(Modifier.isPrivate(modifiers));
+        assertFalse(Modifier.isStatic(modifiers));
+        assertFalse(Modifier.isFinal(modifiers));
+    }
+}


### PR DESCRIPTION
Publishes readiness, shutdown, and stopped-state changes across worker threads.

Room layout and special-type replacements receive the same visibility guarantee while public direct writes, field types, and binary descriptors remain compatible.
