### PR TITLE
fix(catalog): handle limited stock race

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
@@ -11,6 +11,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.OptionalInt;
 
 public class CatalogLimitedConfiguration implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogLimitedConfiguration.class);
@@ -23,11 +24,25 @@ public class CatalogLimitedConfiguration implements Runnable {
     private int soldOutFromPageId = 0;
 
     public CatalogLimitedConfiguration(int itemId, LinkedList<Integer> availableNumbers, int totalSet) {
+        this(
+                itemId,
+                availableNumbers,
+                totalSet,
+                Emulator.getConfig().getBoolean("catalog.ltd.random", true)
+        );
+    }
+
+    CatalogLimitedConfiguration(
+            int itemId,
+            LinkedList<Integer> availableNumbers,
+            int totalSet,
+            boolean randomize
+    ) {
         this.itemId = itemId;
         this.totalSet = totalSet;
         this.limitedNumbers = availableNumbers;
 
-        if (Emulator.getConfig().getBoolean("catalog.ltd.random", true)) {
+        if (randomize) {
             Collections.shuffle(this.limitedNumbers);
         } else {
             Collections.reverse(this.limitedNumbers);
@@ -37,6 +52,12 @@ public class CatalogLimitedConfiguration implements Runnable {
     public int getNumber() {
         synchronized (this.limitedNumbers) {
             return this.limitedNumbers.pop();
+        }
+    }
+
+    OptionalInt pollNumber() {
+        synchronized (this.limitedNumbers) {
+            return OptionalInt.of(this.limitedNumbers.pop());
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
@@ -57,7 +57,8 @@ public class CatalogLimitedConfiguration implements Runnable {
 
     OptionalInt pollNumber() {
         synchronized (this.limitedNumbers) {
-            return OptionalInt.of(this.limitedNumbers.pop());
+            Integer number = this.limitedNumbers.pollFirst();
+            return number == null ? OptionalInt.empty() : OptionalInt.of(number);
         }
     }
 
@@ -163,7 +164,9 @@ public class CatalogLimitedConfiguration implements Runnable {
     }
 
     public int available() {
-        return this.limitedNumbers.size();
+        synchronized (this.limitedNumbers) {
+            return this.limitedNumbers.size();
+        }
     }
 
     public int getTotalSet() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -1130,7 +1130,14 @@ public class CatalogManager {
                 if (totalPoints > habbo.getHabboInfo().getCurrencyAmount(item.getPointsType()))
                     return;
 
-                if (limitedConfiguration != null) limitedNumber = limitedConfiguration.getNumber();
+                if (limitedConfiguration != null) {
+                    OptionalInt limitedNumberReservation = limitedConfiguration.pollNumber();
+                    if (limitedNumberReservation.isEmpty()) {
+                        habbo.getClient().sendResponse(new AlertLimitedSoldOutComposer());
+                        return;
+                    }
+                    limitedNumber = limitedNumberReservation.getAsInt();
+                }
 
                 if (this.isAtomicEntitlementPurchase(item)) {
                     this.purchaseEntitlementsAtomically(item, habbo, amount, free, totalCredits, totalPoints);

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfigurationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfigurationTest.java
@@ -2,11 +2,21 @@ package com.eu.habbo.habbohotel.catalog;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.OptionalInt;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -32,10 +42,66 @@ class CatalogLimitedConfigurationTest {
         assertEquals(0, configuration.available());
     }
 
+    @Test
+    void internalPollingReportsEmptyStockWithoutThrowing() {
+        assertTrue(configurationWith().pollNumber().isEmpty());
+    }
+
+    @Test
+    void concurrentPollingReservesTheLastNumberOnce() throws Exception {
+        CatalogLimitedConfiguration configuration = configurationWith(17);
+        int buyers = 8;
+        CountDownLatch ready = new CountDownLatch(buyers);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(buyers);
+
+        try {
+            List<Future<OptionalInt>> reservations = new ArrayList<>();
+            for (int buyer = 0; buyer < buyers; buyer++) {
+                reservations.add(executor.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    return configuration.pollNumber();
+                }));
+            }
+
+            assertTrue(ready.await(2, TimeUnit.SECONDS));
+            start.countDown();
+
+            int reserved = 0;
+            for (Future<OptionalInt> reservation : reservations) {
+                if (reservation.get(2, TimeUnit.SECONDS).isPresent()) reserved++;
+            }
+
+            assertEquals(1, reserved);
+            assertEquals(0, configuration.available());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void purchasePathMapsAnEmptyReservationToSoldOut() throws Exception {
+        String manager = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"
+        ));
+        String configuration = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java"
+        ));
+
+        assertTrue(manager.contains("limitedConfiguration.pollNumber()"));
+        assertTrue(manager.contains("limitedNumberReservation.isEmpty()"));
+        assertFalse(manager.contains("limitedNumber = limitedConfiguration.getNumber()"));
+        assertTrue(configuration.contains("this.limitedNumbers.pollFirst()"));
+        assertTrue(configuration.contains(
+                "public int available() {\n        synchronized (this.limitedNumbers) {"
+        ));
+    }
+
     private static CatalogLimitedConfiguration configurationWith(Integer... numbers) {
         return new CatalogLimitedConfiguration(
                 1,
-                new LinkedList<>(java.util.List.of(numbers)),
+                new LinkedList<>(List.of(numbers)),
                 numbers.length,
                 false
         );

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfigurationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfigurationTest.java
@@ -1,0 +1,43 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedList;
+import java.util.NoSuchElementException;
+import java.util.OptionalInt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogLimitedConfigurationTest {
+
+    @Test
+    void publicNumberDrawingKeepsItsExistingLifoAndEmptyBehavior() {
+        CatalogLimitedConfiguration configuration = configurationWith(1, 2);
+
+        assertEquals(2, configuration.getNumber());
+        assertEquals(1, configuration.getNumber());
+        assertThrows(NoSuchElementException.class, configuration::getNumber);
+    }
+
+    @Test
+    void internalPollingReturnsAnAvailableNumber() {
+        CatalogLimitedConfiguration configuration = configurationWith(17);
+
+        OptionalInt number = configuration.pollNumber();
+
+        assertTrue(number.isPresent());
+        assertEquals(17, number.getAsInt());
+        assertEquals(0, configuration.available());
+    }
+
+    private static CatalogLimitedConfiguration configurationWith(Integer... numbers) {
+        return new CatalogLimitedConfiguration(
+                1,
+                new LinkedList<>(java.util.List.of(numbers)),
+                numbers.length,
+                false
+        );
+    }
+}


### PR DESCRIPTION
Uses an atomic limited-number reservation so concurrent buyers cannot turn the last-unit race into a generic server error. A buyer that loses the final serial now receives the existing sold-out response while the legacy public API remains compatible.
