### PR TITLE
test(net): profile room broadcast allocations

### DIFF
--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/BroadcastJfrProfileTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/BroadcastJfrProfileTest.java
@@ -1,0 +1,240 @@
+package com.eu.habbo.networking.gameserver;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.networking.gameserver.encoders.GameServerMessageEncoder;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedFrame;
+import jdk.jfr.consumer.RecordingFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIfSystemProperty(
+        named = "polaris.profile.broadcast",
+        matches = "true")
+class BroadcastJfrProfileTest {
+
+    private static final int RECIPIENTS = 50;
+    private static final int WARMUP_BROADCASTS = 500;
+    private static final int PROFILE_BROADCASTS = 5_000;
+    private static volatile long blackhole;
+
+    @Test
+    void capturesRepresentativeRoomBroadcastAllocationProfile()
+            throws Exception {
+        Path profileDirectory =
+                Path.of("target", "profiles");
+        Files.createDirectories(profileDirectory);
+        Path recordingPath =
+                profileDirectory.resolve(
+                        "broadcast-baseline.jfr");
+        Path summaryPath =
+                profileDirectory.resolve(
+                        "broadcast-baseline.txt");
+
+        EmbeddedChannel channel =
+                new EmbeddedChannel(
+                        new GameServerMessageEncoder());
+        ServerMessage message = representativeMessage();
+        try {
+            runBroadcasts(
+                    channel,
+                    message,
+                    WARMUP_BROADCASTS);
+
+            long startedAt = System.nanoTime();
+            try (Recording recording = new Recording()) {
+                recording.enable(
+                                "jdk.ObjectAllocationSample")
+                        .withStackTrace();
+                recording.enable("jdk.ExecutionSample")
+                        .withPeriod(
+                                Duration.ofMillis(10));
+                recording.enable(
+                        "jdk.GarbageCollection");
+                recording.start();
+                runBroadcasts(
+                        channel,
+                        message,
+                        PROFILE_BROADCASTS);
+                recording.stop();
+                recording.dump(recordingPath);
+            }
+            long elapsedNanos =
+                    System.nanoTime() - startedAt;
+
+            ProfileSummary summary =
+                    summarize(
+                            recordingPath,
+                            elapsedNanos);
+            Files.writeString(
+                    summaryPath,
+                    summary.format());
+
+            System.out.println(
+                    "BROADCAST_JFR "
+                            + summary.format()
+                            .replace(
+                                    System.lineSeparator(),
+                                    " "));
+            assertTrue(
+                    summary.totalSampledBytes() > 0L);
+            assertTrue(
+                    summary.serverMessageSampledBytes()
+                            > 0L);
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private static ServerMessage representativeMessage() {
+        ServerMessage message =
+                new ServerMessage(1_234);
+        message.appendString("room-cycle-broadcast");
+        message.appendRawBytes(new byte[1_024]);
+        return message;
+    }
+
+    private static void runBroadcasts(
+            EmbeddedChannel channel,
+            ServerMessage message,
+            int broadcasts) {
+        for (int broadcast = 0;
+             broadcast < broadcasts;
+             broadcast++) {
+            for (int recipient = 0;
+                 recipient < RECIPIENTS;
+                 recipient++) {
+                assertTrue(
+                        channel.writeOutbound(message));
+                ByteBuf encoded = channel.readOutbound();
+                blackhole += encoded.getByte(
+                        encoded.readerIndex());
+                encoded.release();
+            }
+        }
+    }
+
+    private static ProfileSummary summarize(
+            Path recordingPath,
+            long elapsedNanos) throws Exception {
+        long totalSampledBytes = 0L;
+        long serverMessageSampledBytes = 0L;
+        long allocationSamples = 0L;
+        long serverMessageSamples = 0L;
+        long executionSamples = 0L;
+        long serverMessageExecutionSamples = 0L;
+        long garbageCollections = 0L;
+
+        List<RecordedEvent> events =
+                RecordingFile.readAllEvents(
+                        recordingPath);
+        for (RecordedEvent event : events) {
+            switch (event.getEventType().getName()) {
+                case "jdk.ObjectAllocationSample" -> {
+                    long weight = event.getLong("weight");
+                    totalSampledBytes += weight;
+                    allocationSamples++;
+                    if (hasServerMessageFrame(event)) {
+                        serverMessageSampledBytes += weight;
+                        serverMessageSamples++;
+                    }
+                }
+                case "jdk.ExecutionSample" -> {
+                    executionSamples++;
+                    if (hasServerMessageFrame(event)) {
+                        serverMessageExecutionSamples++;
+                    }
+                }
+                case "jdk.GarbageCollection" ->
+                        garbageCollections++;
+                default -> {
+                }
+            }
+        }
+
+        return new ProfileSummary(
+                PROFILE_BROADCASTS,
+                RECIPIENTS,
+                elapsedNanos / 1_000_000D,
+                totalSampledBytes,
+                serverMessageSampledBytes,
+                allocationSamples,
+                serverMessageSamples,
+                executionSamples,
+                serverMessageExecutionSamples,
+                garbageCollections);
+    }
+
+    private static boolean hasServerMessageFrame(
+            RecordedEvent event) {
+        if (event.getStackTrace() == null) {
+            return false;
+        }
+        for (RecordedFrame frame
+                : event.getStackTrace().getFrames()) {
+            String type =
+                    frame.getMethod()
+                            .getType()
+                            .getName();
+            if (type.equals(
+                    "com.eu.habbo.messages.ServerMessage")
+                    || type.equals(
+                    "com.eu.habbo.networking.gameserver."
+                            + "encoders.GameServerMessageEncoder")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private record ProfileSummary(
+            int broadcasts,
+            int recipients,
+            double elapsedMs,
+            long totalSampledBytes,
+            long serverMessageSampledBytes,
+            long allocationSamples,
+            long serverMessageSamples,
+            long executionSamples,
+            long serverMessageExecutionSamples,
+            long garbageCollections) {
+
+        String format() {
+            return String.format(
+                    Locale.ROOT,
+                    "broadcasts=%d%n"
+                            + "recipients=%d%n"
+                            + "encodedFrames=%d%n"
+                            + "elapsedMs=%.3f%n"
+                            + "totalSampledBytes=%d%n"
+                            + "serverMessageSampledBytes=%d%n"
+                            + "allocationSamples=%d%n"
+                            + "serverMessageSamples=%d%n"
+                            + "executionSamples=%d%n"
+                            + "serverMessageExecutionSamples=%d%n"
+                            + "garbageCollections=%d%n",
+                    broadcasts,
+                    recipients,
+                    broadcasts * recipients,
+                    elapsedMs,
+                    totalSampledBytes,
+                    serverMessageSampledBytes,
+                    allocationSamples,
+                    serverMessageSamples,
+                    executionSamples,
+                    serverMessageExecutionSamples,
+                    garbageCollections);
+        }
+    }
+}

--- a/docs/performance/broadcast-jfr-profile.md
+++ b/docs/performance/broadcast-jfr-profile.md
@@ -1,0 +1,40 @@
+# Broadcast JFR profile
+
+This profile measures the established room-broadcast encoding path with one
+representative 1,024-byte `ServerMessage`, 50 recipients, and 5,000 broadcasts.
+It uses the real `GameServerMessageEncoder` through Netty's
+`EmbeddedChannel`, producing 250,000 recipient frames.
+
+Run it from the repository root with JDK 25:
+
+```bash
+mvn -f Emulator/pom.xml test \
+  -Dtest=BroadcastJfrProfileTest \
+  -Dpolaris.profile.broadcast=true
+```
+
+The recording and text summary are written to:
+
+- `Emulator/target/profiles/broadcast-baseline.jfr`
+- `Emulator/target/profiles/broadcast-baseline.txt`
+
+## Baseline
+
+Captured on 2026-07-20 from commit `d9fe1232` with Temurin 25.0.3+9:
+
+| Measurement | Value |
+| --- | ---: |
+| Broadcasts | 5,000 |
+| Recipients per broadcast | 50 |
+| Encoded frames | 250,000 |
+| Elapsed recording window | 146.637 ms |
+| Total sampled allocation | 478,218,808 bytes |
+| `ServerMessage` / encoder sampled allocation | 317,071,848 bytes |
+| Allocation samples | 371 |
+| `ServerMessage` / encoder allocation samples | 322 |
+| Garbage collections | 3 |
+
+About 66% of sampled allocation was attributed to the message/encoder stack.
+This confirms the T2.1 serialize-once candidate. The same harness must be run
+after the internal broadcast path changes; public `ServerMessage.get()`
+defensive-copy behavior is outside the optimization and must remain unchanged.


### PR DESCRIPTION
Adds an opt-in JFR harness for the real 50-recipient message encoder path and records the current allocation baseline. The profile attributes roughly 317 MB of 478 MB sampled allocation to ServerMessage encoding across 250,000 frames.