### PR TITLE
refactor(rooms): consolidate item operations

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -912,67 +912,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   }
 
   public void pickUpItem(HabboItem item, Habbo picker) {
-    if (item == null) {
-      return;
-    }
-
-    boolean trackedBuildersClubItem = BuildersClubRoomSupport.isTrackedItem(item.getId());
-
-    if (Emulator.getPluginManager().isRegistered(FurniturePickedUpEvent.class, true)) {
-      Event furniturePickedUpEvent = new FurniturePickedUpEvent(item, picker);
-      Emulator.getPluginManager().fireEvent(furniturePickedUpEvent);
-
-      if (furniturePickedUpEvent.isCancelled()) {
-        return;
-      }
-    }
-
-    this.removeHabboItem(item.getId());
-    item.onPickUp(this);
-    item.setRoomId(0);
-    item.needsUpdate(true);
-
-    if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
-      this.sendComposer(new RemoveFloorItemComposer(item).compose());
-
-      Set<RoomTile> updatedTiles = new HashSet<>();
-      Rectangle rectangle = RoomLayout.getRectangle(item.getX(), item.getY(),
-              item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
-
-      for (short x = (short) rectangle.x; x < rectangle.x + rectangle.getWidth(); x++) {
-        for (short y = (short) rectangle.y; y < rectangle.y + rectangle.getHeight(); y++) {
-          double stackHeight = this.getStackHeight(x, y, false);
-          RoomTile tile = this.layout.getTile(x, y);
-
-          if (tile != null) {
-            tile.setStackHeight(stackHeight);
-            updatedTiles.add(tile);
-          }
-        }
-      }
-      this.sendComposer(new UpdateStackHeightComposer(this, updatedTiles).compose());
-      this.updateTiles(updatedTiles);
-      for (RoomTile tile : updatedTiles) {
-        this.updateHabbosAt(tile.x, tile.y);
-        this.updateBotsAt(tile.x, tile.y);
-      }
-    } else if (item.getBaseItem().getType() == FurnitureType.WALL) {
-      this.sendComposer(new RemoveWallItemComposer(item).compose());
-    }
-
-    if (trackedBuildersClubItem) {
-      Emulator.getGameEnvironment().getItemManager().deleteItem(item);
-      return;
-    }
-
-    Habbo habbo = (picker != null && picker.getHabboInfo().getId() == item.getUserId() ? picker
-            : Emulator.getGameServer().getGameClientManager().getHabbo(item.getUserId()));
-    if (!trackedBuildersClubItem && habbo != null) {
-      habbo.getInventory().getItemsComponent().addItem(item);
-      habbo.getClient().sendResponse(new AddHabboItemComposer(item));
-      habbo.getClient().sendResponse(new InventoryRefreshComposer());
-    }
-    Emulator.getThreading().run(item);
+    this.itemManager.pickUpItem(item, picker);
   }
 
   public void updateHabbosAt(Rectangle rectangle) {
@@ -1392,6 +1332,10 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   }
 
   public RoomLayout getLayout() {
+    return this.layout;
+  }
+
+  RoomLayout currentLayout() {
     return this.layout;
   }
 
@@ -2636,66 +2580,11 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   }
 
   public void updateItem(HabboItem item) {
-    if (this.isLoaded()) {
-      if (item != null && item.getRoomId() == this.id) {
-        if (item.getBaseItem() != null) {
-          if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
-            this.sendComposer(new FloorItemUpdateComposer(item).compose());
-            this.updateTiles(this.getLayout()
-                    .getTilesAt(this.layout.getTile(item.getX(), item.getY()),
-                            item.getBaseItem().getWidth(), item.getBaseItem().getLength(),
-                            item.getRotation()));
-
-            if (RoomAreaHideSupport.isControllerItem(item)) {
-              RoomAreaHideSupport.sendState(this, item);
-            }
-          } else if (item.getBaseItem().getType() == FurnitureType.WALL) {
-            this.sendComposer(new WallItemUpdateComposer(item).compose());
-          }
-        }
-      }
-    }
+    this.itemManager.updateItem(item);
   }
 
   public void updateItemState(HabboItem item) {
-    if (item == null) {
-      return;
-    }
-
-    if (RoomAreaHideSupport.isControllerItem(item)) {
-      this.updateItem(item);
-      return;
-    }
-
-    if (!item.isLimited()) {
-      this.sendComposer(new ItemStateComposer(item).compose());
-    } else {
-      this.sendComposer(new FloorItemUpdateComposer(item).compose());
-    }
-
-    if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
-      if (this.layout == null) {
-        return;
-      }
-
-      this.updateTiles(this.getLayout()
-              .getTilesAt(this.layout.getTile(item.getX(), item.getY()), item.getBaseItem().getWidth(),
-                      item.getBaseItem().getLength(), item.getRotation()));
-
-      if (item instanceof InteractionMultiHeight) {
-        ((InteractionMultiHeight) item).updateUnitsOnItem(this);
-      }
-    }
-
-    if (item.getBaseItem().getType() == FurnitureType.FLOOR
-            && (RoomConfInvisSupport.isControllerItem(item) || RoomConfInvisSupport.isTarget(item))) {
-      RoomConfInvisSupport.sendState(this);
-    }
-
-    if (item.getBaseItem().getType() == FurnitureType.FLOOR
-            && RoomHanditemBlockSupport.isControllerItem(item)) {
-      RoomHanditemBlockSupport.sendState(this);
-    }
+    this.itemManager.updateItemState(item);
   }
 
   public int getUserFurniCount(int userId) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -60,6 +60,7 @@ public class RoomItemManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(RoomItemManager.class);
 
     private final Room room;
+    private final RoomItemOperations operations;
 
     // Item storage
     private final Int2ObjectMap<HabboItem> roomItems;
@@ -73,6 +74,7 @@ public class RoomItemManager {
 
     public RoomItemManager(Room room) {
         this.room = room;
+        this.operations = new RoomItemOperations(room);
         this.roomItems = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
         this.furniOwnerNames = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
         this.furniOwnerCount = Int2IntMaps.synchronize(new Int2IntOpenHashMap(0));
@@ -859,47 +861,14 @@ public class RoomItemManager {
      * Updates an item's display.
      */
     public void updateItem(HabboItem item) {
-        if (this.room.isLoaded()) {
-            if (item != null && item.getRoomId() == this.room.getId()) {
-                if (item.getBaseItem() != null) {
-                    if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
-                        this.room.sendComposer(new FloorItemUpdateComposer(item).compose());
-                        this.room.updateTiles(this.room.getLayout()
-                                .getTilesAt(this.room.getLayout().getTile(item.getX(), item.getY()),
-                                        item.getBaseItem().getWidth(), item.getBaseItem().getLength(),
-                                        item.getRotation()));
-                    } else if (item.getBaseItem().getType() == FurnitureType.WALL) {
-                        this.room.sendComposer(new WallItemUpdateComposer(item).compose());
-                    }
-                }
-            }
-        }
+        this.operations.updateItem(item);
     }
 
     /**
      * Updates an item's state.
      */
     public void updateItemState(HabboItem item) {
-        if (!item.isLimited()) {
-            this.room.sendComposer(new ItemStateComposer(item).compose());
-        } else {
-            this.room.sendComposer(new FloorItemUpdateComposer(item).compose());
-        }
-
-        if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
-            if (this.room.getLayout() == null) {
-                return;
-            }
-
-            this.room.updateTiles(this.room.getLayout()
-                    .getTilesAt(this.room.getLayout().getTile(item.getX(), item.getY()),
-                            item.getBaseItem().getWidth(), item.getBaseItem().getLength(),
-                            item.getRotation()));
-
-            if (item instanceof InteractionMultiHeight) {
-                ((InteractionMultiHeight) item).updateUnitsOnItem(this.room);
-            }
-        }
+        this.operations.updateItemState(item);
     }
 
     // ==================== FURNITURE OWNER MANAGEMENT ====================
@@ -955,62 +924,7 @@ public class RoomItemManager {
      * Picks up an item from the room.
      */
     public void pickUpItem(HabboItem item, Habbo picker) {
-        if (item == null) {
-            return;
-        }
-
-        boolean trackedBuildersClubItem = BuildersClubRoomSupport.isTrackedItem(item.getId());
-
-        if (Emulator.getPluginManager().isRegistered(FurniturePickedUpEvent.class, true)) {
-            FurniturePickedUpEvent event = Emulator.getPluginManager()
-                    .fireEvent(new FurniturePickedUpEvent(item, picker));
-
-            if (event.isCancelled()) {
-                return;
-            }
-        }
-
-        this.removeHabboItem(item);
-        item.onPickUp(this.room);
-        item.setRoomId(0);
-        item.needsUpdate(true);
-
-        if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
-            this.room.sendComposer(new RemoveFloorItemComposer(item).compose());
-
-            if (RoomConfInvisSupport.isControllerItem(item) || RoomConfInvisSupport.isTarget(item)) {
-                RoomConfInvisSupport.sendState(this.room);
-            }
-
-            if (RoomAreaHideSupport.isControllerItem(item)) {
-                RoomAreaHideSupport.sendState(this.room, item);
-            }
-
-            if (RoomHanditemBlockSupport.isControllerItem(item)) {
-                RoomHanditemBlockSupport.sendState(this.room);
-            }
-
-            Set<RoomTile> updatedTiles = this.room.getLayout().getTilesAt(
-                    this.room.getLayout().getTile(item.getX(), item.getY()),
-                    item.getBaseItem().getWidth(),
-                    item.getBaseItem().getLength(),
-                    item.getRotation());
-            this.room.updateTiles(updatedTiles);
-
-            for (RoomTile tile : updatedTiles) {
-                this.room.updateHabbosAt(tile.x, tile.y);
-                this.room.updateBotsAt(tile.x, tile.y);
-            }
-        } else if (item.getBaseItem().getType() == FurnitureType.WALL) {
-            this.room.sendComposer(new RemoveWallItemComposer(item).compose());
-        }
-
-        if (trackedBuildersClubItem) {
-            Emulator.getGameEnvironment().getItemManager().deleteItem(item);
-            return;
-        }
-
-        Emulator.getThreading().run(item);
+        this.operations.pickUpItem(item, picker);
     }
 
     /**

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemOperations.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemOperations.java
@@ -1,0 +1,197 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.items.FurnitureType;
+import com.eu.habbo.habbohotel.items.interactions.InteractionMultiHeight;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
+import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
+import com.eu.habbo.messages.outgoing.rooms.UpdateStackHeightComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.FloorItemUpdateComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.ItemStateComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.RemoveFloorItemComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.RemoveWallItemComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.WallItemUpdateComposer;
+import com.eu.habbo.plugin.Event;
+import com.eu.habbo.plugin.events.furniture.FurniturePickedUpEvent;
+
+import java.awt.Rectangle;
+import java.util.HashSet;
+import java.util.Set;
+
+final class RoomItemOperations {
+
+    private final Room room;
+
+    RoomItemOperations(Room room) {
+        this.room = room;
+    }
+
+    void pickUpItem(HabboItem item, Habbo picker) {
+        if (item == null) {
+            return;
+        }
+
+        boolean trackedBuildersClubItem =
+                BuildersClubRoomSupport.isTrackedItem(item.getId());
+
+        if (Emulator.getPluginManager().isRegistered(
+                FurniturePickedUpEvent.class,
+                true)) {
+            Event furniturePickedUpEvent =
+                    new FurniturePickedUpEvent(item, picker);
+            Emulator.getPluginManager().fireEvent(furniturePickedUpEvent);
+
+            if (furniturePickedUpEvent.isCancelled()) {
+                return;
+            }
+        }
+
+        this.room.removeHabboItem(item.getId());
+        item.onPickUp(this.room);
+        item.setRoomId(0);
+        item.needsUpdate(true);
+
+        if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
+            this.room.sendComposer(
+                    new RemoveFloorItemComposer(item).compose());
+
+            Set<RoomTile> updatedTiles = new HashSet<>();
+            Rectangle rectangle = RoomLayout.getRectangle(
+                    item.getX(),
+                    item.getY(),
+                    item.getBaseItem().getWidth(),
+                    item.getBaseItem().getLength(),
+                    item.getRotation());
+
+            for (short x = (short) rectangle.x;
+                 x < rectangle.x + rectangle.getWidth();
+                 x++) {
+                for (short y = (short) rectangle.y;
+                     y < rectangle.y + rectangle.getHeight();
+                     y++) {
+                    double stackHeight =
+                            this.room.getStackHeight(x, y, false);
+                    RoomTile tile = this.room.currentLayout().getTile(x, y);
+
+                    if (tile != null) {
+                        tile.setStackHeight(stackHeight);
+                        updatedTiles.add(tile);
+                    }
+                }
+            }
+            this.room.sendComposer(
+                    new UpdateStackHeightComposer(
+                            this.room,
+                            updatedTiles).compose());
+            this.room.updateTiles(updatedTiles);
+            for (RoomTile tile : updatedTiles) {
+                this.room.updateHabbosAt(tile.x, tile.y);
+                this.room.updateBotsAt(tile.x, tile.y);
+            }
+        } else if (item.getBaseItem().getType() == FurnitureType.WALL) {
+            this.room.sendComposer(
+                    new RemoveWallItemComposer(item).compose());
+        }
+
+        if (trackedBuildersClubItem) {
+            Emulator.getGameEnvironment()
+                    .getItemManager()
+                    .deleteItem(item);
+            return;
+        }
+
+        Habbo owner = picker != null
+                && picker.getHabboInfo().getId() == item.getUserId()
+                ? picker
+                : Emulator.getGameServer()
+                        .getGameClientManager()
+                        .getHabbo(item.getUserId());
+        if (owner != null) {
+            owner.getInventory().getItemsComponent().addItem(item);
+            owner.getClient().sendResponse(
+                    new AddHabboItemComposer(item));
+            owner.getClient().sendResponse(
+                    new InventoryRefreshComposer());
+        }
+        Emulator.getThreading().run(item);
+    }
+
+    void updateItem(HabboItem item) {
+        if (!this.room.isLoaded()
+                || item == null
+                || item.getRoomId() != this.room.getId()
+                || item.getBaseItem() == null) {
+            return;
+        }
+
+        if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
+            this.room.sendComposer(
+                    new FloorItemUpdateComposer(item).compose());
+            this.room.updateTiles(this.room.getLayout()
+                    .getTilesAt(
+                            this.room.currentLayout().getTile(
+                                    item.getX(),
+                                    item.getY()),
+                            item.getBaseItem().getWidth(),
+                            item.getBaseItem().getLength(),
+                            item.getRotation()));
+
+            if (RoomAreaHideSupport.isControllerItem(item)) {
+                RoomAreaHideSupport.sendState(this.room, item);
+            }
+        } else if (item.getBaseItem().getType() == FurnitureType.WALL) {
+            this.room.sendComposer(
+                    new WallItemUpdateComposer(item).compose());
+        }
+    }
+
+    void updateItemState(HabboItem item) {
+        if (item == null) {
+            return;
+        }
+
+        if (RoomAreaHideSupport.isControllerItem(item)) {
+            this.updateItem(item);
+            return;
+        }
+
+        if (!item.isLimited()) {
+            this.room.sendComposer(new ItemStateComposer(item).compose());
+        } else {
+            this.room.sendComposer(
+                    new FloorItemUpdateComposer(item).compose());
+        }
+
+        if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
+            if (this.room.currentLayout() == null) {
+                return;
+            }
+
+            this.room.updateTiles(this.room.getLayout()
+                    .getTilesAt(
+                            this.room.currentLayout().getTile(
+                                    item.getX(),
+                                    item.getY()),
+                            item.getBaseItem().getWidth(),
+                            item.getBaseItem().getLength(),
+                            item.getRotation()));
+
+            if (item instanceof InteractionMultiHeight multiHeight) {
+                multiHeight.updateUnitsOnItem(this.room);
+            }
+        }
+
+        if (item.getBaseItem().getType() == FurnitureType.FLOOR
+                && (RoomConfInvisSupport.isControllerItem(item)
+                || RoomConfInvisSupport.isTarget(item))) {
+            RoomConfInvisSupport.sendState(this.room);
+        }
+
+        if (item.getBaseItem().getType() == FurnitureType.FLOOR
+                && RoomHanditemBlockSupport.isControllerItem(item)) {
+            RoomHanditemBlockSupport.sendState(this.room);
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemOperationBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemOperationBehaviorTest.java
@@ -37,6 +37,21 @@ class RoomItemOperationBehaviorTest {
     }
 
     @Test
+    void managerItemUpdateMatchesTheCanonicalAreaHideBehavior()
+            throws Exception {
+        RecordingRoom room = roomWithLayout();
+        HabboItem controller = item("wf_conf_area_hide", null);
+
+        room.getItemManager().updateItem(controller);
+
+        assertEquals(
+                List.of(
+                        Outgoing.FloorItemUpdateComposer,
+                        Outgoing.AreaHideComposer),
+                room.messageHeaders());
+    }
+
+    @Test
     void roomItemStateUpdatePublishesInvisibilityState() throws Exception {
         RecordingRoom room = roomWithLayout();
         HabboItem controller = item("wf_conf_invis_control", null);
@@ -54,6 +69,24 @@ class RoomItemOperationBehaviorTest {
     }
 
     @Test
+    void managerItemStateUpdateMatchesCanonicalInvisibilityBehavior()
+            throws Exception {
+        RecordingRoom room = roomWithLayout();
+        HabboItem controller = item("wf_conf_invis_control", null);
+        when(controller.getExtradata()).thenReturn("1");
+        HabboItem target = item("default", "is_invisible");
+        room.floorItems = Set.of(controller, target);
+
+        room.getItemManager().updateItemState(target);
+
+        assertEquals(
+                List.of(
+                        Outgoing.ItemStateComposer,
+                        Outgoing.ConfInvisStateComposer),
+                room.messageHeaders());
+    }
+
+    @Test
     void roomItemStateUpdatePublishesHanditemBlockState()
             throws Exception {
         RecordingRoom room = roomWithLayout();
@@ -62,6 +95,23 @@ class RoomItemOperationBehaviorTest {
         room.floorItems = Set.of(controller);
 
         room.updateItemState(controller);
+
+        assertEquals(
+                List.of(
+                        Outgoing.ItemStateComposer,
+                        Outgoing.HanditemBlockStateComposer),
+                room.messageHeaders());
+    }
+
+    @Test
+    void managerItemStateUpdateMatchesCanonicalHanditemBehavior()
+            throws Exception {
+        RecordingRoom room = roomWithLayout();
+        HabboItem controller = item("wf_conf_handitem_block", null);
+        when(controller.getExtradata()).thenReturn("1");
+        room.floorItems = Set.of(controller);
+
+        room.getItemManager().updateItemState(controller);
 
         assertEquals(
                 List.of(

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomPickupOwnershipContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomPickupOwnershipContractTest.java
@@ -27,6 +27,17 @@ class RoomPickupOwnershipContractTest {
 
     @Test
     void pickupReturnsItemToThePickerWhenThePickerOwnsIt() throws Exception {
+        assertPickupReturnsItemToOwner(false);
+    }
+
+    @Test
+    void managerPickupMatchesTheCanonicalOwnerReturnBehavior()
+            throws Exception {
+        assertPickupReturnsItemToOwner(true);
+    }
+
+    private static void assertPickupReturnsItemToOwner(
+            boolean throughManager) throws Exception {
         RecordingRoom room = new RecordingRoom();
         RoomLayout layout = mock(RoomLayout.class);
         setField(room, "layout", layout);
@@ -61,7 +72,11 @@ class RoomPickupOwnershipContractTest {
                     BuildersClubRoomSupport.isTrackedItem(1001))
                     .thenReturn(false);
 
-            room.pickUpItem(item, picker);
+            if (throughManager) {
+                room.getItemManager().pickUpItem(item, picker);
+            } else {
+                room.pickUpItem(item, picker);
+            }
         }
 
         assertEquals(1001, room.removedItemId);


### PR DESCRIPTION
Moves pickup, item update, and item-state update behavior into one internal RoomItemOperations component.

Both Room and RoomItemManager retain their public entry points and now share owner inventory return, stack-height refresh, and area-hide, invisibility, and hand-item broadcasts.