### PR TITLE
test(core): characterize runtime facades

### DIFF
--- a/Emulator/src/test/java/com/eu/habbo/EmulatorRuntimeFacadeCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorRuntimeFacadeCompatibilityTest.java
@@ -1,0 +1,67 @@
+package com.eu.habbo;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.SecureRandom;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+class EmulatorRuntimeFacadeCompatibilityTest {
+
+    @Test
+    void serviceGettersReturnTheExactInstalledStaticInstances()
+            throws Exception {
+        Map<String, String> gettersByField = new LinkedHashMap<>();
+        gettersByField.put("config", "getConfig");
+        gettersByField.put("crypto", "getCrypto");
+        gettersByField.put("texts", "getTexts");
+        gettersByField.put("database", "getDatabase");
+        gettersByField.put("databaseLogger", "getDatabaseLogger");
+        gettersByField.put("runtime", "getRuntime");
+        gettersByField.put("gameServer", "getGameServer");
+        gettersByField.put("rconServer", "getRconServer");
+        gettersByField.put("logging", "getLogging");
+        gettersByField.put("threading", "getThreading");
+        gettersByField.put("gameEnvironment", "getGameEnvironment");
+        gettersByField.put("pluginManager", "getPluginManager");
+        gettersByField.put("badgeImager", "getBadgeImager");
+
+        Map<Field, Object> originalValues = new LinkedHashMap<>();
+        try {
+            for (Map.Entry<String, String> entry
+                    : gettersByField.entrySet()) {
+                Field field = Emulator.class.getDeclaredField(
+                        entry.getKey());
+                field.setAccessible(true);
+                originalValues.put(field, field.get(null));
+                Object installed = field.getType() == Runtime.class
+                        ? Runtime.getRuntime()
+                        : mock(field.getType());
+                field.set(null, installed);
+                Method getter = Emulator.class.getMethod(entry.getValue());
+
+                assertSame(installed, getter.invoke(null), entry.getValue());
+            }
+        } finally {
+            for (Map.Entry<Field, Object> entry
+                    : originalValues.entrySet()) {
+                entry.getKey().set(null, entry.getValue());
+            }
+        }
+    }
+
+    @Test
+    void secureRandomGetterKeepsTheSingletonIdentity() throws Exception {
+        Field field = Emulator.class.getDeclaredField("secureRandom");
+        field.setAccessible(true);
+
+        assertSame(
+                (SecureRandom) field.get(null),
+                Emulator.getRandomDice());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/GameEnvironmentFacadeCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/GameEnvironmentFacadeCompatibilityTest.java
@@ -1,0 +1,52 @@
+package com.eu.habbo.habbohotel;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
+import org.junit.jupiter.api.Test;
+
+import java.beans.Introspector;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+class GameEnvironmentFacadeCompatibilityTest {
+
+    @Test
+    void everyManagerGetterReturnsItsExactBackingInstance()
+            throws Exception {
+        GameEnvironment environment = new GameEnvironment();
+        Field configField = Emulator.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        Object originalConfig = configField.get(null);
+        configField.set(null, mock(ConfigurationManager.class));
+
+        try {
+            for (Method getter : GameEnvironment.class.getDeclaredMethods()) {
+                if (!Modifier.isPublic(getter.getModifiers())
+                        || getter.getParameterCount() != 0
+                        || !getter.getName().startsWith("get")
+                        || getter.getReturnType() == void.class) {
+                    continue;
+                }
+
+                String fieldName = Introspector.decapitalize(
+                        getter.getName().substring(3));
+                Field field =
+                        GameEnvironment.class.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                Object installed = mock(field.getType());
+                field.set(environment, installed);
+
+                assertSame(
+                        installed,
+                        getter.invoke(environment),
+                        getter.getName());
+            }
+        } finally {
+            configField.set(null, originalConfig);
+        }
+    }
+}


### PR DESCRIPTION
Adds executable identity contracts for the selected Emulator runtime getters and every GameEnvironment manager getter.

The fixtures pin the existing backing-instance behavior before runtime ownership moves behind either public facade.