### PR TITLE
refactor(rooms): add database dependency seam

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -122,6 +122,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   private final Int2ObjectMap<RoomBan> bannedHabbos;
   private final Set<Game> games;
   private final Int2ObjectMap<RoomMoodlightData> moodlightData;
+  private final RoomDependencies dependencies;
   public volatile double lastCycleCpuMs = 0.0;
   public volatile String lastCycleThread = "N/A";
 
@@ -240,7 +241,12 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   }
 
   Room(int id, int ownerId) {
+    this(id, ownerId, RoomDependencies.runtime());
+  }
+
+  Room(int id, int ownerId, RoomDependencies dependencies) {
     this.cache = new HashMap<>();
+    this.dependencies = Objects.requireNonNull(dependencies, "dependencies");
     this.id = id;
     this.ownerId = ownerId;
     this.bannedHabbos = new Int2ObjectOpenHashMap<>();
@@ -254,7 +260,12 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   }
 
   public Room(ResultSet set) throws SQLException {
+    this(set, RoomDependencies.runtime());
+  }
+
+  Room(ResultSet set, RoomDependencies dependencies) throws SQLException {
     this.cache = new HashMap<>(1000);
+    this.dependencies = Objects.requireNonNull(dependencies, "dependencies");
     RoomSnapshot.Initial initial = RoomSnapshot.readInitial(set);
     this.id = initial.id();
     this.ownerId = initial.ownerId();
@@ -302,7 +313,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
     this.bannedHabbos = new Int2ObjectOpenHashMap<>();
 
-    try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+    try (Connection connection = this.dependencies.database().openConnection()) {
       // Load bans eagerly (needed for entry check before loadData)
       this.loadBans(connection);
     } catch (SQLException e) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomDependencies.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomDependencies.java
@@ -1,0 +1,24 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.Emulator;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Objects;
+
+record RoomDependencies(ConnectionProvider database) {
+
+    RoomDependencies {
+        Objects.requireNonNull(database, "database");
+    }
+
+    static RoomDependencies runtime() {
+        return new RoomDependencies(
+                () -> Emulator.getDatabase().getDataSource().getConnection());
+    }
+
+    @FunctionalInterface
+    interface ConnectionProvider {
+        Connection openConnection() throws SQLException;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomConstructionCharacterizationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomConstructionCharacterizationTest.java
@@ -181,6 +181,23 @@ class RoomConstructionCharacterizationTest {
         assertSame(room.getWordFilterWords(), room.getWordFilterWords());
     }
 
+    @Test
+    void packagePrivateConstructionUsesAnExplicitDatabaseDependency() throws Exception {
+        setEmulatorField("database", null);
+
+        Room room = new Room(
+                roomRow(),
+                new RoomDependencies(this.dataSource::getConnection));
+
+        assertEquals(41, room.getId());
+        assertEquals(
+                "SELECT users.username, users.id, room_bans.* FROM room_bans "
+                        + "INNER JOIN users ON room_bans.user_id = users.id "
+                        + "WHERE ends > ? AND room_bans.room_id = ?",
+                this.dataSource.sql);
+        assertEquals(41, this.dataSource.parameters.get(2));
+    }
+
     private static void setEmulatorField(String name, Object value) throws Exception {
         Field field = Emulator.class.getDeclaredField(name);
         field.setAccessible(true);


### PR DESCRIPTION
Adds an internal `RoomDependencies` boundary for database connections while preserving the public `Room(ResultSet)` constructor.

Eager room-ban loading now supports an explicit test dependency without changing the legacy runtime path or SQL behavior.
