### PR TITLE
test(items): characterize room persistence

### DIFF
--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemPersistenceBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemPersistenceBehaviorTest.java
@@ -1,0 +1,120 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class RoomItemPersistenceBehaviorTest {
+
+    @Test
+    void pendingItemSaveRetainsUpdateDeleteAndDirtyStateContracts()
+            throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource =
+                new RoomJdbcTestSupport.RecordingDataSource();
+        RoomItemManager manager = new RoomItemManager(new Room(41, 7));
+        TestItem updated = item(1001, "updated");
+        TestItem deleted = item(1002, "deleted");
+        TestItem clean = item(1003, "clean");
+        updated.needsUpdate(true);
+        deleted.needsUpdate(true);
+        deleted.needsDelete(true);
+        items(manager).put(updated.getId(), updated);
+        items(manager).put(deleted.getId(), deleted);
+        items(manager).put(clean.getId(), clean);
+
+        try (RoomJdbcTestSupport.InstalledDatabase ignored =
+                     RoomJdbcTestSupport.install(dataSource)) {
+            manager.saveAllPendingItems();
+            manager.saveAllPendingItems();
+        }
+
+        assertEquals(2, dataSource.calls().size());
+        RoomJdbcTestSupport.SqlCall update = dataSource.calls().stream()
+                .filter(call -> call.sql().startsWith("UPDATE items"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(
+                "UPDATE items SET user_id = ?, room_id = ?, wall_pos = ?, "
+                        + "x = ?, y = ?, z = ?, rot = ?, extra_data = ?, "
+                        + "limited_data = ? WHERE id = ?",
+                update.sql());
+        assertEquals(
+                Map.of(
+                        1, 7,
+                        2, 41,
+                        3, ":w=1,2 l=3,4",
+                        4, 5,
+                        5, 6,
+                        6, 7.125D,
+                        7, 3,
+                        8, "updated",
+                        9, "11:2",
+                        10, 1001),
+                update.parameters());
+        RoomJdbcTestSupport.SqlCall delete = dataSource.calls().stream()
+                .filter(call -> call.sql().startsWith("DELETE FROM items"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("DELETE FROM items WHERE id = ?", delete.sql());
+        assertEquals(Map.of(1, 1002), delete.parameters());
+        assertFalse(updated.needsUpdate());
+        assertFalse(updated.needsDelete());
+        assertFalse(deleted.needsUpdate());
+        assertFalse(deleted.needsDelete());
+        assertFalse(clean.needsUpdate());
+        assertFalse(clean.needsDelete());
+    }
+
+    private static TestItem item(int id, String extraData) {
+        TestItem item = new TestItem(id, extraData);
+        item.setRoomId(41);
+        item.setWallPosition(":w=1,2 l=3,4");
+        item.setX((short) 5);
+        item.setY((short) 6);
+        item.setZ(7.125D);
+        item.setRotation(3);
+        return item;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Int2ObjectMap<HabboItem> items(RoomItemManager manager)
+            throws ReflectiveOperationException {
+        Field field = RoomItemManager.class.getDeclaredField("roomItems");
+        field.setAccessible(true);
+        return (Int2ObjectMap<HabboItem>) field.get(manager);
+    }
+
+    private static final class TestItem extends HabboItem {
+
+        private TestItem(int id, String extraData) {
+            super(id, 7, (Item) null, extraData, 11, 2);
+        }
+
+        @Override
+        public boolean canWalkOn(
+                RoomUnit roomUnit,
+                Room room,
+                Object[] objects) {
+            return false;
+        }
+
+        @Override
+        public boolean isWalkable() {
+            return false;
+        }
+
+        @Override
+        public void onWalk(
+                RoomUnit roomUnit,
+                Room room,
+                Object[] objects) {
+        }
+    }
+}


### PR DESCRIPTION
Adds executable fixtures for room-item update and delete persistence.

The tests pin SQL, parameter mapping, dirty-state transitions, and clean-item skipping before the save path is batched.
