### PR TITLE
build(test): support Mockito on Java 25

### DIFF
--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -32,7 +32,7 @@
         <javaparser.version>3.27.1</javaparser.version>
         <flyway.version>12.11.0</flyway.version>
         <testcontainers.version>1.21.4</testcontainers.version>
-        <mockito.version>5.14.2</mockito.version>
+        <mockito.version>5.23.0</mockito.version>
         <datafaker.version>2.4.2</datafaker.version>
 
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/Emulator/src/test/java/com/eu/habbo/build/MockitoJavaCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/build/MockitoJavaCompatibilityTest.java
@@ -1,0 +1,19 @@
+package com.eu.habbo.build;
+
+import com.eu.habbo.habbohotel.rooms.Room;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MockitoJavaCompatibilityTest {
+
+    @Test
+    void mocksConcretePolarisTypesOnTheRequiredJdk() {
+        Room room = mock(Room.class);
+        when(room.getId()).thenReturn(7);
+
+        assertEquals(7, room.getId());
+    }
+}


### PR DESCRIPTION
## Summary

- Upgrade Mockito from 5.14.2 to 5.23.0 for Java 25-compatible Byte Buddy instrumentation.
- Add a regression test covering concrete Polaris type mocking on the required JDK.
