### PR TITLE
fix(catalog): snapshot reloadable cache reads

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -51,6 +51,12 @@ public class CatalogManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogManager.class);
 
+    public record GiftWrappingSnapshot(
+            Map<Integer, Integer> wrappers,
+            Map<Integer, Integer> furniture
+    ) {
+    }
+
     public static final Map<String, Class<? extends CatalogPage>> pageDefinitions = new HashMap<String, Class<? extends CatalogPage>>(CatalogPageLayouts.values().length) {
         {
             for (CatalogPageLayouts layout : CatalogPageLayouts.values()) {
@@ -453,11 +459,11 @@ public class CatalogManager {
 
 
     private synchronized void loadCatalogFeaturedPages() {
-        this.catalogFeaturedPages.clear();
+        Int2ObjectMap<CatalogFeaturedPage> loadedFeaturedPages = new Int2ObjectOpenHashMap<>();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM catalog_featured_pages ORDER BY slot_id ASC")) {
             while (set.next()) {
-                this.catalogFeaturedPages.put(set.getInt("slot_id"), new CatalogFeaturedPage(
+                loadedFeaturedPages.put(set.getInt("slot_id"), new CatalogFeaturedPage(
                         set.getInt("slot_id"),
                         set.getString("caption"),
                         set.getString("image"),
@@ -471,6 +477,8 @@ public class CatalogManager {
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
         }
+
+        this.replaceFeaturedPages(loadedFeaturedPages);
     }
 
     private synchronized void loadCatalogItems() {
@@ -597,20 +605,20 @@ public class CatalogManager {
     }
 
     private void loadTargetOffers() {
-        synchronized (this.targetOffers) {
-            this.targetOffers.clear();
+        Map<Integer, TargetOffer> loadedTargetOffers = new HashMap<>();
 
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM catalog_target_offers WHERE end_timestamp > ?")) {
-                statement.setInt(1, Emulator.getIntUnixTimestamp());
-                try (ResultSet set = statement.executeQuery()) {
-                    while (set.next()) {
-                        this.targetOffers.put(set.getInt("id"), new TargetOffer(set));
-                    }
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM catalog_target_offers WHERE end_timestamp > ?")) {
+            statement.setInt(1, Emulator.getIntUnixTimestamp());
+            try (ResultSet set = statement.executeQuery()) {
+                while (set.next()) {
+                    loadedTargetOffers.put(set.getInt("id"), new TargetOffer(set));
                 }
-            } catch (SQLException e) {
-                LOGGER.error("Caught SQL exception", e);
             }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
         }
+
+        replaceContents(this.targetOffers, loadedTargetOffers);
     }
 
 
@@ -630,72 +638,87 @@ public class CatalogManager {
 
 
     public void loadRecycler() {
-        synchronized (this.prizes) {
-            this.prizes.clear();
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM recycler_prizes")) {
-                while (set.next()) {
-                    Item item = Emulator.getGameEnvironment().getItemManager().getItem(set.getInt("item_id"));
+        Map<Integer, Set<Item>> loadedPrizes = new HashMap<>();
 
-                    if (item != null) {
-                        if (this.prizes.get(set.getInt("rarity")) == null) {
-                            this.prizes.put(set.getInt("rarity"), new HashSet<>());
-                        }
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM recycler_prizes")) {
+            while (set.next()) {
+                Item item = Emulator.getGameEnvironment().getItemManager().getItem(set.getInt("item_id"));
 
-                        this.prizes.get(set.getInt("rarity")).add(item);
-                    } else {
-                        LOGGER.error("Cannot load item with ID: {} as recycler reward!", set.getInt("item_id"));
+                if (item != null) {
+                    if (loadedPrizes.get(set.getInt("rarity")) == null) {
+                        loadedPrizes.put(set.getInt("rarity"), new HashSet<>());
                     }
+
+                    loadedPrizes.get(set.getInt("rarity")).add(item);
+                } else {
+                    LOGGER.error("Cannot load item with ID: {} as recycler reward!", set.getInt("item_id"));
                 }
-            } catch (SQLException e) {
-                LOGGER.error("Caught SQL exception", e);
             }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
         }
+
+        replaceContents(this.prizes, loadedPrizes);
     }
 
 
     public void loadGiftWrappers() {
+        Map<Integer, Integer> loadedGiftWrappers = new HashMap<>();
+        Map<Integer, Integer> loadedGiftFurnis = new HashMap<>();
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM gift_wrappers ORDER BY sprite_id DESC")) {
+            while (set.next()) {
+                switch (set.getString("type")) {
+                    case "wrapper":
+                        loadedGiftWrappers.put(set.getInt("sprite_id"), set.getInt("item_id"));
+                        break;
+
+                    case "gift":
+                        loadedGiftFurnis.put(set.getInt("sprite_id"), set.getInt("item_id"));
+                        break;
+                }
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+
+        this.replaceGiftWrapping(loadedGiftWrappers, loadedGiftFurnis);
+    }
+
+    void replaceGiftWrapping(
+            Map<Integer, Integer> loadedGiftWrappers,
+            Map<Integer, Integer> loadedGiftFurnis
+    ) {
         synchronized (this.giftWrappers) {
             synchronized (this.giftFurnis) {
                 this.giftWrappers.clear();
                 this.giftFurnis.clear();
-
-                try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM gift_wrappers ORDER BY sprite_id DESC")) {
-                    while (set.next()) {
-                        switch (set.getString("type")) {
-                            case "wrapper":
-                                this.giftWrappers.put(set.getInt("sprite_id"), set.getInt("item_id"));
-                                break;
-
-                            case "gift":
-                                this.giftFurnis.put(set.getInt("sprite_id"), set.getInt("item_id"));
-                                break;
-                        }
-                    }
-                } catch (SQLException e) {
-                    LOGGER.error("Caught SQL exception", e);
-                }
+                this.giftWrappers.putAll(loadedGiftWrappers);
+                this.giftFurnis.putAll(loadedGiftFurnis);
             }
         }
     }
 
     private void loadClothing() {
-        synchronized (this.clothing) {
-            this.clothing.clear();
+        Map<Integer, ClothItem> loadedClothing = new HashMap<>();
 
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM catalog_clothing")) {
-                while (set.next()) {
-                    this.clothing.put(set.getInt("id"), new ClothItem(set));
-                }
-            } catch (SQLException e) {
-                LOGGER.error("Caught SQL exception", e);
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM catalog_clothing")) {
+            while (set.next()) {
+                loadedClothing.put(set.getInt("id"), new ClothItem(set));
             }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
         }
+
+        replaceContents(this.clothing, loadedClothing);
     }
 
     public ClothItem getClothing(String name) {
-        for (ClothItem item : this.clothing.values()) {
-            if (item.name.equalsIgnoreCase(name)) {
-                return item;
+        synchronized (this.clothing) {
+            for (ClothItem item : this.clothing.values()) {
+                if (item.name.equalsIgnoreCase(name)) {
+                    return item;
+                }
             }
         }
 
@@ -853,6 +876,45 @@ public class CatalogManager {
         return this.catalogFeaturedPages;
     }
 
+    public List<CatalogFeaturedPage> getCatalogFeaturedPagesSnapshot() {
+        synchronized (this.catalogFeaturedPages) {
+            return new ArrayList<>(this.catalogFeaturedPages.values());
+        }
+    }
+
+    public GiftWrappingSnapshot getGiftWrappingSnapshot() {
+        synchronized (this.giftWrappers) {
+            synchronized (this.giftFurnis) {
+                return new GiftWrappingSnapshot(
+                        new HashMap<>(this.giftWrappers),
+                        new HashMap<>(this.giftFurnis)
+                );
+            }
+        }
+    }
+
+    public Map<Integer, Set<Item>> getRecyclerPrizesSnapshot() {
+        synchronized (this.prizes) {
+            Map<Integer, Set<Item>> snapshot = new HashMap<>();
+            for (Map.Entry<Integer, Set<Item>> entry : this.prizes.entrySet()) {
+                snapshot.put(entry.getKey(), new HashSet<>(entry.getValue()));
+            }
+            return snapshot;
+        }
+    }
+
+    public Map<Integer, ClothItem> getClothingSnapshot() {
+        synchronized (this.clothing) {
+            return new HashMap<>(this.clothing);
+        }
+    }
+
+    public Map<Integer, TargetOffer> getTargetOffersSnapshot() {
+        synchronized (this.targetOffers) {
+            return new HashMap<>(this.targetOffers);
+        }
+    }
+
 
     public CatalogItem getClubItem(int itemId) {
         synchronized (this.clubItems) {
@@ -902,12 +964,14 @@ public class CatalogManager {
             level = 2;
         }
 
-        if (this.prizes.containsKey(level) && !this.prizes.get(level).isEmpty()) {
-            return (Item) this.prizes.get(level).toArray()[Emulator.getRandom().nextInt(this.prizes.get(level).size())];
-        } else {
-            LOGGER.error("No rewards specified for rarity level {}", level);
+        synchronized (this.prizes) {
+            Set<Item> levelPrizes = this.prizes.get(level);
+            if (levelPrizes != null && !levelPrizes.isEmpty()) {
+                return (Item) levelPrizes.toArray()[Emulator.getRandom().nextInt(levelPrizes.size())];
+            }
         }
 
+        LOGGER.error("No rewards specified for rarity level {}", level);
         return null;
     }
 
@@ -1949,7 +2013,23 @@ public class CatalogManager {
     }
 
     public TargetOffer getTargetOffer(int offerId) {
-        return this.targetOffers.get(offerId);
+        synchronized (this.targetOffers) {
+            return this.targetOffers.get(offerId);
+        }
+    }
+
+    void replaceFeaturedPages(Int2ObjectMap<CatalogFeaturedPage> loadedFeaturedPages) {
+        synchronized (this.catalogFeaturedPages) {
+            this.catalogFeaturedPages.clear();
+            this.catalogFeaturedPages.putAll(loadedFeaturedPages);
+        }
+    }
+
+    static <K, V> void replaceContents(Map<K, V> target, Map<K, V> loaded) {
+        synchronized (target) {
+            target.clear();
+            target.putAll(loaded);
+        }
     }
 
     private int calculateDiscountedPrice(int originalPrice, int amount, CatalogItem item) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -209,6 +209,10 @@ public class CatalogManager {
     private volatile byte[] rareValuesPayloadCache;
 
     public CatalogManager() {
+        this(true);
+    }
+
+    CatalogManager(boolean initialize) {
         long millis = System.currentTimeMillis();
         this.catalogPages = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
         this.buildersClubCatalogPages = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
@@ -226,11 +230,13 @@ public class CatalogManager {
         this.limitedNumbers = new HashMap<>();
         this.furnitureValues = new Int2ObjectOpenHashMap<>();
 
-        this.initialize();
-
-        this.ecotronItem = Emulator.getGameEnvironment().getItemManager().getItem("ecotron_box");
-
-        LOGGER.info("Catalog Manager -> Loaded! ({} MS)", System.currentTimeMillis() - millis);
+        if (initialize) {
+            this.initialize();
+            this.ecotronItem = Emulator.getGameEnvironment().getItemManager().getItem("ecotron_box");
+            LOGGER.info("Catalog Manager -> Loaded! ({} MS)", System.currentTimeMillis() - millis);
+        } else {
+            this.ecotronItem = null;
+        }
     }
 
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/layouts/FrontPageFeaturedLayout.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/layouts/FrontPageFeaturedLayout.java
@@ -7,6 +7,7 @@ import com.eu.habbo.messages.ServerMessage;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 
 public class FrontPageFeaturedLayout extends CatalogPage {
     public FrontPageFeaturedLayout(ResultSet set) throws SQLException {
@@ -36,9 +37,11 @@ public class FrontPageFeaturedLayout extends CatalogPage {
 
     public void serializeExtra(ServerMessage message) {
 
-        message.appendInt(Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPages().size());
+        List<CatalogFeaturedPage> featuredPages = Emulator.getGameEnvironment().getCatalogManager()
+                .getCatalogFeaturedPagesSnapshot();
+        message.appendInt(featuredPages.size());
 
-        for (CatalogFeaturedPage page : Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPages().values()) {
+        for (CatalogFeaturedPage page : featuredPages) {
             page.serialize(message);
         }
         message.appendInt(1); //Position

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/GiftCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/GiftCommand.java
@@ -64,7 +64,11 @@ public class GiftCommand extends Command {
 
             HabboItem item = Emulator.getGameEnvironment().getItemManager().createItem(0, baseItem, 0, 0, "");
 
-            Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem((Integer) Emulator.getGameEnvironment().getCatalogManager().giftFurnis.values().toArray()[Emulator.getRandom().nextInt(Emulator.getGameEnvironment().getCatalogManager().giftFurnis.size())]);
+            Map<Integer, Integer> giftFurniture = Emulator.getGameEnvironment().getCatalogManager()
+                    .getGiftWrappingSnapshot().furniture();
+            Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem(
+                    (Integer) giftFurniture.values().toArray()[Emulator.getRandom().nextInt(giftFurniture.size())]
+            );
 
             String extraData = "1\t" + item.getId();
             extraData += "\t0\t0\t0\t" + finalMessage + "\t0\t0";

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/MassGiftCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/MassGiftCommand.java
@@ -58,6 +58,8 @@ public class MassGiftCommand extends Command {
             keys.put("image", "${image.library.url}notifications/gift.gif");
             keys.put("message", Emulator.getTexts().getValue("generic.gift.received.anonymous"));
             ServerMessage giftNotificiationMessage = new BubbleAlertComposer(BubbleAlertKeys.RECEIVED_BADGE.key, keys).compose();
+            Map<Integer, Integer> giftFurniture = Emulator.getGameEnvironment().getCatalogManager()
+                    .getGiftWrappingSnapshot().furniture();
 
             Emulator.getThreading().run(() -> {
                 for (Map.Entry<Integer, Habbo> set : Emulator.getGameEnvironment().getHabboManager().getOnlineHabbos().entrySet()) {
@@ -65,7 +67,9 @@ public class MassGiftCommand extends Command {
 
                     HabboItem item = Emulator.getGameEnvironment().getItemManager().createItem(0, baseItem, 0, 0, "");
 
-                    Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem((Integer) Emulator.getGameEnvironment().getCatalogManager().giftFurnis.values().toArray()[Emulator.getRandom().nextInt(Emulator.getGameEnvironment().getCatalogManager().giftFurnis.size())]);
+                    Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem(
+                            (Integer) giftFurniture.values().toArray()[Emulator.getRandom().nextInt(giftFurniture.size())]
+                    );
 
                     String extraData = "1\t" + item.getId();
                     extraData += "\t0\t0\t0\t" + finalMessage + "\t0\t0";

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/PromoteTargetOfferCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/PromoteTargetOfferCommand.java
@@ -27,7 +27,8 @@ public class PromoteTargetOfferCommand extends Command {
         String offerKey = params[1];
 
         if (offerKey.equalsIgnoreCase(Emulator.getTexts().getValue("commands.cmd_promote_offer.info"))) {
-            Map<Integer, TargetOffer> targetOffers = Emulator.getGameEnvironment().getCatalogManager().targetOffers;
+            Map<Integer, TargetOffer> targetOffers = Emulator.getGameEnvironment().getCatalogManager()
+                    .getTargetOffersSnapshot();
             String[] textConfig = Emulator.getTexts().getValue("commands.cmd_promote_offer.list").replace("%amount%", targetOffers.size() + "").split("<br>");
 
             String entryConfig = Emulator.getTexts().getValue("commands.cmd_promote_offer.list.entry");

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/RoomGiftCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/RoomGiftCommand.java
@@ -9,6 +9,8 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.wired.WiredRewardAlertComposer;
 
+import java.util.Map;
+
 public class RoomGiftCommand extends Command {
     public RoomGiftCommand() {
         super("cmd_roomgift", Emulator.getTexts().getValue("commands.keys.cmd_roomgift").split(";"));
@@ -47,11 +49,15 @@ public class RoomGiftCommand extends Command {
             }
 
             final String finalMessage = message.toString();
+            Map<Integer, Integer> giftFurniture = Emulator.getGameEnvironment().getCatalogManager()
+                    .getGiftWrappingSnapshot().furniture();
 
             for (Habbo habbo : gameClient.getHabbo().getHabboInfo().getCurrentRoom().getHabbos()) {
                 HabboItem item = Emulator.getGameEnvironment().getItemManager().createItem(0, baseItem, 0, 0, "");
 
-                Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem((Integer) Emulator.getGameEnvironment().getCatalogManager().giftFurnis.values().toArray()[Emulator.getRandom().nextInt(Emulator.getGameEnvironment().getCatalogManager().giftFurnis.size())]);
+                Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem(
+                        (Integer) giftFurniture.values().toArray()[Emulator.getRandom().nextInt(giftFurniture.size())]
+                );
 
                 String extraData = "1\t" + item.getId();
                 extraData += "\t0\t0\t0\t" + finalMessage + "\t0\t0";

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -628,7 +628,7 @@ public class Habbo implements Runnable {
     public Set<Integer> getForbiddenClothing() {
         IntCollection clothingIDs = this.getInventory().getWardrobeComponent().getClothing();
 
-        return Emulator.getGameEnvironment().getCatalogManager().clothing.values().stream()
+        return Emulator.getGameEnvironment().getCatalogManager().getClothingSnapshot().values().stream()
                 .filter(c -> !clothingIDs.contains(c.id))
                 .map(c -> c.setId)
                 .flatMap(c -> Arrays.stream(c).boxed())

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
@@ -104,8 +104,12 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                     return;
                 }
 
-                if (!Emulator.getGameEnvironment().getCatalogManager().giftWrappers.containsKey(spriteId)
-                        && !Emulator.getGameEnvironment().getCatalogManager().giftFurnis.containsKey(spriteId)) {
+                CatalogManager.GiftWrappingSnapshot giftWrapping =
+                        Emulator.getGameEnvironment().getCatalogManager().getGiftWrappingSnapshot();
+                Map<Integer, Integer> giftWrappers = giftWrapping.wrappers();
+                Map<Integer, Integer> giftFurniture = giftWrapping.furniture();
+
+                if (!giftWrappers.containsKey(spriteId) && !giftFurniture.containsKey(spriteId)) {
                     LOGGER.debug("invalid spriteId for gift wrapper/furni -> {}", spriteId);
                     this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                     return;
@@ -117,10 +121,10 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                     return;
                 }
 
-                Integer iItemId = Emulator.getGameEnvironment().getCatalogManager().giftWrappers.get(spriteId);
+                Integer iItemId = giftWrappers.get(spriteId);
 
                 if (iItemId == null) {
-                    iItemId = Emulator.getGameEnvironment().getCatalogManager().giftFurnis.get(spriteId);
+                    iItemId = giftFurniture.get(spriteId);
                 }
 
                 if (iItemId == null) {
@@ -133,11 +137,12 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
 
                 if (giftItem == null) {
                     LOGGER.debug("direct giftItem null, trying random fallback. iItemId={}", iItemId);
-                    giftItem = Emulator.getGameEnvironment().getItemManager().getItem(
-                            (Integer) Emulator.getGameEnvironment().getCatalogManager().giftFurnis.values().toArray()[
-                                    Emulator.getRandom().nextInt(Emulator.getGameEnvironment().getCatalogManager().giftFurnis.size())
-                                    ]
-                    );
+                    Object[] giftFurnitureIds = giftFurniture.values().toArray();
+                    if (giftFurnitureIds.length > 0) {
+                        giftItem = Emulator.getGameEnvironment().getItemManager().getItem(
+                                (Integer) giftFurnitureIds[Emulator.getRandom().nextInt(giftFurnitureIds.length)]
+                        );
+                    }
 
                     if (giftItem == null) {
                         LOGGER.debug("fallback giftItem also null");
@@ -230,7 +235,7 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                     }
 
                     // Paid wrapping (giftWrappers) costs hotel.gifts.special.price; default furni wrap is free.
-                    boolean isPaidWrap = Emulator.getGameEnvironment().getCatalogManager().giftWrappers.containsKey(spriteId);
+                    boolean isPaidWrap = giftWrappers.containsKey(spriteId);
                     int wrapFee = isPaidWrap ? Emulator.getConfig().getInt("hotel.gifts.special.price", 0) : 0;
                     int totalCredits;
                     int totalPoints;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPageComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPageComposer.java
@@ -62,9 +62,11 @@ public class CatalogPageComposer extends MessageComposer {
     }
 
     public void serializeExtra(ServerMessage message) {
-        message.appendInt(Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPages().size());
+        List<CatalogFeaturedPage> featuredPages = Emulator.getGameEnvironment().getCatalogManager()
+                .getCatalogFeaturedPagesSnapshot();
+        message.appendInt(featuredPages.size());
 
-        for (CatalogFeaturedPage page : Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPages().values()) {
+        for (CatalogFeaturedPage page : featuredPages) {
             page.serialize(message);
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/GiftConfigurationComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/GiftConfigurationComposer.java
@@ -19,8 +19,10 @@ public class GiftConfigurationComposer extends MessageComposer {
         this.response.appendBoolean(true);
         this.response.appendInt(Emulator.getConfig().getInt("hotel.gifts.special.price", 2));
 
-        this.response.appendInt(Emulator.getGameEnvironment().getCatalogManager().giftWrappers.size());
-        for (Integer i : Emulator.getGameEnvironment().getCatalogManager().giftWrappers.keySet()) {
+        var giftWrapping = Emulator.getGameEnvironment().getCatalogManager().getGiftWrappingSnapshot();
+
+        this.response.appendInt(giftWrapping.wrappers().size());
+        for (Integer i : giftWrapping.wrappers().keySet()) {
             this.response.appendInt(i);
         }
 
@@ -34,9 +36,9 @@ public class GiftConfigurationComposer extends MessageComposer {
             this.response.appendInt(type);
         }
 
-        this.response.appendInt(Emulator.getGameEnvironment().getCatalogManager().giftFurnis.size());
+        this.response.appendInt(giftWrapping.furniture().size());
 
-        for (Map.Entry<Integer, Integer> set : Emulator.getGameEnvironment().getCatalogManager().giftFurnis.entrySet()) {
+        for (Map.Entry<Integer, Integer> set : giftWrapping.furniture().entrySet()) {
             this.response.appendInt(set.getKey());
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/RecyclerLogicComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/RecyclerLogicComposer.java
@@ -13,8 +13,10 @@ public class RecyclerLogicComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.RecyclerLogicComposer);
-        this.response.appendInt(Emulator.getGameEnvironment().getCatalogManager().prizes.size());
-        for (Map.Entry<Integer, Set<Item>> map : Emulator.getGameEnvironment().getCatalogManager().prizes.entrySet()) {
+        Map<Integer, Set<Item>> prizes = Emulator.getGameEnvironment().getCatalogManager()
+                .getRecyclerPrizesSnapshot();
+        this.response.appendInt(prizes.size());
+        for (Map.Entry<Integer, Set<Item>> map : prizes.entrySet()) {
             this.response.appendInt(map.getKey());
             this.response.appendInt(Integer.valueOf(Emulator.getConfig().getValue("hotel.ecotron.rarity.chance." + map.getKey())));
             this.response.appendInt(map.getValue().size());

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/UserClothesComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/UserClothesComposer.java
@@ -8,6 +8,7 @@ import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 public class UserClothesComposer extends MessageComposer {
     private static class ClothEntry {
@@ -25,8 +26,11 @@ public class UserClothesComposer extends MessageComposer {
     private final ArrayList<ClothEntry> clothEntries = new ArrayList<>();
 
     public UserClothesComposer(Habbo habbo) {
+        Map<Integer, ClothItem> clothing = Emulator.getGameEnvironment().getCatalogManager()
+                .getClothingSnapshot();
+
         for (int value : habbo.getInventory().getWardrobeComponent().getClothing()) {
-            ClothItem item = Emulator.getGameEnvironment().getCatalogManager().clothing.get(value);
+            ClothItem item = clothing.get(value);
 
             if (item != null) {
                 for (Integer j : item.setId) {
@@ -37,7 +41,7 @@ public class UserClothesComposer extends MessageComposer {
             }
         }
 
-        for (ClothItem item : Emulator.getGameEnvironment().getCatalogManager().clothing.values()) {
+        for (ClothItem item : clothing.values()) {
             if (item != null) {
                 this.clothEntries.add(new ClothEntry(item.name, item.setId));
             }

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/SendGift.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/SendGift.java
@@ -10,6 +10,8 @@ import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.google.gson.Gson;
 import jakarta.validation.constraints.Positive;
 
+import java.util.Map;
+
 public class SendGift extends RCONMessage<SendGift.SendGiftJSON> {
     private static final int DEFAULT_MAX_MESSAGE_LENGTH = 300;
 
@@ -77,15 +79,17 @@ public class SendGift extends RCONMessage<SendGift.SendGiftJSON> {
     }
 
     private Item randomGiftItem() {
-        synchronized (Emulator.getGameEnvironment().getCatalogManager().giftFurnis) {
-            int size = Emulator.getGameEnvironment().getCatalogManager().giftFurnis.size();
-            if (size == 0) {
-                return null;
-            }
-
-            Object[] giftIds = Emulator.getGameEnvironment().getCatalogManager().giftFurnis.values().toArray();
-            return Emulator.getGameEnvironment().getItemManager().getItem((Integer) giftIds[Emulator.getRandom().nextInt(size)]);
+        Map<Integer, Integer> giftFurnis = Emulator.getGameEnvironment().getCatalogManager()
+                .getGiftWrappingSnapshot().furniture();
+        int size = giftFurnis.size();
+        if (size == 0) {
+            return null;
         }
+
+        Object[] giftIds = giftFurnis.values().toArray();
+        return Emulator.getGameEnvironment().getItemManager().getItem(
+                (Integer) giftIds[Emulator.getRandom().nextInt(size)]
+        );
     }
 
     static String sanitizeGiftMessage(String message) {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPublicCacheCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPublicCacheCompatibilityTest.java
@@ -1,0 +1,75 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.habbohotel.items.Item;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogPublicCacheCompatibilityTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void publicCatalogCachesRemainFinalMutableObjects() throws Exception {
+        Path configFile = this.tempDir.resolve("config.ini");
+        Files.writeString(configFile, "");
+        Field configField = Emulator.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        Object previousConfig = configField.get(null);
+        CatalogManager manager;
+        try {
+            configField.set(null, new ConfigurationManager(configFile.toString()));
+            manager = new CatalogManager(false);
+        } finally {
+            configField.set(null, previousConfig);
+        }
+
+        assertPublicFinalField("giftWrappers");
+        assertPublicFinalField("giftFurnis");
+        assertPublicFinalField("prizes");
+        assertPublicFinalField("targetOffers");
+        assertPublicFinalField("clothing");
+        assertPublicFinalField("catalogFeaturedPages");
+
+        Map<Integer, Integer> giftWrappers = manager.giftWrappers;
+        Map<Integer, Integer> giftFurnis = manager.giftFurnis;
+        Map<Integer, Set<Item>> prizes = manager.prizes;
+        Map<Integer, TargetOffer> targetOffers = manager.targetOffers;
+        Map<Integer, ClothItem> clothing = manager.clothing;
+
+        giftWrappers.put(1, 11);
+        giftFurnis.put(2, 22);
+        prizes.put(3, new java.util.HashSet<>());
+        targetOffers.put(4, null);
+        clothing.put(5, null);
+        manager.catalogFeaturedPages.put(6, null);
+
+        assertSame(giftWrappers, manager.giftWrappers);
+        assertSame(giftFurnis, manager.giftFurnis);
+        assertSame(prizes, manager.prizes);
+        assertSame(targetOffers, manager.targetOffers);
+        assertSame(clothing, manager.clothing);
+        assertEquals(11, manager.giftWrappers.get(1));
+        assertEquals(22, manager.giftFurnis.get(2));
+        assertTrue(manager.catalogFeaturedPages.containsKey(6));
+    }
+
+    private static void assertPublicFinalField(String name) throws Exception {
+        Field field = CatalogManager.class.getField(name);
+        assertTrue(Modifier.isPublic(field.getModifiers()));
+        assertTrue(Modifier.isFinal(field.getModifiers()));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPublicCacheCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPublicCacheCompatibilityTest.java
@@ -3,39 +3,33 @@ package com.eu.habbo.habbohotel.catalog;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.core.ConfigurationManager;
 import com.eu.habbo.habbohotel.items.Item;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CatalogPublicCacheCompatibilityTest {
 
-    @TempDir
-    Path tempDir;
-
     @Test
     void publicCatalogCachesRemainFinalMutableObjects() throws Exception {
-        Path configFile = this.tempDir.resolve("config.ini");
-        Files.writeString(configFile, "");
-        Field configField = Emulator.class.getDeclaredField("config");
-        configField.setAccessible(true);
-        Object previousConfig = configField.get(null);
-        CatalogManager manager;
-        try {
-            configField.set(null, new ConfigurationManager(configFile.toString()));
-            manager = new CatalogManager(false);
-        } finally {
-            configField.set(null, previousConfig);
-        }
+        CatalogManager manager = createManager();
 
         assertPublicFinalField("giftWrappers");
         assertPublicFinalField("giftFurnis");
@@ -67,9 +61,193 @@ class CatalogPublicCacheCompatibilityTest {
         assertTrue(manager.catalogFeaturedPages.containsKey(6));
     }
 
+    @Test
+    void firstPartyReadersUseSnapshotsAndReloadsReplaceContents() throws Exception {
+        String manager = source("habbohotel/catalog/CatalogManager.java");
+
+        assertTrue(manager.contains("GiftWrappingSnapshot getGiftWrappingSnapshot()"));
+        assertTrue(manager.contains("getRecyclerPrizesSnapshot()"));
+        assertTrue(manager.contains("getClothingSnapshot()"));
+        assertTrue(manager.contains("getTargetOffersSnapshot()"));
+        assertTrue(manager.contains("getCatalogFeaturedPagesSnapshot()"));
+        assertTrue(manager.contains("return this.catalogFeaturedPages;"),
+                "the legacy featured-page getter must remain live");
+
+        assertTrue(manager.contains("replaceContents(this.targetOffers, loadedTargetOffers);"));
+        assertTrue(manager.contains("replaceContents(this.prizes, loadedPrizes);"));
+        assertTrue(manager.contains("replaceContents(this.clothing, loadedClothing);"));
+        assertTrue(manager.contains("replaceGiftWrapping(loadedGiftWrappers, loadedGiftFurnis);"));
+        assertTrue(manager.contains("replaceFeaturedPages(loadedFeaturedPages);"));
+
+        assertNoDirectCacheRead("messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java",
+                ".giftWrappers", ".giftFurnis");
+        assertNoDirectCacheRead("messages/outgoing/catalog/GiftConfigurationComposer.java",
+                ".giftWrappers", ".giftFurnis");
+        assertNoDirectCacheRead("habbohotel/commands/GiftCommand.java", ".giftFurnis");
+        assertNoDirectCacheRead("habbohotel/commands/MassGiftCommand.java", ".giftFurnis");
+        assertNoDirectCacheRead("habbohotel/commands/RoomGiftCommand.java", ".giftFurnis");
+        assertNoDirectCacheRead("messages/rcon/SendGift.java", ".giftFurnis");
+        assertNoDirectCacheRead("messages/outgoing/catalog/RecyclerLogicComposer.java", ".prizes");
+        assertNoDirectCacheRead("messages/outgoing/users/UserClothesComposer.java", ".clothing");
+        assertNoDirectCacheRead("habbohotel/users/Habbo.java", ".clothing");
+        assertNoDirectCacheRead("habbohotel/commands/PromoteTargetOfferCommand.java", ".targetOffers");
+
+        assertFalse(source("messages/outgoing/catalog/CatalogPageComposer.java")
+                .contains("getCatalogFeaturedPages()"));
+        assertFalse(source("habbohotel/catalog/layouts/FrontPageFeaturedLayout.java")
+                .contains("getCatalogFeaturedPages()"));
+    }
+
+    @Test
+    void snapshotsAreIndependentAndCacheReplacementPreservesIdentity() throws Exception {
+        CatalogManager manager = createManager();
+        Map<Integer, Integer> giftWrappers = manager.giftWrappers;
+        Map<Integer, Integer> giftFurnis = manager.giftFurnis;
+        Map<Integer, Set<Item>> prizes = manager.prizes;
+        Map<Integer, TargetOffer> targetOffers = manager.targetOffers;
+        Map<Integer, ClothItem> clothing = manager.clothing;
+        var featuredPages = manager.catalogFeaturedPages;
+
+        manager.giftWrappers.put(1, 11);
+        manager.giftFurnis.put(2, 22);
+        manager.prizes.put(3, new HashSet<>());
+        manager.targetOffers.put(4, null);
+        manager.clothing.put(5, null);
+        manager.catalogFeaturedPages.put(6, null);
+
+        CatalogManager.GiftWrappingSnapshot giftSnapshot = manager.getGiftWrappingSnapshot();
+        giftSnapshot.wrappers().clear();
+        giftSnapshot.furniture().clear();
+        manager.getRecyclerPrizesSnapshot().get(3).add(null);
+        manager.getTargetOffersSnapshot().clear();
+        manager.getClothingSnapshot().clear();
+        manager.getCatalogFeaturedPagesSnapshot().clear();
+
+        assertEquals(11, manager.giftWrappers.get(1));
+        assertEquals(22, manager.giftFurnis.get(2));
+        assertFalse(manager.prizes.get(3).contains(null));
+        assertTrue(manager.targetOffers.containsKey(4));
+        assertTrue(manager.clothing.containsKey(5));
+        assertTrue(manager.catalogFeaturedPages.containsKey(6));
+
+        manager.replaceGiftWrapping(Map.of(7, 77), Map.of(8, 88));
+        CatalogManager.replaceContents(manager.prizes, Map.of(9, new HashSet<>()));
+        Map<Integer, TargetOffer> replacementOffers = new HashMap<>();
+        replacementOffers.put(10, null);
+        CatalogManager.replaceContents(manager.targetOffers, replacementOffers);
+        Map<Integer, ClothItem> replacementClothing = new HashMap<>();
+        replacementClothing.put(11, null);
+        CatalogManager.replaceContents(manager.clothing, replacementClothing);
+        var replacementFeaturedPages = new Int2ObjectOpenHashMap<CatalogFeaturedPage>();
+        replacementFeaturedPages.put(12, null);
+        manager.replaceFeaturedPages(replacementFeaturedPages);
+
+        assertSame(giftWrappers, manager.giftWrappers);
+        assertSame(giftFurnis, manager.giftFurnis);
+        assertSame(prizes, manager.prizes);
+        assertSame(targetOffers, manager.targetOffers);
+        assertSame(clothing, manager.clothing);
+        assertSame(featuredPages, manager.catalogFeaturedPages);
+        assertEquals(Map.of(7, 77), manager.giftWrappers);
+        assertEquals(Map.of(8, 88), manager.giftFurnis);
+        assertTrue(manager.prizes.containsKey(9));
+        assertTrue(manager.targetOffers.containsKey(10));
+        assertTrue(manager.clothing.containsKey(11));
+        assertTrue(manager.catalogFeaturedPages.containsKey(12));
+    }
+
+    @Test
+    void concurrentReloadReplacementAndSnapshotIterationRemainConsistent() throws Exception {
+        CatalogManager manager = createManager();
+        Map<Integer, Integer> giftWrappers = manager.giftWrappers;
+        Map<Integer, Integer> giftFurnis = manager.giftFurnis;
+        Map<Integer, Set<Item>> prizes = manager.prizes;
+        Map<Integer, TargetOffer> targetOffers = manager.targetOffers;
+        Map<Integer, ClothItem> clothing = manager.clothing;
+        var featuredPages = manager.catalogFeaturedPages;
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<?> reloads = executor.submit(() -> {
+                start.await();
+                for (int index = 0; index < 1_000; index++) {
+                    manager.replaceGiftWrapping(Map.of(index, index), Map.of(index, index));
+                    CatalogManager.replaceContents(manager.prizes, Map.of(index, new HashSet<>()));
+
+                    Map<Integer, TargetOffer> offers = new HashMap<>();
+                    offers.put(index, null);
+                    CatalogManager.replaceContents(manager.targetOffers, offers);
+
+                    Map<Integer, ClothItem> clothes = new HashMap<>();
+                    clothes.put(index, null);
+                    CatalogManager.replaceContents(manager.clothing, clothes);
+
+                    var featured = new Int2ObjectOpenHashMap<CatalogFeaturedPage>();
+                    featured.put(index, null);
+                    manager.replaceFeaturedPages(featured);
+                }
+                return null;
+            });
+            Future<?> readers = executor.submit(() -> {
+                start.await();
+                for (int index = 0; index < 1_000; index++) {
+                    CatalogManager.GiftWrappingSnapshot giftWrapping = manager.getGiftWrappingSnapshot();
+                    assertEquals(giftWrapping.wrappers().keySet(), giftWrapping.furniture().keySet());
+                    manager.getRecyclerPrizesSnapshot().values().forEach(Set::size);
+                    manager.getTargetOffersSnapshot().values().forEach(value -> {
+                    });
+                    manager.getClothingSnapshot().values().forEach(value -> {
+                    });
+                    manager.getCatalogFeaturedPagesSnapshot().forEach(value -> {
+                    });
+                }
+                return null;
+            });
+
+            start.countDown();
+            reloads.get(5, TimeUnit.SECONDS);
+            readers.get(5, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertSame(giftWrappers, manager.giftWrappers);
+        assertSame(giftFurnis, manager.giftFurnis);
+        assertSame(prizes, manager.prizes);
+        assertSame(targetOffers, manager.targetOffers);
+        assertSame(clothing, manager.clothing);
+        assertSame(featuredPages, manager.catalogFeaturedPages);
+    }
+
     private static void assertPublicFinalField(String name) throws Exception {
         Field field = CatalogManager.class.getField(name);
         assertTrue(Modifier.isPublic(field.getModifiers()));
         assertTrue(Modifier.isFinal(field.getModifiers()));
+    }
+
+    private static void assertNoDirectCacheRead(String relativePath, String... fragments) throws Exception {
+        String source = source(relativePath);
+        for (String fragment : fragments) {
+            assertFalse(source.contains(fragment), relativePath + " reads " + fragment + " directly");
+        }
+    }
+
+    private static String source(String relativePath) throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/" + relativePath));
+    }
+
+    private CatalogManager createManager() throws Exception {
+        Field configField = Emulator.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        Object previousConfig = configField.get(null);
+        try {
+            configField.set(null, new ConfigurationManager(
+                    Path.of("..", "config example", "config.ini.example").toString()
+            ));
+            return new CatalogManager(false);
+        } finally {
+            configField.set(null, previousConfig);
+        }
     }
 }


### PR DESCRIPTION
Builds reloadable catalog caches off to the side and updates their existing public map objects under the matching locks. First-party gift, recycler, clothing, target-offer, and featured-page readers now use consistent snapshots during catalog reloads.
