### PR TITLE
perf(auth): honor configured worker width

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/auth/AuthHttpHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/auth/AuthHttpHandler.java
@@ -35,18 +35,38 @@ public class AuthHttpHandler extends ChannelInboundHandlerAdapter {
     // Netty event loop stalls every client on the same worker. A SEPARATE pool
     // (not the shared game ThreadPooling) also keeps it from starving room cycles.
     private static final int AUTH_POOL_MAX = authPoolMax();
-    private static final ThreadPoolExecutor AUTH_EXECUTOR = new ThreadPoolExecutor(
-            Math.min(4, AUTH_POOL_MAX), AUTH_POOL_MAX, 60L, TimeUnit.SECONDS,
-            new LinkedBlockingQueue<>(512),
-            new java.util.concurrent.ThreadFactory() {
-                private final AtomicInteger counter = new AtomicInteger(1);
-                @Override
-                public Thread newThread(Runnable r) {
-                    Thread t = new Thread(r, "auth-http-worker-" + counter.getAndIncrement());
-                    t.setDaemon(true);
-                    return t;
-                }
-            });
+    private static final ThreadPoolExecutor AUTH_EXECUTOR =
+            createAuthExecutor(AUTH_POOL_MAX);
+
+    static ThreadPoolExecutor createAuthExecutor(int width) {
+        if (width <= 0) {
+            throw new IllegalArgumentException(
+                    "Auth executor width must be positive");
+        }
+
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                width,
+                width,
+                60L,
+                TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(512),
+                new java.util.concurrent.ThreadFactory() {
+                    private final AtomicInteger counter =
+                            new AtomicInteger(1);
+
+                    @Override
+                    public Thread newThread(Runnable runnable) {
+                        Thread thread = new Thread(
+                                runnable,
+                                "auth-http-worker-"
+                                        + this.counter.getAndIncrement());
+                        thread.setDaemon(true);
+                        return thread;
+                    }
+                });
+        executor.allowCoreThreadTimeOut(true);
+        return executor;
+    }
 
     // Max threads for the auth pool. Defaults to 16; set the optional
     // `auth.http.pool.size` config key to override.

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/auth/AuthExecutorGeometryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/auth/AuthExecutorGeometryTest.java
@@ -1,0 +1,60 @@
+package com.eu.habbo.networking.gameserver.auth;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AuthExecutorGeometryTest {
+
+    @Test
+    void configuredWidthIsUsedBeforeRequestsEnterTheQueue() {
+        ThreadPoolExecutor executor =
+                AuthHttpHandler.createAuthExecutor(6);
+        try {
+            assertEquals(6, executor.getCorePoolSize());
+            assertEquals(6, executor.getMaximumPoolSize());
+            assertEquals(512, executor.getQueue().remainingCapacity());
+            assertTrue(executor.allowsCoreThreadTimeOut());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void fillsConfiguredWorkersBeforeQueueingTheNextRequest()
+            throws Exception {
+        ThreadPoolExecutor executor =
+                AuthHttpHandler.createAuthExecutor(3);
+        CountDownLatch started = new CountDownLatch(3);
+        CountDownLatch release = new CountDownLatch(1);
+        Runnable blocking = () -> {
+            started.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+            }
+        };
+        try {
+            executor.execute(blocking);
+            executor.execute(blocking);
+            executor.execute(blocking);
+
+            assertTrue(started.await(1, TimeUnit.SECONDS));
+            assertEquals(0, executor.getQueue().size());
+
+            executor.execute(() -> {
+            });
+
+            assertEquals(1, executor.getQueue().size());
+        } finally {
+            release.countDown();
+            executor.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
Uses the configured auth pool size before requests enter the bounded queue. Core workers may time out when idle, while queue capacity and busy-response behavior remain unchanged.