### PR TITLE
perf(net): skip unused outgoing events

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
@@ -7,6 +7,7 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.plugin.PluginManager;
 import com.eu.habbo.plugin.events.emulator.OutgoingPacketEvent;
 import io.netty.channel.Channel;
 import org.slf4j.Logger;
@@ -113,15 +114,15 @@ public class GameClient {
                 return;
             }
 
-            OutgoingPacketEvent event = new OutgoingPacketEvent(this.habbo, response.getComposer(), response);
-            Emulator.getPluginManager().fireEvent(event);
-
-            if (event.isCancelled()) {
+            PluginManager plugins = Emulator.getPluginManager();
+            response = this.applyOutgoingPacketEvent(
+                    response,
+                    plugins,
+                    plugins.isRegistered(
+                            OutgoingPacketEvent.class,
+                            false));
+            if (response == null) {
                 return;
-            }
-
-            if (event.hasCustomMessage()) {
-                response = event.getCustomMessage();
             }
 
             this.channel.write(response, this.channel.voidPromise());
@@ -131,20 +132,21 @@ public class GameClient {
 
     public void sendResponses(ArrayList<ServerMessage> responses) {
         if (this.channel.isOpen()) {
+            PluginManager plugins = Emulator.getPluginManager();
+            boolean eventsRegistered = plugins.isRegistered(
+                    OutgoingPacketEvent.class,
+                    false);
             for (ServerMessage response : responses) {
                 if (response == null || response.getHeader() <= 0) {
                     return;
                 }
 
-                OutgoingPacketEvent event = new OutgoingPacketEvent(this.habbo, response.getComposer(), response);
-                Emulator.getPluginManager().fireEvent(event);
-
-                if (event.isCancelled()) {
+                response = this.applyOutgoingPacketEvent(
+                        response,
+                        plugins,
+                        eventsRegistered);
+                if (response == null) {
                     continue;
-                }
-
-                if (event.hasCustomMessage()) {
-                    response = event.getCustomMessage();
                 }
 
                 this.channel.write(response);
@@ -152,6 +154,27 @@ public class GameClient {
 
             this.channel.flush();
         }
+    }
+
+    private ServerMessage applyOutgoingPacketEvent(
+            ServerMessage response,
+            PluginManager plugins,
+            boolean eventsRegistered) {
+        if (!eventsRegistered) {
+            return response;
+        }
+
+        OutgoingPacketEvent event = new OutgoingPacketEvent(
+                this.habbo,
+                response.getComposer(),
+                response);
+        plugins.fireEvent(event);
+        if (event.isCancelled()) {
+            return null;
+        }
+        return event.hasCustomMessage()
+                ? event.getCustomMessage()
+                : response;
     }
 	
 	public void sendKeepAlive() {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
@@ -136,6 +136,24 @@ class GameClientOutgoingPacketCompatibilityTest {
         assertSame(response, this.channel.readOutbound());
     }
 
+    @Test
+    void noSubscriberBatchChecksRegistrationOnceAndWritesEveryResponse() {
+        ServerMessage first = new ServerMessage(100);
+        ServerMessage second = new ServerMessage(101);
+
+        this.client.sendResponses(new ArrayList<>(
+                java.util.List.of(first, second)));
+
+        verify(this.pluginManager).isRegistered(
+                OutgoingPacketEvent.class,
+                false);
+        verify(this.pluginManager, never()).fireEvent(
+                any(OutgoingPacketEvent.class));
+        assertSame(first, this.channel.readOutbound());
+        assertSame(second, this.channel.readOutbound());
+        assertNull(this.channel.readOutbound());
+    }
+
     private static Field field(String name) throws Exception {
         Field field = Emulator.class.getDeclaredField(name);
         field.setAccessible(true);

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -119,6 +120,20 @@ class GameClientOutgoingPacketCompatibilityTest {
                 any(OutgoingPacketEvent.class));
         assertSame(replacement, this.channel.readOutbound());
         assertNull(this.channel.readOutbound());
+    }
+
+    @Test
+    void noSubscriberSkipsEventDispatchAndWritesTheResponse() {
+        ServerMessage response = new ServerMessage(100);
+
+        this.client.sendResponse(response);
+
+        verify(this.pluginManager).isRegistered(
+                OutgoingPacketEvent.class,
+                false);
+        verify(this.pluginManager, never()).fireEvent(
+                any(OutgoingPacketEvent.class));
+        assertSame(response, this.channel.readOutbound());
     }
 
     private static Field field(String name) throws Exception {


### PR DESCRIPTION
Skips outgoing event construction and dispatch when no default or plugin listener is registered. Batch sends check registration once while preserving per-packet cancellation and replacement.