### PR TITLE
refactor(rooms): introduce room repository

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -130,6 +130,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   private final Int2ObjectMap<RoomMoodlightData> moodlightData;
   private final RoomDependencies dependencies;
   private final RoomLoader loader;
+  private final RoomRepository repository;
   public volatile double lastCycleCpuMs = 0.0;
   public volatile String lastCycleThread = "N/A";
 
@@ -254,6 +255,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   Room(int id, int ownerId, RoomDependencies dependencies) {
     this.cache = new HashMap<>();
     this.dependencies = Objects.requireNonNull(dependencies, "dependencies");
+    this.repository = new RoomRepository(this.dependencies.database());
     this.id = id;
     this.ownerId = ownerId;
     this.bannedHabbos = new Int2ObjectOpenHashMap<>();
@@ -274,6 +276,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   Room(ResultSet set, RoomDependencies dependencies) throws SQLException {
     this.cache = new HashMap<>(1000);
     this.dependencies = Objects.requireNonNull(dependencies, "dependencies");
+    this.repository = new RoomRepository(this.dependencies.database());
     RoomSnapshot.Initial initial = RoomSnapshot.readInitial(set);
     this.id = initial.id();
     this.ownerId = initial.ownerId();
@@ -1444,12 +1447,8 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
    * Made public for access by RoomUnitManager.
    */
   public void updateDatabaseUserCount() {
-    try (Connection connection = Emulator.getDatabase().getDataSource()
-            .getConnection(); PreparedStatement statement = connection.prepareStatement(
-            "UPDATE rooms SET users = ? WHERE id = ? LIMIT 1")) {
-      statement.setInt(1, this.getUserCount());
-      statement.setInt(2, this.id);
-      statement.executeUpdate();
+    try {
+      this.repository.updateUserCount(this.id, this.getUserCount());
     } catch (SQLException e) {
       LOGGER.error("Caught SQL exception", e);
     }
@@ -1676,15 +1675,8 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
       return this.guild;
     }
 
-    try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-         PreparedStatement statement = connection.prepareStatement("SELECT guild_id FROM rooms WHERE id = ? LIMIT 1")) {
-      statement.setInt(1, this.id);
-
-      try (ResultSet set = statement.executeQuery()) {
-        if (set.next()) {
-          this.guild = set.getInt("guild_id");
-        }
-      }
+    try {
+      this.guild = this.repository.findGuildId(this.id);
     } catch (SQLException e) {
       LOGGER.error("Caught SQL exception resolving room guild", e);
     }
@@ -2631,17 +2623,13 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
       this.wiredInspectMask = WIRED_ACCESS_DEFAULT_INSPECT_MASK;
       this.wiredModifyMask = WIRED_ACCESS_DEFAULT_MODIFY_MASK;
 
-      try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-           PreparedStatement statement = connection.prepareStatement(
-                   "SELECT inspect_mask, modify_mask FROM room_wired_settings WHERE room_id = ? LIMIT 1")) {
-        statement.setInt(1, this.id);
-
-        try (ResultSet set = statement.executeQuery()) {
-          if (set.next()) {
-            this.wiredInspectMask = sanitizeWiredInspectMask(set.getInt("inspect_mask"));
-            this.wiredModifyMask = sanitizeWiredModifyMask(set.getInt("modify_mask"));
-          }
-        }
+      try {
+        RoomRepository.WiredSettings settings =
+            this.repository.findWiredSettings(this.id);
+        this.wiredInspectMask =
+            sanitizeWiredInspectMask(settings.inspectMask());
+        this.wiredModifyMask =
+            sanitizeWiredModifyMask(settings.modifyMask());
       } catch (SQLException e) {
         LOGGER.error("Caught SQL exception while loading wired room settings", e);
       }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRepository.java
@@ -1,0 +1,73 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+
+final class RoomRepository {
+
+    private static final String FIND_GUILD_ID_SQL =
+            "SELECT guild_id FROM rooms WHERE id = ? LIMIT 1";
+    private static final String FIND_WIRED_SETTINGS_SQL =
+            "SELECT inspect_mask, modify_mask FROM room_wired_settings "
+                    + "WHERE room_id = ? LIMIT 1";
+    private static final String UPDATE_USER_COUNT_SQL =
+            "UPDATE rooms SET users = ? WHERE id = ? LIMIT 1";
+
+    private final RoomDependencies.ConnectionProvider database;
+
+    RoomRepository(RoomDependencies.ConnectionProvider database) {
+        this.database = Objects.requireNonNull(database, "database");
+    }
+
+    int findGuildId(int roomId) throws SQLException {
+        try (Connection connection = this.database.openConnection();
+             PreparedStatement statement =
+                     connection.prepareStatement(FIND_GUILD_ID_SQL)) {
+            statement.setInt(1, roomId);
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next() ? resultSet.getInt("guild_id") : 0;
+            }
+        }
+    }
+
+    WiredSettings findWiredSettings(int roomId) throws SQLException {
+        try (Connection connection = this.database.openConnection();
+             PreparedStatement statement =
+                     connection.prepareStatement(FIND_WIRED_SETTINGS_SQL)) {
+            statement.setInt(1, roomId);
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return new WiredSettings(
+                            resultSet.getInt("inspect_mask"),
+                            resultSet.getInt("modify_mask"));
+                }
+            }
+        }
+
+        return WiredSettings.defaults();
+    }
+
+    void updateUserCount(int roomId, int userCount) throws SQLException {
+        try (Connection connection = this.database.openConnection();
+             PreparedStatement statement =
+                     connection.prepareStatement(UPDATE_USER_COUNT_SQL)) {
+            statement.setInt(1, userCount);
+            statement.setInt(2, roomId);
+            statement.executeUpdate();
+        }
+    }
+
+    record WiredSettings(int inspectMask, int modifyMask) {
+
+        static WiredSettings defaults() {
+            return new WiredSettings(
+                    Room.WIRED_ACCESS_DEFAULT_INSPECT_MASK,
+                    Room.WIRED_ACCESS_DEFAULT_MODIFY_MASK);
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomPersistenceBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomPersistenceBehaviorTest.java
@@ -27,28 +27,28 @@ class RoomPersistenceBehaviorTest {
             return List.of();
         });
 
-        try (RoomJdbcTestSupport.InstalledDatabase ignored =
-                     RoomJdbcTestSupport.install(dataSource)) {
-            Room room = new Room(41, 7);
+        Room room = new Room(
+                41,
+                7,
+                new RoomDependencies(dataSource::getConnection));
 
-            assertEquals(23, room.getGuildId());
-            assertEquals(23, room.getGuildId());
-            assertEquals(13, room.getWiredInspectMask());
-            assertEquals(12, room.getWiredModifyMask());
-            assertEquals(13, room.getWiredInspectMask());
-            assertEquals(12, room.getWiredModifyMask());
+        assertEquals(23, room.getGuildId());
+        assertEquals(23, room.getGuildId());
+        assertEquals(13, room.getWiredInspectMask());
+        assertEquals(12, room.getWiredModifyMask());
+        assertEquals(13, room.getWiredInspectMask());
+        assertEquals(12, room.getWiredModifyMask());
 
-            assertEquals(2, dataSource.calls().size());
-            assertEquals(
-                    "SELECT guild_id FROM rooms WHERE id = ? LIMIT 1",
-                    dataSource.calls().get(0).sql());
-            assertEquals(Map.of(1, 41), dataSource.calls().get(0).parameters());
-            assertEquals(
-                    "SELECT inspect_mask, modify_mask FROM room_wired_settings "
-                            + "WHERE room_id = ? LIMIT 1",
-                    dataSource.calls().get(1).sql());
-            assertEquals(Map.of(1, 41), dataSource.calls().get(1).parameters());
-        }
+        assertEquals(2, dataSource.calls().size());
+        assertEquals(
+                "SELECT guild_id FROM rooms WHERE id = ? LIMIT 1",
+                dataSource.calls().get(0).sql());
+        assertEquals(Map.of(1, 41), dataSource.calls().get(0).parameters());
+        assertEquals(
+                "SELECT inspect_mask, modify_mask FROM room_wired_settings "
+                        + "WHERE room_id = ? LIMIT 1",
+                dataSource.calls().get(1).sql());
+        assertEquals(Map.of(1, 41), dataSource.calls().get(1).parameters());
     }
 
     @Test
@@ -56,19 +56,19 @@ class RoomPersistenceBehaviorTest {
         RoomJdbcTestSupport.RecordingDataSource dataSource =
                 new RoomJdbcTestSupport.RecordingDataSource();
 
-        try (RoomJdbcTestSupport.InstalledDatabase ignored =
-                     RoomJdbcTestSupport.install(dataSource)) {
-            Room room = new Room(41, 7);
+        Room room = new Room(
+                41,
+                7,
+                new RoomDependencies(dataSource::getConnection));
 
-            room.updateDatabaseUserCount();
+        room.updateDatabaseUserCount();
 
-            assertEquals(1, dataSource.calls().size());
-            RoomJdbcTestSupport.SqlCall call = dataSource.calls().getFirst();
-            assertEquals(
-                    "UPDATE rooms SET users = ? WHERE id = ? LIMIT 1",
-                    call.sql());
-            assertEquals(Map.of(1, 0, 2, 41), call.parameters());
-            assertEquals("update", call.operation());
-        }
+        assertEquals(1, dataSource.calls().size());
+        RoomJdbcTestSupport.SqlCall call = dataSource.calls().getFirst();
+        assertEquals(
+                "UPDATE rooms SET users = ? WHERE id = ? LIMIT 1",
+                call.sql());
+        assertEquals(Map.of(1, 0, 2, 41), call.parameters());
+        assertEquals("update", call.operation());
     }
 }


### PR DESCRIPTION
Introduces an internal RoomRepository for guild lookup, wired-settings reads, and user-count updates.

Room uses its injected database provider for these operations while retaining existing SQL, caching, sanitization, and error behavior.
