### PR TITLE
refactor(rooms): extract item ownership

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -2,32 +2,17 @@ package com.eu.habbo.habbohotel.rooms;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.items.FurnitureType;
-import com.eu.habbo.habbohotel.items.ICycleable;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.*;
-import com.eu.habbo.habbohotel.items.interactions.games.InteractionGameGate;
-import com.eu.habbo.habbohotel.items.interactions.games.InteractionGameScoreboard;
-import com.eu.habbo.habbohotel.items.interactions.games.InteractionGameTimer;
-import com.eu.habbo.habbohotel.items.interactions.games.battlebanzai.InteractionBattleBanzaiSphere;
-import com.eu.habbo.habbohotel.items.interactions.games.battlebanzai.InteractionBattleBanzaiTeleporter;
-import com.eu.habbo.habbohotel.items.interactions.games.freeze.InteractionFreezeExitTile;
-import com.eu.habbo.habbohotel.items.interactions.games.tag.InteractionTagField;
-import com.eu.habbo.habbohotel.items.interactions.games.tag.InteractionTagPole;
 import com.eu.habbo.habbohotel.items.interactions.pets.*;
 import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectSendSignal;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.*;
 import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerReceiveSignal;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.users.Habbo;
-import com.eu.habbo.habbohotel.users.HabboInfo;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import com.eu.habbo.habbohotel.users.HabboManager;
-import com.eu.habbo.habbohotel.wired.core.WiredContextVariableSupport;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredMovementPhysics;
-import com.eu.habbo.habbohotel.wired.tick.WiredTickable;
-import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
-import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.*;
 import com.eu.habbo.plugin.Event;
 import com.eu.habbo.plugin.events.furniture.*;
@@ -41,10 +26,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -58,6 +41,7 @@ public class RoomItemManager {
     private final Room room;
     private final RoomItemIndex index;
     private final RoomItemOperations operations;
+    private final RoomItemOwnershipService ownership;
     private final RoomItemRegistry registry;
 
     // Tile cache for item lookups
@@ -68,6 +52,11 @@ public class RoomItemManager {
         this.index = new RoomItemIndex(room);
         this.operations = new RoomItemOperations(room);
         this.registry = new RoomItemRegistry(room);
+        this.ownership =
+                new RoomItemOwnershipService(
+                        room,
+                        this.index,
+                        this.registry);
         this.tileCache = this.index.tileCache();
     }
 
@@ -439,48 +428,8 @@ public class RoomItemManager {
      * Adds an item to the room.
      */
     public void addHabboItem(HabboItem item) {
-        if (item == null) {
-            return;
-        }
-
-        synchronized (this.index.items()) {
-            try {
-                this.index.items().put(item.getId(), item);
-            } catch (Exception e) {
-                // Ignore
-            }
-        }
-
-        if (BuildersClubRoomSupport.isTrackedItem(item.getId()) && item.getUserId() != BuildersClubRoomSupport.VIRTUAL_OWNER_ID) {
-            item.setVirtualUserId(BuildersClubRoomSupport.VIRTUAL_OWNER_ID);
-            item.needsUpdate(true);
-        }
-
-        synchronized (this.index.ownerCounts()) {
-            this.index.ownerCounts().put(item.getUserId(), this.index.ownerCounts().get(item.getUserId()) + 1);
-        }
-
-        synchronized (this.index.ownerNames()) {
-            if (!this.index.ownerNames().containsKey(item.getUserId())) {
-                if (item.getUserId() == BuildersClubRoomSupport.VIRTUAL_OWNER_ID && BuildersClubRoomSupport.isTrackedItem(item.getId())) {
-                    this.index.ownerNames().put(item.getUserId(), BuildersClubRoomSupport.DISPLAY_OWNER_NAME);
-                } else {
-                    HabboInfo habbo = HabboManager.getOfflineHabboInfo(item.getUserId());
-
-                    if (habbo != null) {
-                        this.index.ownerNames().put(item.getUserId(), habbo.getUsername());
-                    } else {
-                        LOGGER.error("Failed to find username for item (ID: {}, UserID: {})",
-                                item.getId(), item.getUserId());
-                    }
-                }
-            }
-        }
-
-        // Register with special types
-        this.registry.register(item);
+        this.ownership.add(item);
     }
-
 
     /**
      * Removes an item by ID.
@@ -493,47 +442,8 @@ public class RoomItemManager {
      * Removes an item from the room.
      */
     public void removeHabboItem(HabboItem item) {
-        if (item == null) {
-            return;
-        }
-
-        boolean trackedBuildersClubItem = BuildersClubRoomSupport.isTrackedItem(item.getId());
-        int trackedUserId = trackedBuildersClubItem ? BuildersClubRoomSupport.getTrackedUserId(item.getId()) : item.getUserId();
-
-        HabboItem i;
-        synchronized (this.index.items()) {
-            i = this.index.items().remove(item.getId());
-        }
-
-        if (i != null) {
-            synchronized (this.index.ownerCounts()) {
-                synchronized (this.index.ownerNames()) {
-                    int count = this.index.ownerCounts().get(i.getUserId());
-
-                    if (count > 1) {
-                        this.index.ownerCounts().put(i.getUserId(), count - 1);
-                    } else {
-                        this.index.ownerCounts().remove(i.getUserId());
-                        this.index.ownerNames().remove(i.getUserId());
-                    }
-                }
-            }
-
-            // Unregister from special types
-            this.registry.unregister(item);
-        }
-
-        if (trackedBuildersClubItem) {
-            BuildersClubRoomSupport.deleteTrackedItem(item.getId());
-
-            if (BuildersClubRoomSupport.syncRoom(this.room) == BuildersClubRoomSupport.SyncResult.UNLOCKED) {
-                BuildersClubRoomSupport.sendRoomUnlockedBubble(this.room.getOwnerId());
-            }
-
-            BuildersClubRoomSupport.sendPlacementStatusForPool(this.room, trackedUserId);
-        }
+        this.ownership.remove(item);
     }
-
 
     // ==================== ITEM UPDATES ====================
 
@@ -585,17 +495,7 @@ public class RoomItemManager {
      * Gets the unique furniture count for a user.
      */
     public int getUserUniqueFurniCount(int userId) {
-        Set<Item> items = new HashSet<>();
-
-        synchronized (this.index.items()) {
-            for (HabboItem item : this.index.items().values()) {
-                if (!items.contains(item.getBaseItem()) && item.getUserId() == userId) {
-                    items.add(item.getBaseItem());
-                }
-            }
-        }
-
-        return items.size();
+        return this.ownership.uniqueItemCount(userId);
     }
 
     // ==================== PICKUP AND EJECT ====================
@@ -604,48 +504,21 @@ public class RoomItemManager {
      * Picks up an item from the room.
      */
     public void pickUpItem(HabboItem item, Habbo picker) {
-        this.operations.pickUpItem(item, picker);
+        this.ownership.pickUp(item, picker);
     }
 
     /**
      * Ejects all furniture belonging to a user.
      */
     public void ejectUserFurni(int userId) {
-        Set<HabboItem> items = new HashSet<>();
-        Set<HabboItem> inventoryItems = new HashSet<>();
-
-        synchronized (this.index.items()) {
-            for (HabboItem item : this.index.items().values()) {
-                if (item.getUserId() == userId) {
-                    items.add(item);
-
-                    if (!BuildersClubRoomSupport.isTrackedItem(item.getId())) {
-                        inventoryItems.add(item);
-                    }
-
-                    item.setRoomId(0);
-                }
-            }
-        }
-
-        Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(userId);
-
-        if (habbo != null && !inventoryItems.isEmpty()) {
-            habbo.getInventory().getItemsComponent().addItems(inventoryItems);
-            habbo.getClient().sendResponse(new AddHabboItemComposer(inventoryItems));
-            habbo.getClient().sendResponse(new InventoryRefreshComposer());
-        }
-
-        for (HabboItem i : items) {
-            this.pickUpItem(i, null);
-        }
+        this.ownership.ejectUserFurniture(userId);
     }
 
     /**
      * Ejects a single user item.
      */
     public void ejectUserItem(HabboItem item) {
-        this.pickUpItem(item, null);
+        this.ownership.pickUp(item, null);
     }
 
     /**
@@ -659,43 +532,7 @@ public class RoomItemManager {
      * Ejects all items from the room except those belonging to the specified Habbo.
      */
     public void ejectAll(Habbo habbo) {
-        Map<Integer, Set<HabboItem>> userItemsMap = new HashMap<>();
-
-        synchronized (this.index.items()) {
-            for (HabboItem item : this.index.items().values()) {
-                if (habbo != null && item.getUserId() == habbo.getHabboInfo().getId()) {
-                    continue;
-                }
-
-                if (item instanceof InteractionPostIt) {
-                    continue;
-                }
-
-                userItemsMap.computeIfAbsent(item.getUserId(), k -> new HashSet<>()).add(item);
-            }
-        }
-
-        for (Map.Entry<Integer, Set<HabboItem>> entrySet : userItemsMap.entrySet()) {
-            Set<HabboItem> inventoryItems = new HashSet<>();
-
-            for (HabboItem item : entrySet.getValue()) {
-                if (!BuildersClubRoomSupport.isTrackedItem(item.getId())) {
-                    inventoryItems.add(item);
-                }
-            }
-
-            for (HabboItem i : entrySet.getValue()) {
-                this.pickUpItem(i, null);
-            }
-
-            Habbo user = Emulator.getGameEnvironment().getHabboManager().getHabbo(entrySet.getKey());
-
-            if (user != null && !inventoryItems.isEmpty()) {
-                user.getInventory().getItemsComponent().addItems(inventoryItems);
-                user.getClient().sendResponse(new AddHabboItemComposer(inventoryItems));
-                user.getClient().sendResponse(new InventoryRefreshComposer());
-            }
-        }
+        this.ownership.ejectAll(habbo);
     }
 
     // ==================== LOCKED TILES ====================

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemOperations.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemOperations.java
@@ -1,24 +1,11 @@
 package com.eu.habbo.habbohotel.rooms;
 
-import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.items.FurnitureType;
 import com.eu.habbo.habbohotel.items.interactions.InteractionMultiHeight;
-import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
-import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
-import com.eu.habbo.messages.outgoing.rooms.UpdateStackHeightComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.FloorItemUpdateComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.ItemStateComposer;
-import com.eu.habbo.messages.outgoing.rooms.items.RemoveFloorItemComposer;
-import com.eu.habbo.messages.outgoing.rooms.items.RemoveWallItemComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.WallItemUpdateComposer;
-import com.eu.habbo.plugin.Event;
-import com.eu.habbo.plugin.events.furniture.FurniturePickedUpEvent;
-
-import java.awt.Rectangle;
-import java.util.HashSet;
-import java.util.Set;
 
 final class RoomItemOperations {
 
@@ -26,96 +13,6 @@ final class RoomItemOperations {
 
     RoomItemOperations(Room room) {
         this.room = room;
-    }
-
-    void pickUpItem(HabboItem item, Habbo picker) {
-        if (item == null) {
-            return;
-        }
-
-        boolean trackedBuildersClubItem =
-                BuildersClubRoomSupport.isTrackedItem(item.getId());
-
-        if (Emulator.getPluginManager().isRegistered(
-                FurniturePickedUpEvent.class,
-                true)) {
-            Event furniturePickedUpEvent =
-                    new FurniturePickedUpEvent(item, picker);
-            Emulator.getPluginManager().fireEvent(furniturePickedUpEvent);
-
-            if (furniturePickedUpEvent.isCancelled()) {
-                return;
-            }
-        }
-
-        this.room.removeHabboItem(item.getId());
-        item.onPickUp(this.room);
-        item.setRoomId(0);
-        item.needsUpdate(true);
-
-        if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
-            this.room.sendComposer(
-                    new RemoveFloorItemComposer(item).compose());
-
-            Set<RoomTile> updatedTiles = new HashSet<>();
-            Rectangle rectangle = RoomLayout.getRectangle(
-                    item.getX(),
-                    item.getY(),
-                    item.getBaseItem().getWidth(),
-                    item.getBaseItem().getLength(),
-                    item.getRotation());
-
-            for (short x = (short) rectangle.x;
-                 x < rectangle.x + rectangle.getWidth();
-                 x++) {
-                for (short y = (short) rectangle.y;
-                     y < rectangle.y + rectangle.getHeight();
-                     y++) {
-                    double stackHeight =
-                            this.room.getStackHeight(x, y, false);
-                    RoomTile tile = this.room.currentLayout().getTile(x, y);
-
-                    if (tile != null) {
-                        tile.setStackHeight(stackHeight);
-                        updatedTiles.add(tile);
-                    }
-                }
-            }
-            this.room.sendComposer(
-                    new UpdateStackHeightComposer(
-                            this.room,
-                            updatedTiles).compose());
-            this.room.updateTiles(updatedTiles);
-            for (RoomTile tile : updatedTiles) {
-                this.room.updateHabbosAt(tile.x, tile.y);
-                this.room.updateBotsAt(tile.x, tile.y);
-            }
-        } else if (item.getBaseItem().getType() == FurnitureType.WALL) {
-            this.room.sendComposer(
-                    new RemoveWallItemComposer(item).compose());
-        }
-
-        if (trackedBuildersClubItem) {
-            Emulator.getGameEnvironment()
-                    .getItemManager()
-                    .deleteItem(item);
-            return;
-        }
-
-        Habbo owner = picker != null
-                && picker.getHabboInfo().getId() == item.getUserId()
-                ? picker
-                : Emulator.getGameServer()
-                        .getGameClientManager()
-                        .getHabbo(item.getUserId());
-        if (owner != null) {
-            owner.getInventory().getItemsComponent().addItem(item);
-            owner.getClient().sendResponse(
-                    new AddHabboItemComposer(item));
-            owner.getClient().sendResponse(
-                    new InventoryRefreshComposer());
-        }
-        Emulator.getThreading().run(item);
     }
 
     void updateItem(HabboItem item) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemOwnershipService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemOwnershipService.java
@@ -1,0 +1,335 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.items.FurnitureType;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionPostIt;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.users.HabboManager;
+import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
+import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
+import com.eu.habbo.messages.outgoing.rooms.UpdateStackHeightComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.RemoveFloorItemComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.RemoveWallItemComposer;
+import com.eu.habbo.plugin.Event;
+import com.eu.habbo.plugin.events.furniture.FurniturePickedUpEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.Rectangle;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+final class RoomItemOwnershipService {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(RoomItemOwnershipService.class);
+
+    private final Room room;
+    private final RoomItemIndex index;
+    private final RoomItemRegistry registry;
+
+    RoomItemOwnershipService(
+            Room room,
+            RoomItemIndex index,
+            RoomItemRegistry registry) {
+        this.room = room;
+        this.index = index;
+        this.registry = registry;
+    }
+
+    void add(HabboItem item) {
+        if (item == null) {
+            return;
+        }
+
+        synchronized (this.index.items()) {
+            try {
+                this.index.items().put(item.getId(), item);
+            } catch (Exception ignored) {
+                // Preserve the legacy best-effort registration behavior.
+            }
+        }
+
+        if (BuildersClubRoomSupport.isTrackedItem(item.getId())
+                && item.getUserId()
+                != BuildersClubRoomSupport.VIRTUAL_OWNER_ID) {
+            item.setVirtualUserId(
+                    BuildersClubRoomSupport.VIRTUAL_OWNER_ID);
+            item.needsUpdate(true);
+        }
+
+        synchronized (this.index.ownerCounts()) {
+            this.index.ownerCounts().put(
+                    item.getUserId(),
+                    this.index.ownerCounts().get(item.getUserId()) + 1);
+        }
+
+        synchronized (this.index.ownerNames()) {
+            if (!this.index.ownerNames().containsKey(item.getUserId())) {
+                this.addOwnerName(item);
+            }
+        }
+
+        this.registry.register(item);
+    }
+
+    void remove(HabboItem item) {
+        if (item == null) {
+            return;
+        }
+
+        boolean trackedBuildersClubItem =
+                BuildersClubRoomSupport.isTrackedItem(item.getId());
+        int trackedUserId = trackedBuildersClubItem
+                ? BuildersClubRoomSupport.getTrackedUserId(item.getId())
+                : item.getUserId();
+
+        HabboItem removed;
+        synchronized (this.index.items()) {
+            removed = this.index.items().remove(item.getId());
+        }
+
+        if (removed != null) {
+            this.removeOwnerIndex(removed);
+            this.registry.unregister(item);
+        }
+
+        if (trackedBuildersClubItem) {
+            BuildersClubRoomSupport.deleteTrackedItem(item.getId());
+            if (BuildersClubRoomSupport.syncRoom(this.room)
+                    == BuildersClubRoomSupport.SyncResult.UNLOCKED) {
+                BuildersClubRoomSupport.sendRoomUnlockedBubble(
+                        this.room.getOwnerId());
+            }
+            BuildersClubRoomSupport.sendPlacementStatusForPool(
+                    this.room,
+                    trackedUserId);
+        }
+    }
+
+    int uniqueItemCount(int userId) {
+        Set<Item> baseItems = new HashSet<>();
+        synchronized (this.index.items()) {
+            for (HabboItem item : this.index.items().values()) {
+                if (!baseItems.contains(item.getBaseItem())
+                        && item.getUserId() == userId) {
+                    baseItems.add(item.getBaseItem());
+                }
+            }
+        }
+        return baseItems.size();
+    }
+
+    void pickUp(HabboItem item, Habbo picker) {
+        if (item == null) {
+            return;
+        }
+
+        boolean trackedBuildersClubItem =
+                BuildersClubRoomSupport.isTrackedItem(item.getId());
+
+        if (Emulator.getPluginManager().isRegistered(
+                FurniturePickedUpEvent.class,
+                true)) {
+            Event furniturePickedUpEvent =
+                    new FurniturePickedUpEvent(item, picker);
+            Emulator.getPluginManager().fireEvent(furniturePickedUpEvent);
+            if (furniturePickedUpEvent.isCancelled()) {
+                return;
+            }
+        }
+
+        this.room.removeHabboItem(item.getId());
+        item.onPickUp(this.room);
+        item.setRoomId(0);
+        item.needsUpdate(true);
+
+        if (item.getBaseItem().getType() == FurnitureType.FLOOR) {
+            this.room.sendComposer(
+                    new RemoveFloorItemComposer(item).compose());
+            this.refreshRemovedFloorArea(item);
+        } else if (item.getBaseItem().getType() == FurnitureType.WALL) {
+            this.room.sendComposer(
+                    new RemoveWallItemComposer(item).compose());
+        }
+
+        if (trackedBuildersClubItem) {
+            Emulator.getGameEnvironment()
+                    .getItemManager()
+                    .deleteItem(item);
+            return;
+        }
+
+        Habbo owner = picker != null
+                && picker.getHabboInfo().getId() == item.getUserId()
+                ? picker
+                : Emulator.getGameServer()
+                        .getGameClientManager()
+                        .getHabbo(item.getUserId());
+        if (owner != null) {
+            owner.getInventory().getItemsComponent().addItem(item);
+            owner.getClient().sendResponse(
+                    new AddHabboItemComposer(item));
+            owner.getClient().sendResponse(
+                    new InventoryRefreshComposer());
+        }
+        Emulator.getThreading().run(item);
+    }
+
+    void ejectUserFurniture(int userId) {
+        Set<HabboItem> items = new HashSet<>();
+        Set<HabboItem> inventoryItems = new HashSet<>();
+        synchronized (this.index.items()) {
+            for (HabboItem item : this.index.items().values()) {
+                if (item.getUserId() == userId) {
+                    items.add(item);
+                    if (!BuildersClubRoomSupport.isTrackedItem(
+                            item.getId())) {
+                        inventoryItems.add(item);
+                    }
+                    item.setRoomId(0);
+                }
+            }
+        }
+
+        Habbo owner = Emulator.getGameEnvironment()
+                .getHabboManager()
+                .getHabbo(userId);
+        if (owner != null && !inventoryItems.isEmpty()) {
+            addInventoryItems(owner, inventoryItems);
+        }
+        for (HabboItem item : items) {
+            this.pickUp(item, null);
+        }
+    }
+
+    void ejectAll(Habbo exemptOwner) {
+        Map<Integer, Set<HabboItem>> itemsByOwner = new HashMap<>();
+        synchronized (this.index.items()) {
+            for (HabboItem item : this.index.items().values()) {
+                if (exemptOwner != null
+                        && item.getUserId()
+                        == exemptOwner.getHabboInfo().getId()) {
+                    continue;
+                }
+                if (item instanceof InteractionPostIt) {
+                    continue;
+                }
+                itemsByOwner
+                        .computeIfAbsent(
+                                item.getUserId(),
+                                ignored -> new HashSet<>())
+                        .add(item);
+            }
+        }
+
+        for (Map.Entry<Integer, Set<HabboItem>> entry
+                : itemsByOwner.entrySet()) {
+            Set<HabboItem> inventoryItems = new HashSet<>();
+            for (HabboItem item : entry.getValue()) {
+                if (!BuildersClubRoomSupport.isTrackedItem(item.getId())) {
+                    inventoryItems.add(item);
+                }
+            }
+            for (HabboItem item : entry.getValue()) {
+                this.pickUp(item, null);
+            }
+
+            Habbo owner = Emulator.getGameEnvironment()
+                    .getHabboManager()
+                    .getHabbo(entry.getKey());
+            if (owner != null && !inventoryItems.isEmpty()) {
+                addInventoryItems(owner, inventoryItems);
+            }
+        }
+    }
+
+    private void addOwnerName(HabboItem item) {
+        if (item.getUserId()
+                == BuildersClubRoomSupport.VIRTUAL_OWNER_ID
+                && BuildersClubRoomSupport.isTrackedItem(item.getId())) {
+            this.index.ownerNames().put(
+                    item.getUserId(),
+                    BuildersClubRoomSupport.DISPLAY_OWNER_NAME);
+            return;
+        }
+
+        HabboInfo owner = HabboManager.getOfflineHabboInfo(item.getUserId());
+        if (owner != null) {
+            this.index.ownerNames().put(
+                    item.getUserId(),
+                    owner.getUsername());
+        } else {
+            LOGGER.error(
+                    "Failed to find username for item (ID: {}, UserID: {})",
+                    item.getId(),
+                    item.getUserId());
+        }
+    }
+
+    private void removeOwnerIndex(HabboItem item) {
+        synchronized (this.index.ownerCounts()) {
+            synchronized (this.index.ownerNames()) {
+                int count =
+                        this.index.ownerCounts().get(item.getUserId());
+                if (count > 1) {
+                    this.index.ownerCounts().put(
+                            item.getUserId(),
+                            count - 1);
+                } else {
+                    this.index.ownerCounts().remove(item.getUserId());
+                    this.index.ownerNames().remove(item.getUserId());
+                }
+            }
+        }
+    }
+
+    private void refreshRemovedFloorArea(HabboItem item) {
+        Set<RoomTile> updatedTiles = new HashSet<>();
+        Rectangle rectangle = RoomLayout.getRectangle(
+                item.getX(),
+                item.getY(),
+                item.getBaseItem().getWidth(),
+                item.getBaseItem().getLength(),
+                item.getRotation());
+
+        for (short x = (short) rectangle.x;
+             x < rectangle.x + rectangle.getWidth();
+             x++) {
+            for (short y = (short) rectangle.y;
+                 y < rectangle.y + rectangle.getHeight();
+                 y++) {
+                double stackHeight =
+                        this.room.getStackHeight(x, y, false);
+                RoomTile tile = this.room.currentLayout().getTile(x, y);
+                if (tile != null) {
+                    tile.setStackHeight(stackHeight);
+                    updatedTiles.add(tile);
+                }
+            }
+        }
+
+        this.room.sendComposer(
+                new UpdateStackHeightComposer(
+                        this.room,
+                        updatedTiles).compose());
+        this.room.updateTiles(updatedTiles);
+        for (RoomTile tile : updatedTiles) {
+            this.room.updateHabbosAt(tile.x, tile.y);
+            this.room.updateBotsAt(tile.x, tile.y);
+        }
+    }
+
+    private static void addInventoryItems(
+            Habbo owner,
+            Set<HabboItem> items) {
+        owner.getInventory().getItemsComponent().addItems(items);
+        owner.getClient().sendResponse(new AddHabboItemComposer(items));
+        owner.getClient().sendResponse(new InventoryRefreshComposer());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemOwnershipBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemOwnershipBehaviorTest.java
@@ -1,6 +1,9 @@
 package com.eu.habbo.habbohotel.rooms;
 
 import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionPostIt;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +13,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class RoomItemOwnershipBehaviorTest {
 
@@ -83,6 +88,29 @@ class RoomItemOwnershipBehaviorTest {
         assertTrue(ownerNames.isEmpty());
         assertTrue(ownerCounts.isEmpty());
         assertTrue(tileCache.isEmpty());
+    }
+
+    @Test
+    void ejectAllPreservesPostItsAndTheExemptOwnersItems() {
+        Room room = new Room(41, 7);
+        RoomItemManager manager = room.getItemManager();
+        InteractionPostIt postIt = mock(InteractionPostIt.class);
+        when(postIt.getId()).thenReturn(1001);
+        when(postIt.getUserId()).thenReturn(8);
+        HabboItem exemptItem = mock(HabboItem.class);
+        when(exemptItem.getId()).thenReturn(1002);
+        when(exemptItem.getUserId()).thenReturn(7);
+        manager.getRoomItems().put(1001, postIt);
+        manager.getRoomItems().put(1002, exemptItem);
+        Habbo exemptOwner = mock(Habbo.class);
+        HabboInfo exemptInfo = mock(HabboInfo.class);
+        when(exemptOwner.getHabboInfo()).thenReturn(exemptInfo);
+        when(exemptInfo.getId()).thenReturn(7);
+
+        manager.ejectAll(exemptOwner);
+
+        assertSame(postIt, manager.getRoomItems().get(1001));
+        assertSame(exemptItem, manager.getRoomItems().get(1002));
     }
 
     private static final class TestItem extends HabboItem {


### PR DESCRIPTION
Moves item add/remove ownership accounting, pickup, owner ejection, and inventory return behavior into RoomItemOwnershipService.

RoomItemManager and Room retain their existing public entry points, owner-index identity, and pickup event ordering.