### PR TITLE
refactor(core): extract runtime bootstrap

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -133,100 +133,22 @@ public final class Emulator {
             Emulator.polarisRuntime = new PolarisRuntime(
                     () -> SessionResumeManager.getInstance().disposeAll());
             ConsoleCommand.load();
-            Emulator.logging = new Logging();
-            Emulator.polarisRuntime.installLogging(Emulator.logging);
+            PolarisBootstrap bootstrap = new PolarisBootstrap(
+                    Emulator.polarisRuntime,
+                    Emulator::registerStartupConfigDefaults);
+            bootstrap.initializeLogging();
 
             System.out.println(startupHero(styledConsole));
 
             long startTime = System.nanoTime();
 
             Emulator.runtime = Runtime.getRuntime();
-            Emulator.config = new ConfigurationManager("config.ini");
-            Emulator.polarisRuntime.installConfiguration(Emulator.config);
-            Emulator.crypto = new CryptoConfig(
-                    Emulator.getConfig().getBoolean("enc.enabled", false),
-                    Emulator.getConfig().getValue("enc.e"),
-                    Emulator.getConfig().getValue("enc.n"),
-                    Emulator.getConfig().getValue("enc.d"));
-            Emulator.polarisRuntime.installCrypto(Emulator.crypto);
-            Emulator.database = new Database(Emulator.getConfig());
-            Emulator.polarisRuntime.installDatabase(Emulator.database);
-            // Migrate before loading database-backed configuration.
-            if (Emulator.getDatabase() != null && Emulator.getDatabase().getDataSource() != null) {
-                if (migrationOptions.mode() == MigrationOptions.Mode.VALIDATE) {
-                    System.out.print(MigrationRunner.statusAtStartup(Emulator.getDatabase().getDataSource()));
-                    DatabaseIntegrityAudit.auditAtStartup(
-                            Emulator.getDatabase().getDataSource(),
-                            Emulator.getConfig(),
-                            integrityAuditOptions);
-                    Emulator.database.dispose();
-                    return;
-                }
-
-                if (migrationOptions.mode() == MigrationOptions.Mode.APPLY
-                        || migrationOptions.migrationsOnly()) {
-                    MigrationRunner.migrateAtStartup(
-                            Emulator.getDatabase().getDataSource(),
-                            Emulator.getConfig());
-                } else {
-                    MigrationRunner.runAtStartup(Emulator.getDatabase().getDataSource(), Emulator.getConfig());
-                }
-
-                DatabaseIntegrityAudit.auditAtStartup(
-                        Emulator.getDatabase().getDataSource(),
-                        Emulator.getConfig(),
-                        integrityAuditOptions);
-
-                if (migrationOptions.migrationsOnly()) {
-                    LOGGER.info("[migrate] Database migration completed; --migrations-only requested, so the emulator will not start.");
-                    Emulator.database.dispose();
-                    return;
-                }
+            if (!bootstrap.start(
+                    migrationOptions,
+                    integrityAuditOptions)) {
+                Emulator.polarisRuntime.shutdown();
+                return;
             }
-            com.eu.habbo.database.indexing.DatabaseIndexAuditor.auditAtStartup(
-                    Emulator.getDatabase().getDataSource());
-            Emulator.databaseLogger = new DatabaseLogger();
-            Emulator.polarisRuntime.installDatabaseLogger(Emulator.databaseLogger);
-            Emulator.config.loaded = true;
-            Emulator.config.loadFromDatabase();
-            Emulator.threading = new ThreadPooling(Emulator.getConfig().getInt("runtime.threads"));
-            Emulator.polarisRuntime.installThreading(Emulator.threading);
-            Emulator.getDatabase().getDataSource().setMaximumPoolSize(Emulator.getConfig().getInt("runtime.threads") * 2);
-            Emulator.getDatabase().getDataSource().setMinimumIdle(10);
-            registerStartupConfigDefaults();
-            Emulator.pluginManager = new PluginManager();
-            Emulator.polarisRuntime.installPluginManager(Emulator.pluginManager);
-            Emulator.pluginManager.reload();
-            Emulator.getPluginManager().fireEvent(new EmulatorConfigUpdatedEvent());
-            Emulator.texts = new TextsManager();
-            Emulator.polarisRuntime.installTexts(Emulator.texts);
-
-            String hotelTimezoneId = Emulator.getConfig().getValue("hotel.timezone", java.time.ZoneId.systemDefault().getId());
-            System.out.println(startupCard(hotelTimezoneId));
-            Emulator.texts.register("camera.permission", "You don't have permission to use the camera!");
-            Emulator.texts.register("camera.wait", "Please wait %seconds% seconds before making another picture.");
-            Emulator.texts.register("camera.error.creation", "Failed to create your picture. *sadpanda*");
-
-            File thumbnailDir = new File(Emulator.config.getValue("imager.location.output.thumbnail"));
-            if (!thumbnailDir.exists()) {
-                thumbnailDir.mkdirs();
-            }
-
-            new CleanerThread();
-            Emulator.gameServer = new GameServer(getConfig().getValue("game.host", "127.0.0.1"), getConfig().getInt("game.port", 30000));
-            Emulator.polarisRuntime.installGameServer(Emulator.gameServer);
-            Emulator.rconServer = new RCONServer(getConfig().getValue("rcon.host", "127.0.0.1"), getConfig().getInt("rcon.port", 30001));
-            Emulator.polarisRuntime.installRconServer(Emulator.rconServer);
-            Emulator.gameEnvironment = new GameEnvironment();
-            Emulator.polarisRuntime.installGameEnvironment(Emulator.gameEnvironment);
-            Emulator.gameEnvironment.load();
-            Emulator.gameServer.initializePipeline();
-            Emulator.gameServer.connect();
-            Emulator.getGameServer().getGameClientManager().CFKeepAlive();
-            Emulator.rconServer.initializePipeline();
-            Emulator.rconServer.connect();
-            Emulator.badgeImager = new BadgeImager();
-            Emulator.polarisRuntime.installBadgeImager(Emulator.badgeImager);
 
             LOGGER.info("Polaris has successfully loaded.");
             LOGGER.info("System launched in: {}ms. Using {} threads!", (System.nanoTime() - startTime) / 1e6, Runtime.getRuntime().availableProcessors() * 2);
@@ -589,6 +511,49 @@ public final class Emulator {
         Emulator.database = database;
         if (Emulator.polarisRuntime != null && database != null) {
             Emulator.polarisRuntime.installDatabase(database);
+        }
+    }
+
+    /**
+     * Keeps the private legacy backing fields aligned with the runtime owner.
+     * Public compatibility getters still prefer the runtime-owned instances.
+     */
+    static void synchronizeLegacyFacade(PolarisRuntime services) {
+        if (services.configuration() != null) {
+            Emulator.config = services.configuration();
+        }
+        if (services.crypto() != null) {
+            Emulator.crypto = services.crypto();
+        }
+        if (services.texts() != null) {
+            Emulator.texts = services.texts();
+        }
+        if (services.database() != null) {
+            Emulator.database = services.database();
+        }
+        if (services.databaseLogger() != null) {
+            Emulator.databaseLogger = services.databaseLogger();
+        }
+        if (services.gameServer() != null) {
+            Emulator.gameServer = services.gameServer();
+        }
+        if (services.rconServer() != null) {
+            Emulator.rconServer = services.rconServer();
+        }
+        if (services.logging() != null) {
+            Emulator.logging = services.logging();
+        }
+        if (services.threading() != null) {
+            Emulator.threading = services.threading();
+        }
+        if (services.gameEnvironment() != null) {
+            Emulator.gameEnvironment = services.gameEnvironment();
+        }
+        if (services.pluginManager() != null) {
+            Emulator.pluginManager = services.pluginManager();
+        }
+        if (services.badgeImager() != null) {
+            Emulator.badgeImager = services.badgeImager();
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
+++ b/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
@@ -1,0 +1,200 @@
+package com.eu.habbo;
+
+import com.eu.habbo.core.CleanerThread;
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.core.CryptoConfig;
+import com.eu.habbo.core.DatabaseLogger;
+import com.eu.habbo.core.Logging;
+import com.eu.habbo.core.TextsManager;
+import com.eu.habbo.database.Database;
+import com.eu.habbo.database.indexing.DatabaseIndexAuditor;
+import com.eu.habbo.database.integrity.DatabaseIntegrityAudit;
+import com.eu.habbo.database.integrity.IntegrityAuditOptions;
+import com.eu.habbo.database.migration.MigrationOptions;
+import com.eu.habbo.database.migration.MigrationRunner;
+import com.eu.habbo.habbohotel.GameEnvironment;
+import com.eu.habbo.networking.gameserver.GameServer;
+import com.eu.habbo.networking.rconserver.RCONServer;
+import com.eu.habbo.plugin.PluginManager;
+import com.eu.habbo.plugin.events.emulator.EmulatorConfigUpdatedEvent;
+import com.eu.habbo.threading.ThreadPooling;
+import com.eu.habbo.util.imager.badges.BadgeImager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Manually wires the process runtime in explicit dependency phases.
+ */
+final class PolarisBootstrap {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(PolarisBootstrap.class);
+
+    private final PolarisRuntime runtime;
+    private final Runnable registerConfigurationDefaults;
+
+    PolarisBootstrap(
+            PolarisRuntime runtime,
+            Runnable registerConfigurationDefaults) {
+        this.runtime = runtime;
+        this.registerConfigurationDefaults = registerConfigurationDefaults;
+    }
+
+    void initializeLogging() {
+        runtime.installLogging(new Logging());
+        Emulator.synchronizeLegacyFacade(runtime);
+    }
+
+    boolean start(
+            MigrationOptions migrationOptions,
+            IntegrityAuditOptions integrityAuditOptions) throws Exception {
+        return StartupPhases.run(List.of(
+                new StartupPhases.Phase(
+                        "configuration",
+                        this::initializeConfiguration),
+                new StartupPhases.Phase(
+                        "database",
+                        () -> initializeDatabase(
+                                migrationOptions,
+                                integrityAuditOptions)),
+                new StartupPhases.Phase("plugins", this::initializePlugins),
+                new StartupPhases.Phase("hotel", this::initializeHotel),
+                new StartupPhases.Phase("network", this::initializeNetwork)));
+    }
+
+    private boolean initializeConfiguration() {
+        ConfigurationManager configuration =
+                new ConfigurationManager("config.ini");
+        runtime.installConfiguration(configuration);
+        runtime.installCrypto(new CryptoConfig(
+                configuration.getBoolean("enc.enabled", false),
+                configuration.getValue("enc.e"),
+                configuration.getValue("enc.n"),
+                configuration.getValue("enc.d")));
+        Emulator.synchronizeLegacyFacade(runtime);
+        return true;
+    }
+
+    private boolean initializeDatabase(
+            MigrationOptions migrationOptions,
+            IntegrityAuditOptions integrityAuditOptions) throws Exception {
+        ConfigurationManager configuration = runtime.configuration();
+        Database database = new Database(configuration);
+        runtime.installDatabase(database);
+        Emulator.synchronizeLegacyFacade(runtime);
+
+        if (database.getDataSource() != null) {
+            if (migrationOptions.mode() == MigrationOptions.Mode.VALIDATE) {
+                System.out.print(MigrationRunner.statusAtStartup(
+                        database.getDataSource()));
+                DatabaseIntegrityAudit.auditAtStartup(
+                        database.getDataSource(),
+                        configuration,
+                        integrityAuditOptions);
+                return false;
+            }
+
+            if (migrationOptions.mode() == MigrationOptions.Mode.APPLY
+                    || migrationOptions.migrationsOnly()) {
+                MigrationRunner.migrateAtStartup(
+                        database.getDataSource(),
+                        configuration);
+            } else {
+                MigrationRunner.runAtStartup(
+                        database.getDataSource(),
+                        configuration);
+            }
+
+            DatabaseIntegrityAudit.auditAtStartup(
+                    database.getDataSource(),
+                    configuration,
+                    integrityAuditOptions);
+
+            if (migrationOptions.migrationsOnly()) {
+                LOGGER.info(
+                        "[migrate] Database migration completed; "
+                                + "--migrations-only requested, so the "
+                                + "emulator will not start.");
+                return false;
+            }
+        }
+
+        DatabaseIndexAuditor.auditAtStartup(database.getDataSource());
+        runtime.installDatabaseLogger(new DatabaseLogger());
+        configuration.loaded = true;
+        configuration.loadFromDatabase();
+
+        int runtimeThreads = configuration.getInt("runtime.threads");
+        runtime.installThreading(new ThreadPooling(runtimeThreads));
+        Emulator.synchronizeLegacyFacade(runtime);
+        database.getDataSource().setMaximumPoolSize(runtimeThreads * 2);
+        database.getDataSource().setMinimumIdle(10);
+        registerConfigurationDefaults.run();
+        return true;
+    }
+
+    private boolean initializePlugins() {
+        PluginManager plugins = new PluginManager();
+        runtime.installPluginManager(plugins);
+        plugins.reload();
+        plugins.fireEvent(new EmulatorConfigUpdatedEvent());
+
+        TextsManager texts = new TextsManager();
+        runtime.installTexts(texts);
+        Emulator.synchronizeLegacyFacade(runtime);
+        String hotelTimezoneId = runtime.configuration().getValue(
+                "hotel.timezone",
+                java.time.ZoneId.systemDefault().getId());
+        System.out.println(Emulator.startupCard(hotelTimezoneId));
+        texts.register(
+                "camera.permission",
+                "You don't have permission to use the camera!");
+        texts.register(
+                "camera.wait",
+                "Please wait %seconds% seconds before making another picture.");
+        texts.register(
+                "camera.error.creation",
+                "Failed to create your picture. *sadpanda*");
+
+        File thumbnailDirectory = new File(runtime.configuration().getValue(
+                "imager.location.output.thumbnail"));
+        if (!thumbnailDirectory.exists()) {
+            thumbnailDirectory.mkdirs();
+        }
+        return true;
+    }
+
+    private boolean initializeHotel() throws Exception {
+        new CleanerThread();
+        GameEnvironment environment = new GameEnvironment();
+        runtime.installGameEnvironment(environment);
+        Emulator.synchronizeLegacyFacade(runtime);
+        environment.load();
+        return true;
+    }
+
+    private boolean initializeNetwork() throws Exception {
+        ConfigurationManager configuration = runtime.configuration();
+        GameServer gameServer = new GameServer(
+                configuration.getValue("game.host", "127.0.0.1"),
+                configuration.getInt("game.port", 30000));
+        runtime.installGameServer(gameServer);
+        RCONServer rconServer = new RCONServer(
+                configuration.getValue("rcon.host", "127.0.0.1"),
+                configuration.getInt("rcon.port", 30001));
+        runtime.installRconServer(rconServer);
+        Emulator.synchronizeLegacyFacade(runtime);
+
+        gameServer.initializePipeline();
+        gameServer.connect();
+        gameServer.getGameClientManager().CFKeepAlive();
+        rconServer.initializePipeline();
+        rconServer.connect();
+        runtime.installBadgeImager(new BadgeImager());
+        Emulator.synchronizeLegacyFacade(runtime);
+        return true;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/RuntimeLifecycle.java
+++ b/Emulator/src/main/java/com/eu/habbo/RuntimeLifecycle.java
@@ -105,6 +105,7 @@ final class RuntimeLifecycle {
     private boolean canPersistConfiguration() {
         Database database = services.database();
         return services.configuration() != null
+                && services.configuration().loaded
                 && database != null
                 && database.getDataSource() != null
                 && !database.getDataSource().isClosed();

--- a/Emulator/src/main/java/com/eu/habbo/StartupPhases.java
+++ b/Emulator/src/main/java/com/eu/habbo/StartupPhases.java
@@ -1,0 +1,35 @@
+package com.eu.habbo;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Runs bootstrap phases in their declared order and supports intentional
+ * short-circuit modes such as migration validation.
+ */
+final class StartupPhases {
+
+    private StartupPhases() {
+    }
+
+    static boolean run(List<Phase> phases) throws Exception {
+        for (Phase phase : phases) {
+            if (!phase.action().run()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    record Phase(String name, Action action) {
+        Phase {
+            Objects.requireNonNull(name);
+            Objects.requireNonNull(action);
+        }
+    }
+
+    @FunctionalInterface
+    interface Action {
+        boolean run() throws Exception;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/EmulatorStartupConfigDefaultsTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorStartupConfigDefaultsTest.java
@@ -11,13 +11,14 @@ class EmulatorStartupConfigDefaultsTest {
 
     @Test
     void registersStartupConfigDefaultsBeforePluginConfigEvent() throws Exception {
-        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/Emulator.java"));
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/PolarisBootstrap.java"));
 
-        int defaults = source.indexOf("registerStartupConfigDefaults();");
-        int plugins = source.indexOf("Emulator.pluginManager = new PluginManager();");
+        int defaults = source.indexOf("registerConfigurationDefaults.run()");
+        int plugins = source.indexOf("new PluginManager()");
 
-        assertTrue(defaults > 0, "Emulator must register startup config defaults explicitly");
-        assertTrue(plugins > 0, "Emulator must initialize the plugin manager explicitly");
+        assertTrue(defaults > 0, "bootstrap must register startup config defaults explicitly");
+        assertTrue(plugins > 0, "bootstrap must initialize the plugin manager explicitly");
         assertTrue(defaults < plugins, "startup config defaults must exist before plugin reload/config events");
     }
 

--- a/Emulator/src/test/java/com/eu/habbo/EmulatorStartupConsoleTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/EmulatorStartupConsoleTest.java
@@ -78,8 +78,8 @@ class EmulatorStartupConsoleTest {
                 "gui.enabled must be registered disabled by default so it does not log missing config errors or start the UI unexpectedly");
         assertTrue(source.contains("register(\"gui.autostart.enabled\", \"0\")"),
                 "GUI autostart must use a new disabled-by-default key so old gui.enabled=1 settings do not launch the current UI");
-        assertTrue(source.indexOf("registerStartupConfigDefaults();") < source.indexOf("shouldLaunchGui()"),
-                "GUI autostart must be registered before the launch decision");
+        assertTrue(source.indexOf("bootstrap.start(") < source.indexOf("shouldLaunchGui()"),
+                "bootstrap must register GUI defaults before the launch decision");
         assertFalse(source.contains("getBoolean(\"gui.enabled\", true)"),
                 "GUI must not use a true fallback");
         assertFalse(source.contains("getBoolean(\"gui.enabled\", false)"),

--- a/Emulator/src/test/java/com/eu/habbo/PolarisRuntimeTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/PolarisRuntimeTest.java
@@ -112,6 +112,89 @@ class PolarisRuntimeTest {
         }
     }
 
+    @Test
+    void synchronizationMirrorsEveryInstalledServiceIntoLegacyFields()
+            throws Exception {
+        PolarisRuntime runtime = new PolarisRuntime(() -> {
+        });
+        Map<String, LegacyService<?>> services = new LinkedHashMap<>();
+        services.put(
+                "config",
+                legacyService(
+                        ConfigurationManager.class,
+                        runtime::installConfiguration));
+        services.put(
+                "crypto",
+                legacyService(CryptoConfig.class, runtime::installCrypto));
+        services.put(
+                "texts",
+                legacyService(TextsManager.class, runtime::installTexts));
+        services.put(
+                "database",
+                legacyService(Database.class, runtime::installDatabase));
+        services.put(
+                "databaseLogger",
+                legacyService(
+                        DatabaseLogger.class,
+                        runtime::installDatabaseLogger));
+        services.put(
+                "gameServer",
+                legacyService(GameServer.class, runtime::installGameServer));
+        services.put(
+                "rconServer",
+                legacyService(RCONServer.class, runtime::installRconServer));
+        services.put(
+                "logging",
+                legacyService(Logging.class, runtime::installLogging));
+        services.put(
+                "threading",
+                legacyService(ThreadPooling.class, runtime::installThreading));
+        services.put(
+                "gameEnvironment",
+                legacyService(
+                        GameEnvironment.class,
+                        runtime::installGameEnvironment));
+        services.put(
+                "pluginManager",
+                legacyService(
+                        PluginManager.class,
+                        runtime::installPluginManager));
+        services.put(
+                "badgeImager",
+                legacyService(
+                        BadgeImager.class,
+                        runtime::installBadgeImager));
+
+        Map<Field, Object> originalValues = new LinkedHashMap<>();
+        Map<Field, Object> installedValues = new LinkedHashMap<>();
+        try {
+            for (Map.Entry<String, LegacyService<?>> entry
+                    : services.entrySet()) {
+                Field field = Emulator.class.getDeclaredField(entry.getKey());
+                field.setAccessible(true);
+                originalValues.put(field, field.get(null));
+                installedValues.put(
+                        field,
+                        installMock(entry.getValue()));
+            }
+
+            Emulator.synchronizeLegacyFacade(runtime);
+
+            for (Map.Entry<Field, Object> entry
+                    : installedValues.entrySet()) {
+                assertSame(
+                        entry.getValue(),
+                        entry.getKey().get(null),
+                        entry.getKey().getName());
+            }
+        } finally {
+            for (Map.Entry<Field, Object> entry
+                    : originalValues.entrySet()) {
+                entry.getKey().set(null, entry.getValue());
+            }
+        }
+    }
+
     private static <T> RuntimeService<T> service(
             Consumer<T> installer,
             Supplier<T> facadeGetter) {
@@ -129,8 +212,28 @@ class PolarisRuntimeTest {
         assertSame(installed, service.facadeGetter().get(), type.getName());
     }
 
+    private static <T> LegacyService<T> legacyService(
+            Class<T> type,
+            Consumer<T> installer) {
+        return new LegacyService<>(type, installer);
+    }
+
+    private static <T> Object installMock(
+            LegacyService<?> untypedService) {
+        @SuppressWarnings("unchecked")
+        LegacyService<T> service = (LegacyService<T>) untypedService;
+        T installed = mock(service.type());
+        service.installer().accept(installed);
+        return installed;
+    }
+
     private record RuntimeService<T>(
             Consumer<T> installer,
             Supplier<T> facadeGetter) {
+    }
+
+    private record LegacyService<T>(
+            Class<T> type,
+            Consumer<T> installer) {
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/RuntimeLifecycleTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/RuntimeLifecycleTest.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class RuntimeLifecycleTest {
@@ -30,6 +32,7 @@ class RuntimeLifecycleTest {
                 new PolarisRuntime(() -> calls.add("sessions.dispose"));
         ConfigurationManager configuration =
                 mock(ConfigurationManager.class);
+        configuration.loaded = true;
         Database database = mock(Database.class);
         HikariDataSource dataSource = mock(HikariDataSource.class);
         GameServer gameServer = mock(GameServer.class);
@@ -123,5 +126,24 @@ class RuntimeLifecycleTest {
         runtime.shutdown();
 
         assertEquals(List.of("database.dispose"), calls);
+    }
+
+    @Test
+    void shutdownDoesNotPersistConfigurationBeforeDatabaseLoadingCompletes() {
+        PolarisRuntime runtime = new PolarisRuntime(() -> {
+        });
+        ConfigurationManager configuration =
+                mock(ConfigurationManager.class);
+        Database database = mock(Database.class);
+        HikariDataSource dataSource = mock(HikariDataSource.class);
+        when(database.getDataSource()).thenReturn(dataSource);
+        when(dataSource.isClosed()).thenReturn(false);
+        runtime.installConfiguration(configuration);
+        runtime.installDatabase(database);
+
+        runtime.shutdown();
+
+        verify(configuration, never()).saveToDatabase();
+        verify(database).dispose();
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/StartupPhasesTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/StartupPhasesTest.java
@@ -1,0 +1,78 @@
+package com.eu.habbo;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StartupPhasesTest {
+
+    @Test
+    void phasesRunInDeclaredDependencyOrder() throws Exception {
+        List<String> calls = new ArrayList<>();
+
+        boolean started = StartupPhases.run(List.of(
+                phase("configuration", calls),
+                phase("database", calls),
+                phase("plugins", calls),
+                phase("hotel", calls),
+                phase("network", calls)));
+
+        assertTrue(started);
+        assertEquals(List.of(
+                "configuration",
+                "database",
+                "plugins",
+                "hotel",
+                "network"), calls);
+    }
+
+    @Test
+    void intentionalToolModeStopsBeforeLaterPhases() throws Exception {
+        List<String> calls = new ArrayList<>();
+
+        boolean started = StartupPhases.run(List.of(
+                phase("configuration", calls),
+                new StartupPhases.Phase("database", () -> {
+                    calls.add("database");
+                    return false;
+                }),
+                phase("plugins", calls)));
+
+        assertFalse(started);
+        assertEquals(List.of("configuration", "database"), calls);
+    }
+
+    @Test
+    void failureStopsBeforeDependentPhasesAndPropagates() {
+        List<String> calls = new ArrayList<>();
+        IllegalStateException failure = new IllegalStateException("expected");
+
+        IllegalStateException thrown = assertThrows(
+                IllegalStateException.class,
+                () -> StartupPhases.run(List.of(
+                        phase("configuration", calls),
+                        new StartupPhases.Phase("database", () -> {
+                            calls.add("database");
+                            throw failure;
+                        }),
+                        phase("plugins", calls))));
+
+        assertEquals(failure, thrown);
+        assertEquals(List.of("configuration", "database"), calls);
+    }
+
+    private static StartupPhases.Phase phase(
+            String name,
+            List<String> calls) {
+        return new StartupPhases.Phase(name, () -> {
+            calls.add(name);
+            return true;
+        });
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerContractTest.java
@@ -20,6 +20,11 @@ class RCONServerHandlerContractTest {
         return Files.readString(Path.of("src/main/java/com/eu/habbo/Emulator.java"));
     }
 
+    private static String bootstrapSource() throws Exception {
+        return Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/PolarisBootstrap.java"));
+    }
+
     @Test
     void rconRequestsAreRateLimitedPerRemoteAddress() throws Exception {
         String source = serverSource();
@@ -39,8 +44,10 @@ class RCONServerHandlerContractTest {
     @Test
     void rconRateLimitDefaultsAreRegisteredBeforeServerStarts() throws Exception {
         String source = emulatorSource();
-        int registerIndex = source.indexOf("registerStartupConfigDefaults();");
-        int serverIndex = source.indexOf("new RCONServer");
+        String bootstrap = bootstrapSource();
+        int registerIndex =
+                bootstrap.indexOf("registerConfigurationDefaults.run()");
+        int serverIndex = bootstrap.indexOf("new RCONServer");
 
         assertTrue(registerIndex >= 0, "RCON rate limiting must have a registered default toggle");
         assertTrue(source.contains("register(\"rcon.rate_limit.limit_for_period\", \"60\")"),


### PR DESCRIPTION
Moves runtime construction into explicit configuration, database, plugin, hotel, and network phases. Tool-only modes short-circuit safely, startup failures remain available to lifecycle unwind, and legacy facade fields stay synchronized.