### PR TITLE
fix(core): use immutable timestamp formatters

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/VisitorBot.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/VisitorBot.java
@@ -26,7 +26,11 @@ public class VisitorBot extends Bot {
     }
 
     public static void initialise() {
-        DATE_FORMAT = new SimpleDateFormat(Emulator.getConfig().getValue("bots.visitor.dateformat"));
+        initialise(Emulator.getConfig().getValue("bots.visitor.dateformat"));
+    }
+
+    static void initialise(String pattern) {
+        DATE_FORMAT = new SimpleDateFormat(pattern);
     }
 
     @Override
@@ -42,7 +46,7 @@ public class VisitorBot extends Bot {
                     list.append("\r");
                     list.append(visit.roomName).append(" ");
                     list.append(Emulator.getTexts().getValue("generic.time.at")).append(" ");
-                    list.append(DATE_FORMAT.format(new Date((visit.timestamp * 1000L))));
+                    list.append(formatTimestamp(visit.timestamp));
                 }
 
                 visitMessage = visitMessage.replace("%list%", list.toString());
@@ -66,6 +70,10 @@ public class VisitorBot extends Bot {
                 }
             }
         }
+    }
+
+    static String formatTimestamp(int timestamp) {
+        return DATE_FORMAT.format(new Date(timestamp * 1000L));
     }
 
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/VisitorBot.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/VisitorBot.java
@@ -7,13 +7,14 @@ import com.eu.habbo.habbohotel.users.Habbo;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.Set;
 
 public class VisitorBot extends Bot {
-    private static SimpleDateFormat DATE_FORMAT;
+    private static DateTimeFormatter DATE_FORMAT;
     private boolean showedLog = false;
     private Set<ModToolRoomVisit> visits = new HashSet<>(3);
 
@@ -30,7 +31,7 @@ public class VisitorBot extends Bot {
     }
 
     static void initialise(String pattern) {
-        DATE_FORMAT = new SimpleDateFormat(pattern);
+        DATE_FORMAT = DateTimeFormatter.ofPattern(pattern).withZone(ZoneId.systemDefault());
     }
 
     @Override
@@ -73,7 +74,7 @@ public class VisitorBot extends Bot {
     }
 
     static String formatTimestamp(int timestamp) {
-        return DATE_FORMAT.format(new Date(timestamp * 1000L));
+        return DATE_FORMAT.format(Instant.ofEpochSecond(timestamp));
     }
 
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolBan.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolBan.java
@@ -9,9 +9,14 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 public class ModToolBan implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(ModToolBan.class);
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
 
     public static SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
     public int userId;
@@ -85,6 +90,6 @@ public class ModToolBan implements Runnable {
     }
 
     static String formatTimestamp(int timestamp) {
-        return dateFormat.format(timestamp * 1000L);
+        return TIMESTAMP_FORMATTER.format(Instant.ofEpochSecond(timestamp));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolBan.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolBan.java
@@ -77,10 +77,14 @@ public class ModToolBan implements Runnable {
                 "Type: " + this.type.getType() + "\r" +
                 "Reason: " + "<i>" + this.reason + "</i>" + "\r" +
                 "Moderator Id: " + this.staffId + "\r" +
-                "Date: " + dateFormat.format(this.timestamp * 1000L) + "\r" +
-                "Expire Date: " + dateFormat.format(this.expireDate * 1000L) + "\r" +
+                "Date: " + formatTimestamp(this.timestamp) + "\r" +
+                "Expire Date: " + formatTimestamp(this.expireDate) + "\r" +
                 "IP: " + this.ip + "\r" +
                 "MachineID: " + this.machineId + "\r" +
                 "Topic: " + this.cfhTopic;
+    }
+
+    static String formatTimestamp(int timestamp) {
+        return dateFormat.format(timestamp * 1000L);
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolIssueChatlogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolIssueChatlogComposer.java
@@ -88,7 +88,7 @@ public class ModToolIssueChatlogComposer extends MessageComposer {
 
         this.response.appendShort(this.chatlog.size());
         for (ModToolChatLog chatLog : this.chatlog) {
-            this.response.appendString(format.format(chatLog.timestamp * 1000L));
+            this.response.appendString(formatTimestamp(chatLog.timestamp));
             this.response.appendInt(chatLog.habboId);
             this.response.appendString(chatLog.username);
             this.response.appendString(chatLog.message);
@@ -97,6 +97,10 @@ public class ModToolIssueChatlogComposer extends MessageComposer {
         //}
 
         return this.response;
+    }
+
+    static String formatTimestamp(int timestamp) {
+        return format.format(timestamp * 1000L);
     }
 
     public ModToolIssue getIssue() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolIssueChatlogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolIssueChatlogComposer.java
@@ -8,11 +8,16 @@ import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 
 public class ModToolIssueChatlogComposer extends MessageComposer {
     public static SimpleDateFormat format = new SimpleDateFormat("HH:mm");
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+            DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault());
     private final ModToolIssue issue;
     private final List<ModToolChatLog> chatlog;
     private final String roomName;
@@ -100,7 +105,7 @@ public class ModToolIssueChatlogComposer extends MessageComposer {
     }
 
     static String formatTimestamp(int timestamp) {
-        return format.format(timestamp * 1000L);
+        return TIMESTAMP_FORMATTER.format(Instant.ofEpochSecond(timestamp));
     }
 
     public ModToolIssue getIssue() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserChatlogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserChatlogComposer.java
@@ -40,7 +40,7 @@ public class ModToolUserChatlogComposer extends MessageComposer {
 
             this.response.appendShort(visit.chat.size());
             for (ModToolChatLog chatLog : visit.chat) {
-                this.response.appendString(format.format(chatLog.timestamp * 1000L));
+                this.response.appendString(formatTimestamp(chatLog.timestamp));
                 this.response.appendInt(chatLog.habboId);
                 this.response.appendString(chatLog.username);
                 this.response.appendString(chatLog.message);
@@ -48,6 +48,10 @@ public class ModToolUserChatlogComposer extends MessageComposer {
             }
         }
         return this.response;
+    }
+
+    static String formatTimestamp(int timestamp) {
+        return format.format(timestamp * 1000L);
     }
 
     public ArrayList<ModToolRoomVisit> getSet() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserChatlogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserChatlogComposer.java
@@ -7,10 +7,15 @@ import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 
 public class ModToolUserChatlogComposer extends MessageComposer {
     public static SimpleDateFormat format = new SimpleDateFormat("HH:mm");
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+            DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault());
     private final ArrayList<ModToolRoomVisit> set;
     private final int userId;
     private final String username;
@@ -51,7 +56,7 @@ public class ModToolUserChatlogComposer extends MessageComposer {
     }
 
     static String formatTimestamp(int timestamp) {
-        return format.format(timestamp * 1000L);
+        return TIMESTAMP_FORMATTER.format(Instant.ofEpochSecond(timestamp));
     }
 
     public ArrayList<ModToolRoomVisit> getSet() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserInfoComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserInfoComposer.java
@@ -11,14 +11,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.*;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Map;
 
 public class ModToolUserInfoComposer extends MessageComposer {
     private static final Logger LOGGER = LoggerFactory.getLogger(ModToolUserInfoComposer.class);
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+    private static final DateTimeFormatter DATE_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault());
 
     private final ResultSet set;
     private final boolean hideMail;
@@ -167,6 +169,6 @@ public class ModToolUserInfoComposer extends MessageComposer {
      */
     static String formatUnixTimestamp(int timestamp) {
         if (timestamp <= 0) return "";
-        return DATE_FORMAT.format(new Date(timestamp * 1000L));
+        return DATE_FORMAT.format(Instant.ofEpochSecond(timestamp));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserInfoComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserInfoComposer.java
@@ -165,7 +165,7 @@ public class ModToolUserInfoComposer extends MessageComposer {
      * is rendered as an empty string so the client falls back to its
      * empty-state placeholder.
      */
-    private static String formatUnixTimestamp(int timestamp) {
+    static String formatUnixTimestamp(int timestamp) {
         if (timestamp <= 0) return "";
         return DATE_FORMAT.format(new Date(timestamp * 1000L));
     }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/bots/VisitorBotDateFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/bots/VisitorBotDateFormattingTest.java
@@ -3,6 +3,7 @@ package com.eu.habbo.habbohotel.bots;
 import org.junit.jupiter.api.Test;
 
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,5 +19,12 @@ class VisitorBotDateFormattingTest {
         assertEquals(
                 new SimpleDateFormat(pattern).format(new Date(timestamp * 1000L)),
                 VisitorBot.formatTimestamp(timestamp));
+    }
+
+    @Test
+    void visitorBotUsesAnImmutableFormatter() throws Exception {
+        assertEquals(
+                DateTimeFormatter.class,
+                VisitorBot.class.getDeclaredField("DATE_FORMAT").getType());
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/bots/VisitorBotDateFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/bots/VisitorBotDateFormattingTest.java
@@ -1,0 +1,22 @@
+package com.eu.habbo.habbohotel.bots;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class VisitorBotDateFormattingTest {
+
+    @Test
+    void preservesConfiguredTimestampPattern() {
+        int timestamp = 1_700_000_000;
+        String pattern = "yyyy-mm-dd HH:mm";
+        VisitorBot.initialise(pattern);
+
+        assertEquals(
+                new SimpleDateFormat(pattern).format(new Date(timestamp * 1000L)),
+                VisitorBot.formatTimestamp(timestamp));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/modtool/ModToolBanDateFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/modtool/ModToolBanDateFormattingTest.java
@@ -27,4 +27,19 @@ class ModToolBanDateFormattingTest {
             ModToolBan.dateFormat = original;
         }
     }
+
+    @Test
+    void firstPartyBanFormattingDoesNotUseThePublicMutableFormatter() {
+        int timestamp = 1_700_000_000;
+        String expected = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+                .format(new Date(timestamp * 1000L));
+        SimpleDateFormat original = ModToolBan.dateFormat;
+        try {
+            ModToolBan.dateFormat = new SimpleDateFormat("ss");
+
+            assertEquals(expected, ModToolBan.formatTimestamp(timestamp));
+        } finally {
+            ModToolBan.dateFormat = original;
+        }
+    }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/modtool/ModToolBanDateFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/modtool/ModToolBanDateFormattingTest.java
@@ -1,0 +1,30 @@
+package com.eu.habbo.habbohotel.modtool;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ModToolBanDateFormattingTest {
+
+    @Test
+    void preservesBanTimestampTextAndPublicFieldMutability() {
+        int timestamp = 1_700_000_000;
+        String expected = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+                .format(new Date(timestamp * 1000L));
+
+        assertEquals(expected, ModToolBan.formatTimestamp(timestamp));
+
+        SimpleDateFormat original = ModToolBan.dateFormat;
+        try {
+            SimpleDateFormat replacement = new SimpleDateFormat("ss");
+            ModToolBan.dateFormat = replacement;
+            assertSame(replacement, ModToolBan.dateFormat);
+        } finally {
+            ModToolBan.dateFormat = original;
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/outgoing/modtool/ModToolTimestampFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/outgoing/modtool/ModToolTimestampFormattingTest.java
@@ -1,0 +1,48 @@
+package com.eu.habbo.messages.outgoing.modtool;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ModToolTimestampFormattingTest {
+    private static final int TIMESTAMP = 1_700_000_000;
+
+    @Test
+    void preservesChatlogAndUserInfoTimestampText() {
+        assertEquals(
+                format("HH:mm", TIMESTAMP),
+                ModToolUserChatlogComposer.formatTimestamp(TIMESTAMP));
+        assertEquals(
+                format("HH:mm", TIMESTAMP),
+                ModToolIssueChatlogComposer.formatTimestamp(TIMESTAMP));
+        assertEquals(
+                format("yyyy-MM-dd HH:mm", TIMESTAMP),
+                ModToolUserInfoComposer.formatUnixTimestamp(TIMESTAMP));
+        assertEquals("", ModToolUserInfoComposer.formatUnixTimestamp(0));
+    }
+
+    @Test
+    void publicChatlogFormattersRemainDirectlyWritable() {
+        SimpleDateFormat userFormatter = ModToolUserChatlogComposer.format;
+        SimpleDateFormat issueFormatter = ModToolIssueChatlogComposer.format;
+        try {
+            SimpleDateFormat replacement = new SimpleDateFormat("ss");
+            ModToolUserChatlogComposer.format = replacement;
+            ModToolIssueChatlogComposer.format = replacement;
+
+            assertSame(replacement, ModToolUserChatlogComposer.format);
+            assertSame(replacement, ModToolIssueChatlogComposer.format);
+        } finally {
+            ModToolUserChatlogComposer.format = userFormatter;
+            ModToolIssueChatlogComposer.format = issueFormatter;
+        }
+    }
+
+    private static String format(String pattern, int timestamp) {
+        return new SimpleDateFormat(pattern).format(new Date(timestamp * 1000L));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/outgoing/modtool/ModToolTimestampFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/outgoing/modtool/ModToolTimestampFormattingTest.java
@@ -3,6 +3,7 @@ package com.eu.habbo.messages.outgoing.modtool;
 import org.junit.jupiter.api.Test;
 
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,6 +41,30 @@ class ModToolTimestampFormattingTest {
             ModToolUserChatlogComposer.format = userFormatter;
             ModToolIssueChatlogComposer.format = issueFormatter;
         }
+    }
+
+    @Test
+    void firstPartyChatFormattingDoesNotUsePublicMutableFormatters() {
+        SimpleDateFormat userFormatter = ModToolUserChatlogComposer.format;
+        SimpleDateFormat issueFormatter = ModToolIssueChatlogComposer.format;
+        try {
+            ModToolUserChatlogComposer.format = new SimpleDateFormat("ss");
+            ModToolIssueChatlogComposer.format = new SimpleDateFormat("ss");
+            String expected = format("HH:mm", TIMESTAMP);
+
+            assertEquals(expected, ModToolUserChatlogComposer.formatTimestamp(TIMESTAMP));
+            assertEquals(expected, ModToolIssueChatlogComposer.formatTimestamp(TIMESTAMP));
+        } finally {
+            ModToolUserChatlogComposer.format = userFormatter;
+            ModToolIssueChatlogComposer.format = issueFormatter;
+        }
+    }
+
+    @Test
+    void userInfoUsesAnImmutableFormatter() throws Exception {
+        assertEquals(
+                DateTimeFormatter.class,
+                ModToolUserInfoComposer.class.getDeclaredField("DATE_FORMAT").getType());
     }
 
     private static String format(String pattern, int timestamp) {


### PR DESCRIPTION
Replaces the five audited shared mutable timestamp formatters with immutable `DateTimeFormatter` paths while preserving existing output patterns and the startup default time zone.

The three public `SimpleDateFormat` fields remain directly writable with their existing types for plugin compatibility, but first-party formatting no longer shares their mutable state.
