### PR TITLE
refactor(net): share room broadcast batches

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomMessagingManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomMessagingManager.java
@@ -57,7 +57,7 @@ public class RoomMessagingManager {
                 continue;
             }
 
-            habbo.getClient().sendResponses(new ArrayList<>(responses));
+            habbo.getClient().sendResponses(responses);
         }
     }
 

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomMessagingManagerBatchTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomMessagingManagerBatchTest.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -59,6 +60,28 @@ class RoomMessagingManagerBatchTest {
         messaging.sendComposers(List.of());
 
         verify(room, never()).getHabbos();
+    }
+
+    @Test
+    void reusesTheFilteredBatchAcrossRecipients() {
+        Room room = mock(Room.class);
+        Habbo firstHabbo = mock(Habbo.class);
+        Habbo secondHabbo = mock(Habbo.class);
+        GameClient firstClient = mock(GameClient.class);
+        GameClient secondClient = mock(GameClient.class);
+        when(firstHabbo.getClient()).thenReturn(firstClient);
+        when(secondHabbo.getClient()).thenReturn(secondClient);
+        when(room.getHabbos()).thenReturn(
+                List.of(firstHabbo, secondHabbo));
+        RoomMessagingManager messaging =
+                new RoomMessagingManager(room);
+
+        messaging.sendComposers(
+                List.of(new ServerMessage(100)));
+
+        assertSame(
+                capturedBatch(firstClient),
+                capturedBatch(secondClient));
     }
 
     private static ArrayList<ServerMessage> capturedBatch(


### PR DESCRIPTION
Reuses one null-filtered packet batch across connected room clients. Packet order, empty-batch behavior, event processing, and one flush per client remain unchanged.