### PR TITLE
refactor(core): index authenticated clients

### DIFF
--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -32,7 +32,7 @@
         <javaparser.version>3.27.1</javaparser.version>
         <flyway.version>12.11.0</flyway.version>
         <testcontainers.version>1.21.4</testcontainers.version>
-        <mockito.version>5.14.2</mockito.version>
+        <mockito.version>5.23.0</mockito.version>
         <datafaker.version>2.4.2</datafaker.version>
 
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClientManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClientManager.java
@@ -121,6 +121,16 @@ public class GameClientManager {
 
 
     public Habbo getHabbo(int id) {
+        GameClient authenticatedClient = this.authenticatedClients.get(id);
+        if (authenticatedClient != null) {
+            Habbo authenticatedHabbo = authenticatedClient.getHabbo();
+            if (authenticatedHabbo != null
+                    && authenticatedHabbo.getHabboInfo() != null
+                    && authenticatedHabbo.getHabboInfo().getId() == id) {
+                return authenticatedHabbo;
+            }
+        }
+
         for (GameClient client : this.clients.values()) {
             if (client.getHabbo() == null)
                 continue;

--- a/Emulator/src/test/java/com/eu/habbo/build/MockitoJavaCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/build/MockitoJavaCompatibilityTest.java
@@ -1,0 +1,19 @@
+package com.eu.habbo.build;
+
+import com.eu.habbo.habbohotel.rooms.Room;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MockitoJavaCompatibilityTest {
+
+    @Test
+    void mocksConcretePolarisTypesOnTheRequiredJdk() {
+        Room room = mock(Room.class);
+        when(room.getId()).thenReturn(7);
+
+        assertEquals(7, room.getId());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientLookupTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientLookupTest.java
@@ -1,0 +1,53 @@
+package com.eu.habbo.habbohotel.gameclients;
+
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GameClientLookupTest {
+
+    @Test
+    void lookupFallsBackToRegisteredClientsAfterIndexRelease() {
+        GameClientManager manager = new GameClientManager();
+        GameClient client = clientFor(7);
+        Habbo habbo = client.getHabbo();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        manager.getSessions().put(channel.id(), client);
+        manager.claimAuthenticatedSession(7, client);
+        manager.releaseAuthenticatedSession(7, client);
+
+        assertSame(habbo, manager.getHabbo(7));
+
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void lookupFallsBackWhileTheIndexedClientHasNoHabbo() {
+        GameClientManager manager = new GameClientManager();
+        GameClient indexedClient = mock(GameClient.class);
+        GameClient teardownClient = clientFor(7);
+        Habbo habbo = teardownClient.getHabbo();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        manager.getSessions().put(channel.id(), teardownClient);
+        manager.claimAuthenticatedSession(7, indexedClient);
+
+        assertSame(habbo, manager.getHabbo(7));
+
+        channel.finishAndReleaseAll();
+    }
+
+    private static GameClient clientFor(int userId) {
+        HabboInfo info = mock(HabboInfo.class);
+        when(info.getId()).thenReturn(userId);
+        Habbo habbo = mock(Habbo.class);
+        when(habbo.getHabboInfo()).thenReturn(info);
+        GameClient client = mock(GameClient.class);
+        when(client.getHabbo()).thenReturn(habbo);
+        return client;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientLookupTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientLookupTest.java
@@ -12,6 +12,16 @@ import static org.mockito.Mockito.when;
 class GameClientLookupTest {
 
     @Test
+    void lookupUsesTheAuthenticatedClientIndex() {
+        GameClientManager manager = new GameClientManager();
+        GameClient client = clientFor(7);
+        Habbo habbo = client.getHabbo();
+        manager.claimAuthenticatedSession(7, client);
+
+        assertSame(habbo, manager.getHabbo(7));
+    }
+
+    @Test
     void lookupFallsBackToRegisteredClientsAfterIndexRelease() {
         GameClientManager manager = new GameClientManager();
         GameClient client = clientFor(7);


### PR DESCRIPTION
Adds Java 25-compatible Mockito support and uses the authenticated-client index as a fast path with the legacy teardown and resume scan retained as fallback.