### PR TITLE
refactor(rooms): make guild getter state-only

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -1675,16 +1675,6 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   }
 
   public int getGuildId() {
-    if (this.guild > 0) {
-      return this.guild;
-    }
-
-    try {
-      this.guild = this.repository.findGuildId(this.id);
-    } catch (SQLException e) {
-      LOGGER.error("Caught SQL exception resolving room guild", e);
-    }
-
     return this.guild;
   }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRepository.java
@@ -8,8 +8,6 @@ import java.util.Objects;
 
 final class RoomRepository {
 
-    private static final String FIND_GUILD_ID_SQL =
-            "SELECT guild_id FROM rooms WHERE id = ? LIMIT 1";
     private static final String FIND_WIRED_SETTINGS_SQL =
             "SELECT inspect_mask, modify_mask FROM room_wired_settings "
                     + "WHERE room_id = ? LIMIT 1";
@@ -20,18 +18,6 @@ final class RoomRepository {
 
     RoomRepository(RoomDependencies.ConnectionProvider database) {
         this.database = Objects.requireNonNull(database, "database");
-    }
-
-    int findGuildId(int roomId) throws SQLException {
-        try (Connection connection = this.database.openConnection();
-             PreparedStatement statement =
-                     connection.prepareStatement(FIND_GUILD_ID_SQL)) {
-            statement.setInt(1, roomId);
-
-            try (ResultSet resultSet = statement.executeQuery()) {
-                return resultSet.next() ? resultSet.getInt("guild_id") : 0;
-            }
-        }
     }
 
     WiredSettings findWiredSettings(int roomId) throws SQLException {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomPersistenceBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomPersistenceBehaviorTest.java
@@ -10,14 +10,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class RoomPersistenceBehaviorTest {
 
     @Test
-    void hiddenGuildAndWiredReadsUseTheEstablishedQueriesAndCacheResults()
+    void guildGetterReturnsLoadedStateWithoutQueryingPersistence()
+            throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource =
+                new RoomJdbcTestSupport.RecordingDataSource();
+        dataSource.rows(sql -> List.of(Map.of("guild_id", 23)));
+        Room room = new Room(
+                41,
+                7,
+                new RoomDependencies(dataSource::getConnection));
+
+        assertEquals(0, room.getGuildId());
+        assertEquals(0, room.getGuildId());
+        assertEquals(0, dataSource.connectionCount());
+        assertEquals(List.of(), dataSource.calls());
+    }
+
+    @Test
+    void wiredReadsUseTheEstablishedQueryAndCacheResults()
             throws Exception {
         RoomJdbcTestSupport.RecordingDataSource dataSource =
                 new RoomJdbcTestSupport.RecordingDataSource();
         dataSource.rows(sql -> {
-            if (sql.startsWith("SELECT guild_id FROM rooms")) {
-                return List.of(Map.of("guild_id", 23));
-            }
             if (sql.startsWith(
                     "SELECT inspect_mask, modify_mask FROM room_wired_settings")) {
                 return List.of(Map.of(
@@ -32,23 +46,17 @@ class RoomPersistenceBehaviorTest {
                 7,
                 new RoomDependencies(dataSource::getConnection));
 
-        assertEquals(23, room.getGuildId());
-        assertEquals(23, room.getGuildId());
         assertEquals(13, room.getWiredInspectMask());
         assertEquals(12, room.getWiredModifyMask());
         assertEquals(13, room.getWiredInspectMask());
         assertEquals(12, room.getWiredModifyMask());
 
-        assertEquals(2, dataSource.calls().size());
-        assertEquals(
-                "SELECT guild_id FROM rooms WHERE id = ? LIMIT 1",
-                dataSource.calls().get(0).sql());
-        assertEquals(Map.of(1, 41), dataSource.calls().get(0).parameters());
+        assertEquals(1, dataSource.calls().size());
         assertEquals(
                 "SELECT inspect_mask, modify_mask FROM room_wired_settings "
                         + "WHERE room_id = ? LIMIT 1",
-                dataSource.calls().get(1).sql());
-        assertEquals(Map.of(1, 41), dataSource.calls().get(1).parameters());
+                dataSource.calls().get(0).sql());
+        assertEquals(Map.of(1, 41), dataSource.calls().get(0).parameters());
     }
 
     @Test


### PR DESCRIPTION
Makes `getGuildId()` a pure read of room metadata loaded during construction.

The getter no longer opens a database connection or mutates room state when the stored guild ID is zero.
