### PR TITLE
refactor(net): share broadcast packet frames

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
@@ -5,11 +5,15 @@ import com.eu.habbo.crypto.HabboEncryption;
 import com.eu.habbo.habbohotel.LatencyTracker;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.ServerMessageFrame;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.monitoring.EmulatorNetworkStats;
 import com.eu.habbo.plugin.PluginManager;
 import com.eu.habbo.plugin.events.emulator.OutgoingPacketEvent;
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
+import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,17 +119,21 @@ public class GameClient {
             }
 
             PluginManager plugins = Emulator.getPluginManager();
+            boolean eventsRegistered = plugins.isRegistered(
+                    OutgoingPacketEvent.class,
+                    false);
             response = this.applyOutgoingPacketEvent(
                     response,
                     plugins,
-                    plugins.isRegistered(
-                            OutgoingPacketEvent.class,
-                            false));
+                    eventsRegistered);
             if (response == null) {
                 return;
             }
 
-            this.channel.write(response, this.channel.voidPromise());
+            this.writeResponse(
+                    response,
+                    !eventsRegistered,
+                    true);
             this.channel.flush();
         }
     }
@@ -149,7 +157,10 @@ public class GameClient {
                     continue;
                 }
 
-                this.channel.write(response);
+                this.writeResponse(
+                        response,
+                        !eventsRegistered,
+                        false);
             }
 
             this.channel.flush();
@@ -175,6 +186,40 @@ public class GameClient {
         return event.hasCustomMessage()
                 ? event.getCustomMessage()
                 : response;
+    }
+
+    private void writeResponse(
+            ServerMessage response,
+            boolean sharedBroadcastAllowed,
+            boolean useVoidPromise) {
+        if (!sharedBroadcastAllowed
+                || !ServerMessageFrame.isBroadcastPrepared(response)) {
+            if (useVoidPromise) {
+                this.channel.write(
+                        response,
+                        this.channel.voidPromise());
+            } else {
+                this.channel.write(response);
+            }
+            return;
+        }
+
+        ByteBuf frame =
+                ServerMessageFrame.retainedDuplicate(response);
+        try {
+            EmulatorNetworkStats.recordOutgoing(
+                    frame.readableBytes());
+            if (useVoidPromise) {
+                this.channel.write(
+                        frame,
+                        this.channel.voidPromise());
+            } else {
+                this.channel.write(frame);
+            }
+        } catch (RuntimeException | Error exception) {
+            ReferenceCountUtil.safeRelease(frame);
+            throw exception;
+        }
     }
 	
 	public void sendKeepAlive() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomMessagingManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomMessagingManager.java
@@ -2,6 +2,7 @@ package com.eu.habbo.habbohotel.rooms;
 
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.ServerMessageFrame;
 import com.eu.habbo.messages.outgoing.generic.alerts.GenericAlertComposer;
 
 import java.util.ArrayList;
@@ -24,6 +25,8 @@ public class RoomMessagingManager {
      * Sends a message to all Habbos in the room.
      */
     public void sendComposer(ServerMessage message) {
+        prepareBroadcast(message);
+
         for (Habbo habbo : this.room.getHabbos()) {
             if (habbo.getClient() == null) {
                 continue;
@@ -46,6 +49,7 @@ public class RoomMessagingManager {
             }
 
             responses.add(message);
+            prepareBroadcast(message);
         }
 
         if (responses.isEmpty()) {
@@ -65,6 +69,8 @@ public class RoomMessagingManager {
      * Sends a message to all Habbos with rights in the room.
      */
     public void sendComposerToHabbosWithRights(ServerMessage message) {
+        prepareBroadcast(message);
+
         for (Habbo habbo : this.room.getHabbos()) {
             if (this.room.hasRights(habbo)) {
                 habbo.getClient().sendResponse(message);
@@ -78,6 +84,8 @@ public class RoomMessagingManager {
      * Sends a pet chat message to all Habbos who don't ignore pets.
      */
     public void petChat(ServerMessage message) {
+        prepareBroadcast(message);
+
         for (Habbo habbo : this.room.getHabbos()) {
             if (!habbo.getHabboStats().ignorePets) {
                 habbo.getClient().sendResponse(message);
@@ -92,6 +100,8 @@ public class RoomMessagingManager {
         if (message == null) {
             return;
         }
+
+        prepareBroadcast(message);
 
         for (Habbo habbo : this.room.getHabbos()) {
             if (habbo == null) {
@@ -110,5 +120,11 @@ public class RoomMessagingManager {
      */
     public void alert(String message) {
         this.sendComposer(new GenericAlertComposer(message).compose());
+    }
+
+    private static void prepareBroadcast(ServerMessage message) {
+        if (message != null) {
+            ServerMessageFrame.prepareBroadcast(message);
+        }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/ServerMessage.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/ServerMessage.java
@@ -17,6 +17,8 @@ public class ServerMessage {
     private ByteBufOutputStream stream;
     private ByteBuf channelBuffer;
     private MessageComposer composer;
+    private volatile boolean broadcastPrepared;
+    private int framedWriterIndex = -1;
 
     public ServerMessage() {
 
@@ -177,10 +179,33 @@ public class ServerMessage {
         return this.header;
     }
 
-    public ByteBuf get() {
-        this.channelBuffer.setInt(0, this.channelBuffer.writerIndex() - 4);
-
+    public synchronized ByteBuf get() {
+        this.frameLength();
         return this.channelBuffer.copy();
+    }
+
+    synchronized void prepareBroadcast() {
+        this.broadcastPrepared = true;
+        this.frameLength();
+    }
+
+    synchronized ByteBuf retainedDuplicateForBroadcast() {
+        this.frameLength();
+        return this.channelBuffer.retainedDuplicate();
+    }
+
+    boolean isBroadcastPrepared() {
+        return this.broadcastPrepared;
+    }
+
+    private void frameLength() {
+        int writerIndex = this.channelBuffer.writerIndex();
+        if (this.framedWriterIndex == writerIndex) {
+            return;
+        }
+
+        this.channelBuffer.setInt(0, writerIndex - 4);
+        this.framedWriterIndex = writerIndex;
     }
 
     public MessageComposer getComposer() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/ServerMessageFrame.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/ServerMessageFrame.java
@@ -1,0 +1,29 @@
+package com.eu.habbo.messages;
+
+import io.netty.buffer.ByteBuf;
+
+import java.util.Objects;
+
+/**
+ * Prepares one packet frame for reuse across broadcast recipients while
+ * retaining independent Netty reader indexes.
+ */
+public final class ServerMessageFrame {
+
+    private ServerMessageFrame() {
+    }
+
+    public static void prepareBroadcast(ServerMessage message) {
+        Objects.requireNonNull(message, "message").prepareBroadcast();
+    }
+
+    public static boolean isBroadcastPrepared(ServerMessage message) {
+        return message != null && message.isBroadcastPrepared();
+    }
+
+    public static ByteBuf retainedDuplicate(ServerMessage message) {
+        return Objects.requireNonNull(
+                message,
+                "message").retainedDuplicateForBroadcast();
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
@@ -3,9 +3,11 @@ package com.eu.habbo.habbohotel.gameclients;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.core.CryptoConfig;
 import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.ServerMessageFrame;
 import com.eu.habbo.plugin.PluginManager;
 import com.eu.habbo.plugin.events.emulator.OutgoingPacketEvent;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.buffer.ByteBuf;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +16,7 @@ import org.mockito.ArgumentCaptor;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
@@ -152,6 +155,70 @@ class GameClientOutgoingPacketCompatibilityTest {
         assertSame(first, this.channel.readOutbound());
         assertSame(second, this.channel.readOutbound());
         assertNull(this.channel.readOutbound());
+    }
+
+    @Test
+    void preparedBroadcastWritesTheSharedFrameWithoutSubscribers() {
+        ServerMessage response =
+                new ServerMessage(100);
+        response.appendInt(77);
+        ServerMessageFrame.prepareBroadcast(response);
+        ByteBuf expected = response.get();
+
+        this.client.sendResponse(response);
+
+        ByteBuf actual = this.channel.readOutbound();
+        try {
+            assertEquals(expected, actual);
+        } finally {
+            expected.release();
+            actual.release();
+        }
+    }
+
+    @Test
+    void preparedBroadcastStillUsesPacketEventsWhenRegistered() {
+        org.mockito.Mockito.when(this.pluginManager.isRegistered(
+                OutgoingPacketEvent.class,
+                false)).thenReturn(true);
+        ServerMessage response =
+                new ServerMessage(100);
+        ServerMessageFrame.prepareBroadcast(response);
+
+        this.client.sendResponse(response);
+
+        verify(this.pluginManager).fireEvent(
+                any(OutgoingPacketEvent.class));
+        assertSame(response, this.channel.readOutbound());
+    }
+
+    @Test
+    void preparedBroadcastBatchWritesEachSharedFrame() {
+        ServerMessage first =
+                new ServerMessage(100);
+        first.appendInt(1);
+        ServerMessage second =
+                new ServerMessage(101);
+        second.appendInt(2);
+        ServerMessageFrame.prepareBroadcast(first);
+        ServerMessageFrame.prepareBroadcast(second);
+        ByteBuf expectedFirst = first.get();
+        ByteBuf expectedSecond = second.get();
+
+        this.client.sendResponses(new ArrayList<>(
+                java.util.List.of(first, second)));
+
+        ByteBuf actualFirst = this.channel.readOutbound();
+        ByteBuf actualSecond = this.channel.readOutbound();
+        try {
+            assertEquals(expectedFirst, actualFirst);
+            assertEquals(expectedSecond, actualSecond);
+        } finally {
+            expectedFirst.release();
+            expectedSecond.release();
+            actualFirst.release();
+            actualSecond.release();
+        }
     }
 
     private static Field field(String name) throws Exception {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomMessagingManagerBatchTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomMessagingManagerBatchTest.java
@@ -3,6 +3,7 @@ package com.eu.habbo.habbohotel.rooms;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.ServerMessageFrame;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -12,6 +13,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -48,6 +50,10 @@ class RoomMessagingManagerBatchTest {
         assertEquals(
                 List.of(first, second),
                 capturedBatch(secondClient));
+        assertTrue(
+                ServerMessageFrame.isBroadcastPrepared(first));
+        assertTrue(
+                ServerMessageFrame.isBroadcastPrepared(second));
     }
 
     @Test

--- a/Emulator/src/test/java/com/eu/habbo/messages/SharedBroadcastFrameTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/SharedBroadcastFrameTest.java
@@ -1,0 +1,76 @@
+package com.eu.habbo.messages;
+
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SharedBroadcastFrameTest {
+
+    @Test
+    void retainedRecipientFramesSharePreparedStorage()
+            throws Exception {
+        ServerMessage message =
+                new ServerMessage(456);
+        message.appendInt(123);
+
+        ServerMessageFrame.prepareBroadcast(message);
+        ByteBuf first =
+                ServerMessageFrame.retainedDuplicate(
+                        message);
+        ByteBuf second =
+                ServerMessageFrame.retainedDuplicate(
+                        message);
+        try {
+            assertTrue(
+                    ServerMessageFrame.isBroadcastPrepared(
+                            message));
+            assertSame(first.unwrap(), second.unwrap());
+            assertEquals(
+                    first.readableBytes() - 4,
+                    first.getInt(0));
+            assertEquals(456, first.getUnsignedShort(4));
+            assertEquals(123, first.getInt(6));
+
+            first.readerIndex(6);
+            assertEquals(0, second.readerIndex());
+        } finally {
+            first.release();
+            second.release();
+        }
+    }
+
+    @Test
+    void appendAfterPreparationUpdatesTheSharedFrame() {
+        ServerMessage message =
+                new ServerMessage(456);
+        ServerMessageFrame.prepareBroadcast(message);
+        message.appendString("later");
+
+        ByteBuf frame =
+                ServerMessageFrame.retainedDuplicate(
+                        message);
+        try {
+            assertEquals(
+                    frame.readableBytes() - 4,
+                    frame.getInt(0));
+            assertEquals(
+                    "later",
+                    readString(frame, 6));
+        } finally {
+            frame.release();
+        }
+    }
+
+    private static String readString(
+            ByteBuf frame,
+            int index) {
+        int length = frame.getUnsignedShort(index);
+        return frame.toString(
+                index + 2,
+                length,
+                java.nio.charset.StandardCharsets.UTF_8);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/BroadcastJfrProfileTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/BroadcastJfrProfileTest.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.networking.gameserver;
 
 import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.ServerMessageFrame;
 import com.eu.habbo.networking.gameserver.encoders.GameServerMessageEncoder;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -35,22 +36,32 @@ class BroadcastJfrProfileTest {
         Path profileDirectory =
                 Path.of("target", "profiles");
         Files.createDirectories(profileDirectory);
+        boolean sharedFrame =
+                Boolean.getBoolean(
+                        "polaris.profile.broadcast.shared");
+        String profileName = sharedFrame
+                ? "broadcast-shared-frame"
+                : "broadcast-baseline";
         Path recordingPath =
                 profileDirectory.resolve(
-                        "broadcast-baseline.jfr");
+                        profileName + ".jfr");
         Path summaryPath =
                 profileDirectory.resolve(
-                        "broadcast-baseline.txt");
+                        profileName + ".txt");
 
         EmbeddedChannel channel =
                 new EmbeddedChannel(
                         new GameServerMessageEncoder());
         ServerMessage message = representativeMessage();
+        if (sharedFrame) {
+            ServerMessageFrame.prepareBroadcast(message);
+        }
         try {
             runBroadcasts(
                     channel,
                     message,
-                    WARMUP_BROADCASTS);
+                    WARMUP_BROADCASTS,
+                    sharedFrame);
 
             long startedAt = System.nanoTime();
             try (Recording recording = new Recording()) {
@@ -66,7 +77,8 @@ class BroadcastJfrProfileTest {
                 runBroadcasts(
                         channel,
                         message,
-                        PROFILE_BROADCASTS);
+                        PROFILE_BROADCASTS,
+                        sharedFrame);
                 recording.stop();
                 recording.dump(recordingPath);
             }
@@ -108,7 +120,8 @@ class BroadcastJfrProfileTest {
     private static void runBroadcasts(
             EmbeddedChannel channel,
             ServerMessage message,
-            int broadcasts) {
+            int broadcasts,
+            boolean sharedFrame) {
         for (int broadcast = 0;
              broadcast < broadcasts;
              broadcast++) {
@@ -116,7 +129,12 @@ class BroadcastJfrProfileTest {
                  recipient < RECIPIENTS;
                  recipient++) {
                 assertTrue(
-                        channel.writeOutbound(message));
+                        channel.writeOutbound(
+                                sharedFrame
+                                        ? ServerMessageFrame
+                                                .retainedDuplicate(
+                                                        message)
+                                        : message));
                 ByteBuf encoded = channel.readOutbound();
                 blackhole += encoded.getByte(
                         encoded.readerIndex());
@@ -189,6 +207,8 @@ class BroadcastJfrProfileTest {
                             .getName();
             if (type.equals(
                     "com.eu.habbo.messages.ServerMessage")
+                    || type.equals(
+                    "com.eu.habbo.messages.ServerMessageFrame")
                     || type.equals(
                     "com.eu.habbo.networking.gameserver."
                             + "encoders.GameServerMessageEncoder")) {

--- a/docs/performance/broadcast-jfr-profile.md
+++ b/docs/performance/broadcast-jfr-profile.md
@@ -18,6 +18,9 @@ The recording and text summary are written to:
 - `Emulator/target/profiles/broadcast-baseline.jfr`
 - `Emulator/target/profiles/broadcast-baseline.txt`
 
+Add `-Dpolaris.profile.broadcast.shared=true` to exercise the shared-frame
+broadcast path. Its artifacts use the `broadcast-shared-frame` prefix.
+
 ## Baseline
 
 Captured on 2026-07-20 from commit `d9fe1232` with Temurin 25.0.3+9:
@@ -38,3 +41,25 @@ About 66% of sampled allocation was attributed to the message/encoder stack.
 This confirms the T2.1 serialize-once candidate. The same harness must be run
 after the internal broadcast path changes; public `ServerMessage.get()`
 defensive-copy behavior is outside the optimization and must remain unchanged.
+
+## Shared-frame result
+
+Captured on 2026-07-20 with Temurin 25.0.3+9:
+
+| Measurement | Baseline | Shared frame |
+| --- | ---: | ---: |
+| Broadcasts | 5,000 | 5,000 |
+| Recipients per broadcast | 50 | 50 |
+| Encoded frames | 250,000 | 250,000 |
+| Elapsed recording window | 146.637 ms | 91.046 ms |
+| Total sampled allocation | 478,218,808 bytes | 136,879,312 bytes |
+| `ServerMessage` / encoder sampled allocation | 317,071,848 bytes | 13,438,248 bytes |
+| Allocation samples | 371 | 82 |
+| `ServerMessage` / encoder allocation samples | 322 | 19 |
+| Garbage collections | 3 | 0 |
+
+The shared-frame run reduced total sampled allocation by about 71% and
+message/encoder-attributed sampled allocation by about 96%. Room broadcasts
+prepare one frame and give each recipient an independently retained duplicate.
+Ordinary sends and plugin-observed outgoing packets keep the established
+`ServerMessage` encoder path.


### PR DESCRIPTION
Shares one prepared packet frame across room-broadcast recipients using independently retained Netty duplicates.

Keeps ordinary sends and plugin-observed outgoing packets on the established encoder path, and records the JFR comparison in the performance guide.