### PR TITLE
fix(core): harden time utilities

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -34,7 +34,14 @@ import java.net.URL;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
+import java.text.ParsePosition;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
+import java.time.temporal.TemporalAccessor;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
@@ -51,6 +58,32 @@ public final class Emulator {
     private static final String ANSI_GREEN = "\u001B[32m";
     private static final String ANSI_YELLOW = "\u001B[33m";
     private static final String ANSI_DIM = "\u001B[2m";
+    private static final Pattern TIME_DURATION_PATTERN =
+            Pattern.compile("(([0-9]*) (second|minute|hour|day|week|month|year))");
+    private static final Map<String, Integer> TIME_DURATION_SECONDS = Map.of(
+            "second", 1,
+            "minute", 60,
+            "hour", 3600,
+            "day", 86400,
+            "week", 604800,
+            "month", 2628000,
+            "year", 31536000);
+    private static final Map<String, Integer> TIME_DURATION_CALENDAR_FIELDS = Map.of(
+            "second", Calendar.SECOND,
+            "minute", Calendar.MINUTE,
+            "hour", Calendar.HOUR,
+            "day", Calendar.DAY_OF_MONTH,
+            "week", Calendar.WEEK_OF_MONTH,
+            "month", Calendar.MONTH,
+            "year", Calendar.YEAR);
+    private static final DateTimeFormatter BUILD_TIMESTAMP_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final DateTimeFormatter LEGACY_TIMESTAMP_PARSER =
+            new DateTimeFormatterBuilder()
+                    .parseLenient()
+                    .appendPattern("uuuu-MM-dd HH:mm:ss")
+                    .toFormatter(Locale.ENGLISH)
+                    .withResolverStyle(ResolverStyle.LENIENT);
 
     // Fallback version, only used when running outside a packaged jar (e.g. from
     // the IDE). In production the version comes from the jar manifest below.
@@ -87,7 +120,7 @@ public final class Emulator {
     public static boolean isShuttingDown = false;
     public static boolean stopped = false;
     public static boolean debugging = false;
-    private static int timeStarted = 0;
+    private static long timeStarted = 0;
     private static Runtime runtime;
     private static ConfigurationManager config;
     private static CryptoConfig crypto;
@@ -227,7 +260,7 @@ public final class Emulator {
 
             Emulator.getPluginManager().fireEvent(new EmulatorLoadedEvent());
             Emulator.isReady = true;
-            Emulator.timeStarted = getIntUnixTimestamp();
+            Emulator.timeStarted = getLongUnixTimestamp();
 
             if (shouldLaunchGui()) {
                 EmulatorDashboard.launch();
@@ -477,15 +510,15 @@ public final class Emulator {
             return "UNKNOWN";
         }
 
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-
+        ZoneId zoneId;
         try {
-            format.setTimeZone(TimeZone.getTimeZone(java.time.ZoneId.of(timezoneId)));
+            zoneId = ZoneId.of(timezoneId);
         } catch (Exception ignored) {
-            format.setTimeZone(TimeZone.getDefault());
+            zoneId = ZoneId.systemDefault();
         }
 
-        return format.format(new Timestamp(buildTimestamp));
+        return BUILD_TIMESTAMP_FORMAT.format(
+                Instant.ofEpochMilli(buildTimestamp).atZone(zoneId));
     }
 
     private static void dispose() {
@@ -635,11 +668,11 @@ public final class Emulator {
     }
 
     public static int getTimeStarted() {
-        return timeStarted;
+        return (int) timeStarted;
     }
 
     public static int getOnlineTime() {
-        return getIntUnixTimestamp() - timeStarted;
+        return elapsedSeconds(timeStarted, getLongUnixTimestamp());
     }
 
     public static void prepareShutdown() {
@@ -647,55 +680,36 @@ public final class Emulator {
     }
 
     public static int timeStringToSeconds(String timeString) {
-        int totalSeconds = 0;
-
-        Matcher m = Pattern.compile("(([0-9]*) (second|minute|hour|day|week|month|year))").matcher(timeString);
-        Map<String,Integer> map = new HashMap<String,Integer>() {
-            {
-                put("second", 1);
-                put("minute", 60);
-                put("hour", 3600);
-                put("day", 86400);
-                put("week", 604800);
-                put("month", 2628000);
-                put("year", 31536000);
-            }
-        };
+        long totalSeconds = 0;
+        Matcher m = TIME_DURATION_PATTERN.matcher(timeString);
 
         while (m.find()) {
             try {
                 int amount = Integer.parseInt(m.group(2));
                 String what = m.group(3);
-                totalSeconds += amount * map.get(what);
+                long seconds = (long) amount * TIME_DURATION_SECONDS.get(what);
+                if (totalSeconds > Integer.MAX_VALUE - seconds) {
+                    return Integer.MAX_VALUE;
+                }
+                totalSeconds += seconds;
             }
             catch (Exception ignored) { }
         }
 
-        return totalSeconds;
+        return (int) totalSeconds;
     }
 
     public static Date modifyDate(Date date, String timeString) {
         Calendar c = Calendar.getInstance();
         c.setTime(date);
 
-        Matcher m = Pattern.compile("(([0-9]*) (second|minute|hour|day|week|month|year))").matcher(timeString);
-        Map<String, Integer> map = new HashMap<String, Integer>() {
-            {
-                put("second", Calendar.SECOND);
-                put("minute", Calendar.MINUTE);
-                put("hour", Calendar.HOUR);
-                put("day", Calendar.DAY_OF_MONTH);
-                put("week", Calendar.WEEK_OF_MONTH);
-                put("month", Calendar.MONTH);
-                put("year", Calendar.YEAR);
-            }
-        };
+        Matcher m = TIME_DURATION_PATTERN.matcher(timeString);
 
         while (m.find()) {
             try {
                 int amount = Integer.parseInt(m.group(2));
                 String what = m.group(3);
-                c.add(map.get(what), amount);
+                c.add(TIME_DURATION_CALENDAR_FIELDS.get(what), amount);
             }
             catch (Exception ignored) { }
         }
@@ -704,24 +718,30 @@ public final class Emulator {
     }
 
     private static String dateToUnixTimestamp(Date date) {
-        String res = "";
-        Date aux = stringToDate("1970-01-01 00:00:00");
-        Timestamp aux1 = dateToTimeStamp(aux);
-        Timestamp aux2 = dateToTimeStamp(date);
-        long difference = aux2.getTime() - aux1.getTime();
+        Instant localEpoch = LocalDateTime.of(1970, 1, 1, 0, 0)
+                .atZone(ZoneId.systemDefault())
+                .toInstant();
+        long difference = date.getTime() - localEpoch.toEpochMilli();
         long seconds = difference / 1000L;
-        return res + seconds;
+        return Long.toString(seconds);
     }
 
     public static Date stringToDate(String date) {
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        Date res = null;
         try {
-            res = format.parse(date);
+            ParsePosition position = new ParsePosition(0);
+            TemporalAccessor parsed = LEGACY_TIMESTAMP_PARSER.parse(date, position);
+            if (parsed == null || position.getIndex() == 0) {
+                throw new IllegalArgumentException("Unparseable date: " + date);
+            }
+
+            return Date.from(
+                    LocalDateTime.from(parsed)
+                            .atZone(ZoneId.systemDefault())
+                            .toInstant());
         } catch (Exception e) {
             LOGGER.error("Error parsing date", e);
+            return null;
         }
-        return res;
     }
 
     public static Timestamp dateToTimeStamp(Date date) {
@@ -737,7 +757,22 @@ public final class Emulator {
     }
 
     public static int getIntUnixTimestamp() {
-        return (int) (System.currentTimeMillis() / 1000);
+        return (int) getLongUnixTimestamp();
+    }
+
+    public static long getLongUnixTimestamp() {
+        return Instant.now().getEpochSecond();
+    }
+
+    static int elapsedSeconds(long startTimestamp, long endTimestamp) {
+        long elapsed = endTimestamp - startTimestamp;
+        if (elapsed > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        if (elapsed < Integer.MIN_VALUE) {
+            return Integer.MIN_VALUE;
+        }
+        return (int) elapsed;
     }
 
     public static boolean isNumeric(String string)

--- a/Emulator/src/main/java/com/eu/habbo/core/consolecommands/ConsoleInfoCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/consolecommands/ConsoleInfoCommand.java
@@ -16,7 +16,7 @@ public class ConsoleInfoCommand extends ConsoleCommand {
 
     @Override
     public void handle(String[] args) throws Exception {
-        int seconds = Emulator.getIntUnixTimestamp() - Emulator.getTimeStarted();
+        int seconds = Emulator.getOnlineTime();
         int day = (int) TimeUnit.SECONDS.toDays(seconds);
         long hours = TimeUnit.SECONDS.toHours(seconds) - (day * 24L);
         long minute = TimeUnit.SECONDS.toMinutes(seconds) - (TimeUnit.SECONDS.toHours(seconds) * 60);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/AboutCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/AboutCommand.java
@@ -20,7 +20,7 @@ public class AboutCommand extends Command {
 
         Emulator.getRuntime().gc();
 
-        int seconds = Emulator.getIntUnixTimestamp() - Emulator.getTimeStarted();
+        int seconds = Emulator.getOnlineTime();
         int day = (int) TimeUnit.SECONDS.toDays(seconds);
         long hours = TimeUnit.SECONDS.toHours(seconds) - (day * 24L);
         long minute = TimeUnit.SECONDS.toMinutes(seconds) - (TimeUnit.SECONDS.toHours(seconds) * 60);

--- a/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
@@ -38,6 +38,7 @@ import com.eu.habbo.messages.incoming.users.ChangeNameCheckUsernameEvent;
 import com.eu.habbo.messages.outgoing.catalog.DiscountComposer;
 import com.eu.habbo.messages.outgoing.catalog.GiftConfigurationComposer;
 import com.eu.habbo.messages.outgoing.navigator.NewNavigatorEventCategoriesComposer;
+import com.eu.habbo.util.HotelDateTimeUtil;
 import com.eu.habbo.plugin.events.emulator.EmulatorConfigUpdatedEvent;
 import com.eu.habbo.plugin.events.emulator.EmulatorLoadedEvent;
 import com.eu.habbo.plugin.events.roomunit.RoomUnitLookAtPointEvent;
@@ -187,10 +188,8 @@ public class PluginManager {
 
         SubscriptionHabboClub.HC_PAYDAY_ENABLED = Emulator.getConfig().getBoolean("subscriptions.hc.payday.enabled", false);
 
-        try {
-            SubscriptionHabboClub.HC_PAYDAY_NEXT_DATE = (int) (Emulator.stringToDate(Emulator.getConfig().getValue("subscriptions.hc.payday.next_date")).getTime() / 1000);
-        }
-        catch(Exception e) { SubscriptionHabboClub.HC_PAYDAY_NEXT_DATE = Integer.MAX_VALUE; }
+        SubscriptionHabboClub.HC_PAYDAY_NEXT_DATE = parsePaydayTimestamp(
+                Emulator.getConfig().getValue("subscriptions.hc.payday.next_date"));
 
         SubscriptionHabboClub.HC_PAYDAY_INTERVAL = Emulator.getConfig().getValue("subscriptions.hc.payday.interval");
         SubscriptionHabboClub.HC_PAYDAY_QUERY = Emulator.getConfig().getValue("subscriptions.hc.payday.query");
@@ -249,6 +248,22 @@ public class PluginManager {
             Emulator.getGameEnvironment().getPixelScheduler().reloadConfig();
             Emulator.getGameEnvironment().getGotwPointsScheduler().reloadConfig();
             Emulator.getGameEnvironment().subscriptionScheduler.reloadConfig();
+        }
+    }
+
+    static int parsePaydayTimestamp(String value) {
+        try {
+            long timestamp = HotelDateTimeUtil.toEpochSecond(
+                    HotelDateTimeUtil.parseDateTimeStrict(value));
+            if (timestamp > Integer.MAX_VALUE) {
+                return Integer.MAX_VALUE;
+            }
+            if (timestamp < Integer.MIN_VALUE) {
+                return Integer.MIN_VALUE;
+            }
+            return (int) timestamp;
+        } catch (Exception ignored) {
+            return Integer.MAX_VALUE;
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/util/HotelDateTimeUtil.java
+++ b/Emulator/src/main/java/com/eu/habbo/util/HotelDateTimeUtil.java
@@ -9,10 +9,15 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 
 public final class HotelDateTimeUtil {
     private static final Logger LOGGER = LoggerFactory.getLogger(HotelDateTimeUtil.class);
     private static final String CONFIG_KEY = "hotel.timezone";
+    private static final DateTimeFormatter STRICT_TIMESTAMP_FORMAT =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss")
+                    .withResolverStyle(ResolverStyle.STRICT);
     private static volatile String lastInvalidTimezoneId = null;
 
     private HotelDateTimeUtil() {
@@ -57,5 +62,9 @@ public final class HotelDateTimeUtil {
 
     public static long toEpochSecond(LocalDateTime dateTime) {
         return dateTime.atZone(getZoneId()).toEpochSecond();
+    }
+
+    public static LocalDateTime parseDateTimeStrict(String value) {
+        return LocalDateTime.parse(value, STRICT_TIMESTAMP_FORMAT);
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/EmulatorTimeUtilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorTimeUtilityTest.java
@@ -3,11 +3,13 @@ package com.eu.habbo;
 import org.junit.jupiter.api.Test;
 
 import java.text.SimpleDateFormat;
+import java.lang.reflect.Method;
 import java.util.Date;
 import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class EmulatorTimeUtilityTest {
@@ -79,5 +81,34 @@ class EmulatorTimeUtilityTest {
         assertEquals(
                 int.class,
                 Emulator.class.getDeclaredMethod("getOnlineTime").getReturnType());
+    }
+
+    @Test
+    void durationParserSaturatesInsteadOfOverflowing() {
+        assertEquals(
+                Integer.MAX_VALUE,
+                Emulator.timeStringToSeconds("100 year"));
+        assertEquals(
+                Integer.MAX_VALUE,
+                Emulator.timeStringToSeconds("68 year 10 year"));
+    }
+
+    @Test
+    void internalEpochCalculationsRemainValidPastTheIntBoundary() throws Exception {
+        assertEquals(long.class, Emulator.class.getDeclaredField("timeStarted").getType());
+
+        Method longTimestamp = Emulator.class.getDeclaredMethod("getLongUnixTimestamp");
+        assertEquals(long.class, longTimestamp.getReturnType());
+        assertTrue((long) longTimestamp.invoke(null) > 0L);
+
+        Method elapsedSeconds =
+                Emulator.class.getDeclaredMethod("elapsedSeconds", long.class, long.class);
+        elapsedSeconds.setAccessible(true);
+        assertEquals(
+                20,
+                elapsedSeconds.invoke(null, 2_147_483_640L, 2_147_483_660L));
+        assertEquals(
+                Integer.MAX_VALUE,
+                elapsedSeconds.invoke(null, 0L, 3_000_000_000L));
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/EmulatorTimeUtilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorTimeUtilityTest.java
@@ -2,8 +2,9 @@ package com.eu.habbo;
 
 import org.junit.jupiter.api.Test;
 
-import java.text.SimpleDateFormat;
 import java.lang.reflect.Method;
+import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -110,5 +111,28 @@ class EmulatorTimeUtilityTest {
         assertEquals(
                 Integer.MAX_VALUE,
                 elapsedSeconds.invoke(null, 0L, 3_000_000_000L));
+    }
+
+    @Test
+    void timestampParsingAndFormattingUseImmutableFormatters() throws Exception {
+        assertEquals(
+                DateTimeFormatter.class,
+                Emulator.class
+                        .getDeclaredField("BUILD_TIMESTAMP_FORMAT")
+                        .getType());
+        assertEquals(
+                DateTimeFormatter.class,
+                Emulator.class
+                        .getDeclaredField("LEGACY_TIMESTAMP_PARSER")
+                        .getType());
+
+        Method formatter =
+                Emulator.class.getDeclaredMethod(
+                        "formatBuildTimestamp", long.class, String.class);
+        formatter.setAccessible(true);
+        assertEquals(
+                "2023-11-14 22:13:20",
+                formatter.invoke(null, 1_700_000_000_000L, "UTC"));
+        assertEquals("UNKNOWN", formatter.invoke(null, -1L, "UTC"));
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/EmulatorTimeUtilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorTimeUtilityTest.java
@@ -1,0 +1,83 @@
+package com.eu.habbo;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EmulatorTimeUtilityTest {
+
+    @Test
+    void durationParserPreservesLegacyTokenRules() {
+        assertEquals(
+                239_900_521,
+                Emulator.timeStringToSeconds(
+                        "1 second 2 minutes 3 hour 4 day 5 week 6 month 7 year"));
+        assertEquals(1, Emulator.timeStringToSeconds("1 seconds"));
+        assertEquals(0, Emulator.timeStringToSeconds("1 SECOND"));
+        assertEquals(0, Emulator.timeStringToSeconds("invalid"));
+        assertThrows(
+                NullPointerException.class,
+                () -> Emulator.timeStringToSeconds(null));
+    }
+
+    @Test
+    void dateModifierPreservesCalendarArithmetic() throws Exception {
+        TimeZone previous = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        try {
+            SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            Date initial = format.parse("2024-01-31 12:00:00");
+
+            assertEquals(
+                    format.parse("2024-03-07 14:00:00"),
+                    Emulator.modifyDate(initial, "1 month 1 week 2 hour"));
+            assertEquals(initial, Emulator.modifyDate(initial, "INVALID"));
+        } finally {
+            TimeZone.setDefault(previous);
+        }
+    }
+
+    @Test
+    void publicDateParserPreservesLegacyNullAndLenientBehavior() throws Exception {
+        TimeZone previous = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        try {
+            SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+            assertEquals(
+                    format.parse("2024-02-29 01:02:03"),
+                    Emulator.stringToDate("2024-02-29 01:02:03"));
+            assertEquals(
+                    format.parse("2024-03-01 01:02:03"),
+                    Emulator.stringToDate("2024-02-30 01:02:03 trailing"));
+            assertNull(Emulator.stringToDate("not-a-date"));
+            assertNull(Emulator.stringToDate(null));
+        } finally {
+            TimeZone.setDefault(previous);
+        }
+    }
+
+    @Test
+    void legacyTimeMethodDescriptorsRemainIntBased() throws Exception {
+        assertEquals(
+                int.class,
+                Emulator.class
+                        .getDeclaredMethod("timeStringToSeconds", String.class)
+                        .getReturnType());
+        assertEquals(
+                int.class,
+                Emulator.class.getDeclaredMethod("getIntUnixTimestamp").getReturnType());
+        assertEquals(
+                int.class,
+                Emulator.class.getDeclaredMethod("getTimeStarted").getReturnType());
+        assertEquals(
+                int.class,
+                Emulator.class.getDeclaredMethod("getOnlineTime").getReturnType());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/plugin/PluginManagerPaydayDateTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/plugin/PluginManagerPaydayDateTest.java
@@ -34,7 +34,7 @@ class PluginManagerPaydayDateTest {
             parser.setAccessible(true);
 
             assertEquals(
-                    1_706_746_923,
+                    1_706_749_323,
                     parser.invoke(null, "2024-02-01 01:02:03"));
             assertEquals(
                     Integer.MAX_VALUE,

--- a/Emulator/src/test/java/com/eu/habbo/plugin/PluginManagerPaydayDateTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/plugin/PluginManagerPaydayDateTest.java
@@ -1,0 +1,49 @@
+package com.eu.habbo.plugin;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PluginManagerPaydayDateTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void paydayTimestampUsesStrictHotelTimeParsingAndIntSaturation()
+            throws Exception {
+        Field configField = Emulator.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        Object previousConfig = configField.get(null);
+        Path configFile = this.temporaryDirectory.resolve("config.ini");
+        Files.writeString(configFile, "hotel.timezone=UTC\n");
+        configField.set(null, new ConfigurationManager(configFile.toString()));
+
+        try {
+            Method parser =
+                    PluginManager.class.getDeclaredMethod(
+                            "parsePaydayTimestamp", String.class);
+            parser.setAccessible(true);
+
+            assertEquals(
+                    1_706_746_923,
+                    parser.invoke(null, "2024-02-01 01:02:03"));
+            assertEquals(
+                    Integer.MAX_VALUE,
+                    parser.invoke(null, "2024-02-30 01:02:03"));
+            assertEquals(
+                    Integer.MAX_VALUE,
+                    parser.invoke(null, "2040-01-01 00:00:00"));
+        } finally {
+            configField.set(null, previousConfig);
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/util/HotelDateTimeUtilTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/util/HotelDateTimeUtilTest.java
@@ -1,0 +1,36 @@
+package com.eu.habbo.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class HotelDateTimeUtilTest {
+
+    @Test
+    void strictTimestampParserRejectsLenientAndTrailingInput() throws Exception {
+        Method parser =
+                HotelDateTimeUtil.class.getDeclaredMethod(
+                        "parseDateTimeStrict", String.class);
+
+        assertEquals(
+                LocalDateTime.of(2024, 2, 29, 1, 2, 3),
+                parser.invoke(null, "2024-02-29 01:02:03"));
+
+        assertParseFailure(parser, "2024-02-30 01:02:03");
+        assertParseFailure(parser, "2024-02-29 01:02:03 trailing");
+    }
+
+    private static void assertParseFailure(Method parser, String value) {
+        InvocationTargetException exception = assertThrows(
+                InvocationTargetException.class,
+                () -> parser.invoke(null, value));
+        assertInstanceOf(DateTimeParseException.class, exception.getCause());
+    }
+}


### PR DESCRIPTION
## Summary

- Saturate parsed durations that exceed the legacy `int` return range while preserving existing token rules.
- Keep the public lenient date parser compatible and use strict hotel-time parsing for payday configuration.
- Use immutable date-time formatters and long epoch values for internal uptime calculations.
