### PR TITLE
refactor(net): isolate transport work

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/ClientMessage.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/ClientMessage.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 public class ClientMessage {
     private final int header;
     private final ByteBuf buffer;
+    volatile long dispatchEnqueuedAtNanos;
 
     public ClientMessage(int messageId, ByteBuf buffer) {
         this.header = messageId;

--- a/Emulator/src/main/java/com/eu/habbo/messages/ClientMessageDispatchTiming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/ClientMessageDispatchTiming.java
@@ -1,0 +1,22 @@
+package com.eu.habbo.messages;
+
+public final class ClientMessageDispatchTiming {
+
+    private ClientMessageDispatchTiming() {
+    }
+
+    public static void markEnqueued(
+            ClientMessage message,
+            long enqueuedAtNanos) {
+        message.dispatchEnqueuedAtNanos =
+                enqueuedAtNanos;
+    }
+
+    public static long takeEnqueuedAt(
+            ClientMessage message) {
+        long enqueuedAt =
+                message.dispatchEnqueuedAtNanos;
+        message.dispatchEnqueuedAtNanos = 0L;
+        return enqueuedAt;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java
+++ b/Emulator/src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java
@@ -448,6 +448,8 @@ public final class EmulatorStatsService {
         previousIncomingBytes = incomingBytes;
         previousOutgoingBytes = outgoingBytes;
         previousTelemetryAt = now;
+        PacketDispatchLatencyMetrics.Snapshot dispatch =
+                PacketDispatchLatencyMetrics.snapshot();
 
         return new NetworkMetrics(
                 Math.max(0D, incomingPacketsPerSecond),
@@ -455,7 +457,11 @@ public final class EmulatorStatsService {
                 Math.max(0D, incomingKilobytesPerSecond),
                 Math.max(0D, outgoingKilobytesPerSecond),
                 incomingPackets,
-                outgoingPackets
+                outgoingPackets,
+                dispatch.samples(),
+                dispatch.averageMs(),
+                dispatch.p95Ms(),
+                dispatch.maxMs()
         );
     }
 
@@ -785,14 +791,46 @@ public final class EmulatorStatsService {
         public final double outgoingKilobytesPerSecond;
         public final long totalIncomingPackets;
         public final long totalOutgoingPackets;
+        public final long dispatchSamples;
+        public final double dispatchAverageMs;
+        public final double dispatchP95Ms;
+        public final double dispatchMaxMs;
 
         public NetworkMetrics(double incomingPacketsPerSecond, double outgoingPacketsPerSecond, double incomingKilobytesPerSecond, double outgoingKilobytesPerSecond, long totalIncomingPackets, long totalOutgoingPackets) {
+            this(
+                    incomingPacketsPerSecond,
+                    outgoingPacketsPerSecond,
+                    incomingKilobytesPerSecond,
+                    outgoingKilobytesPerSecond,
+                    totalIncomingPackets,
+                    totalOutgoingPackets,
+                    0L,
+                    0D,
+                    0D,
+                    0D);
+        }
+
+        public NetworkMetrics(
+                double incomingPacketsPerSecond,
+                double outgoingPacketsPerSecond,
+                double incomingKilobytesPerSecond,
+                double outgoingKilobytesPerSecond,
+                long totalIncomingPackets,
+                long totalOutgoingPackets,
+                long dispatchSamples,
+                double dispatchAverageMs,
+                double dispatchP95Ms,
+                double dispatchMaxMs) {
             this.incomingPacketsPerSecond = incomingPacketsPerSecond;
             this.outgoingPacketsPerSecond = outgoingPacketsPerSecond;
             this.incomingKilobytesPerSecond = incomingKilobytesPerSecond;
             this.outgoingKilobytesPerSecond = outgoingKilobytesPerSecond;
             this.totalIncomingPackets = totalIncomingPackets;
             this.totalOutgoingPackets = totalOutgoingPackets;
+            this.dispatchSamples = dispatchSamples;
+            this.dispatchAverageMs = dispatchAverageMs;
+            this.dispatchP95Ms = dispatchP95Ms;
+            this.dispatchMaxMs = dispatchMaxMs;
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/monitoring/PacketDispatchLatencyMetrics.java
+++ b/Emulator/src/main/java/com/eu/habbo/monitoring/PacketDispatchLatencyMetrics.java
@@ -1,0 +1,122 @@
+package com.eu.habbo.monitoring;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.concurrent.atomic.LongAdder;
+
+public final class PacketDispatchLatencyMetrics {
+
+    private static final long[] BUCKET_LIMITS_NANOS = {
+            TimeUnit.MICROSECONDS.toNanos(100),
+            TimeUnit.MICROSECONDS.toNanos(250),
+            TimeUnit.MICROSECONDS.toNanos(500),
+            TimeUnit.MILLISECONDS.toNanos(1),
+            TimeUnit.MICROSECONDS.toNanos(2_500),
+            TimeUnit.MILLISECONDS.toNanos(5),
+            TimeUnit.MILLISECONDS.toNanos(10),
+            TimeUnit.MILLISECONDS.toNanos(25),
+            TimeUnit.MILLISECONDS.toNanos(50),
+            TimeUnit.MILLISECONDS.toNanos(100),
+            TimeUnit.MILLISECONDS.toNanos(250),
+            TimeUnit.MILLISECONDS.toNanos(500),
+            TimeUnit.SECONDS.toNanos(1),
+            Long.MAX_VALUE
+    };
+
+    private static final LongAdder SAMPLES =
+            new LongAdder();
+    private static final LongAdder TOTAL_NANOS =
+            new LongAdder();
+    private static final AtomicLong MAX_NANOS =
+            new AtomicLong();
+    private static final AtomicLongArray BUCKETS =
+            new AtomicLongArray(
+                    BUCKET_LIMITS_NANOS.length);
+
+    private PacketDispatchLatencyMetrics() {
+    }
+
+    public static void record(long latencyNanos) {
+        long normalized = Math.max(0L, latencyNanos);
+        SAMPLES.increment();
+        TOTAL_NANOS.add(normalized);
+        MAX_NANOS.accumulateAndGet(
+                normalized,
+                Math::max);
+
+        for (int index = 0;
+             index < BUCKET_LIMITS_NANOS.length;
+             index++) {
+            if (normalized
+                    <= BUCKET_LIMITS_NANOS[index]) {
+                BUCKETS.incrementAndGet(index);
+                break;
+            }
+        }
+    }
+
+    public static Snapshot snapshot() {
+        long samples = SAMPLES.sumThenReset();
+        long totalNanos = TOTAL_NANOS.sumThenReset();
+        long maxNanos = MAX_NANOS.getAndSet(0L);
+        long[] buckets =
+                new long[BUCKET_LIMITS_NANOS.length];
+        for (int index = 0;
+             index < buckets.length;
+             index++) {
+            buckets[index] =
+                    BUCKETS.getAndSet(index, 0L);
+        }
+
+        if (samples == 0L) {
+            return Snapshot.EMPTY;
+        }
+
+        long percentileTarget =
+                Math.max(
+                        1L,
+                        (long) Math.ceil(samples * 0.95D));
+        long cumulative = 0L;
+        long p95Nanos = maxNanos;
+        for (int index = 0;
+             index < buckets.length;
+             index++) {
+            cumulative += buckets[index];
+            if (cumulative >= percentileTarget) {
+                p95Nanos =
+                        BUCKET_LIMITS_NANOS[index]
+                                == Long.MAX_VALUE
+                                ? maxNanos
+                                : BUCKET_LIMITS_NANOS[index];
+                break;
+            }
+        }
+
+        return new Snapshot(
+                samples,
+                nanosToMillis(
+                        (double) totalNanos / samples),
+                nanosToMillis(p95Nanos),
+                nanosToMillis(maxNanos));
+    }
+
+    static void reset() {
+        snapshot();
+    }
+
+    private static double nanosToMillis(
+            double nanos) {
+        return nanos / 1_000_000D;
+    }
+
+    public record Snapshot(
+            long samples,
+            double averageMs,
+            double p95Ms,
+            double maxMs) {
+
+        private static final Snapshot EMPTY =
+                new Snapshot(0L, 0D, 0D, 0D);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
@@ -55,6 +55,13 @@ public class GameServer extends Server {
                 }
                 ch.pipeline().addLast("idleEventHandler", new IdleTimeoutHandler(30, 60));
                 ch.pipeline().addLast(new GameMessageRateLimit());
+                ch.pipeline().addLast(
+                        "packetDispatchMarker",
+                        new PacketDispatchMarker());
+                ch.pipeline().addLast(
+                        GamePacketExecutionGroup.get(),
+                        "packetDispatchLatency",
+                        new PacketDispatchLatencyHandler());
                 ch.pipeline().addLast(GamePacketExecutionGroup.get(), "gameMessageHandler", new GameMessageHandler());
 
                 // Encoders.

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
@@ -85,6 +85,13 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
 
         ch.pipeline().addLast("idleEventHandler", new IdleTimeoutHandler(30, 60));
         ch.pipeline().addLast(new GameMessageRateLimit());
+        ch.pipeline().addLast(
+                "packetDispatchMarker",
+                new PacketDispatchMarker());
+        ch.pipeline().addLast(
+                GamePacketExecutionGroup.get(),
+                "packetDispatchLatency",
+                new PacketDispatchLatencyHandler());
         ch.pipeline().addLast(GamePacketExecutionGroup.get(), "gameMessageHandler", new GameMessageHandler());
         ch.pipeline().addLast("messageEncoder", new GameServerMessageEncoder());
 

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/crypto/WsCryptoExecutor.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/crypto/WsCryptoExecutor.java
@@ -1,0 +1,59 @@
+package com.eu.habbo.networking.gameserver.crypto;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class WsCryptoExecutor {
+
+    private static final int QUEUE_CAPACITY = 256;
+    private static final ThreadPoolExecutor EXECUTOR =
+            createExecutor(defaultWidth());
+
+    private WsCryptoExecutor() {
+    }
+
+    static Executor executor() {
+        return EXECUTOR;
+    }
+
+    static ThreadPoolExecutor createExecutor(int width) {
+        if (width <= 0) {
+            throw new IllegalArgumentException(
+                    "WebSocket crypto executor width "
+                            + "must be positive");
+        }
+
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                width,
+                width,
+                60L,
+                TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(QUEUE_CAPACITY),
+                new java.util.concurrent.ThreadFactory() {
+                    private final AtomicInteger counter =
+                            new AtomicInteger(1);
+
+                    @Override
+                    public Thread newThread(Runnable runnable) {
+                        Thread thread = new Thread(
+                                runnable,
+                                "ws-crypto-worker-"
+                                        + this.counter
+                                        .getAndIncrement());
+                        thread.setDaemon(true);
+                        return thread;
+                    }
+                });
+        executor.allowCoreThreadTimeOut(true);
+        return executor;
+    }
+
+    private static int defaultWidth() {
+        int processors =
+                Runtime.getRuntime().availableProcessors();
+        return Math.max(2, Math.min(8, processors / 2));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeHandler.java
@@ -14,52 +14,156 @@ import org.slf4j.LoggerFactory;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 
 public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
     private static final Logger LOGGER = LoggerFactory.getLogger(WsHandshakeHandler.class);
     public static final String HANDLER_NAME = "wsCryptoHandshake";
-    private static final boolean SIGN_ENABLED = Emulator.getConfig().getBoolean("crypto.ws.signing.enabled", false);
+    private final Executor cryptoExecutor;
+    private final boolean signingEnabled;
     private KeyPair serverKeyPair;
+    private boolean helloStarted = false;
     private boolean helloSent = false;
+    private boolean agreementStarted = false;
     private boolean handshakeComplete = false;
+
+    public WsHandshakeHandler() {
+        this(
+                WsCryptoExecutor.executor(),
+                signingEnabled());
+    }
+
+    WsHandshakeHandler(
+            Executor cryptoExecutor,
+            boolean signingEnabled) {
+        this.cryptoExecutor = Objects.requireNonNull(
+                cryptoExecutor,
+                "cryptoExecutor");
+        this.signingEnabled = signingEnabled;
+    }
+
+    private static boolean signingEnabled() {
+        var configuration = Emulator.getConfig();
+        return configuration != null
+                && configuration.getBoolean(
+                "crypto.ws.signing.enabled",
+                false);
+    }
 
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
-            sendServerHello(ctx);
+            sendServerHello(ctx, evt);
+            return;
         }
         super.userEventTriggered(ctx, evt);
     }
 
-    private void sendServerHello(ChannelHandlerContext ctx) {
-        if (helloSent) return;
+    private void sendServerHello(
+            ChannelHandlerContext ctx,
+            Object handshakeEvent) throws Exception {
+        if (helloStarted) {
+            if (helloSent) {
+                super.userEventTriggered(
+                        ctx,
+                        handshakeEvent);
+            }
+            return;
+        }
+        helloStarted = true;
+
         try {
-            this.serverKeyPair = WsSessionCrypto.generateEphemeralKeyPair();
-            byte[] spki = WsSessionCrypto.encodePublicKeySpki(serverKeyPair.getPublic());
-            byte[] sigIeee = null;
-            if (SIGN_ENABLED) {
-                KeyPair signingKp = CryptoSigningKeyManager.get();
-                byte[] sigDer = WsSessionCrypto.signEcdsaSha256(signingKp.getPrivate(), spki);
-                sigIeee = WsSessionCrypto.derToIeee1363(sigDer);
-            }
-
-            int frameLen = 4 + 1 + 2 + spki.length + (sigIeee != null ? 2 + sigIeee.length : 0);
-            ByteBuf buf = ctx.alloc().buffer(frameLen);
-            buf.writeInt(WsSessionCrypto.HANDSHAKE_MAGIC);
-            buf.writeByte(WsSessionCrypto.TYPE_SERVER_HELLO);
-            buf.writeShort(spki.length);
-            buf.writeBytes(spki);
-            if (sigIeee != null) {
-                buf.writeShort(sigIeee.length);
-                buf.writeBytes(sigIeee);
-            }
-
-            ctx.writeAndFlush(buf);
-            helloSent = true;
-        } catch (Exception e) {
-            LOGGER.error("[ws-crypto] failed to send server_hello", e);
+            this.cryptoExecutor.execute(() ->
+                    createServerHello(
+                            ctx,
+                            handshakeEvent));
+        } catch (RejectedExecutionException rejected) {
+            LOGGER.warn(
+                    "[ws-crypto] handshake executor is full; "
+                            + "closing {}",
+                    clientAddress(ctx));
             ctx.close();
         }
+    }
+
+    private void createServerHello(
+            ChannelHandlerContext ctx,
+            Object handshakeEvent) {
+        try {
+            KeyPair keyPair =
+                    WsSessionCrypto.generateEphemeralKeyPair();
+            byte[] spki =
+                    WsSessionCrypto.encodePublicKeySpki(
+                            keyPair.getPublic());
+            byte[] signature = null;
+            if (this.signingEnabled) {
+                KeyPair signingKeyPair =
+                        CryptoSigningKeyManager.get();
+                byte[] der =
+                        WsSessionCrypto.signEcdsaSha256(
+                                signingKeyPair.getPrivate(),
+                                spki);
+                signature =
+                        WsSessionCrypto.derToIeee1363(der);
+            }
+
+            ServerHello serverHello =
+                    new ServerHello(
+                            keyPair,
+                            spki,
+                            signature);
+            executeOnIoThread(
+                    ctx,
+                    () -> finishServerHello(
+                            ctx,
+                            handshakeEvent,
+                            serverHello));
+        } catch (Exception exception) {
+            executeOnIoThread(
+                    ctx,
+                    () -> failServerHello(ctx, exception));
+        }
+    }
+
+    private void finishServerHello(
+            ChannelHandlerContext ctx,
+            Object handshakeEvent,
+            ServerHello serverHello) {
+        if (!ctx.channel().isActive()) {
+            return;
+        }
+
+        this.serverKeyPair = serverHello.keyPair();
+        byte[] spki = serverHello.spki();
+        byte[] signature = serverHello.signature();
+        int frameLength = 4 + 1 + 2 + spki.length
+                + (signature != null
+                ? 2 + signature.length
+                : 0);
+        ByteBuf buffer = ctx.alloc().buffer(frameLength);
+        buffer.writeInt(WsSessionCrypto.HANDSHAKE_MAGIC);
+        buffer.writeByte(WsSessionCrypto.TYPE_SERVER_HELLO);
+        buffer.writeShort(spki.length);
+        buffer.writeBytes(spki);
+        if (signature != null) {
+            buffer.writeShort(signature.length);
+            buffer.writeBytes(signature);
+        }
+
+        ctx.writeAndFlush(buffer);
+        this.helloSent = true;
+        ctx.fireUserEventTriggered(handshakeEvent);
+    }
+
+    private static void failServerHello(
+            ChannelHandlerContext ctx,
+            Exception exception) {
+        LOGGER.error(
+                "[ws-crypto] failed to send server_hello",
+                exception);
+        ctx.close();
     }
 
     @Override
@@ -106,23 +210,117 @@ public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
             byte[] clientSpki = new byte[keyLen];
             in.readBytes(clientSpki);
 
-            PublicKey clientPub = WsSessionCrypto.decodePublicKeySpki(clientSpki);
-            PrivateKey ourPriv = serverKeyPair.getPrivate();
-            byte[] shared = WsSessionCrypto.deriveSharedSecret(ourPriv, clientPub);
-            byte[] aesKey = WsSessionCrypto.deriveAesKey(shared);
-            ctx.channel().attr(GameServerAttributes.WS_AES_KEY).set(aesKey);
-            ChannelPipeline p = ctx.pipeline();
-            p.addAfter(HANDLER_NAME, "wsAesDecoder", new WsAesDecoder());
-            p.addAfter(HANDLER_NAME, "wsAesEncoder", new WsAesEncoder());
-            handshakeComplete = true;
-            p.remove(this);
-
-            LOGGER.debug("[ws-crypto] handshake complete for {}", clientAddress(ctx));
+            if (!helloSent || serverKeyPair == null
+                    || agreementStarted) {
+                LOGGER.warn(
+                        "[ws-crypto] unexpected client_hello "
+                                + "state from {}",
+                        clientAddress(ctx));
+                ctx.close();
+                return;
+            }
+            this.agreementStarted = true;
+            PrivateKey serverPrivate =
+                    this.serverKeyPair.getPrivate();
+            submitAgreement(
+                    ctx,
+                    serverPrivate,
+                    clientSpki);
         } catch (Exception e) {
             LOGGER.warn("[ws-crypto] handshake failed from {} : {}", clientAddress(ctx), friendlyReason(e));
             ctx.close();
         } finally {
             in.release();
+        }
+    }
+
+    private void submitAgreement(
+            ChannelHandlerContext ctx,
+            PrivateKey serverPrivate,
+            byte[] clientSpki) {
+        try {
+            this.cryptoExecutor.execute(() ->
+                    deriveSessionKey(
+                            ctx,
+                            serverPrivate,
+                            clientSpki));
+        } catch (RejectedExecutionException rejected) {
+            LOGGER.warn(
+                    "[ws-crypto] handshake executor is full; "
+                            + "closing {}",
+                    clientAddress(ctx));
+            ctx.close();
+        }
+    }
+
+    private void deriveSessionKey(
+            ChannelHandlerContext ctx,
+            PrivateKey serverPrivate,
+            byte[] clientSpki) {
+        try {
+            PublicKey clientPublic =
+                    WsSessionCrypto.decodePublicKeySpki(
+                            clientSpki);
+            byte[] sharedSecret =
+                    WsSessionCrypto.deriveSharedSecret(
+                            serverPrivate,
+                            clientPublic);
+            byte[] sessionKey =
+                    WsSessionCrypto.deriveAesKey(sharedSecret);
+            executeOnIoThread(
+                    ctx,
+                    () -> finishAgreement(ctx, sessionKey));
+        } catch (Exception exception) {
+            executeOnIoThread(
+                    ctx,
+                    () -> failAgreement(ctx, exception));
+        }
+    }
+
+    private void finishAgreement(
+            ChannelHandlerContext ctx,
+            byte[] sessionKey) {
+        if (!ctx.channel().isActive()) {
+            return;
+        }
+
+        ctx.channel()
+                .attr(GameServerAttributes.WS_AES_KEY)
+                .set(sessionKey);
+        ChannelPipeline pipeline = ctx.pipeline();
+        pipeline.addAfter(
+                HANDLER_NAME,
+                "wsAesDecoder",
+                new WsAesDecoder());
+        pipeline.addAfter(
+                HANDLER_NAME,
+                "wsAesEncoder",
+                new WsAesEncoder());
+        this.handshakeComplete = true;
+        pipeline.remove(this);
+
+        LOGGER.debug(
+                "[ws-crypto] handshake complete for {}",
+                clientAddress(ctx));
+    }
+
+    private static void failAgreement(
+            ChannelHandlerContext ctx,
+            Exception exception) {
+        LOGGER.warn(
+                "[ws-crypto] handshake failed from {} : {}",
+                clientAddress(ctx),
+                friendlyReason(exception));
+        ctx.close();
+    }
+
+    private static void executeOnIoThread(
+            ChannelHandlerContext ctx,
+            Runnable task) {
+        try {
+            ctx.executor().execute(task);
+        } catch (RejectedExecutionException rejected) {
+            ctx.close();
         }
     }
 
@@ -148,5 +346,11 @@ public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
             LOGGER.error("[ws-crypto] handshake handler error from " + clientAddress(ctx), cause);
         }
         ctx.close();
+    }
+
+    private record ServerHello(
+            KeyPair keyPair,
+            byte[] spki,
+            byte[] signature) {
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeHandler.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.util.ArrayDeque;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
@@ -22,6 +23,7 @@ public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
     private static final Logger LOGGER = LoggerFactory.getLogger(WsHandshakeHandler.class);
     public static final String HANDLER_NAME = "wsCryptoHandshake";
     private static final int MAX_PENDING_HANDSHAKE_FRAMES = 64;
+    private static final int MAX_PENDING_HANDSHAKE_BYTES = 1024 * 1024;
     private final Executor cryptoExecutor;
     private final boolean signingEnabled;
     private KeyPair serverKeyPair;
@@ -29,7 +31,8 @@ public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
     private boolean helloSent = false;
     private boolean agreementStarted = false;
     private boolean handshakeComplete = false;
-    private java.util.ArrayDeque<ByteBuf> pendingFrames;
+    private ArrayDeque<ByteBuf> pendingFrames;
+    private int pendingFrameBytes;
 
     public WsHandshakeHandler() {
         this(
@@ -185,16 +188,19 @@ public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
                 ctx.fireChannelRead(msg);
                 return;
             }
+            ByteBuf frame = (ByteBuf) msg;
             if (this.pendingFrames == null) {
-                this.pendingFrames = new java.util.ArrayDeque<>();
+                this.pendingFrames = new ArrayDeque<>();
             }
-            if (this.pendingFrames.size() >= MAX_PENDING_HANDSHAKE_FRAMES) {
+            if (this.pendingFrames.size() >= MAX_PENDING_HANDSHAKE_FRAMES
+                    || frame.readableBytes() > MAX_PENDING_HANDSHAKE_BYTES - this.pendingFrameBytes) {
                 LOGGER.warn("[ws-crypto] too many frames during key agreement from {}", clientAddress(ctx));
-                ((ByteBuf) msg).release();
+                frame.release();
                 ctx.close();
                 return;
             }
-            this.pendingFrames.add((ByteBuf) msg);
+            this.pendingFrames.add(frame);
+            this.pendingFrameBytes += frame.readableBytes();
             return;
         }
 
@@ -336,8 +342,9 @@ public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
         }
         // Fire queued frames through the now-installed AES decoder, in arrival
         // order, while this handler is still in the pipeline so ctx stays valid.
-        java.util.ArrayDeque<ByteBuf> queued = this.pendingFrames;
+        ArrayDeque<ByteBuf> queued = this.pendingFrames;
         this.pendingFrames = null;
+        this.pendingFrameBytes = 0;
         try {
             ByteBuf frame;
             while ((frame = queued.poll()) != null) {
@@ -360,6 +367,7 @@ public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
             frame.release();
         }
         this.pendingFrames = null;
+        this.pendingFrameBytes = 0;
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeHandler.java
@@ -21,6 +21,7 @@ import java.util.concurrent.RejectedExecutionException;
 public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
     private static final Logger LOGGER = LoggerFactory.getLogger(WsHandshakeHandler.class);
     public static final String HANDLER_NAME = "wsCryptoHandshake";
+    private static final int MAX_PENDING_HANDSHAKE_FRAMES = 64;
     private final Executor cryptoExecutor;
     private final boolean signingEnabled;
     private KeyPair serverKeyPair;
@@ -28,6 +29,7 @@ public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
     private boolean helloSent = false;
     private boolean agreementStarted = false;
     private boolean handshakeComplete = false;
+    private java.util.ArrayDeque<ByteBuf> pendingFrames;
 
     public WsHandshakeHandler() {
         this(
@@ -173,6 +175,29 @@ public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
             return;
         }
 
+        if (agreementStarted) {
+            // Key agreement is running on the crypto pool. The client derives the
+            // session key locally and can start sending AES frames before the
+            // decoder is installed; queue them and replay once finishAgreement
+            // completes, instead of misreading them as handshake frames and
+            // closing the connection.
+            if (!(msg instanceof ByteBuf)) {
+                ctx.fireChannelRead(msg);
+                return;
+            }
+            if (this.pendingFrames == null) {
+                this.pendingFrames = new java.util.ArrayDeque<>();
+            }
+            if (this.pendingFrames.size() >= MAX_PENDING_HANDSHAKE_FRAMES) {
+                LOGGER.warn("[ws-crypto] too many frames during key agreement from {}", clientAddress(ctx));
+                ((ByteBuf) msg).release();
+                ctx.close();
+                return;
+            }
+            this.pendingFrames.add((ByteBuf) msg);
+            return;
+        }
+
         if (!(msg instanceof ByteBuf)) {
             ctx.fireChannelRead(msg);
             return;
@@ -297,11 +322,49 @@ public class WsHandshakeHandler extends ChannelInboundHandlerAdapter {
                 "wsAesEncoder",
                 new WsAesEncoder());
         this.handshakeComplete = true;
+        replayPendingFrames(ctx);
         pipeline.remove(this);
 
         LOGGER.debug(
                 "[ws-crypto] handshake complete for {}",
                 clientAddress(ctx));
+    }
+
+    private void replayPendingFrames(ChannelHandlerContext ctx) {
+        if (this.pendingFrames == null) {
+            return;
+        }
+        // Fire queued frames through the now-installed AES decoder, in arrival
+        // order, while this handler is still in the pipeline so ctx stays valid.
+        java.util.ArrayDeque<ByteBuf> queued = this.pendingFrames;
+        this.pendingFrames = null;
+        try {
+            ByteBuf frame;
+            while ((frame = queued.poll()) != null) {
+                ctx.fireChannelRead(frame);
+            }
+        } finally {
+            ByteBuf leftover;
+            while ((leftover = queued.poll()) != null) {
+                leftover.release();
+            }
+        }
+    }
+
+    private void releasePendingFrames() {
+        if (this.pendingFrames == null) {
+            return;
+        }
+        ByteBuf frame;
+        while ((frame = this.pendingFrames.poll()) != null) {
+            frame.release();
+        }
+        this.pendingFrames = null;
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) {
+        releasePendingFrames();
     }
 
     private static void failAgreement(

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/decoders/PacketDispatchLatencyHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/decoders/PacketDispatchLatencyHandler.java
@@ -1,0 +1,43 @@
+package com.eu.habbo.networking.gameserver.decoders;
+
+import com.eu.habbo.messages.ClientMessage;
+import com.eu.habbo.messages.ClientMessageDispatchTiming;
+import com.eu.habbo.monitoring.PacketDispatchLatencyMetrics;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+import java.util.function.LongSupplier;
+
+public final class PacketDispatchLatencyHandler
+        extends ChannelInboundHandlerAdapter {
+
+    private final LongSupplier nanoClock;
+
+    public PacketDispatchLatencyHandler() {
+        this(System::nanoTime);
+    }
+
+    PacketDispatchLatencyHandler(
+            LongSupplier nanoClock) {
+        this.nanoClock = nanoClock;
+    }
+
+    @Override
+    public void channelRead(
+            ChannelHandlerContext context,
+            Object message) {
+        if (message instanceof ClientMessage clientMessage) {
+            long enqueuedAt =
+                    ClientMessageDispatchTiming
+                            .takeEnqueuedAt(
+                                    clientMessage);
+            if (enqueuedAt != 0L) {
+                PacketDispatchLatencyMetrics.record(
+                        this.nanoClock.getAsLong()
+                                - enqueuedAt);
+            }
+        }
+
+        context.fireChannelRead(message);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/decoders/PacketDispatchMarker.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/decoders/PacketDispatchMarker.java
@@ -1,0 +1,35 @@
+package com.eu.habbo.networking.gameserver.decoders;
+
+import com.eu.habbo.messages.ClientMessage;
+import com.eu.habbo.messages.ClientMessageDispatchTiming;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+import java.util.function.LongSupplier;
+
+public final class PacketDispatchMarker
+        extends ChannelInboundHandlerAdapter {
+
+    private final LongSupplier nanoClock;
+
+    public PacketDispatchMarker() {
+        this(System::nanoTime);
+    }
+
+    PacketDispatchMarker(LongSupplier nanoClock) {
+        this.nanoClock = nanoClock;
+    }
+
+    @Override
+    public void channelRead(
+            ChannelHandlerContext context,
+            Object message) {
+        if (message instanceof ClientMessage clientMessage) {
+            ClientMessageDispatchTiming.markEnqueued(
+                    clientMessage,
+                    this.nanoClock.getAsLong());
+        }
+
+        context.fireChannelRead(message);
+    }
+}

--- a/Emulator/src/main/resources/logback.xml
+++ b/Emulator/src/main/resources/logback.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook"/>
     <conversionRule conversionWord="morningstarLevel" class="com.eu.habbo.util.logback.ConsoleLevelConverter" />
     <conversionRule conversionWord="morningstarLogger" class="com.eu.habbo.util.logback.ConsoleLoggerConverter" />
 

--- a/Emulator/src/main/resources/logback.xml
+++ b/Emulator/src/main/resources/logback.xml
@@ -3,60 +3,95 @@
     <conversionRule conversionWord="morningstarLevel" class="com.eu.habbo.util.logback.ConsoleLevelConverter" />
     <conversionRule conversionWord="morningstarLogger" class="com.eu.habbo.util.logback.ConsoleLoggerConverter" />
 
-    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="ConsoleDelegate" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} %morningstarLevel [%-12thread] %morningstarLogger | %msg%n</pattern>
         </encoder>
     </appender>
 
-    <appender name="FileDebug" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="Console" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>2048</queueSize>
+        <discardingThreshold>20</discardingThreshold>
+        <neverBlock>true</neverBlock>
+        <maxFlushTime>5000</maxFlushTime>
+        <appender-ref ref="ConsoleDelegate" />
+    </appender>
+
+    <appender name="FileDebugRolling" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logging/debug.txt</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logging/debug.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FileDebug" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>DEBUG</level>
             <onMatch>ACCEPT</onMatch>
             <onMismatch>DENY</onMismatch>
         </filter>
+        <queueSize>4096</queueSize>
+        <discardingThreshold>20</discardingThreshold>
+        <neverBlock>true</neverBlock>
+        <maxFlushTime>5000</maxFlushTime>
+        <appender-ref ref="FileDebugRolling" />
+    </appender>
+
+    <appender name="FileErrorsRolling" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logging/errors/runtime.txt</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logging/debug.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <fileNamePattern>logging/errors/runtime.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxFileSize>50MB</maxFileSize>
             <maxHistory>7</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
         </rollingPolicy>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %level %logger - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <appender name="FileErrors" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logging/errors/runtime.txt</file>
+    <appender name="FileErrors" class="ch.qos.logback.classic.AsyncAppender">
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>
             <onMatch>ACCEPT</onMatch>
             <onMismatch>DENY</onMismatch>
         </filter>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logging/errors/runtime.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
-            <maxFileSize>50MB</maxFileSize>
-            <maxHistory>7</maxHistory>
-        </rollingPolicy>
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %level %logger - %msg%n</pattern>
-        </encoder>
+        <queueSize>2048</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>false</neverBlock>
+        <maxFlushTime>5000</maxFlushTime>
+        <appender-ref ref="FileErrorsRolling" />
     </appender>
 
-    <appender name="FileErrorsSql" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="FileErrorsSqlRolling" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logging/errors/sql.txt</file>
-        <filter class="com.eu.habbo.util.logback.SqlExceptionFilter" />
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logging/errors/sql.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxFileSize>50MB</maxFileSize>
             <maxHistory>7</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
         </rollingPolicy>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %level %logger - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <appender name="SlowQueries" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="FileErrorsSql" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="com.eu.habbo.util.logback.SqlExceptionFilter" />
+        <queueSize>2048</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>false</neverBlock>
+        <maxFlushTime>5000</maxFlushTime>
+        <appender-ref ref="FileErrorsSqlRolling" />
+    </appender>
+
+    <appender name="SlowQueriesRolling" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logging/database/slow-queries.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logging/database/slow-queries.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
@@ -67,6 +102,14 @@
         <encoder>
             <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %msg%n</pattern>
         </encoder>
+    </appender>
+
+    <appender name="SlowQueries" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>2048</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>false</neverBlock>
+        <maxFlushTime>5000</maxFlushTime>
+        <appender-ref ref="SlowQueriesRolling" />
     </appender>
 
     <logger name="io.netty" level="INFO"/>

--- a/Emulator/src/test/java/com/eu/habbo/AsyncLogbackConfigurationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/AsyncLogbackConfigurationTest.java
@@ -96,6 +96,20 @@ class AsyncLogbackConfigurationTest {
                 "root.setLevel(Level.DEBUG)"));
     }
 
+    @Test
+    void configurationStopsTheLoggerContextOnShutdown()
+            throws Exception {
+        Document document = configuration();
+
+        NodeList hooks =
+                document.getElementsByTagName("shutdownHook");
+        assertEquals(1, hooks.getLength());
+        Element hook = (Element) hooks.item(0);
+        assertEquals(
+                "ch.qos.logback.core.hook.DefaultShutdownHook",
+                hook.getAttribute("class"));
+    }
+
     private static void assertAsync(
             Document document,
             String name,

--- a/Emulator/src/test/java/com/eu/habbo/AsyncLogbackConfigurationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/AsyncLogbackConfigurationTest.java
@@ -1,0 +1,189 @@
+package com.eu.habbo;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AsyncLogbackConfigurationTest {
+
+    private static final Path CONFIGURATION =
+            Path.of("src/main/resources/logback.xml");
+    private static final String ASYNC_APPENDER =
+            "ch.qos.logback.classic.AsyncAppender";
+
+    @Test
+    void activeRootAppendersUseExplicitAsyncPolicies()
+            throws Exception {
+        Document document = configuration();
+
+        assertAsync(
+                document,
+                "Console",
+                "ConsoleDelegate",
+                "2048",
+                "20",
+                "true");
+        assertAsync(
+                document,
+                "FileDebug",
+                "FileDebugRolling",
+                "4096",
+                "20",
+                "true");
+        assertAsync(
+                document,
+                "FileErrors",
+                "FileErrorsRolling",
+                "2048",
+                "0",
+                "false");
+        assertAsync(
+                document,
+                "FileErrorsSql",
+                "FileErrorsSqlRolling",
+                "2048",
+                "0",
+                "false");
+        assertAsync(
+                document,
+                "SlowQueries",
+                "SlowQueriesRolling",
+                "2048",
+                "0",
+                "false");
+    }
+
+    @Test
+    void everyRollingFileHasAnAggregateSizeCap()
+            throws Exception {
+        Document document = configuration();
+
+        assertTotalSizeCap(
+                document,
+                "FileDebugRolling",
+                "500MB");
+        assertTotalSizeCap(
+                document,
+                "FileErrorsRolling",
+                "500MB");
+        assertTotalSizeCap(
+                document,
+                "FileErrorsSqlRolling",
+                "500MB");
+        assertTotalSizeCap(
+                document,
+                "SlowQueriesRolling",
+                "500MB");
+    }
+
+    @Test
+    void runtimeDebugModeStillRaisesTheRootLevel()
+            throws Exception {
+        String source = Files.readString(
+                Path.of(
+                        "src/main/java/com/eu/habbo/"
+                                + "Emulator.java"));
+
+        assertTrue(source.contains(
+                "root.setLevel(Level.DEBUG)"));
+    }
+
+    private static void assertAsync(
+            Document document,
+            String name,
+            String delegate,
+            String queueSize,
+            String discardingThreshold,
+            String neverBlock) {
+        Element appender = appender(document, name);
+        assertEquals(
+                ASYNC_APPENDER,
+                appender.getAttribute("class"));
+        assertEquals(
+                queueSize,
+                childText(appender, "queueSize"));
+        assertEquals(
+                discardingThreshold,
+                childText(
+                        appender,
+                        "discardingThreshold"));
+        assertEquals(
+                neverBlock,
+                childText(appender, "neverBlock"));
+        assertEquals(
+                delegate,
+                firstChild(
+                        appender,
+                        "appender-ref")
+                        .getAttribute("ref"));
+    }
+
+    private static void assertTotalSizeCap(
+            Document document,
+            String appenderName,
+            String expected) {
+        Element rollingPolicy = firstChild(
+                appender(document, appenderName),
+                "rollingPolicy");
+        assertEquals(
+                expected,
+                childText(
+                        rollingPolicy,
+                        "totalSizeCap"));
+    }
+
+    private static Document configuration()
+            throws Exception {
+        return DocumentBuilderFactory.newInstance()
+                .newDocumentBuilder()
+                .parse(CONFIGURATION.toFile());
+    }
+
+    private static Element appender(
+            Document document,
+            String name) {
+        NodeList appenders =
+                document.getElementsByTagName("appender");
+        for (int index = 0;
+             index < appenders.getLength();
+             index++) {
+            Element appender =
+                    (Element) appenders.item(index);
+            if (name.equals(
+                    appender.getAttribute("name"))) {
+                return appender;
+            }
+        }
+        throw new AssertionError(
+                "Missing appender " + name);
+    }
+
+    private static String childText(
+            Element parent,
+            String tag) {
+        return firstChild(parent, tag)
+                .getTextContent()
+                .trim();
+    }
+
+    private static Element firstChild(
+            Element parent,
+            String tag) {
+        NodeList children =
+                parent.getElementsByTagName(tag);
+        if (children.getLength() == 0) {
+            throw new AssertionError(
+                    "Missing " + tag + " under "
+                            + parent.getAttribute("name"));
+        }
+        return (Element) children.item(0);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/monitoring/NetworkDispatchMetricsContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/monitoring/NetworkDispatchMetricsContractTest.java
@@ -1,0 +1,29 @@
+package com.eu.habbo.monitoring;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NetworkDispatchMetricsContractTest {
+
+    @Test
+    void networkSnapshotExposesDispatchLatencyWindow() {
+        EmulatorStatsService.NetworkMetrics metrics =
+                new EmulatorStatsService.NetworkMetrics(
+                        1D,
+                        2D,
+                        3D,
+                        4D,
+                        5L,
+                        6L,
+                        7L,
+                        8D,
+                        9D,
+                        10D);
+
+        assertEquals(7L, metrics.dispatchSamples);
+        assertEquals(8D, metrics.dispatchAverageMs);
+        assertEquals(9D, metrics.dispatchP95Ms);
+        assertEquals(10D, metrics.dispatchMaxMs);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/monitoring/PacketDispatchLatencyMetricsTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/monitoring/PacketDispatchLatencyMetricsTest.java
@@ -1,0 +1,51 @@
+package com.eu.habbo.monitoring;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PacketDispatchLatencyMetricsTest {
+
+    @BeforeEach
+    void resetMetrics() {
+        PacketDispatchLatencyMetrics.reset();
+    }
+
+    @Test
+    void snapshotReportsCountAverageP95AndMaximum() {
+        PacketDispatchLatencyMetrics.record(
+                TimeUnit.MICROSECONDS.toNanos(100));
+        PacketDispatchLatencyMetrics.record(
+                TimeUnit.MILLISECONDS.toNanos(1));
+        for (int i = 0; i < 18; i++) {
+            PacketDispatchLatencyMetrics.record(
+                    TimeUnit.MILLISECONDS.toNanos(12));
+        }
+
+        PacketDispatchLatencyMetrics.Snapshot snapshot =
+                PacketDispatchLatencyMetrics.snapshot();
+
+        assertEquals(20, snapshot.samples());
+        assertEquals(10.855, snapshot.averageMs(), 0.001);
+        assertEquals(25.0, snapshot.p95Ms(), 0.001);
+        assertEquals(12.0, snapshot.maxMs(), 0.001);
+    }
+
+    @Test
+    void snapshotDrainsTheCurrentMeasurementWindow() {
+        PacketDispatchLatencyMetrics.record(
+                TimeUnit.MILLISECONDS.toNanos(2));
+
+        assertEquals(
+                1,
+                PacketDispatchLatencyMetrics
+                        .snapshot().samples());
+        assertEquals(
+                0,
+                PacketDispatchLatencyMetrics
+                        .snapshot().samples());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/GamePacketExecutionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/GamePacketExecutionContractTest.java
@@ -16,6 +16,8 @@ class GamePacketExecutionContractTest {
 
         assertTrue(tcp.contains("GamePacketExecutionGroup.get()"), "TCP packet handlers must be off the Netty I/O loop");
         assertTrue(webSocket.contains("GamePacketExecutionGroup.get()"), "WebSocket packet handlers must use the shared execution group");
+        assertLatencyProbeOrder(tcp);
+        assertLatencyProbeOrder(webSocket);
     }
 
     @Test
@@ -30,5 +32,23 @@ class GamePacketExecutionContractTest {
 
     private static String source(String file) throws Exception {
         return Files.readString(Path.of("src/main/java/com/eu/habbo/networking/gameserver/" + file));
+    }
+
+    private static void assertLatencyProbeOrder(
+            String pipelineSource) {
+        int marker = pipelineSource.indexOf(
+                "new PacketDispatchMarker()");
+        int latency = pipelineSource.indexOf(
+                "\"packetDispatchLatency\"");
+        int handler = pipelineSource.indexOf(
+                "\"gameMessageHandler\"");
+
+        assertTrue(marker >= 0);
+        assertTrue(
+                latency > marker,
+                "dispatch latency must start after the I/O marker");
+        assertTrue(
+                handler > latency,
+                "dispatch latency must be observed before packet handling");
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsCryptoExecutorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsCryptoExecutorTest.java
@@ -1,0 +1,48 @@
+package com.eu.habbo.networking.gameserver.crypto;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WsCryptoExecutorTest {
+
+    @Test
+    void executorIsFixedWidthAndBounded() {
+        ThreadPoolExecutor executor =
+                WsCryptoExecutor.createExecutor(3);
+        try {
+            assertEquals(3, executor.getCorePoolSize());
+            assertEquals(3, executor.getMaximumPoolSize());
+            assertEquals(
+                    256,
+                    executor.getQueue()
+                            .remainingCapacity());
+            assertTrue(executor.allowsCoreThreadTimeOut());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void workersAreDaemonThreadsWithDedicatedNames()
+            throws Exception {
+        ThreadPoolExecutor executor =
+                WsCryptoExecutor.createExecutor(1);
+        try {
+            String worker = executor.submit(() ->
+                    Thread.currentThread().getName()
+                            + ":"
+                            + Thread.currentThread().isDaemon())
+                    .get();
+
+            assertTrue(worker.startsWith(
+                    "ws-crypto-worker-"));
+            assertTrue(worker.endsWith(":true"));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeHandlerCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeHandlerCompatibilityTest.java
@@ -5,6 +5,8 @@ import com.eu.habbo.core.ConfigurationManager;
 import com.eu.habbo.networking.gameserver.GameServerAttributes;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
@@ -15,6 +17,8 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.security.KeyPair;
 import java.security.PublicKey;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -63,8 +67,7 @@ class WsHandshakeHandlerCompatibilityTest {
         try {
             fireHandshakeComplete(channel);
 
-            ByteBuf hello = channel.readOutbound();
-            assertNotNull(hello);
+            ByteBuf hello = awaitOutbound(channel);
             assertEquals(
                     WsSessionCrypto.HANDSHAKE_MAGIC,
                     hello.readInt());
@@ -91,7 +94,7 @@ class WsHandshakeHandlerCompatibilityTest {
         EmbeddedChannel channel = handshakeChannel();
         try {
             fireHandshakeComplete(channel);
-            ByteBuf hello = channel.readOutbound();
+            ByteBuf hello = awaitOutbound(channel);
             hello.skipBytes(5);
             int serverKeyLength = hello.readUnsignedShort();
             byte[] serverSpki = new byte[serverKeyLength];
@@ -122,6 +125,11 @@ class WsHandshakeHandlerCompatibilityTest {
 
             assertFalse(channel.writeInbound(clientHello));
             assertEquals(0, clientHello.refCnt());
+            awaitCondition(
+                    channel,
+                    () -> channel.attr(
+                                    GameServerAttributes.WS_AES_KEY)
+                            .get() != null);
             assertArrayEquals(
                     expectedSessionKey,
                     channel.attr(
@@ -131,6 +139,42 @@ class WsHandshakeHandlerCompatibilityTest {
                             WsHandshakeHandler.HANDLER_NAME));
             assertNotNull(channel.pipeline().get("wsAesDecoder"));
             assertNotNull(channel.pipeline().get("wsAesEncoder"));
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void serverHelloIsQueuedBeforeHandshakeNotificationContinues()
+            throws Exception {
+        EmbeddedChannel channel = handshakeChannel();
+        AtomicBoolean eventObserved = new AtomicBoolean();
+        AtomicBoolean helloWasQueued = new AtomicBoolean();
+        channel.pipeline().addLast(
+                "handshakeObserver",
+                new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void userEventTriggered(
+                            ChannelHandlerContext context,
+                            Object event) {
+                        if (event instanceof
+                                WebSocketServerProtocolHandler
+                                        .HandshakeComplete) {
+                            helloWasQueued.set(
+                                    !channel.outboundMessages()
+                                            .isEmpty());
+                            eventObserved.set(true);
+                        }
+                        context.fireUserEventTriggered(event);
+                    }
+                });
+        try {
+            fireHandshakeComplete(channel);
+            awaitCondition(channel, eventObserved::get);
+
+            assertTrue(helloWasQueued.get());
+            ByteBuf hello = awaitOutbound(channel);
+            hello.release();
         } finally {
             channel.finishAndReleaseAll();
         }
@@ -170,5 +214,35 @@ class WsHandshakeHandlerCompatibilityTest {
                 WsHandshakeHandler.HANDLER_NAME,
                 new WsHandshakeHandler());
         return channel;
+    }
+
+    private static ByteBuf awaitOutbound(
+            EmbeddedChannel channel) throws Exception {
+        long deadline = System.nanoTime()
+                + java.util.concurrent.TimeUnit.SECONDS.toNanos(1);
+        while (System.nanoTime() < deadline) {
+            channel.runPendingTasks();
+            ByteBuf message = channel.readOutbound();
+            if (message != null) {
+                return message;
+            }
+            Thread.sleep(1);
+        }
+        throw new AssertionError("Timed out waiting for server hello");
+    }
+
+    private static void awaitCondition(
+            EmbeddedChannel channel,
+            BooleanSupplier condition) throws Exception {
+        long deadline = System.nanoTime()
+                + java.util.concurrent.TimeUnit.SECONDS.toNanos(1);
+        while (System.nanoTime() < deadline) {
+            channel.runPendingTasks();
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(1);
+        }
+        throw new AssertionError("Timed out waiting for handshake state");
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeHandlerCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeHandlerCompatibilityTest.java
@@ -1,0 +1,174 @@
+package com.eu.habbo.networking.gameserver.crypto;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.networking.gameserver.GameServerAttributes;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.security.KeyPair;
+import java.security.PublicKey;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class WsHandshakeHandlerCompatibilityTest {
+
+    private static Field configField;
+    private static Field runtimeField;
+    private static Object originalConfig;
+    private static Object originalRuntime;
+
+    @BeforeAll
+    static void configureUnsignedHandshake() throws Exception {
+        configField = Emulator.class.getDeclaredField("config");
+        runtimeField = Emulator.class.getDeclaredField("polarisRuntime");
+        configField.setAccessible(true);
+        runtimeField.setAccessible(true);
+        originalConfig = configField.get(null);
+        originalRuntime = runtimeField.get(null);
+
+        ConfigurationManager configuration =
+                mock(ConfigurationManager.class);
+        when(configuration.getBoolean(
+                "crypto.ws.signing.enabled",
+                false)).thenReturn(false);
+        runtimeField.set(null, null);
+        configField.set(null, configuration);
+    }
+
+    @AfterAll
+    static void restoreConfiguration() throws Exception {
+        configField.set(null, originalConfig);
+        runtimeField.set(null, originalRuntime);
+    }
+
+    @Test
+    void serverHelloKeepsTheEstablishedUnsignedWireLayout()
+            throws Exception {
+        EmbeddedChannel channel = handshakeChannel();
+        try {
+            fireHandshakeComplete(channel);
+
+            ByteBuf hello = channel.readOutbound();
+            assertNotNull(hello);
+            assertEquals(
+                    WsSessionCrypto.HANDSHAKE_MAGIC,
+                    hello.readInt());
+            assertEquals(
+                    WsSessionCrypto.TYPE_SERVER_HELLO,
+                    hello.readByte());
+
+            int publicKeyLength = hello.readUnsignedShort();
+            assertTrue(publicKeyLength > 0);
+            byte[] publicKey = new byte[publicKeyLength];
+            hello.readBytes(publicKey);
+            assertNotNull(
+                    WsSessionCrypto.decodePublicKeySpki(publicKey));
+            assertFalse(hello.isReadable());
+            hello.release();
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void validClientHelloInstallsTheSameSessionKeyAndAesHandlers()
+            throws Exception {
+        EmbeddedChannel channel = handshakeChannel();
+        try {
+            fireHandshakeComplete(channel);
+            ByteBuf hello = channel.readOutbound();
+            hello.skipBytes(5);
+            int serverKeyLength = hello.readUnsignedShort();
+            byte[] serverSpki = new byte[serverKeyLength];
+            hello.readBytes(serverSpki);
+            hello.release();
+
+            PublicKey serverPublic =
+                    WsSessionCrypto.decodePublicKeySpki(serverSpki);
+            KeyPair clientKeyPair =
+                    WsSessionCrypto.generateEphemeralKeyPair();
+            byte[] clientSpki =
+                    WsSessionCrypto.encodePublicKeySpki(
+                            clientKeyPair.getPublic());
+            byte[] expectedSessionKey =
+                    WsSessionCrypto.deriveAesKey(
+                            WsSessionCrypto.deriveSharedSecret(
+                                    clientKeyPair.getPrivate(),
+                                    serverPublic));
+
+            ByteBuf clientHello =
+                    Unpooled.buffer(7 + clientSpki.length);
+            clientHello.writeInt(
+                    WsSessionCrypto.HANDSHAKE_MAGIC);
+            clientHello.writeByte(
+                    WsSessionCrypto.TYPE_CLIENT_HELLO);
+            clientHello.writeShort(clientSpki.length);
+            clientHello.writeBytes(clientSpki);
+
+            assertFalse(channel.writeInbound(clientHello));
+            assertEquals(0, clientHello.refCnt());
+            assertArrayEquals(
+                    expectedSessionKey,
+                    channel.attr(
+                            GameServerAttributes.WS_AES_KEY).get());
+            assertNull(
+                    channel.pipeline().get(
+                            WsHandshakeHandler.HANDLER_NAME));
+            assertNotNull(channel.pipeline().get("wsAesDecoder"));
+            assertNotNull(channel.pipeline().get("wsAesEncoder"));
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void malformedClientHelloIsReleasedAndClosesTheChannel() {
+        EmbeddedChannel channel = handshakeChannel();
+        try {
+            ByteBuf malformed =
+                    Unpooled.buffer(7)
+                            .writeInt(0x01020304)
+                            .writeByte(
+                                    WsSessionCrypto.TYPE_CLIENT_HELLO)
+                            .writeShort(0);
+
+            assertFalse(channel.writeInbound(malformed));
+            assertEquals(0, malformed.refCnt());
+            assertFalse(channel.isOpen());
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private static void fireHandshakeComplete(
+            EmbeddedChannel channel) {
+        channel.pipeline().fireUserEventTriggered(
+                new WebSocketServerProtocolHandler.HandshakeComplete(
+                        "/",
+                        EmptyHttpHeaders.INSTANCE,
+                        null));
+    }
+
+    private static EmbeddedChannel handshakeChannel() {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline().addLast(
+                WsHandshakeHandler.HANDLER_NAME,
+                new WsHandshakeHandler());
+        return channel;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeOffloadTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeOffloadTest.java
@@ -1,0 +1,124 @@
+package com.eu.habbo.networking.gameserver.crypto;
+
+import com.eu.habbo.networking.gameserver.GameServerAttributes;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPair;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class WsHandshakeOffloadTest {
+
+    @Test
+    void keyGenerationLeavesTheCallingIoThread()
+            throws Exception {
+        LinkedBlockingQueue<Runnable> cryptoTasks =
+                new LinkedBlockingQueue<>();
+        WsHandshakeHandler handler =
+                new WsHandshakeHandler(
+                        cryptoTasks::add,
+                        false);
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline().addLast(
+                WsHandshakeHandler.HANDLER_NAME,
+                handler);
+        try {
+            channel.pipeline().fireUserEventTriggered(
+                    new WebSocketServerProtocolHandler
+                            .HandshakeComplete(
+                            "/",
+                            EmptyHttpHeaders.INSTANCE,
+                            null));
+
+            assertNull(channel.readOutbound());
+            assertEquals(1, cryptoTasks.size());
+
+            runCryptoTask(cryptoTasks);
+            channel.runPendingTasks();
+
+            ByteBuf serverHello = channel.readOutbound();
+            assertNotNull(serverHello);
+            serverHello.release();
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void keyAgreementLeavesTheCallingIoThread()
+            throws Exception {
+        LinkedBlockingQueue<Runnable> cryptoTasks =
+                new LinkedBlockingQueue<>();
+        WsHandshakeHandler handler =
+                new WsHandshakeHandler(
+                        cryptoTasks::add,
+                        false);
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline().addLast(
+                WsHandshakeHandler.HANDLER_NAME,
+                handler);
+        try {
+            channel.pipeline().fireUserEventTriggered(
+                    new WebSocketServerProtocolHandler
+                            .HandshakeComplete(
+                            "/",
+                            EmptyHttpHeaders.INSTANCE,
+                            null));
+            runCryptoTask(cryptoTasks);
+            channel.runPendingTasks();
+            ByteBuf serverHello = channel.readOutbound();
+            assertNotNull(serverHello);
+            serverHello.release();
+
+            KeyPair clientKeyPair =
+                    WsSessionCrypto.generateEphemeralKeyPair();
+            byte[] clientSpki =
+                    WsSessionCrypto.encodePublicKeySpki(
+                            clientKeyPair.getPublic());
+            ByteBuf clientHello =
+                    Unpooled.buffer(7 + clientSpki.length)
+                            .writeInt(
+                                    WsSessionCrypto
+                                            .HANDSHAKE_MAGIC)
+                            .writeByte(
+                                    WsSessionCrypto
+                                            .TYPE_CLIENT_HELLO)
+                            .writeShort(clientSpki.length)
+                            .writeBytes(clientSpki);
+
+            assertFalse(channel.writeInbound(clientHello));
+            assertNull(channel.attr(
+                    GameServerAttributes.WS_AES_KEY).get());
+            assertEquals(1, cryptoTasks.size());
+
+            runCryptoTask(cryptoTasks);
+            channel.runPendingTasks();
+
+            assertNotNull(channel.attr(
+                    GameServerAttributes.WS_AES_KEY).get());
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private static void runCryptoTask(
+            LinkedBlockingQueue<Runnable> cryptoTasks)
+            throws InterruptedException {
+        Thread worker = new Thread(
+                cryptoTasks.remove(),
+                "test-ws-crypto-worker");
+        worker.start();
+        worker.join(TimeUnit.SECONDS.toMillis(1));
+        assertFalse(worker.isAlive());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeOffloadTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeOffloadTest.java
@@ -9,9 +9,11 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import org.junit.jupiter.api.Test;
 
 import java.security.KeyPair;
+import java.security.PublicKey;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -126,45 +128,115 @@ class WsHandshakeOffloadTest {
                 WsHandshakeHandler.HANDLER_NAME,
                 handler);
         try {
-            channel.pipeline().fireUserEventTriggered(
-                    new WebSocketServerProtocolHandler
-                            .HandshakeComplete(
-                            "/",
-                            EmptyHttpHeaders.INSTANCE,
-                            null));
-            runCryptoTask(cryptoTasks);
-            channel.runPendingTasks();
-            channel.readOutbound();
-
-            KeyPair clientKeyPair =
-                    WsSessionCrypto.generateEphemeralKeyPair();
-            byte[] clientSpki =
-                    WsSessionCrypto.encodePublicKeySpki(
-                            clientKeyPair.getPublic());
-            ByteBuf clientHello =
-                    Unpooled.buffer(7 + clientSpki.length)
-                            .writeInt(
-                                    WsSessionCrypto
-                                            .HANDSHAKE_MAGIC)
-                            .writeByte(
-                                    WsSessionCrypto
-                                            .TYPE_CLIENT_HELLO)
-                            .writeShort(clientSpki.length)
-                            .writeBytes(clientSpki);
-            assertFalse(channel.writeInbound(clientHello));
-            assertEquals(1, cryptoTasks.size());
+            byte[] sessionKey = beginAgreement(channel, cryptoTasks);
 
             // The client derives the key locally and can send an AES frame before
             // the decoder is installed. It must be queued, not parsed as handshake.
-            ByteBuf earlyFrame = Unpooled.wrappedBuffer(
-                    new byte[]{0, 1, 2, 3, 4, 5, 6, 7});
+            byte[] plaintext = new byte[]{0, 1, 2, 3, 4, 5, 6, 7};
+            byte[] nonce = WsSessionCrypto.randomNonce();
+            byte[] ciphertext =
+                    WsSessionCrypto.aesGcmEncrypt(
+                            sessionKey,
+                            nonce,
+                            plaintext);
+            ByteBuf earlyFrame = Unpooled.buffer(
+                            nonce.length + ciphertext.length)
+                    .writeBytes(nonce)
+                    .writeBytes(ciphertext);
             channel.writeInbound(earlyFrame);
 
             assertTrue(channel.isActive());
             assertEquals(1, cryptoTasks.size());
+
+            runCryptoTask(cryptoTasks);
+            channel.runPendingTasks();
+
+            ByteBuf replayed = channel.readInbound();
+            byte[] actual = new byte[replayed.readableBytes()];
+            replayed.readBytes(actual);
+            replayed.release();
+            assertArrayEquals(plaintext, actual);
+            assertEquals(0, earlyFrame.refCnt());
         } finally {
             channel.finishAndReleaseAll();
         }
+    }
+
+    @Test
+    void pendingFramesAreBoundedByBytesAndReleasedOnClose()
+            throws Exception {
+        LinkedBlockingQueue<Runnable> cryptoTasks =
+                new LinkedBlockingQueue<>();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline().addLast(
+                WsHandshakeHandler.HANDLER_NAME,
+                new WsHandshakeHandler(
+                        cryptoTasks::add,
+                        false));
+        ByteBuf first = Unpooled.buffer(500_000).writeZero(500_000);
+        ByteBuf second = Unpooled.buffer(500_000).writeZero(500_000);
+        ByteBuf overflow = Unpooled.buffer(500_000).writeZero(500_000);
+        try {
+            beginAgreement(channel, cryptoTasks);
+
+            channel.writeInbound(first);
+            channel.writeInbound(second);
+            channel.writeInbound(overflow);
+
+            assertFalse(channel.isOpen());
+            assertEquals(0, overflow.refCnt());
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+        assertEquals(0, first.refCnt());
+        assertEquals(0, second.refCnt());
+    }
+
+    private static byte[] beginAgreement(
+            EmbeddedChannel channel,
+            LinkedBlockingQueue<Runnable> cryptoTasks)
+            throws Exception {
+        channel.pipeline().fireUserEventTriggered(
+                new WebSocketServerProtocolHandler
+                        .HandshakeComplete(
+                        "/",
+                        EmptyHttpHeaders.INSTANCE,
+                        null));
+        runCryptoTask(cryptoTasks);
+        channel.runPendingTasks();
+
+        ByteBuf serverHello = channel.readOutbound();
+        serverHello.skipBytes(5);
+        int serverKeyLength = serverHello.readUnsignedShort();
+        byte[] serverSpki = new byte[serverKeyLength];
+        serverHello.readBytes(serverSpki);
+        serverHello.release();
+
+        KeyPair clientKeyPair =
+                WsSessionCrypto.generateEphemeralKeyPair();
+        PublicKey serverPublic =
+                WsSessionCrypto.decodePublicKeySpki(serverSpki);
+        byte[] sessionKey =
+                WsSessionCrypto.deriveAesKey(
+                        WsSessionCrypto.deriveSharedSecret(
+                                clientKeyPair.getPrivate(),
+                                serverPublic));
+        byte[] clientSpki =
+                WsSessionCrypto.encodePublicKeySpki(
+                        clientKeyPair.getPublic());
+        ByteBuf clientHello =
+                Unpooled.buffer(7 + clientSpki.length)
+                        .writeInt(
+                                WsSessionCrypto
+                                        .HANDSHAKE_MAGIC)
+                        .writeByte(
+                                WsSessionCrypto
+                                        .TYPE_CLIENT_HELLO)
+                        .writeShort(clientSpki.length)
+                        .writeBytes(clientSpki);
+        assertFalse(channel.writeInbound(clientHello));
+        assertEquals(1, cryptoTasks.size());
+        return sessionKey;
     }
 
     private static void runCryptoTask(

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeOffloadTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/crypto/WsHandshakeOffloadTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WsHandshakeOffloadTest {
 
@@ -106,6 +107,61 @@ class WsHandshakeOffloadTest {
 
             assertNotNull(channel.attr(
                     GameServerAttributes.WS_AES_KEY).get());
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void framesArrivingDuringKeyAgreementDoNotCloseTheConnection()
+            throws Exception {
+        LinkedBlockingQueue<Runnable> cryptoTasks =
+                new LinkedBlockingQueue<>();
+        WsHandshakeHandler handler =
+                new WsHandshakeHandler(
+                        cryptoTasks::add,
+                        false);
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline().addLast(
+                WsHandshakeHandler.HANDLER_NAME,
+                handler);
+        try {
+            channel.pipeline().fireUserEventTriggered(
+                    new WebSocketServerProtocolHandler
+                            .HandshakeComplete(
+                            "/",
+                            EmptyHttpHeaders.INSTANCE,
+                            null));
+            runCryptoTask(cryptoTasks);
+            channel.runPendingTasks();
+            channel.readOutbound();
+
+            KeyPair clientKeyPair =
+                    WsSessionCrypto.generateEphemeralKeyPair();
+            byte[] clientSpki =
+                    WsSessionCrypto.encodePublicKeySpki(
+                            clientKeyPair.getPublic());
+            ByteBuf clientHello =
+                    Unpooled.buffer(7 + clientSpki.length)
+                            .writeInt(
+                                    WsSessionCrypto
+                                            .HANDSHAKE_MAGIC)
+                            .writeByte(
+                                    WsSessionCrypto
+                                            .TYPE_CLIENT_HELLO)
+                            .writeShort(clientSpki.length)
+                            .writeBytes(clientSpki);
+            assertFalse(channel.writeInbound(clientHello));
+            assertEquals(1, cryptoTasks.size());
+
+            // The client derives the key locally and can send an AES frame before
+            // the decoder is installed. It must be queued, not parsed as handshake.
+            ByteBuf earlyFrame = Unpooled.wrappedBuffer(
+                    new byte[]{0, 1, 2, 3, 4, 5, 6, 7});
+            channel.writeInbound(earlyFrame);
+
+            assertTrue(channel.isActive());
+            assertEquals(1, cryptoTasks.size());
         } finally {
             channel.finishAndReleaseAll();
         }

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/decoders/PacketDispatchLatencyHandlerTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/decoders/PacketDispatchLatencyHandlerTest.java
@@ -1,0 +1,54 @@
+package com.eu.habbo.networking.gameserver.decoders;
+
+import com.eu.habbo.messages.ClientMessage;
+import com.eu.habbo.monitoring.PacketDispatchLatencyMetrics;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PacketDispatchLatencyHandlerTest {
+
+    @BeforeEach
+    void resetMetrics() {
+        PacketDispatchLatencyMetrics.snapshot();
+    }
+
+    @Test
+    void recordsTimeBetweenIoMarkerAndDispatchHandler() {
+        long step = TimeUnit.MILLISECONDS.toNanos(3);
+        AtomicLong clock = new AtomicLong(
+                TimeUnit.MILLISECONDS.toNanos(1));
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new PacketDispatchMarker(
+                        () -> clock.getAndAdd(step)),
+                new PacketDispatchLatencyHandler(
+                        () -> clock.getAndAdd(step)));
+        ClientMessage message =
+                new ClientMessage(
+                        7,
+                        Unpooled.buffer(1).writeByte(1));
+        try {
+            assertTrue(channel.writeInbound(message));
+            assertSame(message, channel.readInbound());
+
+            PacketDispatchLatencyMetrics.Snapshot snapshot =
+                    PacketDispatchLatencyMetrics.snapshot();
+            assertEquals(1, snapshot.samples());
+            assertEquals(
+                    3D,
+                    snapshot.averageMs(),
+                    0.001);
+        } finally {
+            message.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+}


### PR DESCRIPTION
Offloads WebSocket key generation and agreement without dropping early encrypted frames, bounds pending handshake data, exposes packet-dispatch latency, and isolates active logging appenders with orderly shutdown draining.