### PR TITLE
refactor(net): optimize packet dispatch

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
@@ -7,6 +7,7 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.plugin.PluginManager;
 import com.eu.habbo.plugin.events.emulator.OutgoingPacketEvent;
 import io.netty.channel.Channel;
 import org.slf4j.Logger;
@@ -113,15 +114,15 @@ public class GameClient {
                 return;
             }
 
-            OutgoingPacketEvent event = new OutgoingPacketEvent(this.habbo, response.getComposer(), response);
-            Emulator.getPluginManager().fireEvent(event);
-
-            if (event.isCancelled()) {
+            PluginManager plugins = Emulator.getPluginManager();
+            response = this.applyOutgoingPacketEvent(
+                    response,
+                    plugins,
+                    plugins.isRegistered(
+                            OutgoingPacketEvent.class,
+                            false));
+            if (response == null) {
                 return;
-            }
-
-            if (event.hasCustomMessage()) {
-                response = event.getCustomMessage();
             }
 
             this.channel.write(response, this.channel.voidPromise());
@@ -131,20 +132,21 @@ public class GameClient {
 
     public void sendResponses(ArrayList<ServerMessage> responses) {
         if (this.channel.isOpen()) {
+            PluginManager plugins = Emulator.getPluginManager();
+            boolean eventsRegistered = plugins.isRegistered(
+                    OutgoingPacketEvent.class,
+                    false);
             for (ServerMessage response : responses) {
                 if (response == null || response.getHeader() <= 0) {
                     return;
                 }
 
-                OutgoingPacketEvent event = new OutgoingPacketEvent(this.habbo, response.getComposer(), response);
-                Emulator.getPluginManager().fireEvent(event);
-
-                if (event.isCancelled()) {
+                response = this.applyOutgoingPacketEvent(
+                        response,
+                        plugins,
+                        eventsRegistered);
+                if (response == null) {
                     continue;
-                }
-
-                if (event.hasCustomMessage()) {
-                    response = event.getCustomMessage();
                 }
 
                 this.channel.write(response);
@@ -152,6 +154,27 @@ public class GameClient {
 
             this.channel.flush();
         }
+    }
+
+    private ServerMessage applyOutgoingPacketEvent(
+            ServerMessage response,
+            PluginManager plugins,
+            boolean eventsRegistered) {
+        if (!eventsRegistered) {
+            return response;
+        }
+
+        OutgoingPacketEvent event = new OutgoingPacketEvent(
+                this.habbo,
+                response.getComposer(),
+                response);
+        plugins.fireEvent(event);
+        if (event.isCancelled()) {
+            return null;
+        }
+        return event.hasCustomMessage()
+                ? event.getCustomMessage()
+                : response;
     }
 	
 	public void sendKeepAlive() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -86,6 +86,7 @@ import com.eu.habbo.plugin.events.emulator.EmulatorConfigUpdatedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -95,6 +96,23 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class PacketManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PacketManager.class);
+    private static final ClassValue<
+            Constructor<? extends MessageHandler>> HANDLER_CONSTRUCTORS =
+            new ClassValue<>() {
+                @Override
+                protected Constructor<? extends MessageHandler> computeValue(
+                        Class<?> type) {
+                    try {
+                        return type.asSubclass(MessageHandler.class)
+                                .getDeclaredConstructor();
+                    } catch (NoSuchMethodException exception) {
+                        throw new IllegalArgumentException(
+                                "Incoming handler has no default constructor: "
+                                        + type.getName(),
+                                exception);
+                    }
+                }
+            };
 
     private static final List<Integer> logList = new ArrayList<>();
     public static boolean DEBUG_SHOW_PACKETS = false;
@@ -204,7 +222,8 @@ public class PacketManager {
                     return;
                 }
 
-                final MessageHandler handler = handlerClass.getDeclaredConstructor().newInstance();
+                final MessageHandler handler =
+                        constructorFor(handlerClass).newInstance();
 
                 if (handler.getRatelimit() > 0) {
                     long now = System.currentTimeMillis();
@@ -276,6 +295,11 @@ public class PacketManager {
 
     boolean isRegistered(int header) {
         return this.incoming.containsKey(header);
+    }
+
+    static Constructor<? extends MessageHandler> constructorFor(
+            Class<? extends MessageHandler> handlerClass) {
+        return HANDLER_CONSTRUCTORS.get(handlerClass);
     }
 
     private void registerAmbassadors() throws Exception {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
@@ -1,0 +1,120 @@
+package com.eu.habbo.habbohotel.gameclients;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.CryptoConfig;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.plugin.PluginManager;
+import com.eu.habbo.plugin.events.emulator.OutgoingPacketEvent;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class GameClientOutgoingPacketCompatibilityTest {
+
+    private Field runtimeField;
+    private Field cryptoField;
+    private Field pluginManagerField;
+    private Object originalRuntime;
+    private Object originalCrypto;
+    private Object originalPluginManager;
+    private PluginManager pluginManager;
+    private EmbeddedChannel channel;
+    private GameClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        this.runtimeField = field("polarisRuntime");
+        this.cryptoField = field("crypto");
+        this.pluginManagerField = field("pluginManager");
+        this.originalRuntime = this.runtimeField.get(null);
+        this.originalCrypto = this.cryptoField.get(null);
+        this.originalPluginManager = this.pluginManagerField.get(null);
+        this.runtimeField.set(null, null);
+        this.cryptoField.set(
+                null,
+                new CryptoConfig(false, "", "", ""));
+        this.pluginManager = mock(PluginManager.class);
+        this.pluginManagerField.set(null, this.pluginManager);
+        this.channel = new EmbeddedChannel();
+        this.client = new GameClient(this.channel);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        this.channel.finishAndReleaseAll();
+        this.pluginManagerField.set(null, this.originalPluginManager);
+        this.cryptoField.set(null, this.originalCrypto);
+        this.runtimeField.set(null, this.originalRuntime);
+    }
+
+    @Test
+    void singleResponsePublishesTheExactPacketEventBeforeWriting() {
+        ServerMessage response = new ServerMessage(100);
+
+        this.client.sendResponse(response);
+
+        ArgumentCaptor<OutgoingPacketEvent> event =
+                ArgumentCaptor.forClass(OutgoingPacketEvent.class);
+        verify(this.pluginManager).fireEvent(event.capture());
+        assertSame(response, event.getValue().getOriginalMessage());
+        assertSame(response, this.channel.readOutbound());
+    }
+
+    @Test
+    void cancellationSuppressesTheResponse() {
+        doAnswer(invocation -> {
+            OutgoingPacketEvent event = invocation.getArgument(0);
+            event.setCancelled(true);
+            return event;
+        }).when(this.pluginManager).fireEvent(
+                any(OutgoingPacketEvent.class));
+
+        this.client.sendResponse(new ServerMessage(100));
+
+        assertNull(this.channel.readOutbound());
+    }
+
+    @Test
+    void batchResponsesApplyReplacementAndCancellationPerPacket() {
+        ServerMessage first = new ServerMessage(100);
+        ServerMessage second = new ServerMessage(101);
+        ServerMessage replacement = new ServerMessage(102);
+        doAnswer(invocation -> {
+            OutgoingPacketEvent event = invocation.getArgument(0);
+            if (event.getOriginalMessage() == first) {
+                event.setCustomMessage(replacement);
+            } else {
+                event.setCancelled(true);
+            }
+            return event;
+        }).when(this.pluginManager).fireEvent(
+                any(OutgoingPacketEvent.class));
+
+        this.client.sendResponses(new ArrayList<>(
+                java.util.List.of(first, second)));
+
+        verify(this.pluginManager, times(2)).fireEvent(
+                any(OutgoingPacketEvent.class));
+        assertSame(replacement, this.channel.readOutbound());
+        assertNull(this.channel.readOutbound());
+    }
+
+    private static Field field(String name) throws Exception {
+        Field field = Emulator.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
@@ -62,6 +62,9 @@ class GameClientOutgoingPacketCompatibilityTest {
 
     @Test
     void singleResponsePublishesTheExactPacketEventBeforeWriting() {
+        org.mockito.Mockito.when(this.pluginManager.isRegistered(
+                OutgoingPacketEvent.class,
+                false)).thenReturn(true);
         ServerMessage response = new ServerMessage(100);
 
         this.client.sendResponse(response);
@@ -75,6 +78,9 @@ class GameClientOutgoingPacketCompatibilityTest {
 
     @Test
     void cancellationSuppressesTheResponse() {
+        org.mockito.Mockito.when(this.pluginManager.isRegistered(
+                OutgoingPacketEvent.class,
+                false)).thenReturn(true);
         doAnswer(invocation -> {
             OutgoingPacketEvent event = invocation.getArgument(0);
             event.setCancelled(true);
@@ -89,6 +95,9 @@ class GameClientOutgoingPacketCompatibilityTest {
 
     @Test
     void batchResponsesApplyReplacementAndCancellationPerPacket() {
+        org.mockito.Mockito.when(this.pluginManager.isRegistered(
+                OutgoingPacketEvent.class,
+                false)).thenReturn(true);
         ServerMessage first = new ServerMessage(100);
         ServerMessage second = new ServerMessage(101);
         ServerMessage replacement = new ServerMessage(102);

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
@@ -136,6 +136,24 @@ class GameClientOutgoingPacketCompatibilityTest {
         assertSame(response, this.channel.readOutbound());
     }
 
+    @Test
+    void noSubscriberBatchChecksRegistrationOnceAndWritesEveryResponse() {
+        ServerMessage first = new ServerMessage(100);
+        ServerMessage second = new ServerMessage(101);
+
+        this.client.sendResponses(new ArrayList<>(
+                java.util.List.of(first, second)));
+
+        verify(this.pluginManager).isRegistered(
+                OutgoingPacketEvent.class,
+                false);
+        verify(this.pluginManager, never()).fireEvent(
+                any(OutgoingPacketEvent.class));
+        assertSame(first, this.channel.readOutbound());
+        assertSame(second, this.channel.readOutbound());
+        assertNull(this.channel.readOutbound());
+    }
+
     private static Field field(String name) throws Exception {
         Field field = Emulator.class.getDeclaredField(name);
         field.setAccessible(true);

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -119,6 +120,20 @@ class GameClientOutgoingPacketCompatibilityTest {
                 any(OutgoingPacketEvent.class));
         assertSame(replacement, this.channel.readOutbound());
         assertNull(this.channel.readOutbound());
+    }
+
+    @Test
+    void noSubscriberSkipsEventDispatchAndWritesTheResponse() {
+        ServerMessage response = new ServerMessage(100);
+
+        this.client.sendResponse(response);
+
+        verify(this.pluginManager).isRegistered(
+                OutgoingPacketEvent.class,
+                false);
+        verify(this.pluginManager, never()).fireEvent(
+                any(OutgoingPacketEvent.class));
+        assertSame(response, this.channel.readOutbound());
     }
 
     private static Field field(String name) throws Exception {

--- a/Emulator/src/test/java/com/eu/habbo/messages/PacketManagerHandlerInstanceTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/PacketManagerHandlerInstanceTest.java
@@ -56,6 +56,13 @@ class PacketManagerHandlerInstanceTest {
         assertSame(second, secondHandler.packet);
     }
 
+    @Test
+    void reusesTheResolvedConstructorWithoutReusingHandlers() {
+        assertSame(
+                PacketManager.constructorFor(RecordingHandler.class),
+                PacketManager.constructorFor(RecordingHandler.class));
+    }
+
     private static void setField(
             PacketManager manager,
             String name,

--- a/Emulator/src/test/java/com/eu/habbo/messages/PacketManagerHandlerInstanceTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/PacketManagerHandlerInstanceTest.java
@@ -1,0 +1,79 @@
+package com.eu.habbo.messages;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+class PacketManagerHandlerInstanceTest {
+
+    @Test
+    void createsAFreshHandlerWithExactInvocationStateForEveryPacket()
+            throws Exception {
+        PacketManager manager = mock(
+                PacketManager.class,
+                CALLS_REAL_METHODS);
+        setField(manager, "incoming", new HashMap<>());
+        setField(manager, "callables", new HashMap<>());
+        manager.registerHandler(987654, RecordingHandler.class);
+        GameClient client = mock(GameClient.class);
+        ClientMessage first =
+                new ClientMessage(987654, Unpooled.buffer(0));
+        ClientMessage second =
+                new ClientMessage(987654, Unpooled.buffer(0));
+        boolean originallyShuttingDown = Emulator.isShuttingDown;
+        Emulator.isShuttingDown = false;
+        RecordingHandler.invocations.clear();
+
+        try {
+            manager.handlePacket(client, first);
+            manager.handlePacket(client, second);
+        } finally {
+            Emulator.isShuttingDown = originallyShuttingDown;
+        }
+
+        assertEquals(2, RecordingHandler.invocations.size());
+        RecordingHandler firstHandler =
+                RecordingHandler.invocations.get(0);
+        RecordingHandler secondHandler =
+                RecordingHandler.invocations.get(1);
+        assertNotSame(firstHandler, secondHandler);
+        assertSame(client, firstHandler.client);
+        assertSame(first, firstHandler.packet);
+        assertSame(client, secondHandler.client);
+        assertSame(second, secondHandler.packet);
+    }
+
+    private static void setField(
+            PacketManager manager,
+            String name,
+            Object value) throws Exception {
+        Field field = PacketManager.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(manager, value);
+    }
+
+    @NoAuthMessage
+    public static final class RecordingHandler extends MessageHandler {
+
+        private static final List<RecordingHandler> invocations =
+                new ArrayList<>();
+
+        @Override
+        public void handle() {
+            invocations.add(this);
+        }
+    }
+}


### PR DESCRIPTION
Characterizes outgoing and incoming packet behavior, skips unused outgoing events, and caches incoming handler constructors without changing packet instances or ordering.