### PR TITLE
fix(rooms): snapshot rollers for cycling

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java
@@ -51,7 +51,7 @@ public class RoomRollerManager {
         Set<Integer> rollerFurniIds = new HashSet<>();
         Set<Integer> rolledUnitIds = new HashSet<>();
 
-        for (InteractionRoller roller : this.room.getRoomSpecialTypes().getRollers().values()) {
+        for (InteractionRoller roller : this.room.getRoomSpecialTypes().rollerSnapshot().values()) {
             processRoller(roller, messages, rollerFurniIds, rolledUnitIds, updatedUnit);
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypes.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypes.java
@@ -325,6 +325,12 @@ public class RoomSpecialTypes {
         return this.rollers;
     }
 
+    Map<Integer, InteractionRoller> rollerSnapshot() {
+        synchronized (this.rollers) {
+            return new HashMap<>(this.rollers);
+        }
+    }
+
 
     /**
      * Finds a wired trigger by its item ID.
@@ -1186,7 +1192,9 @@ public class RoomSpecialTypes {
         this.petFoods.clear();
         this.petToys.clear();
         this.petTrees.clear();
-        this.rollers.clear();
+        synchronized (this.rollers) {
+            this.rollers.clear();
+        }
 
         this.wiredTriggers.clear();
         this.wiredEffects.clear();

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomRollerIterationContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomRollerIterationContractTest.java
@@ -1,0 +1,21 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoomRollerIterationContractTest {
+
+    @Test
+    void firstPartyCycleUsesTheLockedRollerSnapshot() throws Exception {
+        String source = Files.readString(
+                Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java"));
+
+        assertTrue(source.contains("rollerSnapshot().values()"));
+        assertFalse(source.contains("getRollers().values()"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypesRollerCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypesRollerCompatibilityTest.java
@@ -4,7 +4,14 @@ import com.eu.habbo.habbohotel.items.interactions.InteractionRoller;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -20,5 +27,32 @@ class RoomSpecialTypesRollerCompatibilityTest {
         assertSame(rollers, specialTypes.getRollers());
         assertTrue(specialTypes.getRollers().containsKey(17));
         rollers.remove(17);
+    }
+
+    @Test
+    void disposeUsesTheRollerMapMonitor() throws Exception {
+        RoomSpecialTypes specialTypes = new RoomSpecialTypes();
+        Map<Integer, InteractionRoller> rollers = specialTypes.getRollers();
+        CountDownLatch disposeAttempted = new CountDownLatch(1);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<?> dispose;
+
+        try {
+            synchronized (rollers) {
+                dispose = executor.submit(() -> {
+                    disposeAttempted.countDown();
+                    specialTypes.dispose();
+                });
+
+                assertTrue(disposeAttempted.await(2, TimeUnit.SECONDS));
+                assertThrows(TimeoutException.class,
+                        () -> dispose.get(100, TimeUnit.MILLISECONDS),
+                        "dispose must wait for first-party roller mutation to leave the shared monitor");
+            }
+
+            dispose.get(2, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypesRollerCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypesRollerCompatibilityTest.java
@@ -11,8 +11,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RoomSpecialTypesRollerCompatibilityTest {
@@ -27,6 +28,19 @@ class RoomSpecialTypesRollerCompatibilityTest {
         assertSame(rollers, specialTypes.getRollers());
         assertTrue(specialTypes.getRollers().containsKey(17));
         rollers.remove(17);
+    }
+
+    @Test
+    void internalSnapshotDoesNotChangeWithTheLiveMap() {
+        RoomSpecialTypes specialTypes = new RoomSpecialTypes();
+        Map<Integer, InteractionRoller> rollers = specialTypes.getRollers();
+        rollers.put(17, null);
+
+        Map<Integer, InteractionRoller> snapshot = specialTypes.rollerSnapshot();
+        rollers.remove(17);
+
+        assertTrue(snapshot.containsKey(17));
+        assertFalse(rollers.containsKey(17));
     }
 
     @Test

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypesRollerCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypesRollerCompatibilityTest.java
@@ -1,0 +1,24 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.items.interactions.InteractionRoller;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoomSpecialTypesRollerCompatibilityTest {
+
+    @Test
+    void publicRollerMapRemainsLiveStableAndMutable() {
+        RoomSpecialTypes specialTypes = new RoomSpecialTypes();
+        Map<Integer, InteractionRoller> rollers = specialTypes.getRollers();
+
+        rollers.put(17, null);
+
+        assertSame(rollers, specialTypes.getRollers());
+        assertTrue(specialTypes.getRollers().containsKey(17));
+        rollers.remove(17);
+    }
+}


### PR DESCRIPTION
Moves first-party roller cycling to a locked snapshot and clears rollers under the same monitor during disposal.

The public `getRollers()` map remains the same live, stable, mutable object for existing plugins.
