### PR TITLE
refactor(rooms): split item persistence

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -131,6 +131,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   private final RoomDependencies dependencies;
   private final RoomLifecycle lifecycle;
   private final RoomLoader loader;
+  private final RoomItemPersistence itemPersistence;
   private final RoomPersistence persistence;
   private final RoomRepository repository;
   public volatile double lastCycleCpuMs = 0.0;
@@ -243,6 +244,8 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     this.cache = new HashMap<>();
     this.dependencies = Objects.requireNonNull(dependencies, "dependencies");
     this.lifecycle = new RoomLifecycle(new RoomCycleTaskSlot());
+    this.itemPersistence =
+        new RoomItemPersistence(this.dependencies.database());
     this.persistence = new RoomPersistence(this.dependencies.database());
     this.repository = new RoomRepository(this.dependencies.database());
     this.id = id;
@@ -266,6 +269,8 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     this.cache = new HashMap<>(1000);
     this.dependencies = Objects.requireNonNull(dependencies, "dependencies");
     this.lifecycle = new RoomLifecycle(new RoomCycleTaskSlot());
+    this.itemPersistence =
+        new RoomItemPersistence(this.dependencies.database());
     this.persistence = new RoomPersistence(this.dependencies.database());
     this.repository = new RoomRepository(this.dependencies.database());
     RoomSnapshot.Initial initial = RoomSnapshot.readInitial(set);
@@ -1247,7 +1252,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
   void savePendingItems(List<HabboItem> items) {
     try {
-      this.persistence.saveItems(items);
+      this.itemPersistence.save(items);
     } catch (SQLException exception) {
       LOGGER.error("Caught SQL exception saving room items", exception);
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemPersistence.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemPersistence.java
@@ -1,0 +1,111 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.items.interactions.InteractionGuildGate;
+import com.eu.habbo.habbohotel.users.HabboItem;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Objects;
+
+final class RoomItemPersistence {
+
+    private static final String DELETE_ITEM_SQL =
+            "DELETE FROM items WHERE id = ?";
+    private static final String UPDATE_ITEM_SQL =
+            "UPDATE items SET user_id = ?, room_id = ?, wall_pos = ?, "
+                    + "x = ?, y = ?, z = ?, rot = ?, extra_data = ?, "
+                    + "limited_data = ? WHERE id = ?";
+
+    private final RoomDependencies.ConnectionProvider database;
+
+    RoomItemPersistence(RoomDependencies.ConnectionProvider database) {
+        this.database = Objects.requireNonNull(database, "database");
+    }
+
+    void save(List<HabboItem> items) throws SQLException {
+        if (items.isEmpty()) {
+            return;
+        }
+
+        List<HabboItem> deletedItems = items.stream()
+                .filter(HabboItem::needsDelete)
+                .toList();
+        List<HabboItem> updatedItems = items.stream()
+                .filter(item -> !item.needsDelete() && item.needsUpdate())
+                .toList();
+
+        try (Connection connection = this.database.openConnection()) {
+            this.deleteItems(connection, deletedItems);
+            this.updateItems(connection, updatedItems);
+        }
+    }
+
+    private void deleteItems(
+            Connection connection,
+            List<HabboItem> items) throws SQLException {
+        if (items.isEmpty()) {
+            return;
+        }
+
+        try (PreparedStatement statement =
+                     connection.prepareStatement(DELETE_ITEM_SQL)) {
+            for (HabboItem item : items) {
+                statement.setInt(1, item.getId());
+                statement.addBatch();
+            }
+
+            statement.executeBatch();
+        }
+
+        for (HabboItem item : items) {
+            item.needsUpdate(false);
+            item.needsDelete(false);
+        }
+    }
+
+    private void updateItems(
+            Connection connection,
+            List<HabboItem> items) throws SQLException {
+        if (items.isEmpty()) {
+            return;
+        }
+
+        try (PreparedStatement statement =
+                     connection.prepareStatement(UPDATE_ITEM_SQL)) {
+            for (HabboItem item : items) {
+                statement.setInt(1, item.getDatabaseUserId());
+                statement.setInt(2, item.getRoomId());
+                statement.setString(3, item.getWallPosition());
+                statement.setInt(4, item.getX());
+                statement.setInt(5, item.getY());
+                statement.setDouble(6, persistedHeight(item.getZ()));
+                statement.setInt(7, item.getRotation());
+                statement.setString(
+                        8,
+                        item instanceof InteractionGuildGate
+                                ? ""
+                                : item.getDatabaseExtraData());
+                statement.setString(
+                        9,
+                        item.getLimitedStack()
+                                + ":"
+                                + item.getLimitedSells());
+                statement.setInt(10, item.getId());
+                statement.addBatch();
+            }
+
+            statement.executeBatch();
+        }
+
+        for (HabboItem item : items) {
+            item.needsUpdate(false);
+        }
+    }
+
+    private static double persistedHeight(double height) {
+        double bounded = Math.max(-9999, Math.min(9999, height));
+        return Math.round(bounded * Math.pow(10, 6)) / Math.pow(10, 6);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomPersistence.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomPersistence.java
@@ -1,8 +1,5 @@
 package com.eu.habbo.habbohotel.rooms;
 
-import com.eu.habbo.habbohotel.items.interactions.InteractionGuildGate;
-import com.eu.habbo.habbohotel.users.HabboItem;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -28,13 +25,6 @@ final class RoomPersistence {
                     + "jukebox_active = ?, hidewired = ?, allow_underpass = ?, "
                     + "youtube_enabled = ?, builders_club_trial_locked = ?, "
                     + "builders_club_original_state = ? WHERE id = ?";
-    private static final String DELETE_ITEM_SQL =
-            "DELETE FROM items WHERE id = ?";
-    private static final String UPDATE_ITEM_SQL =
-            "UPDATE items SET user_id = ?, room_id = ?, wall_pos = ?, "
-                    + "x = ?, y = ?, z = ?, rot = ?, extra_data = ?, "
-                    + "limited_data = ? WHERE id = ?";
-
     private final RoomDependencies.ConnectionProvider database;
 
     RoomPersistence(RoomDependencies.ConnectionProvider database) {
@@ -101,91 +91,6 @@ final class RoomPersistence {
             statement.setInt(44, state.id());
             statement.executeUpdate();
         }
-    }
-
-    void saveItems(List<HabboItem> items) throws SQLException {
-        if (items.isEmpty()) {
-            return;
-        }
-
-        List<HabboItem> deletedItems = items.stream()
-                .filter(HabboItem::needsDelete)
-                .toList();
-        List<HabboItem> updatedItems = items.stream()
-                .filter(item -> !item.needsDelete() && item.needsUpdate())
-                .toList();
-
-        try (Connection connection = this.database.openConnection()) {
-            this.deleteItems(connection, deletedItems);
-            this.updateItems(connection, updatedItems);
-        }
-    }
-
-    private void deleteItems(
-            Connection connection,
-            List<HabboItem> items) throws SQLException {
-        if (items.isEmpty()) {
-            return;
-        }
-
-        try (PreparedStatement statement =
-                     connection.prepareStatement(DELETE_ITEM_SQL)) {
-            for (HabboItem item : items) {
-                statement.setInt(1, item.getId());
-                statement.addBatch();
-            }
-
-            statement.executeBatch();
-        }
-
-        for (HabboItem item : items) {
-            item.needsUpdate(false);
-            item.needsDelete(false);
-        }
-    }
-
-    private void updateItems(
-            Connection connection,
-            List<HabboItem> items) throws SQLException {
-        if (items.isEmpty()) {
-            return;
-        }
-
-        try (PreparedStatement statement =
-                     connection.prepareStatement(UPDATE_ITEM_SQL)) {
-            for (HabboItem item : items) {
-                statement.setInt(1, item.getDatabaseUserId());
-                statement.setInt(2, item.getRoomId());
-                statement.setString(3, item.getWallPosition());
-                statement.setInt(4, item.getX());
-                statement.setInt(5, item.getY());
-                statement.setDouble(6, persistedHeight(item.getZ()));
-                statement.setInt(7, item.getRotation());
-                statement.setString(
-                        8,
-                        item instanceof InteractionGuildGate
-                                ? ""
-                                : item.getDatabaseExtraData());
-                statement.setString(
-                        9,
-                        item.getLimitedStack()
-                                + ":"
-                                + item.getLimitedSells());
-                statement.setInt(10, item.getId());
-                statement.addBatch();
-            }
-
-            statement.executeBatch();
-        }
-
-        for (HabboItem item : items) {
-            item.needsUpdate(false);
-        }
-    }
-
-    private static double persistedHeight(double height) {
-        double bounded = Math.max(-9999, Math.min(9999, height));
-        return Math.round(bounded * Math.pow(10, 6)) / Math.pow(10, 6);
     }
 
     private static String databaseBoolean(boolean value) {


### PR DESCRIPTION
Separates batched room-item updates and deletions from room metadata persistence.

The existing Room and RoomItemManager save entry points remain unchanged, including one-connection batching and dirty-flag behavior.