### PR TITLE
refactor(items): batch room persistence

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -1438,6 +1438,14 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
         this.buildersClubOriginalState);
   }
 
+  void savePendingItems(List<HabboItem> items) {
+    try {
+      this.persistence.saveItems(items);
+    } catch (SQLException exception) {
+      LOGGER.error("Caught SQL exception saving room items", exception);
+    }
+  }
+
   /**
    * Updates the user count in the database.
    * Made public for access by RoomUnitManager.

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -47,6 +47,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1162,13 +1163,14 @@ public class RoomItemManager {
      * Saves all items that need updates to the database.
      */
     public void saveAllPendingItems() {
+        List<HabboItem> pendingItems;
         synchronized (this.roomItems) {
-            for (HabboItem item : this.roomItems.values()) {
-                if (item.needsUpdate()) {
-                    item.run();
-                }
-            }
+            pendingItems = this.roomItems.values().stream()
+                    .filter(HabboItem::needsUpdate)
+                    .toList();
         }
+
+        this.room.savePendingItems(pendingItems);
     }
 
     /**
@@ -2483,4 +2485,3 @@ public class RoomItemManager {
         return height;
     }
 }
-

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomPersistence.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomPersistence.java
@@ -1,5 +1,8 @@
 package com.eu.habbo.habbohotel.rooms;
 
+import com.eu.habbo.habbohotel.items.interactions.InteractionGuildGate;
+import com.eu.habbo.habbohotel.users.HabboItem;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -25,6 +28,12 @@ final class RoomPersistence {
                     + "jukebox_active = ?, hidewired = ?, allow_underpass = ?, "
                     + "youtube_enabled = ?, builders_club_trial_locked = ?, "
                     + "builders_club_original_state = ? WHERE id = ?";
+    private static final String DELETE_ITEM_SQL =
+            "DELETE FROM items WHERE id = ?";
+    private static final String UPDATE_ITEM_SQL =
+            "UPDATE items SET user_id = ?, room_id = ?, wall_pos = ?, "
+                    + "x = ?, y = ?, z = ?, rot = ?, extra_data = ?, "
+                    + "limited_data = ? WHERE id = ?";
 
     private final RoomDependencies.ConnectionProvider database;
 
@@ -92,6 +101,91 @@ final class RoomPersistence {
             statement.setInt(44, state.id());
             statement.executeUpdate();
         }
+    }
+
+    void saveItems(List<HabboItem> items) throws SQLException {
+        if (items.isEmpty()) {
+            return;
+        }
+
+        List<HabboItem> deletedItems = items.stream()
+                .filter(HabboItem::needsDelete)
+                .toList();
+        List<HabboItem> updatedItems = items.stream()
+                .filter(item -> !item.needsDelete() && item.needsUpdate())
+                .toList();
+
+        try (Connection connection = this.database.openConnection()) {
+            this.deleteItems(connection, deletedItems);
+            this.updateItems(connection, updatedItems);
+        }
+    }
+
+    private void deleteItems(
+            Connection connection,
+            List<HabboItem> items) throws SQLException {
+        if (items.isEmpty()) {
+            return;
+        }
+
+        try (PreparedStatement statement =
+                     connection.prepareStatement(DELETE_ITEM_SQL)) {
+            for (HabboItem item : items) {
+                statement.setInt(1, item.getId());
+                statement.addBatch();
+            }
+
+            statement.executeBatch();
+        }
+
+        for (HabboItem item : items) {
+            item.needsUpdate(false);
+            item.needsDelete(false);
+        }
+    }
+
+    private void updateItems(
+            Connection connection,
+            List<HabboItem> items) throws SQLException {
+        if (items.isEmpty()) {
+            return;
+        }
+
+        try (PreparedStatement statement =
+                     connection.prepareStatement(UPDATE_ITEM_SQL)) {
+            for (HabboItem item : items) {
+                statement.setInt(1, item.getDatabaseUserId());
+                statement.setInt(2, item.getRoomId());
+                statement.setString(3, item.getWallPosition());
+                statement.setInt(4, item.getX());
+                statement.setInt(5, item.getY());
+                statement.setDouble(6, persistedHeight(item.getZ()));
+                statement.setInt(7, item.getRotation());
+                statement.setString(
+                        8,
+                        item instanceof InteractionGuildGate
+                                ? ""
+                                : item.getDatabaseExtraData());
+                statement.setString(
+                        9,
+                        item.getLimitedStack()
+                                + ":"
+                                + item.getLimitedSells());
+                statement.setInt(10, item.getId());
+                statement.addBatch();
+            }
+
+            statement.executeBatch();
+        }
+
+        for (HabboItem item : items) {
+            item.needsUpdate(false);
+        }
+    }
+
+    private static double persistedHeight(double height) {
+        double bounded = Math.max(-9999, Math.min(9999, height));
+        return Math.round(bounded * Math.pow(10, 6)) / Math.pow(10, 6);
     }
 
     private static String databaseBoolean(boolean value) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboItem.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboItem.java
@@ -170,6 +170,10 @@ public abstract class HabboItem implements Runnable, IEventTriggers {
         return this.userId;
     }
 
+    public int getDatabaseUserId() {
+        return this.databaseUserId;
+    }
+
     public void setUserId(int userId) {
         this.userId = userId;
         this.databaseUserId = userId;

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemPersistenceBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemPersistenceBehaviorTest.java
@@ -7,11 +7,40 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class RoomItemPersistenceBehaviorTest {
+
+    @Test
+    void pendingItemsShareOneConnectionAndReleaseTheRegistryBeforeJdbc()
+            throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource =
+                new RoomJdbcTestSupport.RecordingDataSource();
+        RoomItemManager manager = new RoomItemManager(new Room(41, 7));
+        Int2ObjectMap<HabboItem> items = items(manager);
+        TestItem first = item(1001, "first");
+        TestItem second = item(1002, "second");
+        first.needsUpdate(true);
+        second.needsUpdate(true);
+        items.put(first.getId(), first);
+        items.put(second.getId(), second);
+        AtomicBoolean registryHeldDuringJdbc = new AtomicBoolean();
+        dataSource.beforeExecution(ignored ->
+                registryHeldDuringJdbc.compareAndSet(
+                        false,
+                        Thread.holdsLock(items)));
+
+        try (RoomJdbcTestSupport.InstalledDatabase ignored =
+                     RoomJdbcTestSupport.install(dataSource)) {
+            manager.saveAllPendingItems();
+        }
+
+        assertEquals(1, dataSource.connectionCount());
+        assertFalse(registryHeldDuringJdbc.get());
+    }
 
     @Test
     void pendingItemSaveRetainsUpdateDeleteAndDirtyStateContracts()

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomJdbcTestSupport.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomJdbcTestSupport.java
@@ -16,6 +16,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 final class RoomJdbcTestSupport {
@@ -46,13 +48,24 @@ final class RoomJdbcTestSupport {
 
     static final class RecordingDataSource extends HikariDataSource {
         private final List<SqlCall> calls = new CopyOnWriteArrayList<>();
+        private final AtomicInteger connectionCount = new AtomicInteger();
         private Function<String, List<Map<String, Object>>> rows =
                 ignored -> List.of();
+        private Consumer<String> beforeExecution = ignored -> {
+        };
         private volatile boolean failQueries;
         private volatile boolean failUpdates;
 
         List<SqlCall> calls() {
             return List.copyOf(this.calls);
+        }
+
+        int connectionCount() {
+            return this.connectionCount.get();
+        }
+
+        void beforeExecution(Consumer<String> beforeExecution) {
+            this.beforeExecution = beforeExecution;
         }
 
         void rows(Function<String, List<Map<String, Object>>> rows) {
@@ -69,6 +82,7 @@ final class RoomJdbcTestSupport {
 
         @Override
         public Connection getConnection() {
+            this.connectionCount.incrementAndGet();
             return proxy(Connection.class, (ignored, method, arguments) -> switch (method.getName()) {
                 case "prepareStatement" -> statement((String) arguments[0]);
                 case "close" -> null;
@@ -80,6 +94,7 @@ final class RoomJdbcTestSupport {
 
         private PreparedStatement statement(String sql) {
             Map<Integer, Object> parameters = new LinkedHashMap<>();
+            List<Map<Integer, Object>> batches = new CopyOnWriteArrayList<>();
             return proxy(PreparedStatement.class, (ignored, method, arguments) -> {
                 String name = method.getName();
                 if (name.startsWith("set") && arguments != null && arguments.length >= 2) {
@@ -88,7 +103,22 @@ final class RoomJdbcTestSupport {
                 }
 
                 return switch (name) {
+                    case "addBatch" -> {
+                        batches.add(Map.copyOf(parameters));
+                        yield null;
+                    }
+                    case "executeBatch" -> {
+                        this.beforeExecution.accept(sql);
+                        if (this.failUpdates) {
+                            throw new SQLException("fixture update failure");
+                        }
+                        for (Map<Integer, Object> batch : batches) {
+                            this.calls.add(new SqlCall(sql, batch, "batch"));
+                        }
+                        yield batches.stream().mapToInt(ignoredBatch -> 1).toArray();
+                    }
                     case "executeQuery" -> {
+                        this.beforeExecution.accept(sql);
                         this.calls.add(new SqlCall(
                                 sql,
                                 Map.copyOf(parameters),
@@ -99,6 +129,7 @@ final class RoomJdbcTestSupport {
                         yield resultSet(this.rows.apply(sql));
                     }
                     case "executeUpdate" -> {
+                        this.beforeExecution.accept(sql);
                         this.calls.add(new SqlCall(
                                 sql,
                                 Map.copyOf(parameters),
@@ -109,6 +140,7 @@ final class RoomJdbcTestSupport {
                         yield 1;
                     }
                     case "execute" -> {
+                        this.beforeExecution.accept(sql);
                         this.calls.add(new SqlCall(
                                 sql,
                                 Map.copyOf(parameters),


### PR DESCRIPTION
Snapshots dirty room items under the item registry lock, then persists them in delete and update batches through one room-owned connection.

The legacy single-item save entry point remains available, while room disposal no longer holds the item registry across JDBC work.
