### PR TITLE
fix(network): drain responses before closing

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodec.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodec.java
@@ -16,6 +16,11 @@ public class WebSocketCodec extends MessageToMessageCodec<WebSocketFrame, ByteBu
 
     @Override
     protected void decode(ChannelHandlerContext ctx, WebSocketFrame in, List<Object> out) {
+        if (!(in instanceof BinaryWebSocketFrame) || !in.isFinalFragment()) {
+            ctx.close();
+            return;
+        }
+
         out.add(in.content().retain());
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
@@ -6,7 +6,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.slf4j.Logger;
@@ -101,10 +101,7 @@ public class RCONServerHandler extends ChannelInboundHandlerAdapter {
     }
 
     static void writeAndClose(ChannelHandlerContext ctx, String response) {
-        ChannelFuture f = ctx.channel().write(responseBuffer(response), ctx.channel().voidPromise());
-        ctx.channel().flush();
-        ctx.flush();
-        f.channel().close();
+        ctx.writeAndFlush(responseBuffer(response)).addListener(ChannelFutureListener.CLOSE);
     }
 
     static ByteBuf responseBuffer(String response) {

--- a/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
@@ -100,10 +100,14 @@ public class RCONServerHandler extends ChannelInboundHandlerAdapter {
         return socketAddress == null ? "" : socketAddress.toString().replace("/", "");
     }
 
-    private static void writeAndClose(ChannelHandlerContext ctx, String response) {
-        ChannelFuture f = ctx.channel().write(Unpooled.copiedBuffer(response.getBytes(java.nio.charset.StandardCharsets.UTF_8)), ctx.channel().voidPromise());
+    static void writeAndClose(ChannelHandlerContext ctx, String response) {
+        ChannelFuture f = ctx.channel().write(responseBuffer(response), ctx.channel().voidPromise());
         ctx.channel().flush();
         ctx.flush();
         f.channel().close();
+    }
+
+    static ByteBuf responseBuffer(String response) {
+        return Unpooled.copiedBuffer(response.getBytes(java.nio.charset.StandardCharsets.UTF_8));
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodecTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodecTest.java
@@ -1,0 +1,44 @@
+package com.eu.habbo.networking.gameserver.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class WebSocketCodecTest {
+
+    @Test
+    void binaryFramesExposeTheirExactPayload() {
+        EmbeddedChannel channel = new EmbeddedChannel(new WebSocketCodec());
+        channel.writeInbound(new BinaryWebSocketFrame(
+                Unpooled.copiedBuffer("game-packet", StandardCharsets.UTF_8)));
+
+        ByteBuf payload = channel.readInbound();
+        try {
+            assertEquals("game-packet", payload.toString(StandardCharsets.UTF_8));
+        } finally {
+            payload.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void outboundPayloadsRemainBinaryFrames() {
+        EmbeddedChannel channel = new EmbeddedChannel(new WebSocketCodec());
+        channel.writeOutbound(Unpooled.copiedBuffer("game-packet", StandardCharsets.UTF_8));
+
+        BinaryWebSocketFrame frame = assertInstanceOf(BinaryWebSocketFrame.class, channel.readOutbound());
+        try {
+            assertEquals("game-packet", frame.content().toString(StandardCharsets.UTF_8));
+        } finally {
+            frame.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodecTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodecTest.java
@@ -4,12 +4,22 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.ContinuationWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class WebSocketCodecTest {
 
@@ -38,6 +48,38 @@ class WebSocketCodecTest {
             assertEquals("game-packet", frame.content().toString(StandardCharsets.UTF_8));
         } finally {
             frame.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void nonBinaryFramesAreRejectedAtTheGameProtocolBoundary() {
+        List<Supplier<WebSocketFrame>> unexpectedFrames = List.of(
+                () -> new TextWebSocketFrame("text"),
+                () -> new ContinuationWebSocketFrame(
+                        Unpooled.copiedBuffer("continuation", StandardCharsets.UTF_8)),
+                PingWebSocketFrame::new,
+                PongWebSocketFrame::new,
+                CloseWebSocketFrame::new);
+
+        for (Supplier<WebSocketFrame> frameFactory : unexpectedFrames) {
+            assertRejected(frameFactory.get());
+        }
+    }
+
+    @Test
+    void unaggregatedBinaryFragmentsAreRejected() {
+        assertRejected(new BinaryWebSocketFrame(
+                false, 0, Unpooled.copiedBuffer("fragment", StandardCharsets.UTF_8)));
+    }
+
+    private static void assertRejected(WebSocketFrame frame) {
+        EmbeddedChannel channel = new EmbeddedChannel(new WebSocketCodec());
+        try {
+            assertFalse(channel.writeInbound(frame));
+            assertFalse(channel.isOpen());
+            assertNull(channel.readInbound());
+        } finally {
             channel.finishAndReleaseAll();
         }
     }

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerWriteTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerWriteTest.java
@@ -1,11 +1,22 @@
 package com.eu.habbo.networking.rconserver;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class RCONServerHandlerWriteTest {
 
@@ -17,5 +28,32 @@ class RCONServerHandlerWriteTest {
         } finally {
             response.release();
         }
+    }
+
+    @Test
+    void connectionClosesOnlyAfterTheResponseWriteCompletes() {
+        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+        Channel channel = mock(Channel.class);
+        ChannelPromise voidPromise = mock(ChannelPromise.class);
+        ChannelFuture legacyFuture = mock(ChannelFuture.class);
+        ChannelFuture responseFuture = mock(ChannelFuture.class);
+        when(context.channel()).thenReturn(channel);
+        when(channel.voidPromise()).thenReturn(voidPromise);
+        when(channel.write(any(ByteBuf.class), eq(voidPromise))).thenAnswer(invocation -> {
+            ((ByteBuf) invocation.getArgument(0)).release();
+            return legacyFuture;
+        });
+        when(legacyFuture.channel()).thenReturn(channel);
+        when(context.writeAndFlush(any(ByteBuf.class))).thenAnswer(invocation -> {
+            ((ByteBuf) invocation.getArgument(0)).release();
+            return responseFuture;
+        });
+
+        RCONServerHandler.writeAndClose(context, "{\"status\":1}");
+
+        verify(context).writeAndFlush(any(ByteBuf.class));
+        verify(responseFuture).addListener(ChannelFutureListener.CLOSE);
+        verify(channel, never()).voidPromise();
+        verify(channel, never()).close();
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerWriteTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerWriteTest.java
@@ -1,22 +1,18 @@
 package com.eu.habbo.networking.rconserver;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RCONServerHandlerWriteTest {
 
@@ -32,28 +28,37 @@ class RCONServerHandlerWriteTest {
 
     @Test
     void connectionClosesOnlyAfterTheResponseWriteCompletes() {
-        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
-        Channel channel = mock(Channel.class);
-        ChannelPromise voidPromise = mock(ChannelPromise.class);
-        ChannelFuture legacyFuture = mock(ChannelFuture.class);
-        ChannelFuture responseFuture = mock(ChannelFuture.class);
-        when(context.channel()).thenReturn(channel);
-        when(channel.voidPromise()).thenReturn(voidPromise);
-        when(channel.write(any(ByteBuf.class), eq(voidPromise))).thenAnswer(invocation -> {
-            ((ByteBuf) invocation.getArgument(0)).release();
-            return legacyFuture;
-        });
-        when(legacyFuture.channel()).thenReturn(channel);
-        when(context.writeAndFlush(any(ByteBuf.class))).thenAnswer(invocation -> {
-            ((ByteBuf) invocation.getArgument(0)).release();
-            return responseFuture;
-        });
+        DelayedWriteHandler delayedWrite = new DelayedWriteHandler();
+        ContextMarker marker = new ContextMarker();
+        EmbeddedChannel channel = new EmbeddedChannel(delayedWrite, marker);
 
-        RCONServerHandler.writeAndClose(context, "{\"status\":1}");
+        RCONServerHandler.writeAndClose(
+                channel.pipeline().context(marker), "{\"status\":1}");
 
-        verify(context).writeAndFlush(any(ByteBuf.class));
-        verify(responseFuture).addListener(ChannelFutureListener.CLOSE);
-        verify(channel, never()).voidPromise();
-        verify(channel, never()).close();
+        assertNotNull(delayedWrite.promise);
+        assertTrue(channel.isOpen());
+        assertEquals("{\"status\":1}",
+                delayedWrite.message.toString(StandardCharsets.UTF_8));
+
+        delayedWrite.promise.setSuccess();
+        channel.runPendingTasks();
+
+        assertFalse(channel.isOpen());
+        delayedWrite.message.release();
+        channel.finishAndReleaseAll();
+    }
+
+    private static final class ContextMarker extends io.netty.channel.ChannelInboundHandlerAdapter {
+    }
+
+    private static final class DelayedWriteHandler extends ChannelOutboundHandlerAdapter {
+        private ByteBuf message;
+        private ChannelPromise promise;
+
+        @Override
+        public void write(ChannelHandlerContext context, Object message, ChannelPromise promise) {
+            this.message = (ByteBuf) message;
+            this.promise = promise;
+        }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerWriteTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerWriteTest.java
@@ -1,0 +1,21 @@
+package com.eu.habbo.networking.rconserver;
+
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RCONServerHandlerWriteTest {
+
+    @Test
+    void responseUsesItsExactUtf8Bytes() {
+        ByteBuf response = RCONServerHandler.responseBuffer("{\"message\":\"på gensyn\"}");
+        try {
+            assertEquals("{\"message\":\"på gensyn\"}", response.toString(StandardCharsets.UTF_8));
+        } finally {
+            response.release();
+        }
+    }
+}


### PR DESCRIPTION
Waits for RCON response writes to complete before closing the connection.

Restricts WebSocket game payloads to final binary frames and closes connections when unexpected frame types reach the game codec.
