### PR TITLE
fix(network): offload blocking HTTP handlers

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BlockingHttpExecutionGroup.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BlockingHttpExecutionGroup.java
@@ -1,0 +1,45 @@
+package com.eu.habbo.networking.gameserver;
+
+import com.eu.habbo.Emulator;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.EventExecutorGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+final class BlockingHttpExecutionGroup {
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(BlockingHttpExecutionGroup.class);
+    private static final EventExecutorGroup GROUP = new DefaultEventExecutorGroup(
+            configuredThreads(),
+            new DefaultThreadFactory("BlockingHttp", true));
+
+    private BlockingHttpExecutionGroup() {
+    }
+
+    static EventExecutorGroup get() {
+        return GROUP;
+    }
+
+    static void shutdown() {
+        try {
+            GROUP.shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS)
+                    .syncUninterruptibly();
+        } catch (Exception e) {
+            LOGGER.warn("Blocking HTTP group shutdown interrupted", e);
+        }
+    }
+
+    static int configuredThreads() {
+        int fallback = 8;
+        if (Emulator.getConfig() == null) {
+            return fallback;
+        }
+
+        int configured = Emulator.getConfig().getInt(
+                "http.blocking.pool.size", fallback);
+        return configured > 0 ? configured : fallback;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
@@ -141,6 +141,7 @@ public class GameServer extends Server {
             this.gameClientManager.forceDisposeClient(client);
         }
 
+        BlockingHttpExecutionGroup.shutdown();
         GamePacketExecutionGroup.shutdown();
 
         super.stop();

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.util.concurrent.EventExecutorGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,12 +62,25 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
         ch.pipeline().addLast("httpCodec", new HttpServerCodec());
         ch.pipeline().addLast("httpAggregator", new HttpObjectAggregator(MAX_FRAME_SIZE));
         ch.pipeline().addLast("wsHttpHandler", new WebSocketHttpHandler());
-        ch.pipeline().addLast("nitroSecureAssetHandler", new NitroSecureAssetHandler());
+        EventExecutorGroup blockingHttp = BlockingHttpExecutionGroup.get();
+        ch.pipeline().addLast(
+                blockingHttp,
+                "nitroSecureAssetHandler",
+                new NitroSecureAssetHandler());
         ch.pipeline().addLast("nitroSecureApiHandler", new NitroSecureApiHandler());
         ch.pipeline().addLast("authHttpHandler", new AuthHttpHandler());
-        ch.pipeline().addLast("badgeHttpHandler", new BadgeHttpHandler());
-        ch.pipeline().addLast("badgeLeaderboardHttpHandler", new BadgeLeaderboardHttpHandler());
-        ch.pipeline().addLast("emuStatsHttpHandler", new EmuStatsHttpHandler());
+        ch.pipeline().addLast(
+                blockingHttp,
+                "badgeHttpHandler",
+                new BadgeHttpHandler());
+        ch.pipeline().addLast(
+                blockingHttp,
+                "badgeLeaderboardHttpHandler",
+                new BadgeLeaderboardHttpHandler());
+        ch.pipeline().addLast(
+                blockingHttp,
+                "emuStatsHttpHandler",
+                new EmuStatsHttpHandler());
         ch.pipeline().addLast("wsProtocolHandler", new WebSocketServerProtocolHandler(this.wsConfig));
         ch.pipeline().addLast("wsFrameAggregator", new WebSocketFrameAggregator(MAX_FRAME_SIZE));
         ch.pipeline().addLast("wsCodec", new WebSocketCodec());

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
@@ -1,0 +1,72 @@
+package com.eu.habbo.networking.gameserver;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.concurrent.EventExecutor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class WebSocketHttpOffloadTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void blockingHttpHandlersLeaveTheSocketEventLoopAndKeepChannelOrdering()
+            throws Exception {
+        Field configField = Emulator.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        Object previousConfig = configField.get(null);
+        Path configFile = this.temporaryDirectory.resolve("config.ini");
+        Files.writeString(
+                configFile,
+                "nitro.secure.master_key=test-key\n"
+                        + "nitro.secure.assets.enabled=true\n"
+                        + "crypto.ws.enabled=false\n");
+        configField.set(null, new ConfigurationManager(configFile.toString()));
+
+        EventLoopGroup eventLoops =
+                new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        NioSocketChannel channel = new NioSocketChannel();
+        try {
+            eventLoops.register(channel).syncUninterruptibly();
+            new WebSocketChannelInitializer().initChannel(channel);
+
+            EventExecutor socketExecutor = channel.eventLoop();
+            EventExecutor blockingExecutor =
+                    channel.pipeline().context("nitroSecureAssetHandler").executor();
+
+            assertNotSame(socketExecutor, blockingExecutor);
+            assertSame(
+                    blockingExecutor,
+                    channel.pipeline().context("badgeHttpHandler").executor());
+            assertSame(
+                    blockingExecutor,
+                    channel.pipeline().context("badgeLeaderboardHttpHandler").executor());
+            assertSame(
+                    blockingExecutor,
+                    channel.pipeline().context("emuStatsHttpHandler").executor());
+            assertSame(
+                    socketExecutor,
+                    channel.pipeline().context("wsHttpHandler").executor());
+            assertSame(
+                    socketExecutor,
+                    channel.pipeline().context("authHttpHandler").executor());
+        } finally {
+            channel.close().syncUninterruptibly();
+            eventLoops.shutdownGracefully().syncUninterruptibly();
+            configField.set(null, previousConfig);
+        }
+    }
+}

--- a/config example/config.ini.example
+++ b/config example/config.ini.example
@@ -78,6 +78,7 @@ login.news.limit=5
 #Performance / concurrency (optional — sensible defaults apply if unset; adjust in the Database).
 ## io.packet.handler.threads=24 #Game packet-handler pool size; runs game handlers OFF the Netty I/O loop. Default max(16, 2 x CPU cores).
 ## auth.http.pool.size=16 #Dedicated worker pool for the /api/auth/* HTTP endpoints (BCrypt/JDBC/Turnstile/SMTP run off the event loop). Default 16.
+## http.blocking.pool.size=8 #Dedicated workers for blocking badge, asset, leaderboard, and emulator-stats endpoints. Default 8.
 ## io.netty.allocator.pooled=false #Set true to opt into Netty's pooled ByteBuf allocator. Default false (unpooled-heap).
 
 #Structured slow-query diagnostics. SQL literals and bound values are never logged.


### PR DESCRIPTION
## Summary

- Run secure asset, custom badge, badge leaderboard, and emulator-stats handlers on a dedicated worker group.
- Preserve per-channel request ordering and keep WebSocket upgrade handling on the socket event loop.
- Shut down the worker group with the game server and expose an optional pool-size setting.
