### PR TITLE
test(rooms): characterize item operations

### DIFF
--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -32,7 +32,7 @@
         <javaparser.version>3.27.1</javaparser.version>
         <flyway.version>12.11.0</flyway.version>
         <testcontainers.version>1.21.4</testcontainers.version>
-        <mockito.version>5.14.2</mockito.version>
+        <mockito.version>5.23.0</mockito.version>
         <datafaker.version>2.4.2</datafaker.version>
 
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/Emulator/src/test/java/com/eu/habbo/build/MockitoJavaCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/build/MockitoJavaCompatibilityTest.java
@@ -1,0 +1,19 @@
+package com.eu.habbo.build;
+
+import com.eu.habbo.habbohotel.rooms.Room;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MockitoJavaCompatibilityTest {
+
+    @Test
+    void mocksConcretePolarisTypesOnTheRequiredJdk() {
+        Room room = mock(Room.class);
+        when(room.getId()).thenReturn(7);
+
+        assertEquals(7, room.getId());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemOperationBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemOperationBehaviorTest.java
@@ -1,0 +1,143 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.items.FurnitureType;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.ItemInteraction;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.Outgoing;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RoomItemOperationBehaviorTest {
+
+    @Test
+    void roomItemUpdatePublishesFloorAndAreaHideState() throws Exception {
+        RecordingRoom room = roomWithLayout();
+        HabboItem controller = item("wf_conf_area_hide", null);
+
+        room.updateItem(controller);
+
+        assertEquals(
+                List.of(
+                        Outgoing.FloorItemUpdateComposer,
+                        Outgoing.AreaHideComposer),
+                room.messageHeaders());
+    }
+
+    @Test
+    void roomItemStateUpdatePublishesInvisibilityState() throws Exception {
+        RecordingRoom room = roomWithLayout();
+        HabboItem controller = item("wf_conf_invis_control", null);
+        when(controller.getExtradata()).thenReturn("1");
+        HabboItem target = item("default", "is_invisible");
+        room.floorItems = Set.of(controller, target);
+
+        room.updateItemState(target);
+
+        assertEquals(
+                List.of(
+                        Outgoing.ItemStateComposer,
+                        Outgoing.ConfInvisStateComposer),
+                room.messageHeaders());
+    }
+
+    @Test
+    void roomItemStateUpdatePublishesHanditemBlockState()
+            throws Exception {
+        RecordingRoom room = roomWithLayout();
+        HabboItem controller = item("wf_conf_handitem_block", null);
+        when(controller.getExtradata()).thenReturn("1");
+        room.floorItems = Set.of(controller);
+
+        room.updateItemState(controller);
+
+        assertEquals(
+                List.of(
+                        Outgoing.ItemStateComposer,
+                        Outgoing.HanditemBlockStateComposer),
+                room.messageHeaders());
+    }
+
+    private static RecordingRoom roomWithLayout() throws Exception {
+        RecordingRoom room = new RecordingRoom();
+        RoomLayout layout = mock(RoomLayout.class);
+        when(layout.getTilesAt(
+                nullable(RoomTile.class),
+                anyInt(),
+                anyInt(),
+                anyInt())).thenReturn(Set.of());
+        setField(room, "layout", layout);
+        return room;
+    }
+
+    private static HabboItem item(
+            String interactionName,
+            String customParams) {
+        HabboItem item = mock(HabboItem.class);
+        Item baseItem = mock(Item.class);
+        when(item.getId()).thenReturn(1001);
+        when(item.getRoomId()).thenReturn(41);
+        when(item.getBaseItem()).thenReturn(baseItem);
+        when(item.getExtradata()).thenReturn("0");
+        when(baseItem.getType()).thenReturn(FurnitureType.FLOOR);
+        when(baseItem.getWidth()).thenReturn(1);
+        when(baseItem.getLength()).thenReturn(1);
+        when(baseItem.getInteractionType()).thenReturn(
+                new ItemInteraction(interactionName, HabboItem.class));
+        when(baseItem.getCustomParams()).thenReturn(customParams);
+        return item;
+    }
+
+    private static void setField(Room room, String name, Object value)
+            throws ReflectiveOperationException {
+        Field field = Room.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(room, value);
+    }
+
+    private static final class RecordingRoom extends Room {
+        private final List<ServerMessage> messages = new ArrayList<>();
+        private Set<HabboItem> floorItems = Set.of();
+
+        private RecordingRoom() {
+            super(41, 7);
+        }
+
+        @Override
+        public boolean isLoaded() {
+            return true;
+        }
+
+        @Override
+        public Set<HabboItem> getFloorItems() {
+            return this.floorItems;
+        }
+
+        @Override
+        public void updateTiles(Collection<RoomTile> tiles) {
+        }
+
+        @Override
+        public void sendComposer(ServerMessage message) {
+            this.messages.add(message);
+        }
+
+        private List<Integer> messageHeaders() {
+            return this.messages.stream()
+                    .map(ServerMessage::getHeader)
+                    .toList();
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomPickupOwnershipContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomPickupOwnershipContractTest.java
@@ -1,21 +1,115 @@
 package com.eu.habbo.habbohotel.rooms;
 
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.FurnitureType;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.habbohotel.users.HabboInventory;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.users.inventory.ItemsComponent;
+import com.eu.habbo.plugin.PluginManager;
+import com.eu.habbo.threading.ThreadPooling;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.lang.reflect.Field;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class RoomPickupOwnershipContractTest {
-    @Test
-    void pickupReturnsItemToPickerWhenPickerOwnsTheItem() throws Exception {
-        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/Room.java"));
 
-        assertTrue(source.contains("picker.getHabboInfo().getId() == item.getUserId()"),
-                "Room.pickUpItem should compare the picker id against the item owner id");
-        assertFalse(source.contains("picker.getHabboInfo().getId() == item.getId()"),
-                "Room.pickUpItem must not compare user ids against furniture item ids");
+    @Test
+    void pickupReturnsItemToThePickerWhenThePickerOwnsIt() throws Exception {
+        RecordingRoom room = new RecordingRoom();
+        RoomLayout layout = mock(RoomLayout.class);
+        setField(room, "layout", layout);
+        HabboItem item = mock(HabboItem.class);
+        Item baseItem = mock(Item.class);
+        when(item.getId()).thenReturn(1001);
+        when(item.getUserId()).thenReturn(7);
+        when(item.getBaseItem()).thenReturn(baseItem);
+        when(baseItem.getType()).thenReturn(FurnitureType.FLOOR);
+        when(baseItem.getWidth()).thenReturn(1);
+        when(baseItem.getLength()).thenReturn(1);
+
+        Habbo picker = mock(Habbo.class);
+        HabboInfo pickerInfo = mock(HabboInfo.class);
+        HabboInventory inventory = mock(HabboInventory.class);
+        ItemsComponent items = mock(ItemsComponent.class);
+        GameClient client = mock(GameClient.class);
+        when(picker.getHabboInfo()).thenReturn(pickerInfo);
+        when(pickerInfo.getId()).thenReturn(7);
+        when(picker.getInventory()).thenReturn(inventory);
+        when(inventory.getItemsComponent()).thenReturn(items);
+        when(picker.getClient()).thenReturn(client);
+
+        PluginManager plugins = mock(PluginManager.class);
+        ThreadPooling threading = mock(ThreadPooling.class);
+        try (MockedStatic<Emulator> emulator = mockStatic(Emulator.class);
+             MockedStatic<BuildersClubRoomSupport> buildersClub =
+                     mockStatic(BuildersClubRoomSupport.class)) {
+            emulator.when(Emulator::getPluginManager).thenReturn(plugins);
+            emulator.when(Emulator::getThreading).thenReturn(threading);
+            buildersClub.when(() ->
+                    BuildersClubRoomSupport.isTrackedItem(1001))
+                    .thenReturn(false);
+
+            room.pickUpItem(item, picker);
+        }
+
+        assertEquals(1001, room.removedItemId);
+        verify(item).onPickUp(room);
+        verify(item).setRoomId(0);
+        verify(item).needsUpdate(true);
+        verify(items).addItem(item);
+        verify(client).sendResponse(any(
+                com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer.class));
+        verify(client).sendResponse(any(
+                com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer.class));
+        verify(threading).run(item);
+    }
+
+    private static void setField(Room room, String name, Object value)
+            throws ReflectiveOperationException {
+        Field field = Room.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(room, value);
+    }
+
+    private static final class RecordingRoom extends Room {
+        private int removedItemId;
+
+        private RecordingRoom() {
+            super(41, 7);
+        }
+
+        @Override
+        void removeHabboItem(int id) {
+            this.removedItemId = id;
+        }
+
+        @Override
+        public double getStackHeight(
+                short x,
+                short y,
+                boolean calculateHeightmap) {
+            return 0;
+        }
+
+        @Override
+        public void updateTiles(java.util.Collection<RoomTile> tiles) {
+        }
+
+        @Override
+        public void sendComposer(
+                com.eu.habbo.messages.ServerMessage message) {
+        }
     }
 }


### PR DESCRIPTION
Joins the Java 25 Mockito compatibility dependency into the Room stack and adds executable fixtures for canonical item pickup, updates, and state broadcasts.

The fixtures cover owner inventory return, area-hide updates, invisibility state, and hand-item blocking before the duplicate entry points are consolidated.
