### PR TITLE
feat(rooms): add load metrics

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -721,6 +721,11 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   private final class RoomLoadOperations implements RoomLoader.Operations {
 
     @Override
+    public int roomId() {
+      return Room.this.id;
+    }
+
+    @Override
     public boolean prepare(long generation) {
       synchronized (Room.this.loadLock) {
         if (generation != Room.this.lifecycleGeneration
@@ -816,7 +821,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     }
 
     @Override
-    public void finish(long generation) {
+    public boolean finish(long generation) {
       Room.this.traxManager = new TraxManager(Room.this);
 
       if (Room.this.jukeboxActive) {
@@ -846,12 +851,14 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
                                   TimeUnit.MILLISECONDS))) {
             Emulator.getPluginManager()
                     .fireEvent(new RoomLoadedEvent(Room.this));
+            return true;
           }
         } catch (Exception exception) {
           Room.this.failLoadTransition(generation);
           LOGGER.error("Caught exception publishing room load", exception);
         }
       }
+      return false;
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLoadMeasurement.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLoadMeasurement.java
@@ -1,0 +1,9 @@
+package com.eu.habbo.habbohotel.rooms;
+
+record RoomLoadMeasurement(
+        int roomId,
+        long generation,
+        long durationNanos,
+        int failureCount,
+        boolean published) {
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLoadMetrics.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLoadMetrics.java
@@ -1,0 +1,50 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+@FunctionalInterface
+interface RoomLoadMetrics {
+
+    void record(RoomLoadMeasurement measurement);
+
+    static RoomLoadMetrics flightRecorder() {
+        return measurement -> {
+            RoomLoadEvent event = new RoomLoadEvent();
+            if (!event.isEnabled()) {
+                return;
+            }
+
+            event.roomId = measurement.roomId();
+            event.generation = measurement.generation();
+            event.durationNanos = measurement.durationNanos();
+            event.failureCount = measurement.failureCount();
+            event.published = measurement.published();
+            event.commit();
+        };
+    }
+
+    @Name("com.eu.habbo.RoomLoad")
+    @Label("Room Load")
+    @Category({"Polaris", "Rooms"})
+    @StackTrace(false)
+    final class RoomLoadEvent extends Event {
+        @Label("Room ID")
+        int roomId;
+
+        @Label("Lifecycle Generation")
+        long generation;
+
+        @Label("Duration (ns)")
+        long durationNanos;
+
+        @Label("Failure Count")
+        int failureCount;
+
+        @Label("Published")
+        boolean published;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLoader.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLoader.java
@@ -3,20 +3,37 @@ package com.eu.habbo.habbohotel.rooms;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 final class RoomLoader {
 
     private final Operations operations;
     private final Supplier<Executor> workerExecutor;
+    private final LongSupplier nanoTime;
+    private final RoomLoadMetrics metrics;
 
     RoomLoader(
             Operations operations,
             Supplier<Executor> workerExecutor) {
+        this(
+                operations,
+                workerExecutor,
+                System::nanoTime,
+                RoomLoadMetrics.flightRecorder());
+    }
+
+    RoomLoader(
+            Operations operations,
+            Supplier<Executor> workerExecutor,
+            LongSupplier nanoTime,
+            RoomLoadMetrics metrics) {
         this.operations = Objects.requireNonNull(operations, "operations");
         this.workerExecutor = Objects.requireNonNull(
                 workerExecutor,
                 "workerExecutor");
+        this.nanoTime = Objects.requireNonNull(nanoTime, "nanoTime");
+        this.metrics = Objects.requireNonNull(metrics, "metrics");
     }
 
     void load(long generation) {
@@ -24,6 +41,8 @@ final class RoomLoader {
             return;
         }
 
+        long startedNanos = this.nanoTime.getAsLong();
+        LoadAttempt attempt = new LoadAttempt();
         try {
             this.operations.initialize();
             this.operations.loadLayout();
@@ -46,7 +65,7 @@ final class RoomLoader {
             try {
                 items.join();
             } catch (Exception exception) {
-                this.operations.reportFailure(
+                attempt.report(
                         "Error waiting for items to load",
                         exception);
             }
@@ -66,19 +85,31 @@ final class RoomLoader {
                         heightmap,
                         wired).join();
             } catch (Exception exception) {
-                this.operations.reportFailure(
+                attempt.report(
                         "Error waiting for parallel room data loading",
                         exception);
             }
 
             this.operations.resetIdleCycles();
         } catch (Exception exception) {
-            this.operations.reportFailure(
+            attempt.report(
                     "Caught exception during room load",
                     exception);
         }
 
-        this.operations.finish(generation);
+        boolean published = false;
+        try {
+            published = this.operations.finish(generation);
+        } catch (RuntimeException exception) {
+            attempt.failureCount++;
+            throw exception;
+        } finally {
+            this.recordMeasurement(
+                    generation,
+                    startedNanos,
+                    attempt.failureCount,
+                    published);
+        }
     }
 
     private static CompletableFuture<Void> run(
@@ -87,7 +118,40 @@ final class RoomLoader {
         return CompletableFuture.runAsync(operation, executor);
     }
 
+    private void recordMeasurement(
+            long generation,
+            long startedNanos,
+            int failureCount,
+            boolean published) {
+        long durationNanos = Math.max(
+                0L,
+                this.nanoTime.getAsLong() - startedNanos);
+        try {
+            this.metrics.record(new RoomLoadMeasurement(
+                    this.operations.roomId(),
+                    generation,
+                    durationNanos,
+                    failureCount,
+                    published));
+        } catch (RuntimeException exception) {
+            this.operations.reportFailure(
+                    "Caught exception recording room load metrics",
+                    exception);
+        }
+    }
+
+    private final class LoadAttempt {
+        private int failureCount;
+
+        private void report(String message, Exception exception) {
+            this.failureCount++;
+            RoomLoader.this.operations.reportFailure(message, exception);
+        }
+    }
+
     interface Operations {
+        int roomId();
+
         boolean prepare(long generation);
 
         void initialize();
@@ -114,7 +178,7 @@ final class RoomLoader {
 
         void resetIdleCycles();
 
-        void finish(long generation);
+        boolean finish(long generation);
 
         void reportFailure(String message, Exception exception);
     }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomLoaderTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomLoaderTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -68,6 +69,29 @@ class RoomLoaderTest {
                 "wired",
                 "reset-idle",
                 "finish:19"), operations.calls);
+    }
+
+    @Test
+    void recordsLoadDurationPublicationAndFailureCount() {
+        RecordingOperations operations = new RecordingOperations();
+        operations.failItems = true;
+        List<RoomLoadMeasurement> measurements = new ArrayList<>();
+        long[] times = {100L, 175L};
+        AtomicInteger timeIndex = new AtomicInteger();
+        RoomLoader loader = new RoomLoader(
+                operations,
+                () -> Runnable::run,
+                () -> times[timeIndex.getAndIncrement()],
+                measurements::add);
+
+        loader.load(20);
+
+        assertEquals(List.of(new RoomLoadMeasurement(
+                41,
+                20,
+                75L,
+                1,
+                true)), measurements);
     }
 
     private static final class RecordingOperations
@@ -154,6 +178,10 @@ class RoomLoaderTest {
         @Override
         public void reportFailure(String message, Exception exception) {
             this.calls.add("failure:" + message);
+        }
+
+        public int roomId() {
+            return 41;
         }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomLoaderTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomLoaderTest.java
@@ -171,8 +171,9 @@ class RoomLoaderTest {
         }
 
         @Override
-        public void finish(long generation) {
+        public boolean finish(long generation) {
             this.calls.add("finish:" + generation);
+            return true;
         }
 
         @Override
@@ -180,6 +181,7 @@ class RoomLoaderTest {
             this.calls.add("failure:" + message);
         }
 
+        @Override
         public int roomId() {
             return 41;
         }


### PR DESCRIPTION
Adds JFR metrics for Room load attempts.

Each event records the room ID, lifecycle generation, elapsed nanoseconds, orchestration failure count, and whether the loaded state was published. Metric collection is internal and cannot fail a room load.
