### PR TITLE
refactor(core): centralize runtime lifecycle

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -130,7 +130,8 @@ public final class Emulator {
             Locale.setDefault(Locale.of("en"));
             setBuild();
             Emulator.stopped = false;
-            Emulator.polarisRuntime = new PolarisRuntime();
+            Emulator.polarisRuntime = new PolarisRuntime(
+                    () -> SessionResumeManager.getInstance().disposeAll());
             ConsoleCommand.load();
             Emulator.logging = new Logging();
             Emulator.polarisRuntime.installLogging(Emulator.logging);
@@ -279,15 +280,15 @@ public final class Emulator {
 
         } catch (IllegalArgumentException e) {
             LOGGER.error("Invalid startup option: {}", e.getMessage());
+            shutdownAfterStartupFailure();
             throw e;
         } catch (MigrationException e) {
             LOGGER.error("Polaris could not safely prepare the database, so startup was aborted.", e);
-            if (Emulator.database != null) {
-                Emulator.database.dispose();
-            }
+            shutdownAfterStartupFailure();
             throw e;
         } catch (Exception e) {
             LOGGER.error("Caught exception", e);
+            shutdownAfterStartupFailure();
             throw e;
         }
     }
@@ -504,13 +505,31 @@ public final class Emulator {
 
     private static void dispose() {
         Emulator.isShuttingDown = true;
-        if (Emulator.threading != null) {
-            Emulator.threading.setCanAdd(false);
-        }
         Emulator.isReady = false;
 
         LOGGER.info("Stopping Polaris {}", version);
 
+        if (Emulator.polarisRuntime != null) {
+            Emulator.polarisRuntime.shutdown();
+        } else {
+            disposeLegacyRuntime();
+        }
+
+        LOGGER.info("Stopped Polaris {}", version);
+
+        Emulator.stopped = true;
+    }
+
+    private static void shutdownAfterStartupFailure() {
+        if (Emulator.polarisRuntime != null) {
+            Emulator.polarisRuntime.shutdown();
+        }
+    }
+
+    private static void disposeLegacyRuntime() {
+        if (Emulator.threading != null) {
+            Emulator.threading.setCanAdd(false);
+        }
         if (Emulator.pluginManager != null)
             tryShutdown(() -> Emulator.pluginManager.fireEvent(new EmulatorStartShutdownEvent()));
         if (Emulator.rconServer != null) tryShutdown(() -> Emulator.rconServer.stop());
@@ -524,10 +543,6 @@ public final class Emulator {
         if (Emulator.gameServer != null) tryShutdown(() -> Emulator.gameServer.stop());
         if (Emulator.threading != null) tryShutdown(() -> Emulator.threading.shutDown());
         if (Emulator.database != null) tryShutdown(() -> Emulator.database.dispose());
-
-        LOGGER.info("Stopped Polaris {}", version);
-
-        Emulator.stopped = true;
     }
 
     private static boolean canPersistConfiguration() {

--- a/Emulator/src/main/java/com/eu/habbo/PolarisRuntime.java
+++ b/Emulator/src/main/java/com/eu/habbo/PolarisRuntime.java
@@ -23,6 +23,7 @@ import java.util.Objects;
  */
 final class PolarisRuntime {
 
+    private final RuntimeLifecycle lifecycle;
     private ConfigurationManager configuration;
     private CryptoConfig crypto;
     private TextsManager texts;
@@ -35,6 +36,14 @@ final class PolarisRuntime {
     private GameEnvironment gameEnvironment;
     private PluginManager pluginManager;
     private BadgeImager badgeImager;
+
+    PolarisRuntime(Runnable sessionCleanup) {
+        this.lifecycle = new RuntimeLifecycle(this, sessionCleanup);
+    }
+
+    void shutdown() {
+        lifecycle.shutdown();
+    }
 
     ConfigurationManager configuration() {
         return configuration;

--- a/Emulator/src/main/java/com/eu/habbo/RuntimeLifecycle.java
+++ b/Emulator/src/main/java/com/eu/habbo/RuntimeLifecycle.java
@@ -1,0 +1,123 @@
+package com.eu.habbo;
+
+import com.eu.habbo.database.Database;
+import com.eu.habbo.plugin.events.emulator.EmulatorStartShutdownEvent;
+import com.eu.habbo.plugin.events.emulator.EmulatorStoppedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Coordinates process teardown in the reverse of the runtime startup phases.
+ */
+final class RuntimeLifecycle {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(RuntimeLifecycle.class);
+
+    private final PolarisRuntime services;
+    private final Runnable sessionCleanup;
+    private final AtomicBoolean shutdownStarted = new AtomicBoolean();
+
+    RuntimeLifecycle(
+            PolarisRuntime services,
+            Runnable sessionCleanup) {
+        this.services = Objects.requireNonNull(services);
+        this.sessionCleanup = Objects.requireNonNull(sessionCleanup);
+    }
+
+    void shutdown() {
+        if (!shutdownStarted.compareAndSet(false, true)) {
+            return;
+        }
+
+        quiesceRuntime();
+        stopNetworkPhase();
+        stopHotelPhase();
+        stopPluginPhase();
+        stopFoundationPhase();
+    }
+
+    private void quiesceRuntime() {
+        if (services.threading() != null) {
+            run(
+                    "reject new scheduled work",
+                    () -> services.threading().setCanAdd(false));
+        }
+        if (services.pluginManager() != null) {
+            run(
+                    "publish pre-shutdown event",
+                    () -> services.pluginManager().fireEvent(
+                            new EmulatorStartShutdownEvent()));
+        }
+    }
+
+    private void stopNetworkPhase() {
+        if (services.rconServer() != null) {
+            run("stop RCON server", () -> services.rconServer().stop());
+        }
+        if (services.gameServer() != null) {
+            run("stop game server", () -> services.gameServer().stop());
+        }
+        run("dispose resumed sessions", sessionCleanup);
+    }
+
+    private void stopHotelPhase() {
+        if (services.gameEnvironment() != null) {
+            run(
+                    "dispose hotel services",
+                    () -> services.gameEnvironment().dispose());
+        }
+    }
+
+    private void stopPluginPhase() {
+        if (services.pluginManager() == null) {
+            return;
+        }
+
+        run(
+                "publish hotel-stopped event",
+                () -> services.pluginManager().fireEvent(
+                        new EmulatorStoppedEvent()));
+        run(
+                "dispose plugins",
+                () -> services.pluginManager().dispose());
+    }
+
+    private void stopFoundationPhase() {
+        if (services.threading() != null) {
+            run(
+                    "stop scheduler",
+                    () -> services.threading().shutDown());
+        }
+        run("save configuration", () -> {
+            if (canPersistConfiguration()) {
+                services.configuration().saveToDatabase();
+            }
+        });
+        if (services.database() != null) {
+            run("close database", () -> services.database().dispose());
+        }
+    }
+
+    private boolean canPersistConfiguration() {
+        Database database = services.database();
+        return services.configuration() != null
+                && database != null
+                && database.getDataSource() != null
+                && !database.getDataSource().isClosed();
+    }
+
+    private void run(String actionName, Runnable action) {
+        try {
+            action.run();
+        } catch (Exception exception) {
+            LOGGER.error(
+                    "Runtime shutdown action failed: {}",
+                    actionName,
+                    exception);
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/EmulatorLifecycleCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorLifecycleCompatibilityTest.java
@@ -18,7 +18,9 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -26,6 +28,39 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class EmulatorLifecycleCompatibilityTest {
+
+    @Test
+    void stoppedIsPublishedOnlyAfterRuntimeResourcesClose()
+            throws Exception {
+        AtomicBoolean databaseClosed = new AtomicBoolean();
+        PolarisRuntime runtime = new PolarisRuntime(() -> {
+        });
+        Database database = mock(Database.class);
+        when(database.getDataSource()).thenReturn(null);
+        doAnswer(invocation -> {
+            assertFalse(Emulator.stopped);
+            databaseClosed.set(true);
+            return null;
+        }).when(database).dispose();
+        runtime.installDatabase(database);
+
+        Map<Field, Object> originalFields = new LinkedHashMap<>();
+        Map<Field, Boolean> originalFlags = new LinkedHashMap<>();
+        try {
+            install(originalFields, "polarisRuntime", runtime);
+            installFlag(originalFlags, "stopped", false);
+
+            Method dispose = Emulator.class.getDeclaredMethod("dispose");
+            dispose.setAccessible(true);
+            dispose.invoke(null);
+
+            assertTrue(databaseClosed.get());
+            assertTrue(Emulator.stopped);
+        } finally {
+            restore(originalFields);
+            restoreFlags(originalFlags);
+        }
+    }
 
     @Test
     void shutdownKeepsItsObservableOrderAndContinuesAfterFailure()

--- a/Emulator/src/test/java/com/eu/habbo/PolarisRuntimeTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/PolarisRuntimeTest.java
@@ -28,7 +28,8 @@ class PolarisRuntimeTest {
     @Test
     void emulatorFacadeDelegatesToEveryInstalledRuntimeService()
             throws Exception {
-        PolarisRuntime runtime = new PolarisRuntime();
+        PolarisRuntime runtime = new PolarisRuntime(() -> {
+        });
         Map<Class<?>, RuntimeService<?>> services = new LinkedHashMap<>();
         services.put(
                 ConfigurationManager.class,
@@ -100,7 +101,8 @@ class PolarisRuntimeTest {
         Object originalConfig = configField.get(null);
         ConfigurationManager legacyConfig = mock(ConfigurationManager.class);
         try {
-            runtimeOwner.set(null, new PolarisRuntime());
+            runtimeOwner.set(null, new PolarisRuntime(() -> {
+            }));
             configField.set(null, legacyConfig);
 
             assertSame(legacyConfig, Emulator.getConfig());

--- a/Emulator/src/test/java/com/eu/habbo/RuntimeLifecycleTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/RuntimeLifecycleTest.java
@@ -1,0 +1,127 @@
+package com.eu.habbo;
+
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.database.Database;
+import com.eu.habbo.habbohotel.GameEnvironment;
+import com.eu.habbo.networking.gameserver.GameServer;
+import com.eu.habbo.networking.rconserver.RCONServer;
+import com.eu.habbo.plugin.PluginManager;
+import com.eu.habbo.plugin.events.emulator.EmulatorStartShutdownEvent;
+import com.eu.habbo.plugin.events.emulator.EmulatorStoppedEvent;
+import com.eu.habbo.threading.ThreadPooling;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RuntimeLifecycleTest {
+
+    @Test
+    void shutdownUsesReversePhasesAndIsolatesFailures() {
+        List<String> calls = new ArrayList<>();
+        PolarisRuntime runtime =
+                new PolarisRuntime(() -> calls.add("sessions.dispose"));
+        ConfigurationManager configuration =
+                mock(ConfigurationManager.class);
+        Database database = mock(Database.class);
+        HikariDataSource dataSource = mock(HikariDataSource.class);
+        GameServer gameServer = mock(GameServer.class);
+        RCONServer rconServer = mock(RCONServer.class);
+        ThreadPooling threading = mock(ThreadPooling.class);
+        GameEnvironment environment = mock(GameEnvironment.class);
+        PluginManager plugins = mock(PluginManager.class);
+
+        when(database.getDataSource()).thenReturn(dataSource);
+        when(dataSource.isClosed()).thenReturn(false);
+        doAnswer(invocation -> {
+            calls.add("threading.reject-new-work");
+            return null;
+        }).when(threading).setCanAdd(false);
+        doAnswer(invocation -> {
+            Object event = invocation.getArgument(0);
+            if (event instanceof EmulatorStartShutdownEvent) {
+                calls.add("plugins.before-shutdown");
+            } else if (event instanceof EmulatorStoppedEvent) {
+                calls.add("plugins.after-hotel");
+            }
+            return event;
+        }).when(plugins).fireEvent(any());
+        doAnswer(invocation -> {
+            calls.add("rcon.stop");
+            throw new IllegalStateException("expected");
+        }).when(rconServer).stop();
+        doAnswer(invocation -> {
+            calls.add("game.stop");
+            return null;
+        }).when(gameServer).stop();
+        doAnswer(invocation -> {
+            calls.add("hotel.dispose");
+            return null;
+        }).when(environment).dispose();
+        doAnswer(invocation -> {
+            calls.add("plugins.dispose");
+            return null;
+        }).when(plugins).dispose();
+        doAnswer(invocation -> {
+            calls.add("threading.shutdown");
+            return null;
+        }).when(threading).shutDown();
+        doAnswer(invocation -> {
+            calls.add("configuration.save");
+            return null;
+        }).when(configuration).saveToDatabase();
+        doAnswer(invocation -> {
+            calls.add("database.dispose");
+            return null;
+        }).when(database).dispose();
+
+        runtime.installConfiguration(configuration);
+        runtime.installDatabase(database);
+        runtime.installThreading(threading);
+        runtime.installPluginManager(plugins);
+        runtime.installGameEnvironment(environment);
+        runtime.installGameServer(gameServer);
+        runtime.installRconServer(rconServer);
+
+        runtime.shutdown();
+        runtime.shutdown();
+
+        assertEquals(List.of(
+                "threading.reject-new-work",
+                "plugins.before-shutdown",
+                "rcon.stop",
+                "game.stop",
+                "sessions.dispose",
+                "hotel.dispose",
+                "plugins.after-hotel",
+                "plugins.dispose",
+                "threading.shutdown",
+                "configuration.save",
+                "database.dispose"), calls);
+    }
+
+    @Test
+    void partialRuntimeDisposesOnlyInstalledResources() {
+        List<String> calls = new ArrayList<>();
+        PolarisRuntime runtime = new PolarisRuntime(() -> {
+        });
+        Database database = mock(Database.class);
+        when(database.getDataSource()).thenReturn(null);
+        doAnswer(invocation -> {
+            calls.add("database.dispose");
+            return null;
+        }).when(database).dispose();
+        runtime.installDatabase(database);
+
+        runtime.shutdown();
+
+        assertEquals(List.of("database.dispose"), calls);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/threading/ThreadPoolingGracefulShutdownTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/threading/ThreadPoolingGracefulShutdownTest.java
@@ -107,21 +107,6 @@ class ThreadPoolingGracefulShutdownTest {
     }
 
     @Test
-    void executorDrainsBeforeDatabaseIsClosed() throws Exception {
-        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/Emulator.java"));
-        String shutdownMethod = source.substring(source.indexOf("private static void dispose()"));
-        int threadingShutdown = shutdownMethod.indexOf("Emulator.threading.shutDown()");
-        int databaseShutdown = shutdownMethod.indexOf("Emulator.database.dispose()");
-        int stoppedLog = shutdownMethod.indexOf("LOGGER.info(\"Stopped Polaris {}\", version)");
-
-        assertTrue(threadingShutdown >= 0);
-        assertTrue(databaseShutdown > threadingShutdown,
-                "tasks must finish before their database dependency is closed");
-        assertTrue(stoppedLog > databaseShutdown,
-                "the emulator must only report stopped after dependencies are closed");
-    }
-
-    @Test
     void rejectedDelayedShutdownTaskIsReported() {
         ThreadPooling pooling = new ThreadPooling(1);
         Logger logger = (Logger) LoggerFactory.getLogger(ThreadPooling.class);


### PR DESCRIPTION
Moves process teardown into an idempotent phased lifecycle owner. Startup failures now unwind installed services, and shutdown isolates failures while closing network, hotel, plugin, scheduler, configuration, and database resources in dependency order.