### PR TITLE
perf(net): offload websocket handshake crypto

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/crypto/WsCryptoExecutor.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/crypto/WsCryptoExecutor.java
@@ -1,0 +1,59 @@
+package com.eu.habbo.networking.gameserver.crypto;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class WsCryptoExecutor {
+
+    private static final int QUEUE_CAPACITY = 256;
+    private static final ThreadPoolExecutor EXECUTOR =
+            createExecutor(defaultWidth());
+
+    private WsCryptoExecutor() {
+    }
+
+    static Executor executor() {
+        return EXECUTOR;
+    }
+
+    static ThreadPoolExecutor createExecutor(int width) {
+        if (width <= 0) {
+            throw new IllegalArgumentException(
+                    "WebSocket crypto executor width "
+                            + "must be positive");
+        }
+
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                width,
+                width,
+                60L,
+                TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(QUEUE_CAPACITY),
+                new java.util.concurrent.ThreadFactory() {
+                    private final AtomicInteger counter =
+                            new AtomicInteger(1);
+
+                    @Override
+                    public Thread newThread(Runnable runnable) {
+                        Thread thread = new Thread(
+                                runnable,
+                                "ws-crypto-worker-"
+                                        + this.counter
+                                        .getAndIncrement());
+                        thread.setDaemon(true);
+                        return thread;
+                    }
+                });
+        executor.allowCoreThreadTimeOut(true);
+        return executor;
+    }
+
+    private static int defaultWidth() {
+        int processors =
+                Runtime.getRuntime().availableProcessors();
+        return Math.max(2, Math.min(8, processors / 2));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeHandler.java
@@ -14,52 +14,156 @@ import org.slf4j.LoggerFactory;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 
 public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
     private static final Logger LOGGER = LoggerFactory.getLogger(WsHandshakeHandler.class);
     public static final String HANDLER_NAME = "wsCryptoHandshake";
-    private static final boolean SIGN_ENABLED = Emulator.getConfig().getBoolean("crypto.ws.signing.enabled", false);
+    private final Executor cryptoExecutor;
+    private final boolean signingEnabled;
     private KeyPair serverKeyPair;
+    private boolean helloStarted = false;
     private boolean helloSent = false;
+    private boolean agreementStarted = false;
     private boolean handshakeComplete = false;
+
+    public WsHandshakeHandler() {
+        this(
+                WsCryptoExecutor.executor(),
+                signingEnabled());
+    }
+
+    WsHandshakeHandler(
+            Executor cryptoExecutor,
+            boolean signingEnabled) {
+        this.cryptoExecutor = Objects.requireNonNull(
+                cryptoExecutor,
+                "cryptoExecutor");
+        this.signingEnabled = signingEnabled;
+    }
+
+    private static boolean signingEnabled() {
+        var configuration = Emulator.getConfig();
+        return configuration != null
+                && configuration.getBoolean(
+                "crypto.ws.signing.enabled",
+                false);
+    }
 
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
-            sendServerHello(ctx);
+            sendServerHello(ctx, evt);
+            return;
         }
         super.userEventTriggered(ctx, evt);
     }
 
-    private void sendServerHello(ChannelHandlerContext ctx) {
-        if (helloSent) return;
+    private void sendServerHello(
+            ChannelHandlerContext ctx,
+            Object handshakeEvent) throws Exception {
+        if (helloStarted) {
+            if (helloSent) {
+                super.userEventTriggered(
+                        ctx,
+                        handshakeEvent);
+            }
+            return;
+        }
+        helloStarted = true;
+
         try {
-            this.serverKeyPair = WsSessionCrypto.generateEphemeralKeyPair();
-            byte[] spki = WsSessionCrypto.encodePublicKeySpki(serverKeyPair.getPublic());
-            byte[] sigIeee = null;
-            if (SIGN_ENABLED) {
-                KeyPair signingKp = CryptoSigningKeyManager.get();
-                byte[] sigDer = WsSessionCrypto.signEcdsaSha256(signingKp.getPrivate(), spki);
-                sigIeee = WsSessionCrypto.derToIeee1363(sigDer);
-            }
-
-            int frameLen = 4 + 1 + 2 + spki.length + (sigIeee != null ? 2 + sigIeee.length : 0);
-            ByteBuf buf = ctx.alloc().buffer(frameLen);
-            buf.writeInt(WsSessionCrypto.HANDSHAKE_MAGIC);
-            buf.writeByte(WsSessionCrypto.TYPE_SERVER_HELLO);
-            buf.writeShort(spki.length);
-            buf.writeBytes(spki);
-            if (sigIeee != null) {
-                buf.writeShort(sigIeee.length);
-                buf.writeBytes(sigIeee);
-            }
-
-            ctx.writeAndFlush(buf);
-            helloSent = true;
-        } catch (Exception e) {
-            LOGGER.error("[ws-crypto] failed to send server_hello", e);
+            this.cryptoExecutor.execute(() ->
+                    createServerHello(
+                            ctx,
+                            handshakeEvent));
+        } catch (RejectedExecutionException rejected) {
+            LOGGER.warn(
+                    "[ws-crypto] handshake executor is full; "
+                            + "closing {}",
+                    clientAddress(ctx));
             ctx.close();
         }
+    }
+
+    private void createServerHello(
+            ChannelHandlerContext ctx,
+            Object handshakeEvent) {
+        try {
+            KeyPair keyPair =
+                    WsSessionCrypto.generateEphemeralKeyPair();
+            byte[] spki =
+                    WsSessionCrypto.encodePublicKeySpki(
+                            keyPair.getPublic());
+            byte[] signature = null;
+            if (this.signingEnabled) {
+                KeyPair signingKeyPair =
+                        CryptoSigningKeyManager.get();
+                byte[] der =
+                        WsSessionCrypto.signEcdsaSha256(
+                                signingKeyPair.getPrivate(),
+                                spki);
+                signature =
+                        WsSessionCrypto.derToIeee1363(der);
+            }
+
+            ServerHello serverHello =
+                    new ServerHello(
+                            keyPair,
+                            spki,
+                            signature);
+            executeOnIoThread(
+                    ctx,
+                    () -> finishServerHello(
+                            ctx,
+                            handshakeEvent,
+                            serverHello));
+        } catch (Exception exception) {
+            executeOnIoThread(
+                    ctx,
+                    () -> failServerHello(ctx, exception));
+        }
+    }
+
+    private void finishServerHello(
+            ChannelHandlerContext ctx,
+            Object handshakeEvent,
+            ServerHello serverHello) {
+        if (!ctx.channel().isActive()) {
+            return;
+        }
+
+        this.serverKeyPair = serverHello.keyPair();
+        byte[] spki = serverHello.spki();
+        byte[] signature = serverHello.signature();
+        int frameLength = 4 + 1 + 2 + spki.length
+                + (signature != null
+                ? 2 + signature.length
+                : 0);
+        ByteBuf buffer = ctx.alloc().buffer(frameLength);
+        buffer.writeInt(WsSessionCrypto.HANDSHAKE_MAGIC);
+        buffer.writeByte(WsSessionCrypto.TYPE_SERVER_HELLO);
+        buffer.writeShort(spki.length);
+        buffer.writeBytes(spki);
+        if (signature != null) {
+            buffer.writeShort(signature.length);
+            buffer.writeBytes(signature);
+        }
+
+        ctx.writeAndFlush(buffer);
+        this.helloSent = true;
+        ctx.fireUserEventTriggered(handshakeEvent);
+    }
+
+    private static void failServerHello(
+            ChannelHandlerContext ctx,
+            Exception exception) {
+        LOGGER.error(
+                "[ws-crypto] failed to send server_hello",
+                exception);
+        ctx.close();
     }
 
     @Override
@@ -106,23 +210,117 @@ public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
             byte[] clientSpki = new byte[keyLen];
             in.readBytes(clientSpki);
 
-            PublicKey clientPub = WsSessionCrypto.decodePublicKeySpki(clientSpki);
-            PrivateKey ourPriv = serverKeyPair.getPrivate();
-            byte[] shared = WsSessionCrypto.deriveSharedSecret(ourPriv, clientPub);
-            byte[] aesKey = WsSessionCrypto.deriveAesKey(shared);
-            ctx.channel().attr(GameServerAttributes.WS_AES_KEY).set(aesKey);
-            ChannelPipeline p = ctx.pipeline();
-            p.addAfter(HANDLER_NAME, "wsAesDecoder", new WsAesDecoder());
-            p.addAfter(HANDLER_NAME, "wsAesEncoder", new WsAesEncoder());
-            handshakeComplete = true;
-            p.remove(this);
-
-            LOGGER.debug("[ws-crypto] handshake complete for {}", clientAddress(ctx));
+            if (!helloSent || serverKeyPair == null
+                    || agreementStarted) {
+                LOGGER.warn(
+                        "[ws-crypto] unexpected client_hello "
+                                + "state from {}",
+                        clientAddress(ctx));
+                ctx.close();
+                return;
+            }
+            this.agreementStarted = true;
+            PrivateKey serverPrivate =
+                    this.serverKeyPair.getPrivate();
+            submitAgreement(
+                    ctx,
+                    serverPrivate,
+                    clientSpki);
         } catch (Exception e) {
             LOGGER.warn("[ws-crypto] handshake failed from {} : {}", clientAddress(ctx), friendlyReason(e));
             ctx.close();
         } finally {
             in.release();
+        }
+    }
+
+    private void submitAgreement(
+            ChannelHandlerContext ctx,
+            PrivateKey serverPrivate,
+            byte[] clientSpki) {
+        try {
+            this.cryptoExecutor.execute(() ->
+                    deriveSessionKey(
+                            ctx,
+                            serverPrivate,
+                            clientSpki));
+        } catch (RejectedExecutionException rejected) {
+            LOGGER.warn(
+                    "[ws-crypto] handshake executor is full; "
+                            + "closing {}",
+                    clientAddress(ctx));
+            ctx.close();
+        }
+    }
+
+    private void deriveSessionKey(
+            ChannelHandlerContext ctx,
+            PrivateKey serverPrivate,
+            byte[] clientSpki) {
+        try {
+            PublicKey clientPublic =
+                    WsSessionCrypto.decodePublicKeySpki(
+                            clientSpki);
+            byte[] sharedSecret =
+                    WsSessionCrypto.deriveSharedSecret(
+                            serverPrivate,
+                            clientPublic);
+            byte[] sessionKey =
+                    WsSessionCrypto.deriveAesKey(sharedSecret);
+            executeOnIoThread(
+                    ctx,
+                    () -> finishAgreement(ctx, sessionKey));
+        } catch (Exception exception) {
+            executeOnIoThread(
+                    ctx,
+                    () -> failAgreement(ctx, exception));
+        }
+    }
+
+    private void finishAgreement(
+            ChannelHandlerContext ctx,
+            byte[] sessionKey) {
+        if (!ctx.channel().isActive()) {
+            return;
+        }
+
+        ctx.channel()
+                .attr(GameServerAttributes.WS_AES_KEY)
+                .set(sessionKey);
+        ChannelPipeline pipeline = ctx.pipeline();
+        pipeline.addAfter(
+                HANDLER_NAME,
+                "wsAesDecoder",
+                new WsAesDecoder());
+        pipeline.addAfter(
+                HANDLER_NAME,
+                "wsAesEncoder",
+                new WsAesEncoder());
+        this.handshakeComplete = true;
+        pipeline.remove(this);
+
+        LOGGER.debug(
+                "[ws-crypto] handshake complete for {}",
+                clientAddress(ctx));
+    }
+
+    private static void failAgreement(
+            ChannelHandlerContext ctx,
+            Exception exception) {
+        LOGGER.warn(
+                "[ws-crypto] handshake failed from {} : {}",
+                clientAddress(ctx),
+                friendlyReason(exception));
+        ctx.close();
+    }
+
+    private static void executeOnIoThread(
+            ChannelHandlerContext ctx,
+            Runnable task) {
+        try {
+            ctx.executor().execute(task);
+        } catch (RejectedExecutionException rejected) {
+            ctx.close();
         }
     }
 
@@ -148,5 +346,11 @@ public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
             LOGGER.error("[ws-crypto] handshake handler error from " + clientAddress(ctx), cause);
         }
         ctx.close();
+    }
+
+    private record ServerHello(
+            KeyPair keyPair,
+            byte[] spki,
+            byte[] signature) {
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsCryptoExecutorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsCryptoExecutorTest.java
@@ -1,0 +1,48 @@
+package com.eu.habbo.networking.gameserver.crypto;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WsCryptoExecutorTest {
+
+    @Test
+    void executorIsFixedWidthAndBounded() {
+        ThreadPoolExecutor executor =
+                WsCryptoExecutor.createExecutor(3);
+        try {
+            assertEquals(3, executor.getCorePoolSize());
+            assertEquals(3, executor.getMaximumPoolSize());
+            assertEquals(
+                    256,
+                    executor.getQueue()
+                            .remainingCapacity());
+            assertTrue(executor.allowsCoreThreadTimeOut());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void workersAreDaemonThreadsWithDedicatedNames()
+            throws Exception {
+        ThreadPoolExecutor executor =
+                WsCryptoExecutor.createExecutor(1);
+        try {
+            String worker = executor.submit(() ->
+                    Thread.currentThread().getName()
+                            + ":"
+                            + Thread.currentThread().isDaemon())
+                    .get();
+
+            assertTrue(worker.startsWith(
+                    "ws-crypto-worker-"));
+            assertTrue(worker.endsWith(":true"));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeOffloadTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeOffloadTest.java
@@ -1,0 +1,124 @@
+package com.eu.habbo.networking.gameserver.crypto;
+
+import com.eu.habbo.networking.gameserver.GameServerAttributes;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPair;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class WsHandshakeOffloadTest {
+
+    @Test
+    void keyGenerationLeavesTheCallingIoThread()
+            throws Exception {
+        LinkedBlockingQueue<Runnable> cryptoTasks =
+                new LinkedBlockingQueue<>();
+        WsHandshakeHandler handler =
+                new WsHandshakeHandler(
+                        cryptoTasks::add,
+                        false);
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline().addLast(
+                WsHandshakeHandler.HANDLER_NAME,
+                handler);
+        try {
+            channel.pipeline().fireUserEventTriggered(
+                    new WebSocketServerProtocolHandler
+                            .HandshakeComplete(
+                            "/",
+                            EmptyHttpHeaders.INSTANCE,
+                            null));
+
+            assertNull(channel.readOutbound());
+            assertEquals(1, cryptoTasks.size());
+
+            runCryptoTask(cryptoTasks);
+            channel.runPendingTasks();
+
+            ByteBuf serverHello = channel.readOutbound();
+            assertNotNull(serverHello);
+            serverHello.release();
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void keyAgreementLeavesTheCallingIoThread()
+            throws Exception {
+        LinkedBlockingQueue<Runnable> cryptoTasks =
+                new LinkedBlockingQueue<>();
+        WsHandshakeHandler handler =
+                new WsHandshakeHandler(
+                        cryptoTasks::add,
+                        false);
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline().addLast(
+                WsHandshakeHandler.HANDLER_NAME,
+                handler);
+        try {
+            channel.pipeline().fireUserEventTriggered(
+                    new WebSocketServerProtocolHandler
+                            .HandshakeComplete(
+                            "/",
+                            EmptyHttpHeaders.INSTANCE,
+                            null));
+            runCryptoTask(cryptoTasks);
+            channel.runPendingTasks();
+            ByteBuf serverHello = channel.readOutbound();
+            assertNotNull(serverHello);
+            serverHello.release();
+
+            KeyPair clientKeyPair =
+                    WsSessionCrypto.generateEphemeralKeyPair();
+            byte[] clientSpki =
+                    WsSessionCrypto.encodePublicKeySpki(
+                            clientKeyPair.getPublic());
+            ByteBuf clientHello =
+                    Unpooled.buffer(7 + clientSpki.length)
+                            .writeInt(
+                                    WsSessionCrypto
+                                            .HANDSHAKE_MAGIC)
+                            .writeByte(
+                                    WsSessionCrypto
+                                            .TYPE_CLIENT_HELLO)
+                            .writeShort(clientSpki.length)
+                            .writeBytes(clientSpki);
+
+            assertFalse(channel.writeInbound(clientHello));
+            assertNull(channel.attr(
+                    GameServerAttributes.WS_AES_KEY).get());
+            assertEquals(1, cryptoTasks.size());
+
+            runCryptoTask(cryptoTasks);
+            channel.runPendingTasks();
+
+            assertNotNull(channel.attr(
+                    GameServerAttributes.WS_AES_KEY).get());
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private static void runCryptoTask(
+            LinkedBlockingQueue<Runnable> cryptoTasks)
+            throws InterruptedException {
+        Thread worker = new Thread(
+                cryptoTasks.remove(),
+                "test-ws-crypto-worker");
+        worker.start();
+        worker.join(TimeUnit.SECONDS.toMillis(1));
+        assertFalse(worker.isAlive());
+    }
+}


### PR DESCRIPTION
Moves WebSocket key generation, signing, ECDH, and HKDF work from Netty I/O threads to a fixed-width bounded crypto executor. Pipeline changes remain channel-pinned, saturated queues close the handshake, and the existing wire format and event ordering are preserved.