### PR TITLE
test(net): characterize room broadcast batches

### DIFF
--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomMessagingManagerBatchTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomMessagingManagerBatchTest.java
@@ -1,0 +1,72 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.messages.ServerMessage;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RoomMessagingManagerBatchTest {
+
+    @Test
+    void filtersNullPacketsAndPreservesOrderForEveryConnectedClient() {
+        Room room = mock(Room.class);
+        Habbo firstHabbo = mock(Habbo.class);
+        Habbo secondHabbo = mock(Habbo.class);
+        Habbo disconnected = mock(Habbo.class);
+        GameClient firstClient = mock(GameClient.class);
+        GameClient secondClient = mock(GameClient.class);
+        when(firstHabbo.getClient()).thenReturn(firstClient);
+        when(secondHabbo.getClient()).thenReturn(secondClient);
+        when(disconnected.getClient()).thenReturn(null);
+        when(room.getHabbos()).thenReturn(
+                List.of(firstHabbo, disconnected, secondHabbo));
+        ServerMessage first = new ServerMessage(100);
+        ServerMessage second = new ServerMessage(101);
+        RoomMessagingManager messaging =
+                new RoomMessagingManager(room);
+
+        messaging.sendComposers(Arrays.asList(
+                first,
+                null,
+                second));
+
+        assertEquals(
+                List.of(first, second),
+                capturedBatch(firstClient));
+        assertEquals(
+                List.of(first, second),
+                capturedBatch(secondClient));
+    }
+
+    @Test
+    void nullOrEmptyBatchDoesNotVisitRoomClients() {
+        Room room = mock(Room.class);
+        RoomMessagingManager messaging =
+                new RoomMessagingManager(room);
+
+        messaging.sendComposers(null);
+        messaging.sendComposers(List.of());
+
+        verify(room, never()).getHabbos();
+    }
+
+    private static ArrayList<ServerMessage> capturedBatch(
+            GameClient client) {
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ArrayList<ServerMessage>> captor =
+                ArgumentCaptor.forClass(ArrayList.class);
+        verify(client).sendResponses(captor.capture());
+        return captor.getValue();
+    }
+}


### PR DESCRIPTION
Covers null filtering, packet order, connected-client delivery, and empty-batch behavior before removing per-recipient list copies.