### PR TITLE
fix(network): bound outbound backpressure

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/networking/Server.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/Server.java
@@ -11,6 +11,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -22,6 +23,9 @@ import java.util.concurrent.TimeUnit;
 public abstract class Server {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Server.class);
+    private static final int DEFAULT_WRITE_BUFFER_LOW_WATER_MARK = 32 * 1024;
+    private static final int DEFAULT_WRITE_BUFFER_HIGH_WATER_MARK = 64 * 1024;
+    private static final int DEFAULT_UNWRITABLE_TIMEOUT_SECONDS = 10;
 
     private static volatile ByteBufAllocator sharedAllocator;
 
@@ -79,6 +83,47 @@ public abstract class Server {
         this.serverBootstrap.childOption(ChannelOption.SO_RCVBUF, 4096);
         this.serverBootstrap.childOption(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(4096));
         this.serverBootstrap.childOption(ChannelOption.ALLOCATOR, allocator());
+        this.serverBootstrap.childOption(
+                ChannelOption.WRITE_BUFFER_WATER_MARK, configuredWriteBufferWaterMark());
+    }
+
+    protected static WriteBufferWaterMark configuredWriteBufferWaterMark() {
+        int low = DEFAULT_WRITE_BUFFER_LOW_WATER_MARK;
+        int high = DEFAULT_WRITE_BUFFER_HIGH_WATER_MARK;
+        if (Emulator.getConfig() != null) {
+            low = Emulator.getConfig().getInt(
+                    "io.netty.write_buffer.low_water_mark", low);
+            high = Emulator.getConfig().getInt(
+                    "io.netty.write_buffer.high_water_mark", high);
+        }
+
+        if (low < 0 || high <= low) {
+            LOGGER.warn(
+                    "Invalid Netty write-buffer water marks low={} high={}; using defaults low={} high={}",
+                    low,
+                    high,
+                    DEFAULT_WRITE_BUFFER_LOW_WATER_MARK,
+                    DEFAULT_WRITE_BUFFER_HIGH_WATER_MARK);
+            low = DEFAULT_WRITE_BUFFER_LOW_WATER_MARK;
+            high = DEFAULT_WRITE_BUFFER_HIGH_WATER_MARK;
+        }
+        return new WriteBufferWaterMark(low, high);
+    }
+
+    protected static int configuredUnwritableTimeoutSeconds() {
+        int timeout = Emulator.getConfig() == null
+                ? DEFAULT_UNWRITABLE_TIMEOUT_SECONDS
+                : Emulator.getConfig().getInt(
+                        "io.netty.unwritable.timeout.seconds",
+                        DEFAULT_UNWRITABLE_TIMEOUT_SECONDS);
+        if (timeout <= 0) {
+            LOGGER.warn(
+                    "Invalid Netty unwritable timeout {}; using default {} seconds",
+                    timeout,
+                    DEFAULT_UNWRITABLE_TIMEOUT_SECONDS);
+            return DEFAULT_UNWRITABLE_TIMEOUT_SECONDS;
+        }
+        return timeout;
     }
 
     public void connect() {

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
@@ -9,6 +9,7 @@ import com.eu.habbo.networking.gameserver.decoders.*;
 import com.eu.habbo.networking.gameserver.encoders.GameServerMessageEncoder;
 import com.eu.habbo.networking.gameserver.encoders.GameServerMessageLogger;
 import com.eu.habbo.networking.gameserver.handlers.IdleTimeoutHandler;
+import com.eu.habbo.networking.gameserver.handlers.SustainedUnwritableHandler;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.Channel;
@@ -23,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 
 public class GameServer extends Server {
     private static final Logger LOGGER = LoggerFactory.getLogger(GameServer.class);
@@ -47,6 +49,10 @@ public class GameServer extends Server {
             @Override
             public void initChannel(SocketChannel ch) throws Exception {
                 ch.pipeline().addLast("logger", new LoggingHandler());
+                ch.pipeline().addLast(
+                        "outboundBackpressure",
+                        new SustainedUnwritableHandler(
+                                configuredUnwritableTimeoutSeconds(), TimeUnit.SECONDS));
 
                 // Decoders.
                 ch.pipeline().addLast(new GamePolicyDecoder());
@@ -81,7 +87,8 @@ public class GameServer extends Server {
         String wsHost = Emulator.getConfig().getValue("ws.host", "0.0.0.0");
         int wsPort = Emulator.getConfig().getInt("ws.port", 2096);
 
-        WebSocketChannelInitializer wsInitializer = new WebSocketChannelInitializer();
+        WebSocketChannelInitializer wsInitializer =
+                new WebSocketChannelInitializer(configuredUnwritableTimeoutSeconds());
 
         this.webSocketBootstrap = new ServerBootstrap();
         this.webSocketBootstrap.group(this.getBossGroup(), this.getWorkerGroup());
@@ -92,6 +99,8 @@ public class GameServer extends Server {
         this.webSocketBootstrap.childOption(ChannelOption.SO_RCVBUF, 4096);
         this.webSocketBootstrap.childOption(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(4096));
         this.webSocketBootstrap.childOption(ChannelOption.ALLOCATOR, allocator());
+        this.webSocketBootstrap.childOption(
+                ChannelOption.WRITE_BUFFER_WATER_MARK, configuredWriteBufferWaterMark());
         this.webSocketBootstrap.childHandler(wsInitializer);
 
         ChannelFuture wsFuture = this.webSocketBootstrap.bind(wsHost, wsPort);

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
@@ -13,6 +13,7 @@ import com.eu.habbo.networking.gameserver.decoders.*;
 import com.eu.habbo.networking.gameserver.encoders.GameServerMessageEncoder;
 import com.eu.habbo.networking.gameserver.encoders.GameServerMessageLogger;
 import com.eu.habbo.networking.gameserver.handlers.IdleTimeoutHandler;
+import com.eu.habbo.networking.gameserver.handlers.SustainedUnwritableHandler;
 import com.eu.habbo.networking.gameserver.handlers.WebSocketHttpHandler;
 import com.eu.habbo.networking.gameserver.stats.EmuStatsHttpHandler;
 import com.eu.habbo.networking.gameserver.ssl.SSLCertificateLoader;
@@ -30,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLEngine;
+import java.util.concurrent.TimeUnit;
 
 public class WebSocketChannelInitializer extends ChannelInitializer<SocketChannel> {
     private static final Logger LOGGER = LoggerFactory.getLogger(WebSocketChannelInitializer.class);
@@ -38,8 +40,17 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
     private final SslContext sslContext;
     private final boolean sslEnabled;
     private final WebSocketServerProtocolConfig wsConfig;
+    private final int unwritableTimeoutSeconds;
 
     public WebSocketChannelInitializer() {
+        this(10);
+    }
+
+    WebSocketChannelInitializer(int unwritableTimeoutSeconds) {
+        if (unwritableTimeoutSeconds <= 0) {
+            throw new IllegalArgumentException("unwritableTimeoutSeconds must be positive");
+        }
+        this.unwritableTimeoutSeconds = unwritableTimeoutSeconds;
         this.sslContext = SSLCertificateLoader.getContext();
         this.sslEnabled = this.sslContext != null;
         this.wsConfig = WebSocketServerProtocolConfig.newBuilder()
@@ -52,6 +63,10 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
     @Override
     protected void initChannel(SocketChannel ch) {
         ch.pipeline().addLast("logger", new LoggingHandler());
+        ch.pipeline().addLast(
+                "outboundBackpressure",
+                new SustainedUnwritableHandler(
+                        this.unwritableTimeoutSeconds, TimeUnit.SECONDS));
 
         if (this.sslEnabled) {
             SSLEngine engine = this.sslContext.newEngine(ch.alloc());

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandler.java
@@ -1,0 +1,25 @@
+package com.eu.habbo.networking.gameserver.handlers;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+public final class SustainedUnwritableHandler extends ChannelInboundHandlerAdapter {
+
+    private final long timeoutNanos;
+
+    public SustainedUnwritableHandler(long timeout, TimeUnit unit) {
+        Objects.requireNonNull(unit, "unit");
+        if (timeout <= 0) {
+            throw new IllegalArgumentException("timeout must be positive");
+        }
+        this.timeoutNanos = unit.toNanos(timeout);
+    }
+
+    @Override
+    public void channelWritabilityChanged(ChannelHandlerContext context) {
+        context.fireChannelWritabilityChanged();
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandler.java
@@ -2,13 +2,20 @@ package com.eu.habbo.networking.gameserver.handlers;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 public final class SustainedUnwritableHandler extends ChannelInboundHandlerAdapter {
 
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(SustainedUnwritableHandler.class);
+
     private final long timeoutNanos;
+    private ScheduledFuture<?> closeFuture;
 
     public SustainedUnwritableHandler(long timeout, TimeUnit unit) {
         Objects.requireNonNull(unit, "unit");
@@ -20,6 +27,46 @@ public final class SustainedUnwritableHandler extends ChannelInboundHandlerAdapt
 
     @Override
     public void channelWritabilityChanged(ChannelHandlerContext context) {
+        if (context.channel().isWritable()) {
+            cancelClose();
+        } else if (this.closeFuture == null) {
+            this.closeFuture = context.executor().schedule(
+                    () -> closeIfStillUnwritable(context),
+                    this.timeoutNanos,
+                    TimeUnit.NANOSECONDS);
+        }
         context.fireChannelWritabilityChanged();
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext context) throws Exception {
+        cancelClose();
+        super.channelInactive(context);
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext context) {
+        cancelClose();
+    }
+
+    private void closeIfStillUnwritable(ChannelHandlerContext context) {
+        this.closeFuture = null;
+        if (!context.channel().isOpen() || context.channel().isWritable()) {
+            return;
+        }
+
+        LOGGER.warn(
+                "Disconnecting channel {} after {} ms of sustained unwritability; {} bytes must drain before writes resume",
+                context.channel().remoteAddress(),
+                TimeUnit.NANOSECONDS.toMillis(this.timeoutNanos),
+                context.channel().bytesBeforeWritable());
+        context.close();
+    }
+
+    private void cancelClose() {
+        if (this.closeFuture != null) {
+            this.closeFuture.cancel(false);
+            this.closeFuture = null;
+        }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/ServerOutboundBackpressureTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/ServerOutboundBackpressureTest.java
@@ -1,0 +1,37 @@
+package com.eu.habbo.networking;
+
+import io.netty.channel.ChannelOption;
+import io.netty.channel.WriteBufferWaterMark;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ServerOutboundBackpressureTest {
+
+    @Test
+    void configuresExplicitWriteBufferWaterMarks() throws Exception {
+        TestServer server = new TestServer();
+        try {
+            server.initializePipeline();
+
+            WriteBufferWaterMark waterMark = (WriteBufferWaterMark) server
+                    .getServerBootstrap()
+                    .config()
+                    .childOptions()
+                    .get(ChannelOption.WRITE_BUFFER_WATER_MARK);
+
+            assertNotNull(waterMark);
+            assertEquals(32 * 1024, waterMark.low());
+            assertEquals(64 * 1024, waterMark.high());
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static final class TestServer extends Server {
+        private TestServer() throws Exception {
+            super("Backpressure Test Server", "127.0.0.1", 0, 1, 1);
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandlerTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandlerTest.java
@@ -1,0 +1,67 @@
+package com.eu.habbo.networking.gameserver.handlers;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SustainedUnwritableHandlerTest {
+
+    @Test
+    void closesAChannelThatRemainsUnwritableForTheWholeTimeout() {
+        EmbeddedChannel channel = channelWithTimeout(5);
+
+        setWritable(channel, false);
+        channel.advanceTimeBy(4, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+        assertTrue(channel.isOpen());
+
+        channel.advanceTimeBy(1, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+
+        assertFalse(channel.isOpen());
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void keepsAChannelOpenWhenWritabilityRecovers() {
+        EmbeddedChannel channel = channelWithTimeout(5);
+
+        setWritable(channel, false);
+        channel.advanceTimeBy(4, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+        setWritable(channel, true);
+        channel.advanceTimeBy(2, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+
+        assertTrue(channel.isOpen());
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void repeatedUnwritableEventsDoNotExtendTheOriginalDeadline() {
+        EmbeddedChannel channel = channelWithTimeout(5);
+
+        setWritable(channel, false);
+        channel.advanceTimeBy(4, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+        channel.pipeline().fireChannelWritabilityChanged();
+        channel.advanceTimeBy(1, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+
+        assertFalse(channel.isOpen());
+        channel.finishAndReleaseAll();
+    }
+
+    private static EmbeddedChannel channelWithTimeout(long seconds) {
+        return new EmbeddedChannel(new SustainedUnwritableHandler(seconds, TimeUnit.SECONDS));
+    }
+
+    private static void setWritable(EmbeddedChannel channel, boolean writable) {
+        channel.unsafe().outboundBuffer().setUserDefinedWritability(1, writable);
+        channel.runPendingTasks();
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandlerTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandlerTest.java
@@ -56,6 +56,24 @@ class SustainedUnwritableHandlerTest {
         channel.finishAndReleaseAll();
     }
 
+    @Test
+    void repeatedRecoveryCyclesDoNotLeaveAStaleCloseTask() {
+        EmbeddedChannel channel = channelWithTimeout(5);
+
+        for (int cycle = 0; cycle < 1_000; cycle++) {
+            setWritable(channel, false);
+            channel.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+            channel.runScheduledPendingTasks();
+            setWritable(channel, true);
+        }
+
+        channel.advanceTimeBy(5, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+
+        assertTrue(channel.isOpen());
+        channel.finishAndReleaseAll();
+    }
+
     private static EmbeddedChannel channelWithTimeout(long seconds) {
         return new EmbeddedChannel(new SustainedUnwritableHandler(seconds, TimeUnit.SECONDS));
     }

--- a/config example/config.ini.example
+++ b/config example/config.ini.example
@@ -79,6 +79,9 @@ login.news.limit=5
 ## io.packet.handler.threads=24 #Game packet-handler pool size; runs game handlers OFF the Netty I/O loop. Default max(16, 2 x CPU cores).
 ## auth.http.pool.size=16 #Dedicated worker pool for the /api/auth/* HTTP endpoints (BCrypt/JDBC/Turnstile/SMTP run off the event loop). Default 16.
 ## io.netty.allocator.pooled=false #Set true to opt into Netty's pooled ByteBuf allocator. Default false (unpooled-heap).
+## io.netty.write_buffer.low_water_mark=32768 #Mark a channel writable again after queued outbound bytes drain below this value.
+## io.netty.write_buffer.high_water_mark=65536 #Mark a channel unwritable after queued outbound bytes exceed this value.
+## io.netty.unwritable.timeout.seconds=10 #Disconnect a channel that remains unwritable for this long.
 
 #Structured slow-query diagnostics. SQL literals and bound values are never logged.
 db.slow_query.enabled=true


### PR DESCRIPTION
## Summary

- Configure explicit, operator-adjustable write-buffer water marks for TCP and WebSocket channels.
- Disconnect channels that stay unwritable beyond the configured grace period, cancelling the deadline when they recover.
- Keep outbound packet delivery unchanged instead of silently dropping packets under pressure.
