### PR TITLE
fix(core): publish parsed configuration snapshots

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatMessage.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatMessage.java
@@ -26,7 +26,7 @@ public class RoomChatMessage implements Runnable, ISerialize, DatabaseLoggable {
     public static int MAXIMUM_LENGTH = 100;
     //Configuration. Loaded from database & updated accordingly.
     public static boolean SAVE_ROOM_CHATS = false;
-    public static int[] BANNED_BUBBLES = {};
+    public static volatile int[] BANNED_BUBBLES = {};
     private final Habbo habbo;
     public int roomId;
     public boolean isCommand = false;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/DiscountComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/DiscountComposer.java
@@ -9,7 +9,7 @@ public class DiscountComposer extends MessageComposer {
     public static int DISCOUNT_BATCH_SIZE = 6;
     public static int DISCOUNT_AMOUNT_PER_BATCH = 1;
     public static int MINIMUM_DISCOUNTS_FOR_BONUS = 1;
-    public static int[] ADDITIONAL_DISCOUNT_THRESHOLDS = new int[]{40, 99};
+    public static volatile int[] ADDITIONAL_DISCOUNT_THRESHOLDS = new int[]{40, 99};
 
     @Override
     protected ServerMessage composeInternal() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/GiftConfigurationComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/GiftConfigurationComposer.java
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Map;
 
 public class GiftConfigurationComposer extends MessageComposer {
-    public static List<Integer> BOX_TYPES = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 8);
-    public static List<Integer> RIBBON_TYPES = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    public static volatile List<Integer> BOX_TYPES = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 8);
+    public static volatile List<Integer> RIBBON_TYPES = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
     @Override
     protected ServerMessage composeInternal() {

--- a/Emulator/src/main/java/com/eu/habbo/plugin/NumericConfigurationParser.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/NumericConfigurationParser.java
@@ -1,10 +1,15 @@
 package com.eu.habbo.plugin;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 final class NumericConfigurationParser {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NumericConfigurationParser.class);
 
     private NumericConfigurationParser() {
     }
@@ -16,7 +21,15 @@ final class NumericConfigurationParser {
     }
 
     static int[] parseIntArray(String value, String delimiter, int[] currentValue, String configurationKey) {
-        return parseIntArray(value, delimiter);
+        try {
+            return parseIntArray(value, delimiter);
+        } catch (NumberFormatException exception) {
+            LOGGER.error(
+                    "Invalid integer list for configuration key '{}'; keeping the previous value",
+                    configurationKey
+            );
+            return currentValue;
+        }
     }
 
     static List<Integer> parseIntList(String value, String delimiter) {
@@ -32,6 +45,14 @@ final class NumericConfigurationParser {
             List<Integer> currentValue,
             String configurationKey
     ) {
-        return parseIntList(value, delimiter);
+        try {
+            return parseIntList(value, delimiter);
+        } catch (NumberFormatException exception) {
+            LOGGER.error(
+                    "Invalid integer list for configuration key '{}'; keeping the previous value",
+                    configurationKey
+            );
+            return currentValue;
+        }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/plugin/NumericConfigurationParser.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/NumericConfigurationParser.java
@@ -15,10 +15,23 @@ final class NumericConfigurationParser {
                 .toArray();
     }
 
+    static int[] parseIntArray(String value, String delimiter, int[] currentValue, String configurationKey) {
+        return parseIntArray(value, delimiter);
+    }
+
     static List<Integer> parseIntList(String value, String delimiter) {
         return Arrays.stream(value.split(delimiter))
                 .mapToInt(Integer::parseInt)
                 .boxed()
                 .collect(Collectors.toList());
+    }
+
+    static List<Integer> parseIntList(
+            String value,
+            String delimiter,
+            List<Integer> currentValue,
+            String configurationKey
+    ) {
+        return parseIntList(value, delimiter);
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/plugin/NumericConfigurationParser.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/NumericConfigurationParser.java
@@ -1,0 +1,24 @@
+package com.eu.habbo.plugin;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+final class NumericConfigurationParser {
+
+    private NumericConfigurationParser() {
+    }
+
+    static int[] parseIntArray(String value, String delimiter) {
+        return Arrays.stream(value.split(delimiter))
+                .mapToInt(Integer::parseInt)
+                .toArray();
+    }
+
+    static List<Integer> parseIntList(String value, String delimiter) {
+        return Arrays.stream(value.split(delimiter))
+                .mapToInt(Integer::parseInt)
+                .boxed()
+                .collect(Collectors.toList());
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
@@ -56,12 +56,10 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class PluginManager {
 
@@ -95,7 +93,12 @@ public class PluginManager {
         DiscountComposer.DISCOUNT_BATCH_SIZE = Emulator.getConfig().getInt("discount.batch.size", 6);
         DiscountComposer.DISCOUNT_AMOUNT_PER_BATCH = Emulator.getConfig().getInt("discount.batch.free.items", 1);
         DiscountComposer.MINIMUM_DISCOUNTS_FOR_BONUS = Emulator.getConfig().getInt("discount.bonus.min.discounts", 1);
-        DiscountComposer.ADDITIONAL_DISCOUNT_THRESHOLDS = Arrays.stream(Emulator.getConfig().getValue("discount.additional.thresholds", "40;99").split(";")).mapToInt(Integer::parseInt).toArray();
+        DiscountComposer.ADDITIONAL_DISCOUNT_THRESHOLDS = NumericConfigurationParser.parseIntArray(
+                Emulator.getConfig().getValue("discount.additional.thresholds", "40;99"),
+                ";",
+                DiscountComposer.ADDITIONAL_DISCOUNT_THRESHOLDS,
+                "discount.additional.thresholds"
+        );
 
         BotManager.MINIMUM_CHAT_SPEED = Emulator.getConfig().getInt("hotel.bot.chat.minimum.interval");
         BotManager.MAXIMUM_CHAT_LENGTH = Emulator.getConfig().getInt("hotel.bot.max.chatlength");
@@ -146,15 +149,13 @@ public class PluginManager {
         TraxManager.LARGE_JUKEBOX_LIMIT = Emulator.getConfig().getInt("hotel.jukebox.limit.large");
         TraxManager.NORMAL_JUKEBOX_LIMIT = Emulator.getConfig().getInt("hotel.jukebox.limit.normal");
 
-        String[] bannedBubbles = Emulator.getConfig().getValue("commands.cmd_chatcolor.banned_numbers").split(";");
-        RoomChatMessage.BANNED_BUBBLES = new int[bannedBubbles.length];
-        for (int i = 0; i < RoomChatMessage.BANNED_BUBBLES.length; i++) {
-            try {
-                RoomChatMessage.BANNED_BUBBLES[i] = Integer.parseInt(bannedBubbles[i]);
-            } catch (Exception e) {
-                LOGGER.error("Caught exception", e);
-            }
-        }
+        int[] bannedBubbleSnapshot = NumericConfigurationParser.parseIntArray(
+                Emulator.getConfig().getValue("commands.cmd_chatcolor.banned_numbers"),
+                ";",
+                RoomChatMessage.BANNED_BUBBLES,
+                "commands.cmd_chatcolor.banned_numbers"
+        );
+        RoomChatMessage.BANNED_BUBBLES = bannedBubbleSnapshot;
 
         HabboManager.WELCOME_MESSAGE = Emulator.getConfig().getValue("hotel.welcome.alert.message").replace("<br>", "<br/>").replace("<br />", "<br/>").replace("\\r", "\r").replace("\\n", "\n").replace("\\t", "\t");
         Room.PREFIX_FORMAT = Emulator.getConfig().getValue("room.chat.prefix.format");
@@ -241,8 +242,18 @@ public class PluginManager {
         }
 
         if (Emulator.isReady) {
-            GiftConfigurationComposer.BOX_TYPES = Arrays.stream(Emulator.getConfig().getValue("hotel.gifts.box_types").split(",")).mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
-            GiftConfigurationComposer.RIBBON_TYPES = Arrays.stream(Emulator.getConfig().getValue("hotel.gifts.ribbon_types").split(",")).mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
+            GiftConfigurationComposer.BOX_TYPES = NumericConfigurationParser.parseIntList(
+                    Emulator.getConfig().getValue("hotel.gifts.box_types"),
+                    ",",
+                    GiftConfigurationComposer.BOX_TYPES,
+                    "hotel.gifts.box_types"
+            );
+            GiftConfigurationComposer.RIBBON_TYPES = NumericConfigurationParser.parseIntList(
+                    Emulator.getConfig().getValue("hotel.gifts.ribbon_types"),
+                    ",",
+                    GiftConfigurationComposer.RIBBON_TYPES,
+                    "hotel.gifts.ribbon_types"
+            );
 
             Emulator.getGameEnvironment().getCreditsScheduler().reloadConfig();
             Emulator.getGameEnvironment().getPointsScheduler().reloadConfig();

--- a/Emulator/src/test/java/com/eu/habbo/plugin/NumericConfigurationParserTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/plugin/NumericConfigurationParserTest.java
@@ -1,0 +1,27 @@
+package com.eu.habbo.plugin;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NumericConfigurationParserTest {
+
+    @Test
+    void parsesSemicolonDelimitedIntegerArray() {
+        assertArrayEquals(
+                new int[]{40, 99},
+                NumericConfigurationParser.parseIntArray("40;99", ";")
+        );
+    }
+
+    @Test
+    void parsesCommaDelimitedIntegerList() {
+        assertEquals(
+                List.of(0, 2, 8),
+                NumericConfigurationParser.parseIntList("0,2,8", ",")
+        );
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/plugin/NumericConfigurationParserTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/plugin/NumericConfigurationParserTest.java
@@ -1,11 +1,21 @@
 package com.eu.habbo.plugin;
 
+import com.eu.habbo.habbohotel.rooms.RoomChatMessage;
+import com.eu.habbo.messages.outgoing.catalog.DiscountComposer;
+import com.eu.habbo.messages.outgoing.catalog.GiftConfigurationComposer;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NumericConfigurationParserTest {
 
@@ -33,5 +43,66 @@ class NumericConfigurationParserTest {
                         "hotel.gifts.box_types"
                 )
         );
+    }
+
+    @Test
+    void retainsCurrentArrayWhenAConfiguredValueIsMalformed() {
+        int[] currentValue = {40, 99};
+
+        assertSame(
+                currentValue,
+                NumericConfigurationParser.parseIntArray(
+                        "40;invalid",
+                        ";",
+                        currentValue,
+                        "discount.additional.thresholds"
+                )
+        );
+    }
+
+    @Test
+    void retainsCurrentListWhenAConfiguredValueIsMalformed() {
+        List<Integer> currentValue = List.of(0, 2, 8);
+
+        assertSame(
+                currentValue,
+                NumericConfigurationParser.parseIntList(
+                        "0,invalid,8",
+                        ",",
+                        currentValue,
+                        "hotel.gifts.box_types"
+                )
+        );
+    }
+
+    @Test
+    void bannedBubbleSnapshotIsBuiltBeforePublication() throws IOException {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/plugin/PluginManager.java"
+        ));
+
+        assertTrue(source.contains(
+                "int[] bannedBubbleSnapshot = NumericConfigurationParser.parseIntArray("
+        ));
+        assertTrue(source.contains(
+                "RoomChatMessage.BANNED_BUBBLES = bannedBubbleSnapshot;"
+        ));
+        assertFalse(source.contains("RoomChatMessage.BANNED_BUBBLES[i]"));
+    }
+
+    @Test
+    void numericConfigurationSnapshotsArePublishedThroughVolatileFields() throws NoSuchFieldException {
+        assertTrue(Modifier.isVolatile(
+                RoomChatMessage.class.getField("BANNED_BUBBLES").getModifiers()
+        ));
+        assertTrue(Modifier.isVolatile(
+                DiscountComposer.class.getField("ADDITIONAL_DISCOUNT_THRESHOLDS").getModifiers()
+        ));
+        assertTrue(Modifier.isVolatile(
+                GiftConfigurationComposer.class.getField("BOX_TYPES").getModifiers()
+        ));
+        assertTrue(Modifier.isVolatile(
+                GiftConfigurationComposer.class.getField("RIBBON_TYPES").getModifiers()
+        ));
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/plugin/NumericConfigurationParserTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/plugin/NumericConfigurationParserTest.java
@@ -13,7 +13,12 @@ class NumericConfigurationParserTest {
     void parsesSemicolonDelimitedIntegerArray() {
         assertArrayEquals(
                 new int[]{40, 99},
-                NumericConfigurationParser.parseIntArray("40;99", ";")
+                NumericConfigurationParser.parseIntArray(
+                        "40;99",
+                        ";",
+                        new int[]{1},
+                        "discount.additional.thresholds"
+                )
         );
     }
 
@@ -21,7 +26,12 @@ class NumericConfigurationParserTest {
     void parsesCommaDelimitedIntegerList() {
         assertEquals(
                 List.of(0, 2, 8),
-                NumericConfigurationParser.parseIntList("0,2,8", ",")
+                NumericConfigurationParser.parseIntList(
+                        "0,2,8",
+                        ",",
+                        List.of(1),
+                        "hotel.gifts.box_types"
+                )
         );
     }
 }


### PR DESCRIPTION
Builds numeric configuration values completely before publishing them to readers. Malformed discount, gift, or banned-bubble lists now retain their last valid value without aborting the rest of the reload.
