### PR TITLE
feat(net): expose packet dispatch latency

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/ClientMessage.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/ClientMessage.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 public class ClientMessage {
     private final int header;
     private final ByteBuf buffer;
+    volatile long dispatchEnqueuedAtNanos;
 
     public ClientMessage(int messageId, ByteBuf buffer) {
         this.header = messageId;

--- a/Emulator/src/main/java/com/eu/habbo/messages/ClientMessageDispatchTiming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/ClientMessageDispatchTiming.java
@@ -1,0 +1,22 @@
+package com.eu.habbo.messages;
+
+public final class ClientMessageDispatchTiming {
+
+    private ClientMessageDispatchTiming() {
+    }
+
+    public static void markEnqueued(
+            ClientMessage message,
+            long enqueuedAtNanos) {
+        message.dispatchEnqueuedAtNanos =
+                enqueuedAtNanos;
+    }
+
+    public static long takeEnqueuedAt(
+            ClientMessage message) {
+        long enqueuedAt =
+                message.dispatchEnqueuedAtNanos;
+        message.dispatchEnqueuedAtNanos = 0L;
+        return enqueuedAt;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java
+++ b/Emulator/src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java
@@ -448,6 +448,8 @@ public final class EmulatorStatsService {
         previousIncomingBytes = incomingBytes;
         previousOutgoingBytes = outgoingBytes;
         previousTelemetryAt = now;
+        PacketDispatchLatencyMetrics.Snapshot dispatch =
+                PacketDispatchLatencyMetrics.snapshot();
 
         return new NetworkMetrics(
                 Math.max(0D, incomingPacketsPerSecond),
@@ -455,7 +457,11 @@ public final class EmulatorStatsService {
                 Math.max(0D, incomingKilobytesPerSecond),
                 Math.max(0D, outgoingKilobytesPerSecond),
                 incomingPackets,
-                outgoingPackets
+                outgoingPackets,
+                dispatch.samples(),
+                dispatch.averageMs(),
+                dispatch.p95Ms(),
+                dispatch.maxMs()
         );
     }
 
@@ -785,14 +791,46 @@ public final class EmulatorStatsService {
         public final double outgoingKilobytesPerSecond;
         public final long totalIncomingPackets;
         public final long totalOutgoingPackets;
+        public final long dispatchSamples;
+        public final double dispatchAverageMs;
+        public final double dispatchP95Ms;
+        public final double dispatchMaxMs;
 
         public NetworkMetrics(double incomingPacketsPerSecond, double outgoingPacketsPerSecond, double incomingKilobytesPerSecond, double outgoingKilobytesPerSecond, long totalIncomingPackets, long totalOutgoingPackets) {
+            this(
+                    incomingPacketsPerSecond,
+                    outgoingPacketsPerSecond,
+                    incomingKilobytesPerSecond,
+                    outgoingKilobytesPerSecond,
+                    totalIncomingPackets,
+                    totalOutgoingPackets,
+                    0L,
+                    0D,
+                    0D,
+                    0D);
+        }
+
+        public NetworkMetrics(
+                double incomingPacketsPerSecond,
+                double outgoingPacketsPerSecond,
+                double incomingKilobytesPerSecond,
+                double outgoingKilobytesPerSecond,
+                long totalIncomingPackets,
+                long totalOutgoingPackets,
+                long dispatchSamples,
+                double dispatchAverageMs,
+                double dispatchP95Ms,
+                double dispatchMaxMs) {
             this.incomingPacketsPerSecond = incomingPacketsPerSecond;
             this.outgoingPacketsPerSecond = outgoingPacketsPerSecond;
             this.incomingKilobytesPerSecond = incomingKilobytesPerSecond;
             this.outgoingKilobytesPerSecond = outgoingKilobytesPerSecond;
             this.totalIncomingPackets = totalIncomingPackets;
             this.totalOutgoingPackets = totalOutgoingPackets;
+            this.dispatchSamples = dispatchSamples;
+            this.dispatchAverageMs = dispatchAverageMs;
+            this.dispatchP95Ms = dispatchP95Ms;
+            this.dispatchMaxMs = dispatchMaxMs;
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/monitoring/PacketDispatchLatencyMetrics.java
+++ b/Emulator/src/main/java/com/eu/habbo/monitoring/PacketDispatchLatencyMetrics.java
@@ -1,0 +1,122 @@
+package com.eu.habbo.monitoring;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.concurrent.atomic.LongAdder;
+
+public final class PacketDispatchLatencyMetrics {
+
+    private static final long[] BUCKET_LIMITS_NANOS = {
+            TimeUnit.MICROSECONDS.toNanos(100),
+            TimeUnit.MICROSECONDS.toNanos(250),
+            TimeUnit.MICROSECONDS.toNanos(500),
+            TimeUnit.MILLISECONDS.toNanos(1),
+            TimeUnit.MICROSECONDS.toNanos(2_500),
+            TimeUnit.MILLISECONDS.toNanos(5),
+            TimeUnit.MILLISECONDS.toNanos(10),
+            TimeUnit.MILLISECONDS.toNanos(25),
+            TimeUnit.MILLISECONDS.toNanos(50),
+            TimeUnit.MILLISECONDS.toNanos(100),
+            TimeUnit.MILLISECONDS.toNanos(250),
+            TimeUnit.MILLISECONDS.toNanos(500),
+            TimeUnit.SECONDS.toNanos(1),
+            Long.MAX_VALUE
+    };
+
+    private static final LongAdder SAMPLES =
+            new LongAdder();
+    private static final LongAdder TOTAL_NANOS =
+            new LongAdder();
+    private static final AtomicLong MAX_NANOS =
+            new AtomicLong();
+    private static final AtomicLongArray BUCKETS =
+            new AtomicLongArray(
+                    BUCKET_LIMITS_NANOS.length);
+
+    private PacketDispatchLatencyMetrics() {
+    }
+
+    public static void record(long latencyNanos) {
+        long normalized = Math.max(0L, latencyNanos);
+        SAMPLES.increment();
+        TOTAL_NANOS.add(normalized);
+        MAX_NANOS.accumulateAndGet(
+                normalized,
+                Math::max);
+
+        for (int index = 0;
+             index < BUCKET_LIMITS_NANOS.length;
+             index++) {
+            if (normalized
+                    <= BUCKET_LIMITS_NANOS[index]) {
+                BUCKETS.incrementAndGet(index);
+                break;
+            }
+        }
+    }
+
+    public static Snapshot snapshot() {
+        long samples = SAMPLES.sumThenReset();
+        long totalNanos = TOTAL_NANOS.sumThenReset();
+        long maxNanos = MAX_NANOS.getAndSet(0L);
+        long[] buckets =
+                new long[BUCKET_LIMITS_NANOS.length];
+        for (int index = 0;
+             index < buckets.length;
+             index++) {
+            buckets[index] =
+                    BUCKETS.getAndSet(index, 0L);
+        }
+
+        if (samples == 0L) {
+            return Snapshot.EMPTY;
+        }
+
+        long percentileTarget =
+                Math.max(
+                        1L,
+                        (long) Math.ceil(samples * 0.95D));
+        long cumulative = 0L;
+        long p95Nanos = maxNanos;
+        for (int index = 0;
+             index < buckets.length;
+             index++) {
+            cumulative += buckets[index];
+            if (cumulative >= percentileTarget) {
+                p95Nanos =
+                        BUCKET_LIMITS_NANOS[index]
+                                == Long.MAX_VALUE
+                                ? maxNanos
+                                : BUCKET_LIMITS_NANOS[index];
+                break;
+            }
+        }
+
+        return new Snapshot(
+                samples,
+                nanosToMillis(
+                        (double) totalNanos / samples),
+                nanosToMillis(p95Nanos),
+                nanosToMillis(maxNanos));
+    }
+
+    static void reset() {
+        snapshot();
+    }
+
+    private static double nanosToMillis(
+            double nanos) {
+        return nanos / 1_000_000D;
+    }
+
+    public record Snapshot(
+            long samples,
+            double averageMs,
+            double p95Ms,
+            double maxMs) {
+
+        private static final Snapshot EMPTY =
+                new Snapshot(0L, 0D, 0D, 0D);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
@@ -55,6 +55,13 @@ public class GameServer extends Server {
                 }
                 ch.pipeline().addLast("idleEventHandler", new IdleTimeoutHandler(30, 60));
                 ch.pipeline().addLast(new GameMessageRateLimit());
+                ch.pipeline().addLast(
+                        "packetDispatchMarker",
+                        new PacketDispatchMarker());
+                ch.pipeline().addLast(
+                        GamePacketExecutionGroup.get(),
+                        "packetDispatchLatency",
+                        new PacketDispatchLatencyHandler());
                 ch.pipeline().addLast(GamePacketExecutionGroup.get(), "gameMessageHandler", new GameMessageHandler());
 
                 // Encoders.

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
@@ -85,6 +85,13 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
 
         ch.pipeline().addLast("idleEventHandler", new IdleTimeoutHandler(30, 60));
         ch.pipeline().addLast(new GameMessageRateLimit());
+        ch.pipeline().addLast(
+                "packetDispatchMarker",
+                new PacketDispatchMarker());
+        ch.pipeline().addLast(
+                GamePacketExecutionGroup.get(),
+                "packetDispatchLatency",
+                new PacketDispatchLatencyHandler());
         ch.pipeline().addLast(GamePacketExecutionGroup.get(), "gameMessageHandler", new GameMessageHandler());
         ch.pipeline().addLast("messageEncoder", new GameServerMessageEncoder());
 

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/decoders/PacketDispatchLatencyHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/decoders/PacketDispatchLatencyHandler.java
@@ -1,0 +1,43 @@
+package com.eu.habbo.networking.gameserver.decoders;
+
+import com.eu.habbo.messages.ClientMessage;
+import com.eu.habbo.messages.ClientMessageDispatchTiming;
+import com.eu.habbo.monitoring.PacketDispatchLatencyMetrics;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+import java.util.function.LongSupplier;
+
+public final class PacketDispatchLatencyHandler
+        extends ChannelInboundHandlerAdapter {
+
+    private final LongSupplier nanoClock;
+
+    public PacketDispatchLatencyHandler() {
+        this(System::nanoTime);
+    }
+
+    PacketDispatchLatencyHandler(
+            LongSupplier nanoClock) {
+        this.nanoClock = nanoClock;
+    }
+
+    @Override
+    public void channelRead(
+            ChannelHandlerContext context,
+            Object message) {
+        if (message instanceof ClientMessage clientMessage) {
+            long enqueuedAt =
+                    ClientMessageDispatchTiming
+                            .takeEnqueuedAt(
+                                    clientMessage);
+            if (enqueuedAt != 0L) {
+                PacketDispatchLatencyMetrics.record(
+                        this.nanoClock.getAsLong()
+                                - enqueuedAt);
+            }
+        }
+
+        context.fireChannelRead(message);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/decoders/PacketDispatchMarker.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/decoders/PacketDispatchMarker.java
@@ -1,0 +1,35 @@
+package com.eu.habbo.networking.gameserver.decoders;
+
+import com.eu.habbo.messages.ClientMessage;
+import com.eu.habbo.messages.ClientMessageDispatchTiming;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+import java.util.function.LongSupplier;
+
+public final class PacketDispatchMarker
+        extends ChannelInboundHandlerAdapter {
+
+    private final LongSupplier nanoClock;
+
+    public PacketDispatchMarker() {
+        this(System::nanoTime);
+    }
+
+    PacketDispatchMarker(LongSupplier nanoClock) {
+        this.nanoClock = nanoClock;
+    }
+
+    @Override
+    public void channelRead(
+            ChannelHandlerContext context,
+            Object message) {
+        if (message instanceof ClientMessage clientMessage) {
+            ClientMessageDispatchTiming.markEnqueued(
+                    clientMessage,
+                    this.nanoClock.getAsLong());
+        }
+
+        context.fireChannelRead(message);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/monitoring/NetworkDispatchMetricsContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/monitoring/NetworkDispatchMetricsContractTest.java
@@ -1,0 +1,29 @@
+package com.eu.habbo.monitoring;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NetworkDispatchMetricsContractTest {
+
+    @Test
+    void networkSnapshotExposesDispatchLatencyWindow() {
+        EmulatorStatsService.NetworkMetrics metrics =
+                new EmulatorStatsService.NetworkMetrics(
+                        1D,
+                        2D,
+                        3D,
+                        4D,
+                        5L,
+                        6L,
+                        7L,
+                        8D,
+                        9D,
+                        10D);
+
+        assertEquals(7L, metrics.dispatchSamples);
+        assertEquals(8D, metrics.dispatchAverageMs);
+        assertEquals(9D, metrics.dispatchP95Ms);
+        assertEquals(10D, metrics.dispatchMaxMs);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/monitoring/PacketDispatchLatencyMetricsTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/monitoring/PacketDispatchLatencyMetricsTest.java
@@ -1,0 +1,51 @@
+package com.eu.habbo.monitoring;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PacketDispatchLatencyMetricsTest {
+
+    @BeforeEach
+    void resetMetrics() {
+        PacketDispatchLatencyMetrics.reset();
+    }
+
+    @Test
+    void snapshotReportsCountAverageP95AndMaximum() {
+        PacketDispatchLatencyMetrics.record(
+                TimeUnit.MICROSECONDS.toNanos(100));
+        PacketDispatchLatencyMetrics.record(
+                TimeUnit.MILLISECONDS.toNanos(1));
+        for (int i = 0; i < 18; i++) {
+            PacketDispatchLatencyMetrics.record(
+                    TimeUnit.MILLISECONDS.toNanos(12));
+        }
+
+        PacketDispatchLatencyMetrics.Snapshot snapshot =
+                PacketDispatchLatencyMetrics.snapshot();
+
+        assertEquals(20, snapshot.samples());
+        assertEquals(10.855, snapshot.averageMs(), 0.001);
+        assertEquals(25.0, snapshot.p95Ms(), 0.001);
+        assertEquals(12.0, snapshot.maxMs(), 0.001);
+    }
+
+    @Test
+    void snapshotDrainsTheCurrentMeasurementWindow() {
+        PacketDispatchLatencyMetrics.record(
+                TimeUnit.MILLISECONDS.toNanos(2));
+
+        assertEquals(
+                1,
+                PacketDispatchLatencyMetrics
+                        .snapshot().samples());
+        assertEquals(
+                0,
+                PacketDispatchLatencyMetrics
+                        .snapshot().samples());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/GamePacketExecutionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/GamePacketExecutionContractTest.java
@@ -16,6 +16,8 @@ class GamePacketExecutionContractTest {
 
         assertTrue(tcp.contains("GamePacketExecutionGroup.get()"), "TCP packet handlers must be off the Netty I/O loop");
         assertTrue(webSocket.contains("GamePacketExecutionGroup.get()"), "WebSocket packet handlers must use the shared execution group");
+        assertLatencyProbeOrder(tcp);
+        assertLatencyProbeOrder(webSocket);
     }
 
     @Test
@@ -30,5 +32,23 @@ class GamePacketExecutionContractTest {
 
     private static String source(String file) throws Exception {
         return Files.readString(Path.of("src/main/java/com/eu/habbo/networking/gameserver/" + file));
+    }
+
+    private static void assertLatencyProbeOrder(
+            String pipelineSource) {
+        int marker = pipelineSource.indexOf(
+                "new PacketDispatchMarker()");
+        int latency = pipelineSource.indexOf(
+                "\"packetDispatchLatency\"");
+        int handler = pipelineSource.indexOf(
+                "\"gameMessageHandler\"");
+
+        assertTrue(marker >= 0);
+        assertTrue(
+                latency > marker,
+                "dispatch latency must start after the I/O marker");
+        assertTrue(
+                handler > latency,
+                "dispatch latency must be observed before packet handling");
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/decoders/PacketDispatchLatencyHandlerTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/decoders/PacketDispatchLatencyHandlerTest.java
@@ -1,0 +1,54 @@
+package com.eu.habbo.networking.gameserver.decoders;
+
+import com.eu.habbo.messages.ClientMessage;
+import com.eu.habbo.monitoring.PacketDispatchLatencyMetrics;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PacketDispatchLatencyHandlerTest {
+
+    @BeforeEach
+    void resetMetrics() {
+        PacketDispatchLatencyMetrics.snapshot();
+    }
+
+    @Test
+    void recordsTimeBetweenIoMarkerAndDispatchHandler() {
+        long step = TimeUnit.MILLISECONDS.toNanos(3);
+        AtomicLong clock = new AtomicLong(
+                TimeUnit.MILLISECONDS.toNanos(1));
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new PacketDispatchMarker(
+                        () -> clock.getAndAdd(step)),
+                new PacketDispatchLatencyHandler(
+                        () -> clock.getAndAdd(step)));
+        ClientMessage message =
+                new ClientMessage(
+                        7,
+                        Unpooled.buffer(1).writeByte(1));
+        try {
+            assertTrue(channel.writeInbound(message));
+            assertSame(message, channel.readInbound());
+
+            PacketDispatchLatencyMetrics.Snapshot snapshot =
+                    PacketDispatchLatencyMetrics.snapshot();
+            assertEquals(1, snapshot.samples());
+            assertEquals(
+                    3D,
+                    snapshot.averageMs(),
+                    0.001);
+        } finally {
+            message.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+}


### PR DESCRIPTION
Measures TCP and WebSocket packet queue delay from I/O handoff to the channel-pinned handler without per-packet allocation. The authenticated emulator stats response now exposes windowed sample count, average, p95, and maximum dispatch latency.