### PR TITLE
feat(core): introduce runtime ownership

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -89,6 +89,7 @@ public final class Emulator {
     public static boolean debugging = false;
     private static int timeStarted = 0;
     private static Runtime runtime;
+    private static PolarisRuntime polarisRuntime;
     private static ConfigurationManager config;
     private static CryptoConfig crypto;
     private static TextsManager texts;
@@ -129,8 +130,10 @@ public final class Emulator {
             Locale.setDefault(Locale.of("en"));
             setBuild();
             Emulator.stopped = false;
+            Emulator.polarisRuntime = new PolarisRuntime();
             ConsoleCommand.load();
             Emulator.logging = new Logging();
+            Emulator.polarisRuntime.installLogging(Emulator.logging);
 
             System.out.println(startupHero(styledConsole));
 
@@ -138,12 +141,15 @@ public final class Emulator {
 
             Emulator.runtime = Runtime.getRuntime();
             Emulator.config = new ConfigurationManager("config.ini");
+            Emulator.polarisRuntime.installConfiguration(Emulator.config);
             Emulator.crypto = new CryptoConfig(
                     Emulator.getConfig().getBoolean("enc.enabled", false),
                     Emulator.getConfig().getValue("enc.e"),
                     Emulator.getConfig().getValue("enc.n"),
                     Emulator.getConfig().getValue("enc.d"));
+            Emulator.polarisRuntime.installCrypto(Emulator.crypto);
             Emulator.database = new Database(Emulator.getConfig());
+            Emulator.polarisRuntime.installDatabase(Emulator.database);
             // Migrate before loading database-backed configuration.
             if (Emulator.getDatabase() != null && Emulator.getDatabase().getDataSource() != null) {
                 if (migrationOptions.mode() == MigrationOptions.Mode.VALIDATE) {
@@ -179,16 +185,20 @@ public final class Emulator {
             com.eu.habbo.database.indexing.DatabaseIndexAuditor.auditAtStartup(
                     Emulator.getDatabase().getDataSource());
             Emulator.databaseLogger = new DatabaseLogger();
+            Emulator.polarisRuntime.installDatabaseLogger(Emulator.databaseLogger);
             Emulator.config.loaded = true;
             Emulator.config.loadFromDatabase();
             Emulator.threading = new ThreadPooling(Emulator.getConfig().getInt("runtime.threads"));
+            Emulator.polarisRuntime.installThreading(Emulator.threading);
             Emulator.getDatabase().getDataSource().setMaximumPoolSize(Emulator.getConfig().getInt("runtime.threads") * 2);
             Emulator.getDatabase().getDataSource().setMinimumIdle(10);
             registerStartupConfigDefaults();
             Emulator.pluginManager = new PluginManager();
+            Emulator.polarisRuntime.installPluginManager(Emulator.pluginManager);
             Emulator.pluginManager.reload();
             Emulator.getPluginManager().fireEvent(new EmulatorConfigUpdatedEvent());
             Emulator.texts = new TextsManager();
+            Emulator.polarisRuntime.installTexts(Emulator.texts);
 
             String hotelTimezoneId = Emulator.getConfig().getValue("hotel.timezone", java.time.ZoneId.systemDefault().getId());
             System.out.println(startupCard(hotelTimezoneId));
@@ -203,8 +213,11 @@ public final class Emulator {
 
             new CleanerThread();
             Emulator.gameServer = new GameServer(getConfig().getValue("game.host", "127.0.0.1"), getConfig().getInt("game.port", 30000));
+            Emulator.polarisRuntime.installGameServer(Emulator.gameServer);
             Emulator.rconServer = new RCONServer(getConfig().getValue("rcon.host", "127.0.0.1"), getConfig().getInt("rcon.port", 30001));
+            Emulator.polarisRuntime.installRconServer(Emulator.rconServer);
             Emulator.gameEnvironment = new GameEnvironment();
+            Emulator.polarisRuntime.installGameEnvironment(Emulator.gameEnvironment);
             Emulator.gameEnvironment.load();
             Emulator.gameServer.initializePipeline();
             Emulator.gameServer.connect();
@@ -212,6 +225,7 @@ public final class Emulator {
             Emulator.rconServer.initializePipeline();
             Emulator.rconServer.connect();
             Emulator.badgeImager = new BadgeImager();
+            Emulator.polarisRuntime.installBadgeImager(Emulator.badgeImager);
 
             LOGGER.info("Polaris has successfully loaded.");
             LOGGER.info("System launched in: {}ms. Using {} threads!", (System.nanoTime() - startTime) / 1e6, Runtime.getRuntime().availableProcessors() * 2);
@@ -532,28 +546,41 @@ public final class Emulator {
     }
 
     public static ConfigurationManager getConfig() {
-        return config;
+        return polarisRuntime != null && polarisRuntime.configuration() != null
+                ? polarisRuntime.configuration()
+                : config;
     }
 
     public static CryptoConfig getCrypto() {
-        return crypto;
+        return polarisRuntime != null && polarisRuntime.crypto() != null
+                ? polarisRuntime.crypto()
+                : crypto;
     }
 
     public static TextsManager getTexts() {
-        return texts;
+        return polarisRuntime != null && polarisRuntime.texts() != null
+                ? polarisRuntime.texts()
+                : texts;
     }
 
     public static Database getDatabase() {
-        return database;
+        return polarisRuntime != null && polarisRuntime.database() != null
+                ? polarisRuntime.database()
+                : database;
     }
 
     /** Installs the integration-test database without exposing a public API. */
     static void setDatabaseForTesting(Database database) {
         Emulator.database = database;
+        if (Emulator.polarisRuntime != null && database != null) {
+            Emulator.polarisRuntime.installDatabase(database);
+        }
     }
 
     public static DatabaseLogger getDatabaseLogger() {
-        return databaseLogger;
+        return polarisRuntime != null && polarisRuntime.databaseLogger() != null
+                ? polarisRuntime.databaseLogger()
+                : databaseLogger;
     }
 
     public static Runtime getRuntime() {
@@ -561,7 +588,9 @@ public final class Emulator {
     }
 
     public static GameServer getGameServer() {
-        return gameServer;
+        return polarisRuntime != null && polarisRuntime.gameServer() != null
+                ? polarisRuntime.gameServer()
+                : gameServer;
     }
 
     private static void registerEarningsSettings() {
@@ -601,7 +630,9 @@ public final class Emulator {
     }
 
     public static RCONServer getRconServer() {
-        return rconServer;
+        return polarisRuntime != null && polarisRuntime.rconServer() != null
+                ? polarisRuntime.rconServer()
+                : rconServer;
     }
 
     /**
@@ -609,19 +640,27 @@ public final class Emulator {
      */
     @Deprecated
     public static Logging getLogging() {
-        return logging;
+        return polarisRuntime != null && polarisRuntime.logging() != null
+                ? polarisRuntime.logging()
+                : logging;
     }
 
     public static ThreadPooling getThreading() {
-        return threading;
+        return polarisRuntime != null && polarisRuntime.threading() != null
+                ? polarisRuntime.threading()
+                : threading;
     }
 
     public static GameEnvironment getGameEnvironment() {
-        return gameEnvironment;
+        return polarisRuntime != null && polarisRuntime.gameEnvironment() != null
+                ? polarisRuntime.gameEnvironment()
+                : gameEnvironment;
     }
 
     public static PluginManager getPluginManager() {
-        return pluginManager;
+        return polarisRuntime != null && polarisRuntime.pluginManager() != null
+                ? polarisRuntime.pluginManager()
+                : pluginManager;
     }
 
     public static Random getRandom() {
@@ -631,7 +670,9 @@ public final class Emulator {
         return secureRandom;
     }
     public static BadgeImager getBadgeImager() {
-        return badgeImager;
+        return polarisRuntime != null && polarisRuntime.badgeImager() != null
+                ? polarisRuntime.badgeImager()
+                : badgeImager;
     }
 
     public static int getTimeStarted() {

--- a/Emulator/src/main/java/com/eu/habbo/PolarisRuntime.java
+++ b/Emulator/src/main/java/com/eu/habbo/PolarisRuntime.java
@@ -1,0 +1,134 @@
+package com.eu.habbo;
+
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.core.CryptoConfig;
+import com.eu.habbo.core.DatabaseLogger;
+import com.eu.habbo.core.Logging;
+import com.eu.habbo.core.TextsManager;
+import com.eu.habbo.database.Database;
+import com.eu.habbo.habbohotel.GameEnvironment;
+import com.eu.habbo.networking.gameserver.GameServer;
+import com.eu.habbo.networking.rconserver.RCONServer;
+import com.eu.habbo.plugin.PluginManager;
+import com.eu.habbo.threading.ThreadPooling;
+import com.eu.habbo.util.imager.badges.BadgeImager;
+
+import java.util.Objects;
+
+/**
+ * Owns the services assembled during one Polaris process lifecycle.
+ *
+ * <p>The legacy {@link Emulator} facade remains the public compatibility
+ * surface while bootstrap and new internal code move to explicit ownership.</p>
+ */
+final class PolarisRuntime {
+
+    private ConfigurationManager configuration;
+    private CryptoConfig crypto;
+    private TextsManager texts;
+    private Database database;
+    private DatabaseLogger databaseLogger;
+    private GameServer gameServer;
+    private RCONServer rconServer;
+    private Logging logging;
+    private ThreadPooling threading;
+    private GameEnvironment gameEnvironment;
+    private PluginManager pluginManager;
+    private BadgeImager badgeImager;
+
+    ConfigurationManager configuration() {
+        return configuration;
+    }
+
+    void installConfiguration(ConfigurationManager configuration) {
+        this.configuration = Objects.requireNonNull(configuration);
+    }
+
+    CryptoConfig crypto() {
+        return crypto;
+    }
+
+    void installCrypto(CryptoConfig crypto) {
+        this.crypto = Objects.requireNonNull(crypto);
+    }
+
+    TextsManager texts() {
+        return texts;
+    }
+
+    void installTexts(TextsManager texts) {
+        this.texts = Objects.requireNonNull(texts);
+    }
+
+    Database database() {
+        return database;
+    }
+
+    void installDatabase(Database database) {
+        this.database = Objects.requireNonNull(database);
+    }
+
+    DatabaseLogger databaseLogger() {
+        return databaseLogger;
+    }
+
+    void installDatabaseLogger(DatabaseLogger databaseLogger) {
+        this.databaseLogger = Objects.requireNonNull(databaseLogger);
+    }
+
+    GameServer gameServer() {
+        return gameServer;
+    }
+
+    void installGameServer(GameServer gameServer) {
+        this.gameServer = Objects.requireNonNull(gameServer);
+    }
+
+    RCONServer rconServer() {
+        return rconServer;
+    }
+
+    void installRconServer(RCONServer rconServer) {
+        this.rconServer = Objects.requireNonNull(rconServer);
+    }
+
+    Logging logging() {
+        return logging;
+    }
+
+    void installLogging(Logging logging) {
+        this.logging = Objects.requireNonNull(logging);
+    }
+
+    ThreadPooling threading() {
+        return threading;
+    }
+
+    void installThreading(ThreadPooling threading) {
+        this.threading = Objects.requireNonNull(threading);
+    }
+
+    GameEnvironment gameEnvironment() {
+        return gameEnvironment;
+    }
+
+    void installGameEnvironment(GameEnvironment gameEnvironment) {
+        this.gameEnvironment = Objects.requireNonNull(gameEnvironment);
+    }
+
+    PluginManager pluginManager() {
+        return pluginManager;
+    }
+
+    void installPluginManager(PluginManager pluginManager) {
+        this.pluginManager = Objects.requireNonNull(pluginManager);
+    }
+
+    BadgeImager badgeImager() {
+        return badgeImager;
+    }
+
+    void installBadgeImager(BadgeImager badgeImager) {
+        this.badgeImager = Objects.requireNonNull(badgeImager);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/EmulatorRuntimeFacadeCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorRuntimeFacadeCompatibilityTest.java
@@ -31,8 +31,12 @@ class EmulatorRuntimeFacadeCompatibilityTest {
         gettersByField.put("pluginManager", "getPluginManager");
         gettersByField.put("badgeImager", "getBadgeImager");
 
+        Field runtimeOwner = Emulator.class.getDeclaredField("polarisRuntime");
+        runtimeOwner.setAccessible(true);
+        Object originalRuntimeOwner = runtimeOwner.get(null);
         Map<Field, Object> originalValues = new LinkedHashMap<>();
         try {
+            runtimeOwner.set(null, null);
             for (Map.Entry<String, String> entry
                     : gettersByField.entrySet()) {
                 Field field = Emulator.class.getDeclaredField(
@@ -52,6 +56,7 @@ class EmulatorRuntimeFacadeCompatibilityTest {
                     : originalValues.entrySet()) {
                 entry.getKey().set(null, entry.getValue());
             }
+            runtimeOwner.set(null, originalRuntimeOwner);
         }
     }
 

--- a/Emulator/src/test/java/com/eu/habbo/PolarisRuntimeTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/PolarisRuntimeTest.java
@@ -1,0 +1,134 @@
+package com.eu.habbo;
+
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.core.CryptoConfig;
+import com.eu.habbo.core.DatabaseLogger;
+import com.eu.habbo.core.Logging;
+import com.eu.habbo.core.TextsManager;
+import com.eu.habbo.database.Database;
+import com.eu.habbo.habbohotel.GameEnvironment;
+import com.eu.habbo.networking.gameserver.GameServer;
+import com.eu.habbo.networking.rconserver.RCONServer;
+import com.eu.habbo.plugin.PluginManager;
+import com.eu.habbo.threading.ThreadPooling;
+import com.eu.habbo.util.imager.badges.BadgeImager;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+class PolarisRuntimeTest {
+
+    @Test
+    void emulatorFacadeDelegatesToEveryInstalledRuntimeService()
+            throws Exception {
+        PolarisRuntime runtime = new PolarisRuntime();
+        Map<Class<?>, RuntimeService<?>> services = new LinkedHashMap<>();
+        services.put(
+                ConfigurationManager.class,
+                service(runtime::installConfiguration, Emulator::getConfig));
+        services.put(
+                CryptoConfig.class,
+                service(runtime::installCrypto, Emulator::getCrypto));
+        services.put(
+                TextsManager.class,
+                service(runtime::installTexts, Emulator::getTexts));
+        services.put(
+                Database.class,
+                service(runtime::installDatabase, Emulator::getDatabase));
+        services.put(
+                DatabaseLogger.class,
+                service(
+                        runtime::installDatabaseLogger,
+                        Emulator::getDatabaseLogger));
+        services.put(
+                GameServer.class,
+                service(runtime::installGameServer, Emulator::getGameServer));
+        services.put(
+                RCONServer.class,
+                service(runtime::installRconServer, Emulator::getRconServer));
+        services.put(
+                Logging.class,
+                service(runtime::installLogging, Emulator::getLogging));
+        services.put(
+                ThreadPooling.class,
+                service(runtime::installThreading, Emulator::getThreading));
+        services.put(
+                GameEnvironment.class,
+                service(
+                        runtime::installGameEnvironment,
+                        Emulator::getGameEnvironment));
+        services.put(
+                PluginManager.class,
+                service(
+                        runtime::installPluginManager,
+                        Emulator::getPluginManager));
+        services.put(
+                BadgeImager.class,
+                service(
+                        runtime::installBadgeImager,
+                        Emulator::getBadgeImager));
+
+        Field runtimeOwner = Emulator.class.getDeclaredField("polarisRuntime");
+        runtimeOwner.setAccessible(true);
+        Object originalRuntimeOwner = runtimeOwner.get(null);
+        try {
+            runtimeOwner.set(null, runtime);
+            for (Map.Entry<Class<?>, RuntimeService<?>> entry
+                    : services.entrySet()) {
+                assertRuntimeService(entry.getKey(), entry.getValue());
+            }
+        } finally {
+            runtimeOwner.set(null, originalRuntimeOwner);
+        }
+    }
+
+    @Test
+    void uninstalledRuntimeServiceFallsBackToLegacyFacadeField()
+            throws Exception {
+        Field runtimeOwner = Emulator.class.getDeclaredField("polarisRuntime");
+        Field configField = Emulator.class.getDeclaredField("config");
+        runtimeOwner.setAccessible(true);
+        configField.setAccessible(true);
+        Object originalRuntimeOwner = runtimeOwner.get(null);
+        Object originalConfig = configField.get(null);
+        ConfigurationManager legacyConfig = mock(ConfigurationManager.class);
+        try {
+            runtimeOwner.set(null, new PolarisRuntime());
+            configField.set(null, legacyConfig);
+
+            assertSame(legacyConfig, Emulator.getConfig());
+        } finally {
+            configField.set(null, originalConfig);
+            runtimeOwner.set(null, originalRuntimeOwner);
+        }
+    }
+
+    private static <T> RuntimeService<T> service(
+            Consumer<T> installer,
+            Supplier<T> facadeGetter) {
+        return new RuntimeService<>(installer, facadeGetter);
+    }
+
+    private static <T> void assertRuntimeService(
+            Class<T> type,
+            RuntimeService<?> untypedService) {
+        @SuppressWarnings("unchecked")
+        RuntimeService<T> service = (RuntimeService<T>) untypedService;
+        T installed = mock(type);
+        service.installer().accept(installed);
+
+        assertSame(installed, service.facadeGetter().get(), type.getName());
+    }
+
+    private record RuntimeService<T>(
+            Consumer<T> installer,
+            Supplier<T> facadeGetter) {
+    }
+}


### PR DESCRIPTION
Adds a process-scoped owner for bootstrap services while retaining Emulator as the legacy compatibility facade.

Service getters preserve exact object identity and partial-startup fallback behavior.