### PR TITLE
refactor(rooms): extract item registry

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -58,6 +58,7 @@ public class RoomItemManager {
     private final Room room;
     private final RoomItemIndex index;
     private final RoomItemOperations operations;
+    private final RoomItemRegistry registry;
 
     // Tile cache for item lookups
     public final ConcurrentHashMap<RoomTile, Set<HabboItem>> tileCache;
@@ -66,6 +67,7 @@ public class RoomItemManager {
         this.room = room;
         this.index = new RoomItemIndex(room);
         this.operations = new RoomItemOperations(room);
+        this.registry = new RoomItemRegistry(room);
         this.tileCache = this.index.tileCache();
     }
 
@@ -476,94 +478,9 @@ public class RoomItemManager {
         }
 
         // Register with special types
-        this.registerItemWithSpecialTypes(item);
+        this.registry.register(item);
     }
 
-    /**
-     * Registers an item with room special types.
-     */
-    private void registerItemWithSpecialTypes(HabboItem item) {
-        RoomSpecialTypes specialTypes = this.room.getRoomSpecialTypes();
-        if (specialTypes == null) {
-            return;
-        }
-
-        boolean isWiredItem = false;
-
-        synchronized (specialTypes) {
-            // Register with tick service for time-based wired triggers (new 50ms tick system)
-            // This replaces ICycleable for wired items
-            if (item instanceof WiredTickable) {
-                WiredManager.registerTickable(this.room, (WiredTickable) item);
-            }
-            // Still register non-wired ICycleable items with the old system
-            else if (item instanceof ICycleable) {
-                specialTypes.addCycleTask((ICycleable) item);
-            }
-
-            if (item instanceof InteractionWiredTrigger) {
-                specialTypes.addTrigger((InteractionWiredTrigger) item);
-                isWiredItem = true;
-            } else if (item instanceof InteractionWiredEffect) {
-                specialTypes.addEffect((InteractionWiredEffect) item);
-                isWiredItem = true;
-            } else if (item instanceof InteractionWiredCondition) {
-                specialTypes.addCondition((InteractionWiredCondition) item);
-                isWiredItem = true;
-            } else if (item instanceof InteractionWiredExtra) {
-                specialTypes.addExtra((InteractionWiredExtra) item);
-                isWiredItem = true;
-            } else if (item instanceof InteractionBattleBanzaiTeleporter) {
-                specialTypes.addBanzaiTeleporter((InteractionBattleBanzaiTeleporter) item);
-            } else if (item instanceof InteractionRoller) {
-                specialTypes.addRoller((InteractionRoller) item);
-            } else if (item instanceof InteractionGameScoreboard) {
-                specialTypes.addGameScoreboard((InteractionGameScoreboard) item);
-            } else if (item instanceof InteractionGameGate) {
-                specialTypes.addGameGate((InteractionGameGate) item);
-            } else if (item instanceof InteractionGameTimer) {
-                specialTypes.addGameTimer((InteractionGameTimer) item);
-            } else if (item instanceof InteractionFreezeExitTile) {
-                specialTypes.addFreezeExitTile((InteractionFreezeExitTile) item);
-            } else if (item instanceof InteractionNest) {
-                specialTypes.addNest((InteractionNest) item);
-            } else if (item instanceof InteractionPetDrink) {
-                specialTypes.addPetDrink((InteractionPetDrink) item);
-            } else if (item instanceof InteractionPetFood) {
-                specialTypes.addPetFood((InteractionPetFood) item);
-            } else if (item instanceof InteractionPetToy) {
-                specialTypes.addPetToy((InteractionPetToy) item);
-            } else if (item instanceof InteractionPetTree) {
-                specialTypes.addPetTree((InteractionPetTree) item);
-            } else if (item instanceof InteractionMoodLight ||
-                    item instanceof InteractionPyramid ||
-                    item instanceof InteractionMusicDisc ||
-                    item instanceof InteractionBattleBanzaiSphere ||
-                    item instanceof InteractionTalkingFurniture ||
-                    item instanceof InteractionWater ||
-                    item instanceof InteractionWaterItem ||
-                    item instanceof InteractionMuteArea ||
-                    item instanceof InteractionBuildArea ||
-                    item instanceof InteractionTagPole ||
-                    item instanceof InteractionTagField ||
-                    item instanceof InteractionJukeBox ||
-                    item instanceof InteractionPetBreedingNest ||
-                    item instanceof InteractionBlackHole ||
-                    item instanceof InteractionWiredHighscore ||
-                    item instanceof InteractionStickyPole ||
-                    item instanceof WiredBlob ||
-                    item instanceof InteractionTent ||
-                    item instanceof InteractionSnowboardSlope ||
-                    item instanceof InteractionFireworks || item instanceof InteractionVoteCounter) {
-                specialTypes.addUndefined(item);
-            }
-        }
-
-        // Invalidate wired cache when wired items are added
-        if (isWiredItem) {
-            WiredManager.invalidateRoom(this.room);
-        }
-    }
 
     /**
      * Removes an item by ID.
@@ -603,7 +520,7 @@ public class RoomItemManager {
             }
 
             // Unregister from special types
-            this.unregisterItemFromSpecialTypes(item);
+            this.registry.unregister(item);
         }
 
         if (trackedBuildersClubItem) {
@@ -617,134 +534,6 @@ public class RoomItemManager {
         }
     }
 
-    /**
-     * Unregisters an item from room special types.
-     */
-    private void unregisterItemFromSpecialTypes(HabboItem item) {
-        RoomSpecialTypes specialTypes = this.room.getRoomSpecialTypes();
-        if (specialTypes == null) {
-            return;
-        }
-
-        boolean cleanedSignalAntennaReferences = false;
-        if (this.isAntennaItem(item)) {
-            cleanedSignalAntennaReferences = specialTypes.unlinkSignalAntennaReferences(item.getId());
-        }
-
-        this.room.getFurniVariableManager().removeAssignmentsForFurni(item.getId());
-
-        boolean isWiredItem = false;
-
-        // Unregister from tick service for time-based wired triggers (new 50ms tick system)
-        if (item instanceof WiredTickable) {
-            WiredManager.unregisterTickable(this.room, (WiredTickable) item);
-        }
-        // Still handle non-wired ICycleable items with the old system
-        else if (item instanceof ICycleable) {
-            specialTypes.removeCycleTask((ICycleable) item);
-        }
-
-        if (item instanceof InteractionBattleBanzaiTeleporter) {
-            specialTypes.removeBanzaiTeleporter((InteractionBattleBanzaiTeleporter) item);
-        } else if (item instanceof InteractionWiredTrigger) {
-            specialTypes.removeTrigger((InteractionWiredTrigger) item);
-            isWiredItem = true;
-        } else if (item instanceof InteractionWiredEffect) {
-            specialTypes.removeEffect((InteractionWiredEffect) item);
-            isWiredItem = true;
-        } else if (item instanceof InteractionWiredCondition) {
-            specialTypes.removeCondition((InteractionWiredCondition) item);
-            isWiredItem = true;
-        } else if (item instanceof InteractionWiredExtra) {
-            boolean removedContextDefinition = false;
-            boolean removedVariableTextConnector = false;
-            if (item instanceof WiredExtraUserVariable) {
-                this.room.getUserVariableManager().removeDefinition(item.getId());
-            } else if (item instanceof WiredExtraFurniVariable) {
-                this.room.getFurniVariableManager().removeDefinition(item.getId());
-            } else if (item instanceof WiredExtraRoomVariable) {
-                this.room.getRoomVariableManager().removeDefinition(item.getId());
-            } else if (item instanceof WiredExtraContextVariable) {
-                removedContextDefinition = true;
-            } else if (item instanceof WiredExtraVariableTextConnector) {
-                removedVariableTextConnector = true;
-            } else if (item instanceof WiredExtraVariableReference) {
-                if (((WiredExtraVariableReference) item).isRoomReference()) {
-                    this.room.getRoomVariableManager().removeDefinition(item.getId());
-                } else {
-                    this.room.getUserVariableManager().removeDefinition(item.getId());
-                }
-            } else if (item instanceof WiredExtraVariableEcho) {
-                WiredExtraVariableEcho echo = (WiredExtraVariableEcho) item;
-
-                if (echo.isRoomEcho()) {
-                    this.room.getRoomVariableManager().removeDefinition(item.getId());
-                } else if (echo.isFurniEcho()) {
-                    this.room.getFurniVariableManager().removeDefinition(item.getId());
-                } else {
-                    this.room.getUserVariableManager().removeDefinition(item.getId());
-                }
-            }
-            specialTypes.removeExtra((InteractionWiredExtra) item);
-            if (removedContextDefinition || removedVariableTextConnector) {
-                WiredContextVariableSupport.broadcastDefinitions(this.room);
-            }
-            isWiredItem = true;
-        } else if (item instanceof InteractionRoller) {
-            specialTypes.removeRoller((InteractionRoller) item);
-        } else if (item instanceof InteractionGameScoreboard) {
-            specialTypes.removeScoreboard((InteractionGameScoreboard) item);
-        } else if (item instanceof InteractionGameGate) {
-            specialTypes.removeGameGate((InteractionGameGate) item);
-        } else if (item instanceof InteractionGameTimer) {
-            specialTypes.removeGameTimer((InteractionGameTimer) item);
-        } else if (item instanceof InteractionFreezeExitTile) {
-            specialTypes.removeFreezeExitTile((InteractionFreezeExitTile) item);
-        } else if (item instanceof InteractionNest) {
-            specialTypes.removeNest((InteractionNest) item);
-        } else if (item instanceof InteractionPetDrink) {
-            specialTypes.removePetDrink((InteractionPetDrink) item);
-        } else if (item instanceof InteractionPetFood) {
-            specialTypes.removePetFood((InteractionPetFood) item);
-        } else if (item instanceof InteractionPetToy) {
-            specialTypes.removePetToy((InteractionPetToy) item);
-        } else if (item instanceof InteractionPetTree) {
-            specialTypes.removePetTree((InteractionPetTree) item);
-        } else if (item instanceof InteractionMoodLight ||
-                item instanceof InteractionPyramid ||
-                item instanceof InteractionMusicDisc ||
-                item instanceof InteractionBattleBanzaiSphere ||
-                item instanceof InteractionTalkingFurniture ||
-                item instanceof InteractionWaterItem ||
-                item instanceof InteractionWater ||
-                item instanceof InteractionMuteArea ||
-                item instanceof InteractionTagPole ||
-                item instanceof InteractionTagField ||
-                item instanceof InteractionJukeBox ||
-                item instanceof InteractionPetBreedingNest ||
-                item instanceof InteractionBlackHole ||
-                item instanceof InteractionWiredHighscore ||
-                item instanceof InteractionStickyPole ||
-                item instanceof WiredBlob ||
-                item instanceof InteractionTent ||
-                item instanceof InteractionSnowboardSlope || item instanceof InteractionVoteCounter) {
-            specialTypes.removeUndefined(item);
-        }
-
-        // Invalidate wired cache when wired items are removed
-        if (isWiredItem || cleanedSignalAntennaReferences) {
-            WiredManager.invalidateRoom(this.room);
-        }
-    }
-
-    private boolean isAntennaItem(HabboItem item) {
-        if (item == null || item.getBaseItem() == null || item.getBaseItem().getInteractionType() == null) {
-            return false;
-        }
-
-        String interactionType = item.getBaseItem().getInteractionType().getName();
-        return interactionType != null && interactionType.equalsIgnoreCase("antenna");
-    }
 
     // ==================== ITEM UPDATES ====================
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemRegistry.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemRegistry.java
@@ -1,0 +1,240 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.items.ICycleable;
+import com.eu.habbo.habbohotel.items.interactions.*;
+import com.eu.habbo.habbohotel.items.interactions.games.InteractionGameGate;
+import com.eu.habbo.habbohotel.items.interactions.games.InteractionGameScoreboard;
+import com.eu.habbo.habbohotel.items.interactions.games.InteractionGameTimer;
+import com.eu.habbo.habbohotel.items.interactions.games.battlebanzai.InteractionBattleBanzaiSphere;
+import com.eu.habbo.habbohotel.items.interactions.games.battlebanzai.InteractionBattleBanzaiTeleporter;
+import com.eu.habbo.habbohotel.items.interactions.games.freeze.InteractionFreezeExitTile;
+import com.eu.habbo.habbohotel.items.interactions.games.tag.InteractionTagField;
+import com.eu.habbo.habbohotel.items.interactions.games.tag.InteractionTagPole;
+import com.eu.habbo.habbohotel.items.interactions.pets.*;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.*;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.core.WiredContextVariableSupport;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.tick.WiredTickable;
+
+final class RoomItemRegistry {
+
+    private final Room room;
+
+    RoomItemRegistry(Room room) {
+        this.room = room;
+    }
+
+    void register(HabboItem item) {
+        RoomSpecialTypes specialTypes = this.room.getRoomSpecialTypes();
+        if (specialTypes == null) {
+            return;
+        }
+
+        boolean wiredItem = false;
+        synchronized (specialTypes) {
+            if (item instanceof WiredTickable tickable) {
+                WiredManager.registerTickable(this.room, tickable);
+            } else if (item instanceof ICycleable cycleable) {
+                specialTypes.addCycleTask(cycleable);
+            }
+
+            if (item instanceof InteractionWiredTrigger trigger) {
+                specialTypes.addTrigger(trigger);
+                wiredItem = true;
+            } else if (item instanceof InteractionWiredEffect effect) {
+                specialTypes.addEffect(effect);
+                wiredItem = true;
+            } else if (item instanceof InteractionWiredCondition condition) {
+                specialTypes.addCondition(condition);
+                wiredItem = true;
+            } else if (item instanceof InteractionWiredExtra extra) {
+                specialTypes.addExtra(extra);
+                wiredItem = true;
+            } else if (item instanceof InteractionBattleBanzaiTeleporter teleporter) {
+                specialTypes.addBanzaiTeleporter(teleporter);
+            } else if (item instanceof InteractionRoller roller) {
+                specialTypes.addRoller(roller);
+            } else if (item instanceof InteractionGameScoreboard scoreboard) {
+                specialTypes.addGameScoreboard(scoreboard);
+            } else if (item instanceof InteractionGameGate gate) {
+                specialTypes.addGameGate(gate);
+            } else if (item instanceof InteractionGameTimer timer) {
+                specialTypes.addGameTimer(timer);
+            } else if (item instanceof InteractionFreezeExitTile exitTile) {
+                specialTypes.addFreezeExitTile(exitTile);
+            } else if (item instanceof InteractionNest nest) {
+                specialTypes.addNest(nest);
+            } else if (item instanceof InteractionPetDrink drink) {
+                specialTypes.addPetDrink(drink);
+            } else if (item instanceof InteractionPetFood food) {
+                specialTypes.addPetFood(food);
+            } else if (item instanceof InteractionPetToy toy) {
+                specialTypes.addPetToy(toy);
+            } else if (item instanceof InteractionPetTree tree) {
+                specialTypes.addPetTree(tree);
+            } else if (isUndefinedSpecialType(item)) {
+                specialTypes.addUndefined(item);
+            }
+        }
+
+        if (wiredItem) {
+            WiredManager.invalidateRoom(this.room);
+        }
+    }
+
+    void unregister(HabboItem item) {
+        RoomSpecialTypes specialTypes = this.room.getRoomSpecialTypes();
+        if (specialTypes == null) {
+            return;
+        }
+
+        boolean cleanedSignalAntennaReferences = isAntennaItem(item)
+                && specialTypes.unlinkSignalAntennaReferences(item.getId());
+        this.room.getFurniVariableManager()
+                .removeAssignmentsForFurni(item.getId());
+
+        boolean wiredItem = false;
+        if (item instanceof WiredTickable tickable) {
+            WiredManager.unregisterTickable(this.room, tickable);
+        } else if (item instanceof ICycleable cycleable) {
+            specialTypes.removeCycleTask(cycleable);
+        }
+
+        if (item instanceof InteractionBattleBanzaiTeleporter teleporter) {
+            specialTypes.removeBanzaiTeleporter(teleporter);
+        } else if (item instanceof InteractionWiredTrigger trigger) {
+            specialTypes.removeTrigger(trigger);
+            wiredItem = true;
+        } else if (item instanceof InteractionWiredEffect effect) {
+            specialTypes.removeEffect(effect);
+            wiredItem = true;
+        } else if (item instanceof InteractionWiredCondition condition) {
+            specialTypes.removeCondition(condition);
+            wiredItem = true;
+        } else if (item instanceof InteractionWiredExtra extra) {
+            boolean broadcastDefinitions =
+                    this.removeExtraDefinitions(item);
+            specialTypes.removeExtra(extra);
+            if (broadcastDefinitions) {
+                WiredContextVariableSupport.broadcastDefinitions(this.room);
+            }
+            wiredItem = true;
+        } else if (item instanceof InteractionRoller roller) {
+            specialTypes.removeRoller(roller);
+        } else if (item instanceof InteractionGameScoreboard scoreboard) {
+            specialTypes.removeScoreboard(scoreboard);
+        } else if (item instanceof InteractionGameGate gate) {
+            specialTypes.removeGameGate(gate);
+        } else if (item instanceof InteractionGameTimer timer) {
+            specialTypes.removeGameTimer(timer);
+        } else if (item instanceof InteractionFreezeExitTile exitTile) {
+            specialTypes.removeFreezeExitTile(exitTile);
+        } else if (item instanceof InteractionNest nest) {
+            specialTypes.removeNest(nest);
+        } else if (item instanceof InteractionPetDrink drink) {
+            specialTypes.removePetDrink(drink);
+        } else if (item instanceof InteractionPetFood food) {
+            specialTypes.removePetFood(food);
+        } else if (item instanceof InteractionPetToy toy) {
+            specialTypes.removePetToy(toy);
+        } else if (item instanceof InteractionPetTree tree) {
+            specialTypes.removePetTree(tree);
+        } else if (isUndefinedSpecialTypeOnRemoval(item)) {
+            specialTypes.removeUndefined(item);
+        }
+
+        if (wiredItem || cleanedSignalAntennaReferences) {
+            WiredManager.invalidateRoom(this.room);
+        }
+    }
+
+    private boolean removeExtraDefinitions(HabboItem item) {
+        boolean broadcastDefinitions = false;
+        if (item instanceof WiredExtraUserVariable) {
+            this.room.getUserVariableManager().removeDefinition(item.getId());
+        } else if (item instanceof WiredExtraFurniVariable) {
+            this.room.getFurniVariableManager().removeDefinition(item.getId());
+        } else if (item instanceof WiredExtraRoomVariable) {
+            this.room.getRoomVariableManager().removeDefinition(item.getId());
+        } else if (item instanceof WiredExtraContextVariable
+                || item instanceof WiredExtraVariableTextConnector) {
+            broadcastDefinitions = true;
+        } else if (item instanceof WiredExtraVariableReference reference) {
+            if (reference.isRoomReference()) {
+                this.room.getRoomVariableManager().removeDefinition(item.getId());
+            } else {
+                this.room.getUserVariableManager().removeDefinition(item.getId());
+            }
+        } else if (item instanceof WiredExtraVariableEcho echo) {
+            if (echo.isRoomEcho()) {
+                this.room.getRoomVariableManager().removeDefinition(item.getId());
+            } else if (echo.isFurniEcho()) {
+                this.room.getFurniVariableManager().removeDefinition(item.getId());
+            } else {
+                this.room.getUserVariableManager().removeDefinition(item.getId());
+            }
+        }
+
+        return broadcastDefinitions;
+    }
+
+    private static boolean isAntennaItem(HabboItem item) {
+        if (item == null
+                || item.getBaseItem() == null
+                || item.getBaseItem().getInteractionType() == null) {
+            return false;
+        }
+
+        String interactionType =
+                item.getBaseItem().getInteractionType().getName();
+        return interactionType != null
+                && interactionType.equalsIgnoreCase("antenna");
+    }
+
+    private static boolean isUndefinedSpecialType(HabboItem item) {
+        return item instanceof InteractionMoodLight
+                || item instanceof InteractionPyramid
+                || item instanceof InteractionMusicDisc
+                || item instanceof InteractionBattleBanzaiSphere
+                || item instanceof InteractionTalkingFurniture
+                || item instanceof InteractionWater
+                || item instanceof InteractionWaterItem
+                || item instanceof InteractionMuteArea
+                || item instanceof InteractionBuildArea
+                || item instanceof InteractionTagPole
+                || item instanceof InteractionTagField
+                || item instanceof InteractionJukeBox
+                || item instanceof InteractionPetBreedingNest
+                || item instanceof InteractionBlackHole
+                || item instanceof InteractionWiredHighscore
+                || item instanceof InteractionStickyPole
+                || item instanceof WiredBlob
+                || item instanceof InteractionTent
+                || item instanceof InteractionSnowboardSlope
+                || item instanceof InteractionFireworks
+                || item instanceof InteractionVoteCounter;
+    }
+
+    private static boolean isUndefinedSpecialTypeOnRemoval(HabboItem item) {
+        return item instanceof InteractionMoodLight
+                || item instanceof InteractionPyramid
+                || item instanceof InteractionMusicDisc
+                || item instanceof InteractionBattleBanzaiSphere
+                || item instanceof InteractionTalkingFurniture
+                || item instanceof InteractionWaterItem
+                || item instanceof InteractionWater
+                || item instanceof InteractionMuteArea
+                || item instanceof InteractionTagPole
+                || item instanceof InteractionTagField
+                || item instanceof InteractionJukeBox
+                || item instanceof InteractionPetBreedingNest
+                || item instanceof InteractionBlackHole
+                || item instanceof InteractionWiredHighscore
+                || item instanceof InteractionStickyPole
+                || item instanceof WiredBlob
+                || item instanceof InteractionTent
+                || item instanceof InteractionSnowboardSlope
+                || item instanceof InteractionVoteCounter;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemRegistryBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemRegistryBehaviorTest.java
@@ -1,0 +1,42 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.items.interactions.InteractionRoller;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RoomItemRegistryBehaviorTest {
+
+    @Test
+    void rollerRegistrationAndRemovalUseTheSameSpecialTypeRegistry() {
+        Room room = mock(Room.class);
+        RoomSpecialTypes specialTypes = mock(RoomSpecialTypes.class);
+        RoomFurniVariableManager furniVariables =
+                mock(RoomFurniVariableManager.class);
+        when(room.getRoomSpecialTypes()).thenReturn(specialTypes);
+        when(room.getFurniVariableManager()).thenReturn(furniVariables);
+
+        RoomItemManager manager = new RoomItemManager(room);
+        manager.getFurniOwnerNames().put(7, "owner");
+        InteractionRoller roller = mock(InteractionRoller.class);
+        when(roller.getId()).thenReturn(1001);
+        when(roller.getUserId()).thenReturn(7);
+
+        try (MockedStatic<BuildersClubRoomSupport> buildersClub =
+                     mockStatic(BuildersClubRoomSupport.class)) {
+            buildersClub.when(() ->
+                    BuildersClubRoomSupport.isTrackedItem(1001))
+                    .thenReturn(false);
+            manager.addHabboItem(roller);
+            manager.removeHabboItem(roller);
+        }
+
+        verify(specialTypes).addRoller(roller);
+        verify(specialTypes).removeRoller(roller);
+        verify(furniVariables).removeAssignmentsForFurni(1001);
+    }
+}


### PR DESCRIPTION
Moves special furniture registration, removal, variable-definition cleanup, and wired cache invalidation into RoomItemRegistry.

RoomItemManager retains the same add and remove entry points and registration ordering.