### PR TITLE
refactor(rooms): use owner index for unloading

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -58,6 +58,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 
 public class Room implements Comparable<Room>, ISerialize, Runnable {
 
@@ -136,6 +137,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   public ScheduledFuture<?> roomCycleTask;
   private int id;
   private int ownerId;
+  private volatile BiConsumer<Room, Integer> ownerChangeListener;
   private String ownerName;
   private String name;
   private String description;
@@ -1259,7 +1261,17 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   }
 
   public void setOwnerId(int ownerId) {
+    int previousOwnerId = this.ownerId;
     this.ownerId = ownerId;
+
+    BiConsumer<Room, Integer> listener = this.ownerChangeListener;
+    if (listener != null && previousOwnerId != ownerId) {
+      listener.accept(this, previousOwnerId);
+    }
+  }
+
+  void setOwnerChangeListener(BiConsumer<Room, Integer> ownerChangeListener) {
+    this.ownerChangeListener = ownerChangeListener;
   }
 
   public String getOwnerName() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -228,6 +228,18 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
   public final Map<String, Object> cache;
 
+  Room(int id, int ownerId) {
+    this.cache = new HashMap<>();
+    this.id = id;
+    this.ownerId = ownerId;
+    this.bannedHabbos = new Int2ObjectOpenHashMap<>();
+    this.moodlightData = new Int2ObjectOpenHashMap<>(defaultMoodData);
+    this.mutedHabbos = new Int2IntOpenHashMap();
+    this.games = ConcurrentHashMap.newKeySet();
+    this.rights = new IntArrayList();
+    this.userVotes = new ArrayList<>();
+  }
+
   public Room(ResultSet set) throws SQLException {
     this.cache = new HashMap<>(1000);
     this.id = set.getInt("id");

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -76,26 +76,33 @@ public class RoomManager {
     private final ArrayList<Class<? extends Game>> gameTypes;
 
     public RoomManager() {
+        this(true);
+    }
+
+    RoomManager(boolean initialize) {
         long millis = System.currentTimeMillis();
         this.roomCategories = new HashMap<>();
         this.mapNames = new ArrayList<>();
         this.layoutCache = new ConcurrentHashMap<>();
         this.activeRooms = new ConcurrentHashMap<>();
         this.roomsByOwner = new ConcurrentHashMap<>();
-        this.loadRoomCategories();
-        this.loadRoomModels();
 
         this.gameTypes = new ArrayList<>();
 
-        registerGameType(BattleBanzaiGame.class);
-        registerGameType(FreezeGame.class);
-        registerGameType(WiredGame.class);
-        registerGameType(FootballGame.class);
-        registerGameType(BunnyrunGame.class);
-        registerGameType(IceTagGame.class);
-        registerGameType(RollerskateGame.class);
+        if (initialize) {
+            this.loadRoomCategories();
+            this.loadRoomModels();
 
-        LOGGER.info("Room Manager -> Loaded! ({} MS)", System.currentTimeMillis() - millis);
+            registerGameType(BattleBanzaiGame.class);
+            registerGameType(FreezeGame.class);
+            registerGameType(WiredGame.class);
+            registerGameType(FootballGame.class);
+            registerGameType(BunnyrunGame.class);
+            registerGameType(IceTagGame.class);
+            registerGameType(RollerskateGame.class);
+
+            LOGGER.info("Room Manager -> Loaded! ({} MS)", System.currentTimeMillis() - millis);
+        }
     }
 
     private void trackRoomOwner(Room room) {
@@ -110,6 +117,11 @@ public class RoomManager {
                 this.roomsByOwner.remove(room.getOwnerId());
             }
         }
+    }
+
+    void registerActiveRoom(Room room) {
+        this.activeRooms.put(room.getId(), room);
+        this.trackRoomOwner(room);
     }
 
     public void loadRoomModels() {
@@ -162,8 +174,7 @@ public class RoomManager {
                 while (set.next()) {
                     Room room = new Room(set);
                     room.preventUncaching = true;
-                    this.activeRooms.put(set.getInt("id"), room);
-                    this.trackRoomOwner(room);
+                    this.registerActiveRoom(room);
                 }
             }
         } catch (SQLException e) {
@@ -393,8 +404,7 @@ public class RoomManager {
                 while (set.next()) {
                     if (!this.activeRooms.containsKey(set.getInt("id"))) {
                         Room room = new Room(set);
-                        this.activeRooms.put(room.getId(), room);
-                        this.trackRoomOwner(room);
+                        this.registerActiveRoom(room);
                     }
                 }
             }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 import java.sql.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class RoomManager {
 
@@ -73,6 +74,7 @@ public class RoomManager {
     private final ConcurrentHashMap<String, RoomLayoutData> layoutCache;
     private final ConcurrentHashMap<Integer, Room> activeRooms;
     private final ConcurrentHashMap<Integer, Set<Integer>> roomsByOwner;
+    private final AtomicInteger indexedRoomCount;
     private final ArrayList<Class<? extends Game>> gameTypes;
 
     public RoomManager() {
@@ -86,6 +88,7 @@ public class RoomManager {
         this.layoutCache = new ConcurrentHashMap<>();
         this.activeRooms = new ConcurrentHashMap<>();
         this.roomsByOwner = new ConcurrentHashMap<>();
+        this.indexedRoomCount = new AtomicInteger();
 
         this.gameTypes = new ArrayList<>();
 
@@ -106,22 +109,62 @@ public class RoomManager {
     }
 
     private void trackRoomOwner(Room room) {
-        this.roomsByOwner.computeIfAbsent(room.getOwnerId(), k -> ConcurrentHashMap.newKeySet()).add(room.getId());
+        if (this.roomsByOwner.computeIfAbsent(room.getOwnerId(), k -> ConcurrentHashMap.newKeySet()).add(room.getId())) {
+            this.indexedRoomCount.incrementAndGet();
+        }
     }
 
     private void untrackRoomOwner(Room room) {
-        Set<Integer> rooms = this.roomsByOwner.get(room.getOwnerId());
+        room.setOwnerChangeListener(null);
+        this.removeRoomFromOwner(room.getOwnerId(), room.getId());
+    }
+
+    private void removeRoomFromOwner(int ownerId, int roomId) {
+        Set<Integer> rooms = this.roomsByOwner.get(ownerId);
         if (rooms != null) {
-            rooms.remove(room.getId());
+            if (rooms.remove(roomId)) {
+                this.indexedRoomCount.decrementAndGet();
+            }
             if (rooms.isEmpty()) {
-                this.roomsByOwner.remove(room.getOwnerId());
+                this.roomsByOwner.remove(ownerId, rooms);
             }
         }
     }
 
     void registerActiveRoom(Room room) {
-        this.activeRooms.put(room.getId(), room);
+        Room previousRoom = this.activeRooms.put(room.getId(), room);
+        if (previousRoom != null) {
+            this.untrackRoomOwner(previousRoom);
+        }
+
+        room.setOwnerChangeListener(this::roomOwnerChanged);
         this.trackRoomOwner(room);
+    }
+
+    private void roomOwnerChanged(Room room, int previousOwnerId) {
+        if (this.activeRooms.get(room.getId()) != room) {
+            return;
+        }
+
+        this.removeRoomFromOwner(previousOwnerId, room.getId());
+        this.trackRoomOwner(room);
+    }
+
+    private void reconcileOwnerIndex() {
+        for (Map.Entry<Integer, Set<Integer>> entry : this.roomsByOwner.entrySet()) {
+            int indexedOwnerId = entry.getKey();
+            for (int roomId : new HashSet<>(entry.getValue())) {
+                Room room = this.activeRooms.get(roomId);
+                if (room == null || room.getOwnerId() != indexedOwnerId) {
+                    this.removeRoomFromOwner(indexedOwnerId, roomId);
+                }
+            }
+        }
+
+        for (Room room : this.activeRooms.values()) {
+            room.setOwnerChangeListener(this::roomOwnerChanged);
+            this.trackRoomOwner(room);
+        }
     }
 
     public void loadRoomModels() {
@@ -193,8 +236,7 @@ public class RoomManager {
 
                     if (room == null) {
                         room = new Room(set);
-                        this.activeRooms.put(set.getInt("id"), room);
-                        this.trackRoomOwner(room);
+                        this.registerActiveRoom(room);
                     }
 
                     if (!rooms.containsKey(set.getInt("category"))) {
@@ -353,8 +395,7 @@ public class RoomManager {
             }
 
             if (room != null) {
-                this.activeRooms.put(room.getId(), room);
-                this.trackRoomOwner(room);
+                this.registerActiveRoom(room);
             }
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
@@ -414,12 +455,8 @@ public class RoomManager {
     }
 
     public void unloadRoomsForHabbo(Habbo habbo) {
-        List<Room> roomsToDispose = new ArrayList<>();
-        for (Room room : this.activeRooms.values()) {
-            if (!room.isPublicRoom() && !room.isStaffPromotedRoom() && room.getOwnerId() == habbo.getHabboInfo().getId() && room.getUserCount() == 0 && (this.roomCategories.get(room.getCategory()) == null || !this.roomCategories.get(room.getCategory()).isPublic())) {
-                roomsToDispose.add(room);
-            }
-        }
+        int ownerId = habbo.getHabboInfo().getId();
+        List<Room> roomsToDispose = this.roomsToUnloadForOwner(ownerId);
 
         for (Room room : roomsToDispose) {
             if (Emulator.getPluginManager().fireEvent(new RoomUncachedEvent(room)).isCancelled())
@@ -429,6 +466,35 @@ public class RoomManager {
             this.untrackRoomOwner(room);
             this.activeRooms.remove(room.getId());
         }
+    }
+
+    List<Room> roomsToUnloadForOwner(int ownerId) {
+        if (this.indexedRoomCount.get() != this.activeRooms.size()) {
+            this.reconcileOwnerIndex();
+        }
+
+        List<Room> roomsToDispose = new ArrayList<>();
+        Set<Integer> roomIds = this.roomsByOwner.get(ownerId);
+        if (roomIds == null) {
+            return roomsToDispose;
+        }
+
+        for (int roomId : new HashSet<>(roomIds)) {
+            Room room = this.activeRooms.get(roomId);
+            if (room == null || room.getOwnerId() != ownerId) {
+                this.removeRoomFromOwner(ownerId, roomId);
+                if (room != null) {
+                    this.trackRoomOwner(room);
+                }
+                continue;
+            }
+
+            if (!room.isPublicRoom() && !room.isStaffPromotedRoom() && room.getUserCount() == 0 && (this.roomCategories.get(room.getCategory()) == null || !this.roomCategories.get(room.getCategory()).isPublic())) {
+                roomsToDispose.add(room);
+            }
+        }
+
+        return roomsToDispose;
     }
 
     public void clearInactiveRooms() {
@@ -1219,8 +1285,7 @@ public class RoomManager {
 
                     Room r = new Room(set);
                     rooms.add(r);
-                    this.activeRooms.put(r.getId(), r);
-                    this.trackRoomOwner(r);
+                    this.registerActiveRoom(r);
                 }
             }
         } catch (SQLException e) {
@@ -1280,8 +1345,7 @@ public class RoomManager {
                     Room r = new Room(set);
                     rooms.add(r);
 
-                    this.activeRooms.put(r.getId(), r);
-                    this.trackRoomOwner(r);
+                    this.registerActiveRoom(r);
                 }
             }
         } catch (SQLException e) {
@@ -1344,8 +1408,7 @@ public class RoomManager {
                     if (room == null) {
                         room = new Room(set);
 
-                        this.activeRooms.put(room.getId(), room);
-                        this.trackRoomOwner(room);
+                        this.registerActiveRoom(room);
                     }
 
                     rooms.add(room);
@@ -1581,9 +1644,11 @@ public class RoomManager {
     public synchronized void dispose() {
         for (Room room : this.activeRooms.values()) {
             room.dispose();
+            room.setOwnerChangeListener(null);
         }
 
         this.roomsByOwner.clear();
+        this.indexedRoomCount.set(0);
         this.activeRooms.clear();
 
         LOGGER.info("Room Manager -> Disposed!");

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomOwnerIndexTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomOwnerIndexTest.java
@@ -1,0 +1,42 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RoomOwnerIndexTest {
+
+    @Test
+    void firstPartyRegistrationCachesTheSameRoomAndTracksItsOwner() throws Exception {
+        RoomManager manager = new RoomManager(false);
+        Room room = mock(Room.class);
+        when(room.getId()).thenReturn(41);
+        when(room.getOwnerId()).thenReturn(7);
+
+        manager.registerActiveRoom(room);
+
+        assertSame(room, activeRooms(manager).get(41));
+        assertEquals(Set.of(41), roomsByOwner(manager).get(7));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<Integer, Room> activeRooms(RoomManager manager) throws Exception {
+        Field field = RoomManager.class.getDeclaredField("activeRooms");
+        field.setAccessible(true);
+        return (Map<Integer, Room>) field.get(manager);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<Integer, Set<Integer>> roomsByOwner(RoomManager manager) throws Exception {
+        Field field = RoomManager.class.getDeclaredField("roomsByOwner");
+        field.setAccessible(true);
+        return (Map<Integer, Set<Integer>>) field.get(manager);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomOwnerIndexTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomOwnerIndexTest.java
@@ -3,8 +3,10 @@ package com.eu.habbo.habbohotel.rooms;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.sql.ResultSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -14,22 +16,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Answers.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.clearInvocations;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class RoomOwnerIndexTest {
 
     @Test
     void firstPartyRegistrationCachesTheSameRoomAndTracksItsOwner() throws Exception {
         RoomManager manager = new RoomManager(false);
-        Room room = mock(Room.class);
-        when(room.getId()).thenReturn(41);
-        when(room.getOwnerId()).thenReturn(7);
+        Room room = eligibleRoom(41, 7);
 
         manager.registerActiveRoom(room);
 
@@ -40,15 +33,16 @@ class RoomOwnerIndexTest {
     @Test
     void unloadCandidatesUseTheOwnerIndexAndExcludeOtherOwners() {
         RoomManager manager = new RoomManager(false);
-        Room ownedRoom = eligibleRoom(41, 7);
-        Room otherRoom = eligibleRoom(42, 8);
+        TestRoom ownedRoom = eligibleRoom(41, 7);
+        TestRoom otherRoom = eligibleRoom(42, 8);
         manager.registerActiveRoom(ownedRoom);
         manager.registerActiveRoom(otherRoom);
-        clearInvocations(ownedRoom, otherRoom);
+        ownedRoom.resetEligibilityChecks();
+        otherRoom.resetEligibilityChecks();
 
         assertEquals(Set.of(ownedRoom), new HashSet<>(manager.roomsToUnloadForOwner(7)));
-        verify(ownedRoom).isPublicRoom();
-        verify(otherRoom, never()).isPublicRoom();
+        assertEquals(1, ownedRoom.eligibilityChecks());
+        assertEquals(0, otherRoom.eligibilityChecks());
     }
 
     @Test
@@ -81,18 +75,15 @@ class RoomOwnerIndexTest {
     @Test
     void unloadCandidatesPreserveAllLegacyEligibilityGuards() throws Exception {
         RoomManager manager = new RoomManager(false);
-        Room publicRoom = eligibleRoom(41, 7);
-        Room promotedRoom = eligibleRoom(42, 7);
-        Room occupiedRoom = eligibleRoom(43, 7);
-        Room publicCategoryRoom = eligibleRoom(44, 7);
-        doReturn(true).when(publicRoom).isPublicRoom();
-        doReturn(true).when(promotedRoom).isStaffPromotedRoom();
-        doReturn(1).when(occupiedRoom).getUserCount();
-        doReturn(9).when(publicCategoryRoom).getCategory();
-
-        RoomCategory publicCategory = mock(RoomCategory.class);
-        when(publicCategory.isPublic()).thenReturn(true);
-        roomCategories(manager).put(9, publicCategory);
+        TestRoom publicRoom = eligibleRoom(41, 7);
+        TestRoom promotedRoom = eligibleRoom(42, 7);
+        TestRoom occupiedRoom = eligibleRoom(43, 7);
+        TestRoom publicCategoryRoom = eligibleRoom(44, 7);
+        publicRoom.setPublicRoom(true);
+        promotedRoom.setStaffPromotedRoom(true);
+        occupiedRoom.setUserCount(1);
+        publicCategoryRoom.setCategory(9);
+        roomCategories(manager).put(9, publicCategory());
 
         manager.registerActiveRoom(publicRoom);
         manager.registerActiveRoom(promotedRoom);
@@ -120,15 +111,22 @@ class RoomOwnerIndexTest {
         assertTrue(untrack < removal);
     }
 
-    private static Room eligibleRoom(int id, int ownerId) {
-        Room room = mock(Room.class, CALLS_REAL_METHODS);
-        doReturn(id).when(room).getId();
-        room.setOwnerId(ownerId);
-        doReturn(false).when(room).isPublicRoom();
-        doReturn(false).when(room).isStaffPromotedRoom();
-        doReturn(0).when(room).getUserCount();
-        doReturn(0).when(room).getCategory();
-        return room;
+    private static TestRoom eligibleRoom(int id, int ownerId) {
+        return new TestRoom(id, ownerId);
+    }
+
+    private static RoomCategory publicCategory() throws Exception {
+        ResultSet row = (ResultSet) Proxy.newProxyInstance(
+                ResultSet.class.getClassLoader(),
+                new Class<?>[]{ResultSet.class},
+                (proxy, method, arguments) -> switch (method.getName()) {
+                    case "getInt" -> 0;
+                    case "getBoolean" -> false;
+                    case "getString" -> "public".equals(arguments[0]) ? "1" : "";
+                    case "toString" -> "public room category row";
+                    default -> throw new UnsupportedOperationException(method.getName());
+                });
+        return new RoomCategory(row);
     }
 
     @SuppressWarnings("unchecked")
@@ -150,5 +148,37 @@ class RoomOwnerIndexTest {
         Field field = RoomManager.class.getDeclaredField("roomsByOwner");
         field.setAccessible(true);
         return (Map<Integer, Set<Integer>>) field.get(manager);
+    }
+
+    private static final class TestRoom extends Room {
+        private int userCount;
+        private int eligibilityChecks;
+
+        private TestRoom(int id, int ownerId) {
+            super(id, ownerId);
+        }
+
+        @Override
+        public boolean isPublicRoom() {
+            this.eligibilityChecks++;
+            return super.isPublicRoom();
+        }
+
+        @Override
+        public int getUserCount() {
+            return this.userCount;
+        }
+
+        private void setUserCount(int userCount) {
+            this.userCount = userCount;
+        }
+
+        private int eligibilityChecks() {
+            return this.eligibilityChecks;
+        }
+
+        private void resetEligibilityChecks() {
+            this.eligibilityChecks = 0;
+        }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomOwnerIndexTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomOwnerIndexTest.java
@@ -3,12 +3,23 @@ package com.eu.habbo.habbohotel.rooms;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class RoomOwnerIndexTest {
@@ -26,11 +37,112 @@ class RoomOwnerIndexTest {
         assertEquals(Set.of(41), roomsByOwner(manager).get(7));
     }
 
+    @Test
+    void unloadCandidatesUseTheOwnerIndexAndExcludeOtherOwners() {
+        RoomManager manager = new RoomManager(false);
+        Room ownedRoom = eligibleRoom(41, 7);
+        Room otherRoom = eligibleRoom(42, 8);
+        manager.registerActiveRoom(ownedRoom);
+        manager.registerActiveRoom(otherRoom);
+        clearInvocations(ownedRoom, otherRoom);
+
+        assertEquals(Set.of(ownedRoom), new HashSet<>(manager.roomsToUnloadForOwner(7)));
+        verify(ownedRoom).isPublicRoom();
+        verify(otherRoom, never()).isPublicRoom();
+    }
+
+    @Test
+    void unloadCandidatesFindAndReindexRoomsWhosePublicOwnerWasChanged() throws Exception {
+        RoomManager manager = new RoomManager(false);
+        Room room = eligibleRoom(41, 8);
+        Room existingRoom = eligibleRoom(42, 7);
+        manager.registerActiveRoom(room);
+        manager.registerActiveRoom(existingRoom);
+
+        room.setOwnerId(7);
+
+        List<Room> candidates = manager.roomsToUnloadForOwner(7);
+
+        assertEquals(Set.of(room, existingRoom), new HashSet<>(candidates));
+        assertFalse(roomsByOwner(manager).getOrDefault(8, Set.of()).contains(41));
+        assertEquals(Set.of(41, 42), roomsByOwner(manager).get(7));
+    }
+
+    @Test
+    void unloadCandidatesRetainTheLegacyScanAsAFallback() throws Exception {
+        RoomManager manager = new RoomManager(false);
+        Room room = eligibleRoom(41, 7);
+        activeRooms(manager).put(room.getId(), room);
+
+        assertEquals(List.of(room), manager.roomsToUnloadForOwner(7));
+        assertEquals(Set.of(41), roomsByOwner(manager).get(7));
+    }
+
+    @Test
+    void unloadCandidatesPreserveAllLegacyEligibilityGuards() throws Exception {
+        RoomManager manager = new RoomManager(false);
+        Room publicRoom = eligibleRoom(41, 7);
+        Room promotedRoom = eligibleRoom(42, 7);
+        Room occupiedRoom = eligibleRoom(43, 7);
+        Room publicCategoryRoom = eligibleRoom(44, 7);
+        doReturn(true).when(publicRoom).isPublicRoom();
+        doReturn(true).when(promotedRoom).isStaffPromotedRoom();
+        doReturn(1).when(occupiedRoom).getUserCount();
+        doReturn(9).when(publicCategoryRoom).getCategory();
+
+        RoomCategory publicCategory = mock(RoomCategory.class);
+        when(publicCategory.isPublic()).thenReturn(true);
+        roomCategories(manager).put(9, publicCategory);
+
+        manager.registerActiveRoom(publicRoom);
+        manager.registerActiveRoom(promotedRoom);
+        manager.registerActiveRoom(occupiedRoom);
+        manager.registerActiveRoom(publicCategoryRoom);
+
+        assertTrue(manager.roomsToUnloadForOwner(7).isEmpty());
+    }
+
+    @Test
+    void unloadKeepsCancellationAndDisposalOrdering() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java"));
+        int unload = source.indexOf("public void unloadRoomsForHabbo");
+        int selection = source.indexOf("roomsToUnloadForOwner(ownerId)", unload);
+        int callback = source.indexOf("fireEvent(new RoomUncachedEvent(room))", selection);
+        int disposal = source.indexOf("room.dispose()", callback);
+        int untrack = source.indexOf("this.untrackRoomOwner(room)", disposal);
+        int removal = source.indexOf("this.activeRooms.remove(room.getId())", untrack);
+
+        assertTrue(unload >= 0 && unload < selection);
+        assertTrue(selection < callback);
+        assertTrue(callback < disposal);
+        assertTrue(disposal < untrack);
+        assertTrue(untrack < removal);
+    }
+
+    private static Room eligibleRoom(int id, int ownerId) {
+        Room room = mock(Room.class, CALLS_REAL_METHODS);
+        doReturn(id).when(room).getId();
+        room.setOwnerId(ownerId);
+        doReturn(false).when(room).isPublicRoom();
+        doReturn(false).when(room).isStaffPromotedRoom();
+        doReturn(0).when(room).getUserCount();
+        doReturn(0).when(room).getCategory();
+        return room;
+    }
+
     @SuppressWarnings("unchecked")
     private static Map<Integer, Room> activeRooms(RoomManager manager) throws Exception {
         Field field = RoomManager.class.getDeclaredField("activeRooms");
         field.setAccessible(true);
         return (Map<Integer, Room>) field.get(manager);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<Integer, RoomCategory> roomCategories(RoomManager manager) throws Exception {
+        Field field = RoomManager.class.getDeclaredField("roomCategories");
+        field.setAccessible(true);
+        return (Map<Integer, RoomCategory>) field.get(manager);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Uses the maintained room-owner index to narrow disconnect cleanup and reconciles it when legacy cache mutations are detected.

Rooms whose ownership changes through the public API remain indexed correctly. Existing eligibility rules and uncaching lifecycle order are preserved.
