### PR TITLE
test(core): characterize runtime teardown

### DIFF
--- a/Emulator/src/test/java/com/eu/habbo/EmulatorLifecycleCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorLifecycleCompatibilityTest.java
@@ -1,0 +1,168 @@
+package com.eu.habbo;
+
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.database.Database;
+import com.eu.habbo.habbohotel.GameEnvironment;
+import com.eu.habbo.networking.gameserver.GameServer;
+import com.eu.habbo.networking.rconserver.RCONServer;
+import com.eu.habbo.plugin.PluginManager;
+import com.eu.habbo.plugin.events.emulator.EmulatorStartShutdownEvent;
+import com.eu.habbo.plugin.events.emulator.EmulatorStoppedEvent;
+import com.eu.habbo.threading.ThreadPooling;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EmulatorLifecycleCompatibilityTest {
+
+    @Test
+    void shutdownKeepsItsObservableOrderAndContinuesAfterFailure()
+            throws Exception {
+        List<String> calls = new ArrayList<>();
+        ConfigurationManager configuration =
+                mock(ConfigurationManager.class);
+        Database database = mock(Database.class);
+        HikariDataSource dataSource = mock(HikariDataSource.class);
+        GameServer gameServer = mock(GameServer.class);
+        RCONServer rconServer = mock(RCONServer.class);
+        ThreadPooling threading = mock(ThreadPooling.class);
+        GameEnvironment environment = mock(GameEnvironment.class);
+        PluginManager plugins = mock(PluginManager.class);
+
+        when(database.getDataSource()).thenReturn(dataSource);
+        when(dataSource.isClosed()).thenReturn(false);
+        doAnswer(invocation -> {
+            calls.add("threading.reject-new-work");
+            return null;
+        }).when(threading).setCanAdd(false);
+        doAnswer(invocation -> {
+            Object event = invocation.getArgument(0);
+            if (event instanceof EmulatorStartShutdownEvent) {
+                calls.add("plugins.before-shutdown");
+            } else if (event instanceof EmulatorStoppedEvent) {
+                calls.add("plugins.after-hotel");
+            }
+            return event;
+        }).when(plugins).fireEvent(any());
+        doAnswer(invocation -> {
+            calls.add("rcon.stop");
+            throw new IllegalStateException("expected bind teardown failure");
+        }).when(rconServer).stop();
+        doAnswer(invocation -> {
+            calls.add("hotel.dispose");
+            return null;
+        }).when(environment).dispose();
+        doAnswer(invocation -> {
+            calls.add("plugins.dispose");
+            return null;
+        }).when(plugins).dispose();
+        doAnswer(invocation -> {
+            calls.add("configuration.save");
+            return null;
+        }).when(configuration).saveToDatabase();
+        doAnswer(invocation -> {
+            calls.add("game.stop");
+            return null;
+        }).when(gameServer).stop();
+        doAnswer(invocation -> {
+            calls.add("threading.shutdown");
+            return null;
+        }).when(threading).shutDown();
+        doAnswer(invocation -> {
+            calls.add("database.dispose");
+            return null;
+        }).when(database).dispose();
+
+        Map<Field, Object> originalFields = new LinkedHashMap<>();
+        Map<Field, Boolean> originalFlags = new LinkedHashMap<>();
+        try {
+            install(originalFields, "polarisRuntime", null);
+            install(originalFields, "config", configuration);
+            install(originalFields, "database", database);
+            install(originalFields, "gameServer", gameServer);
+            install(originalFields, "rconServer", rconServer);
+            install(originalFields, "threading", threading);
+            install(originalFields, "gameEnvironment", environment);
+            install(originalFields, "pluginManager", plugins);
+            installFlag(originalFlags, "isReady", true);
+            installFlag(originalFlags, "isShuttingDown", false);
+            installFlag(originalFlags, "stopped", false);
+
+            Method dispose = Emulator.class.getDeclaredMethod("dispose");
+            dispose.setAccessible(true);
+            dispose.invoke(null);
+
+            assertTrue(indexOf(calls, "threading.reject-new-work")
+                    < indexOf(calls, "plugins.before-shutdown"));
+            assertTrue(indexOf(calls, "plugins.before-shutdown")
+                    < indexOf(calls, "hotel.dispose"));
+            assertTrue(indexOf(calls, "hotel.dispose")
+                    < indexOf(calls, "plugins.after-hotel"));
+            assertTrue(indexOf(calls, "plugins.after-hotel")
+                    < indexOf(calls, "plugins.dispose"));
+            assertTrue(indexOf(calls, "rcon.stop")
+                    < indexOf(calls, "database.dispose"));
+            assertTrue(calls.containsAll(List.of(
+                    "rcon.stop",
+                    "configuration.save",
+                    "game.stop",
+                    "threading.shutdown",
+                    "database.dispose")));
+        } finally {
+            restore(originalFields);
+            restoreFlags(originalFlags);
+        }
+    }
+
+    private static int indexOf(List<String> calls, String name) {
+        int index = calls.indexOf(name);
+        assertTrue(index >= 0, () -> "Missing lifecycle call: " + name);
+        return index;
+    }
+
+    private static void install(
+            Map<Field, Object> originals,
+            String name,
+            Object value) throws Exception {
+        Field field = Emulator.class.getDeclaredField(name);
+        field.setAccessible(true);
+        originals.put(field, field.get(null));
+        field.set(null, value);
+    }
+
+    private static void installFlag(
+            Map<Field, Boolean> originals,
+            String name,
+            boolean value) throws Exception {
+        Field field = Emulator.class.getDeclaredField(name);
+        field.setAccessible(true);
+        originals.put(field, field.getBoolean(null));
+        field.setBoolean(null, value);
+    }
+
+    private static void restore(Map<Field, Object> originals)
+            throws IllegalAccessException {
+        for (Map.Entry<Field, Object> entry : originals.entrySet()) {
+            entry.getKey().set(null, entry.getValue());
+        }
+    }
+
+    private static void restoreFlags(Map<Field, Boolean> originals)
+            throws IllegalAccessException {
+        for (Map.Entry<Field, Boolean> entry : originals.entrySet()) {
+            entry.getKey().setBoolean(null, entry.getValue());
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/GameEnvironmentDisposalTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/GameEnvironmentDisposalTest.java
@@ -2,14 +2,16 @@ package com.eu.habbo.habbohotel;
 
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.lang.reflect.Field;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class GameEnvironmentDisposalTest {
 
@@ -34,16 +36,30 @@ class GameEnvironmentDisposalTest {
     }
 
     @Test
-    void roomsAreQuiescedBeforeTheRoomSavePassAndBotsAreDisposed() throws Exception {
-        String source = Files.readString(Path.of(
-                "src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java"
-        ));
-        int quiesce = source.indexOf("this.roomManager.quiesceRoomCycles()");
-        int rooms = source.indexOf("this.roomManager.dispose()");
-        int bots = source.indexOf("this.botManager.dispose()");
+    void roomsAreQuiescedBeforeTheRoomSavePassAndBotsAreDisposed()
+            throws Exception {
+        GameEnvironment environment = new GameEnvironment();
+        com.eu.habbo.habbohotel.rooms.RoomManager rooms =
+                mock(com.eu.habbo.habbohotel.rooms.RoomManager.class);
+        com.eu.habbo.habbohotel.bots.BotManager bots =
+                mock(com.eu.habbo.habbohotel.bots.BotManager.class);
+        setField(environment, "roomManager", rooms);
+        setField(environment, "botManager", bots);
 
-        assertTrue(quiesce >= 0);
-        assertTrue(rooms > quiesce);
-        assertTrue(bots >= 0);
+        environment.dispose();
+
+        var order = inOrder(rooms);
+        order.verify(rooms).quiesceRoomCycles();
+        order.verify(rooms).dispose();
+        verify(bots).dispose();
+    }
+
+    private static void setField(
+            GameEnvironment environment,
+            String name,
+            Object value) throws Exception {
+        Field field = GameEnvironment.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(environment, value);
     }
 }


### PR DESCRIPTION
Adds executable lifecycle contracts for partial hotel teardown, room-cycle quiescence, bot disposal, plugin shutdown events, and failure-isolated process cleanup.