### PR TITLE
fix(rooms): ignore null item state updates

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -2614,7 +2614,11 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   }
 
   public void updateItemState(HabboItem item) {
-    if (item != null && RoomAreaHideSupport.isControllerItem(item)) {
+    if (item == null) {
+      return;
+    }
+
+    if (RoomAreaHideSupport.isControllerItem(item)) {
       this.updateItem(item);
       return;
     }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemStateTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemStateTest.java
@@ -1,0 +1,15 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class RoomItemStateTest {
+
+    @Test
+    void nullItemStateUpdateIsIgnored() {
+        Room room = new Room(41, 7);
+
+        assertDoesNotThrow(() -> room.updateItemState(null));
+    }
+}


### PR DESCRIPTION
## Summary

- Ignore null room item state updates before controller and item-state checks.
- Cover the null path with a focused room fixture test.
