### PR TITLE
test(rooms): freeze core room behavior

### DIFF
--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemOwnershipBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemOwnershipBehaviorTest.java
@@ -1,0 +1,78 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class RoomItemOwnershipBehaviorTest {
+
+    @Test
+    void addingAndRemovingItemsMaintainsTheLiveOwnerIndexes() throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource =
+                new RoomJdbcTestSupport.RecordingDataSource();
+        try (RoomJdbcTestSupport.InstalledDatabase ignored =
+                     RoomJdbcTestSupport.install(dataSource)) {
+            Room room = new Room(41, 7);
+            HabboItem first = new TestItem(1001, 7);
+            HabboItem second = new TestItem(1002, 7);
+            room.getFurniOwnerNames().put(7, "owner");
+
+            room.addHabboItem(first);
+            room.addHabboItem(second);
+
+            assertEquals(2, room.getItemManager().itemCount());
+            assertEquals(2, room.getFurniOwnerCount().get(7));
+            assertEquals("owner", room.getFurniOwnerName(7));
+            assertSame(room.getFurniOwnerNames(), room.getItemManager().getFurniOwnerNames());
+            assertSame(room.getFurniOwnerCount(), room.getItemManager().getFurniOwnerCount());
+
+            room.removeHabboItem(first);
+
+            assertEquals(1, room.getItemManager().itemCount());
+            assertEquals(1, room.getFurniOwnerCount().get(7));
+            assertEquals("owner", room.getFurniOwnerName(7));
+
+            room.removeHabboItem(second);
+
+            assertEquals(0, room.getItemManager().itemCount());
+            assertFalse(room.getFurniOwnerCount().containsKey(7));
+            assertFalse(room.getFurniOwnerNames().containsKey(7));
+        }
+    }
+
+    @Test
+    void nullItemMutationsLeaveOwnershipStateUnchanged() {
+        Room room = new Room(41, 7);
+
+        room.addHabboItem(null);
+        room.removeHabboItem((HabboItem) null);
+
+        assertEquals(0, room.getItemManager().itemCount());
+        assertEquals(0, room.getFurniOwnerCount().size());
+        assertEquals(0, room.getFurniOwnerNames().size());
+    }
+
+    private static final class TestItem extends HabboItem {
+        private TestItem(int id, int ownerId) {
+            super(id, ownerId, (Item) null, "0", 0, 0);
+        }
+
+        @Override
+        public boolean canWalkOn(RoomUnit roomUnit, Room room, Object[] objects) {
+            return false;
+        }
+
+        @Override
+        public boolean isWalkable() {
+            return false;
+        }
+
+        @Override
+        public void onWalk(RoomUnit roomUnit, Room room, Object[] objects) {
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomJdbcTestSupport.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomJdbcTestSupport.java
@@ -1,0 +1,206 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.database.Database;
+import com.zaxxer.hikari.HikariDataSource;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+final class RoomJdbcTestSupport {
+
+    private RoomJdbcTestSupport() {
+    }
+
+    static InstalledDatabase install(RecordingDataSource dataSource) throws Exception {
+        Field field = Emulator.class.getDeclaredField("database");
+        field.setAccessible(true);
+        Database original = (Database) field.get(null);
+        field.set(null, databaseUsing(dataSource));
+        return new InstalledDatabase(field, original);
+    }
+
+    private static Database databaseUsing(HikariDataSource dataSource) throws Exception {
+        Constructor<Database> constructor =
+                Database.class.getDeclaredConstructor(HikariDataSource.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(dataSource);
+    }
+
+    record SqlCall(
+            String sql,
+            Map<Integer, Object> parameters,
+            String operation) {
+    }
+
+    static final class RecordingDataSource extends HikariDataSource {
+        private final List<SqlCall> calls = new ArrayList<>();
+        private Function<String, List<Map<String, Object>>> rows =
+                ignored -> List.of();
+        private boolean failUpdates;
+
+        List<SqlCall> calls() {
+            return List.copyOf(this.calls);
+        }
+
+        void rows(Function<String, List<Map<String, Object>>> rows) {
+            this.rows = rows;
+        }
+
+        void failUpdates(boolean failUpdates) {
+            this.failUpdates = failUpdates;
+        }
+
+        @Override
+        public Connection getConnection() {
+            return proxy(Connection.class, (ignored, method, arguments) -> switch (method.getName()) {
+                case "prepareStatement" -> statement((String) arguments[0]);
+                case "close" -> null;
+                case "isClosed" -> false;
+                case "toString" -> "room JDBC fixture connection";
+                default -> defaultValue(method.getReturnType());
+            });
+        }
+
+        private PreparedStatement statement(String sql) {
+            Map<Integer, Object> parameters = new LinkedHashMap<>();
+            return proxy(PreparedStatement.class, (ignored, method, arguments) -> {
+                String name = method.getName();
+                if (name.startsWith("set") && arguments != null && arguments.length >= 2) {
+                    parameters.put((Integer) arguments[0], arguments[1]);
+                    return null;
+                }
+
+                return switch (name) {
+                    case "executeQuery" -> {
+                        this.calls.add(new SqlCall(
+                                sql,
+                                Map.copyOf(parameters),
+                                "query"));
+                        yield resultSet(this.rows.apply(sql));
+                    }
+                    case "executeUpdate" -> {
+                        this.calls.add(new SqlCall(
+                                sql,
+                                Map.copyOf(parameters),
+                                "update"));
+                        if (this.failUpdates) {
+                            throw new SQLException("fixture update failure");
+                        }
+                        yield 1;
+                    }
+                    case "execute" -> {
+                        this.calls.add(new SqlCall(
+                                sql,
+                                Map.copyOf(parameters),
+                                "execute"));
+                        if (this.failUpdates) {
+                            throw new SQLException("fixture update failure");
+                        }
+                        yield false;
+                    }
+                    case "close" -> null;
+                    case "toString" -> "room JDBC fixture statement";
+                    default -> defaultValue(method.getReturnType());
+                };
+            });
+        }
+    }
+
+    static final class InstalledDatabase implements AutoCloseable {
+        private final Field field;
+        private final Database original;
+
+        private InstalledDatabase(Field field, Database original) {
+            this.field = field;
+            this.original = original;
+        }
+
+        @Override
+        public void close() throws IllegalAccessException {
+            this.field.set(null, this.original);
+        }
+    }
+
+    private static ResultSet resultSet(List<Map<String, Object>> rows) {
+        List<Map<String, Object>> copiedRows = rows.stream()
+                .map(HashMap::new)
+                .map(Map::copyOf)
+                .toList();
+        int[] index = {-1};
+        boolean[] wasNull = {false};
+
+        return proxy(ResultSet.class, (ignored, method, arguments) -> {
+            String name = method.getName();
+            if ("next".equals(name)) {
+                index[0]++;
+                return index[0] < copiedRows.size();
+            }
+            if ("close".equals(name)) {
+                return null;
+            }
+            if ("wasNull".equals(name)) {
+                return wasNull[0];
+            }
+            if ("toString".equals(name)) {
+                return "room JDBC fixture result set";
+            }
+
+            Object key = arguments[0];
+            Object value = value(copiedRows.get(index[0]), key);
+            wasNull[0] = value == null;
+            return switch (name) {
+                case "getInt" -> value == null ? 0 : ((Number) value).intValue();
+                case "getShort" -> value == null ? (short) 0 : ((Number) value).shortValue();
+                case "getDouble" -> value == null ? 0D : ((Number) value).doubleValue();
+                case "getBoolean" -> value instanceof Boolean flag
+                        ? flag
+                        : value != null && ((Number) value).intValue() != 0;
+                case "getString" -> value == null ? null : String.valueOf(value);
+                default -> defaultValue(method.getReturnType());
+            };
+        });
+    }
+
+    private static Object value(Map<String, Object> row, Object key) {
+        if (key instanceof String column) {
+            return row.get(column);
+        }
+        if (key instanceof Integer position) {
+            return row.values().stream().skip(position - 1L).findFirst().orElse(null);
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, java.lang.reflect.InvocationHandler handler) {
+        return (T) Proxy.newProxyInstance(
+                type.getClassLoader(),
+                new Class<?>[]{type},
+                handler);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) return null;
+        if (type == boolean.class) return false;
+        if (type == byte.class) return (byte) 0;
+        if (type == short.class) return (short) 0;
+        if (type == int.class) return 0;
+        if (type == long.class) return 0L;
+        if (type == float.class) return 0F;
+        if (type == double.class) return 0D;
+        if (type == char.class) return '\0';
+        return null;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomRightsBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomRightsBehaviorTest.java
@@ -1,0 +1,104 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import it.unimi.dsi.fastutil.ints.IntList;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class RoomRightsBehaviorTest {
+
+    @Test
+    void roomRightsLoadPreservesOrderDuplicatesAndThePublicLiveList() throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource =
+                new RoomJdbcTestSupport.RecordingDataSource();
+        dataSource.rows(sql -> sql.contains("FROM room_rights")
+                ? List.of(
+                    row("user_id", 12),
+                    row("user_id", 20),
+                    row("user_id", 12))
+                : List.of());
+        Room room = new Room(41, 7);
+        IntList publicRights = room.getRights();
+
+        try (Connection connection = dataSource.getConnection()) {
+            loadRights(room, connection);
+        }
+
+        assertSame(publicRights, room.getRights());
+        assertEquals(IntList.of(12, 20, 12), publicRights);
+        publicRights.add(99);
+        assertEquals(IntList.of(12, 20, 12, 99), room.getRights());
+
+        RoomJdbcTestSupport.SqlCall call = dataSource.calls().getFirst();
+        assertEquals(
+                "SELECT user_id FROM room_rights WHERE room_id = ?",
+                call.sql());
+        assertEquals(41, call.parameters().get(1));
+    }
+
+    @Test
+    void rightsManagerLoadsMembershipAndResolvesThePublicUserMap() throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource =
+                new RoomJdbcTestSupport.RecordingDataSource();
+        dataSource.rows(sql -> {
+            if (sql.contains("INNER JOIN users")) {
+                return List.of(
+                        row("user_id", 12, "username", "alice"),
+                        row("user_id", 20, "username", "bob"));
+            }
+            if (sql.contains("FROM room_rights")) {
+                return List.of(
+                        row("user_id", 12),
+                        row("user_id", 20),
+                        row("user_id", 12));
+            }
+            return List.of();
+        });
+
+        try (RoomJdbcTestSupport.InstalledDatabase ignored =
+                     RoomJdbcTestSupport.install(dataSource);
+             Connection connection = dataSource.getConnection()) {
+            Room room = new Room(41, 7);
+
+            room.getRightsManager().loadRights(connection);
+
+            assertEquals(
+                    Map.of(12, "alice", 20, "bob"),
+                    room.getRightsManager().getUsersWithRights());
+        }
+
+        assertEquals(2, dataSource.calls().size());
+        assertEquals(41, dataSource.calls().get(0).parameters().get(1));
+        assertEquals(41, dataSource.calls().get(1).parameters().get(1));
+    }
+
+    private static void loadRights(Room room, Connection connection) throws Exception {
+        Method method = Room.class.getDeclaredMethod("loadRights", Connection.class);
+        method.setAccessible(true);
+        method.invoke(room, connection);
+    }
+
+    private static Map<String, Object> row(String column, Object value) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put(column, value);
+        return row;
+    }
+
+    private static Map<String, Object> row(
+            String firstColumn,
+            Object firstValue,
+            String secondColumn,
+            Object secondValue) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put(firstColumn, firstValue);
+        row.put(secondColumn, secondValue);
+        return row;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSaveBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSaveBehaviorTest.java
@@ -1,0 +1,149 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoomSaveBehaviorTest {
+
+    @Test
+    void dirtyRoomSavesAllFieldsInTheEstablishedOrderThenBecomesClean() throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource =
+                new RoomJdbcTestSupport.RecordingDataSource();
+        try (RoomJdbcTestSupport.InstalledDatabase ignored =
+                     RoomJdbcTestSupport.install(dataSource)) {
+            Room room = persistedRoom();
+            room.setNeedsUpdate(true);
+
+            room.save();
+            room.save();
+
+            assertEquals(1, dataSource.calls().size());
+            RoomJdbcTestSupport.SqlCall call = dataSource.calls().getFirst();
+            assertEquals("update", call.operation());
+            assertTrue(call.sql().startsWith(
+                    "UPDATE rooms SET name = ?, description = ?, password = ?"));
+            assertTrue(call.sql().endsWith(
+                    "builders_club_original_state = ? WHERE id = ?"));
+            assertEquals(44, call.parameters().size());
+            assertSavedValues(call.parameters());
+        }
+    }
+
+    @Test
+    void failedSaveKeepsTheRoomDirtyForTheNextAttempt() throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource =
+                new RoomJdbcTestSupport.RecordingDataSource();
+        try (RoomJdbcTestSupport.InstalledDatabase ignored =
+                     RoomJdbcTestSupport.install(dataSource)) {
+            Room room = persistedRoom();
+            room.setNeedsUpdate(true);
+            dataSource.failUpdates(true);
+
+            room.save();
+            dataSource.failUpdates(false);
+            room.save();
+            room.save();
+
+            assertEquals(2, dataSource.calls().size());
+            assertEquals("update", dataSource.calls().get(0).operation());
+            assertEquals("update", dataSource.calls().get(1).operation());
+        }
+    }
+
+    private static Room persistedRoom() {
+        return RoomTestBuilder.room(41, 7)
+                .field("ownerName", "owner")
+                .field("name", "Saved room")
+                .field("description", "Persistence characterization")
+                .field("password", "secret")
+                .field("state", RoomState.PASSWORD)
+                .field("usersMax", 25)
+                .field("category", 3)
+                .field("score", 88)
+                .field("floorPaint", "1.1")
+                .field("wallPaint", "2.2")
+                .field("backgroundPaint", "3.3")
+                .field("wallSize", 2)
+                .field("wallHeight", -1)
+                .field("floorSize", 4)
+                .field("tags", "retro,polaris")
+                .field("allowPets", true)
+                .field("allowPetsEat", false)
+                .field("allowWalkthrough", true)
+                .field("hideWall", true)
+                .field("chatMode", 1)
+                .field("chatWeight", 2)
+                .field("chatSpeed", 3)
+                .field("chatDistance", 4)
+                .field("chatProtection", 5)
+                .field("muteOption", 1)
+                .field("kickOption", 2)
+                .field("banOption", 3)
+                .field("pollId", 19)
+                .field("guild", 23)
+                .field("rollerSpeed", 4)
+                .field("overrideModel", true)
+                .field("staffPromotedRoom", true)
+                .field("promoted", true)
+                .field("tradeMode", 2)
+                .field("moveDiagonally", true)
+                .field("jukeboxActive", true)
+                .field("hideWired", true)
+                .field("allowUnderpass", true)
+                .field("youtubeEnabled", true)
+                .field("buildersClubTrialLocked", true)
+                .field("buildersClubOriginalState", RoomState.LOCKED)
+                .build();
+    }
+
+    private static void assertSavedValues(Map<Integer, Object> values) {
+        assertEquals("Saved room", values.get(1));
+        assertEquals("Persistence characterization", values.get(2));
+        assertEquals("secret", values.get(3));
+        assertEquals("password", values.get(4));
+        assertEquals(25, values.get(5));
+        assertEquals(3, values.get(6));
+        assertEquals(88, values.get(7));
+        assertEquals("1.1", values.get(8));
+        assertEquals("2.2", values.get(9));
+        assertEquals("3.3", values.get(10));
+        assertEquals(2, values.get(11));
+        assertEquals(-1, values.get(12));
+        assertEquals(4, values.get(13));
+        assertTrue(((String) values.get(14)).contains("#000000"));
+        assertEquals("retro,polaris", values.get(15));
+        assertEquals("1", values.get(16));
+        assertEquals("0", values.get(17));
+        assertEquals("1", values.get(18));
+        assertEquals("1", values.get(19));
+        assertEquals(1, values.get(20));
+        assertEquals(2, values.get(21));
+        assertEquals(3, values.get(22));
+        assertEquals(4, values.get(23));
+        assertEquals(5, values.get(24));
+        assertEquals(1, values.get(25));
+        assertEquals(2, values.get(26));
+        assertEquals(3, values.get(27));
+        assertEquals(19, values.get(28));
+        assertEquals(23, values.get(29));
+        assertEquals(4, values.get(30));
+        assertEquals("1", values.get(31));
+        assertEquals("1", values.get(32));
+        assertEquals("1", values.get(33));
+        assertEquals(2, values.get(34));
+        assertEquals("1", values.get(35));
+        assertEquals(7, values.get(36));
+        assertEquals("owner", values.get(37));
+        assertEquals("1", values.get(38));
+        assertEquals("1", values.get(39));
+        assertEquals("1", values.get(40));
+        assertEquals("1", values.get(41));
+        assertEquals("1", values.get(42));
+        assertEquals("locked", values.get(43));
+        assertEquals(41, values.get(44));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomTestBuilder.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomTestBuilder.java
@@ -1,0 +1,31 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import java.lang.reflect.Field;
+
+final class RoomTestBuilder {
+
+    private final Room room;
+
+    private RoomTestBuilder(int id, int ownerId) {
+        this.room = new Room(id, ownerId);
+    }
+
+    static RoomTestBuilder room(int id, int ownerId) {
+        return new RoomTestBuilder(id, ownerId);
+    }
+
+    RoomTestBuilder field(String name, Object value) {
+        try {
+            Field field = Room.class.getDeclaredField(name);
+            field.setAccessible(true);
+            field.set(this.room, value);
+            return this;
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalArgumentException("Unknown Room field " + name, exception);
+        }
+    }
+
+    Room build() {
+        return this.room;
+    }
+}


### PR DESCRIPTION
Adds executable room behavior fixtures for furniture ownership indexes, legacy and manager rights loading, and persistence effects.

The save fixture pins field binding order, dirty-state clearing after success, and retry behavior after a failed write. Test-only JDBC and room builders keep the suite independent of a running hotel.
