### PR TITLE
refactor(net): optimize measured broadcast path

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
@@ -134,7 +134,7 @@ public class GameClient {
                     response,
                     !eventsRegistered,
                     true);
-            this.channel.flush();
+            this.flushResponseWrites();
         }
     }
 
@@ -163,7 +163,7 @@ public class GameClient {
                         false);
             }
 
-            this.channel.flush();
+            this.flushResponseWrites();
         }
     }
 
@@ -219,6 +219,13 @@ public class GameClient {
         } catch (RuntimeException | Error exception) {
             ReferenceCountUtil.safeRelease(frame);
             throw exception;
+        }
+    }
+
+    private void flushResponseWrites() {
+        if (!GameClientFlushBatch.deferFlush(
+                this.channel)) {
+            this.channel.flush();
         }
     }
 	

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
@@ -5,11 +5,15 @@ import com.eu.habbo.crypto.HabboEncryption;
 import com.eu.habbo.habbohotel.LatencyTracker;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.ServerMessageFrame;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.monitoring.EmulatorNetworkStats;
 import com.eu.habbo.plugin.PluginManager;
 import com.eu.habbo.plugin.events.emulator.OutgoingPacketEvent;
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
+import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,17 +119,21 @@ public class GameClient {
             }
 
             PluginManager plugins = Emulator.getPluginManager();
+            boolean eventsRegistered = plugins.isRegistered(
+                    OutgoingPacketEvent.class,
+                    false);
             response = this.applyOutgoingPacketEvent(
                     response,
                     plugins,
-                    plugins.isRegistered(
-                            OutgoingPacketEvent.class,
-                            false));
+                    eventsRegistered);
             if (response == null) {
                 return;
             }
 
-            this.channel.write(response, this.channel.voidPromise());
+            this.writeResponse(
+                    response,
+                    !eventsRegistered,
+                    true);
             this.channel.flush();
         }
     }
@@ -149,7 +157,10 @@ public class GameClient {
                     continue;
                 }
 
-                this.channel.write(response);
+                this.writeResponse(
+                        response,
+                        !eventsRegistered,
+                        false);
             }
 
             this.channel.flush();
@@ -175,6 +186,40 @@ public class GameClient {
         return event.hasCustomMessage()
                 ? event.getCustomMessage()
                 : response;
+    }
+
+    private void writeResponse(
+            ServerMessage response,
+            boolean sharedBroadcastAllowed,
+            boolean useVoidPromise) {
+        if (!sharedBroadcastAllowed
+                || !ServerMessageFrame.isBroadcastPrepared(response)) {
+            if (useVoidPromise) {
+                this.channel.write(
+                        response,
+                        this.channel.voidPromise());
+            } else {
+                this.channel.write(response);
+            }
+            return;
+        }
+
+        ByteBuf frame =
+                ServerMessageFrame.retainedDuplicate(response);
+        try {
+            EmulatorNetworkStats.recordOutgoing(
+                    frame.readableBytes());
+            if (useVoidPromise) {
+                this.channel.write(
+                        frame,
+                        this.channel.voidPromise());
+            } else {
+                this.channel.write(frame);
+            }
+        } catch (RuntimeException | Error exception) {
+            ReferenceCountUtil.safeRelease(frame);
+            throw exception;
+        }
     }
 	
 	public void sendKeepAlive() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClientFlushBatch.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClientFlushBatch.java
@@ -1,0 +1,101 @@
+package com.eu.habbo.habbohotel.gameclients;
+
+import io.netty.channel.Channel;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+/**
+ * Coalesces game-client channel flushes on the current thread while preserving
+ * the timing and order of each write.
+ */
+public final class GameClientFlushBatch implements AutoCloseable {
+    private static final ThreadLocal<State> CURRENT =
+            new ThreadLocal<>();
+
+    private final State state;
+    private final Thread owner;
+    private boolean closed;
+
+    private GameClientFlushBatch(State state) {
+        this.state = state;
+        this.owner = Thread.currentThread();
+    }
+
+    public static GameClientFlushBatch open() {
+        State state = CURRENT.get();
+        if (state == null) {
+            state = new State();
+            CURRENT.set(state);
+        }
+        state.depth++;
+        return new GameClientFlushBatch(state);
+    }
+
+    static boolean deferFlush(Channel channel) {
+        State state = CURRENT.get();
+        if (state == null || state.depth == 0) {
+            return false;
+        }
+
+        state.channels.add(channel);
+        return true;
+    }
+
+    @Override
+    public void close() {
+        if (this.closed) {
+            return;
+        }
+        if (Thread.currentThread() != this.owner
+                || CURRENT.get() != this.state) {
+            throw new IllegalStateException(
+                    "Flush batches must close on their opening thread");
+        }
+
+        this.closed = true;
+        this.state.depth--;
+        if (this.state.depth > 0) {
+            return;
+        }
+
+        RuntimeException runtimeFailure = null;
+        Error errorFailure = null;
+        for (Channel channel : this.state.channels) {
+            try {
+                channel.flush();
+            } catch (RuntimeException exception) {
+                if (runtimeFailure == null) {
+                    runtimeFailure = exception;
+                } else {
+                    runtimeFailure.addSuppressed(exception);
+                }
+            } catch (Error error) {
+                if (errorFailure == null) {
+                    errorFailure = error;
+                } else {
+                    errorFailure.addSuppressed(error);
+                }
+            }
+        }
+        this.state.channels.clear();
+
+        if (errorFailure != null) {
+            if (runtimeFailure != null) {
+                errorFailure.addSuppressed(runtimeFailure);
+            }
+            throw errorFailure;
+        }
+        if (runtimeFailure != null) {
+            throw runtimeFailure;
+        }
+    }
+
+    private static final class State {
+        private final Set<Channel> channels =
+                Collections.newSetFromMap(
+                        new IdentityHashMap<>());
+        private int depth;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomCycleManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomCycleManager.java
@@ -3,6 +3,7 @@ package com.eu.habbo.habbohotel.rooms;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.achievements.AchievementManager;
 import com.eu.habbo.habbohotel.bots.Bot;
+import com.eu.habbo.habbohotel.gameclients.GameClientFlushBatch;
 import com.eu.habbo.habbohotel.items.ICycleable;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.pets.Pet;
@@ -50,6 +51,13 @@ public class RoomCycleManager {
     }
 
     public void cycle() {
+        try (GameClientFlushBatch ignored =
+                     GameClientFlushBatch.open()) {
+            this.cycleWithCoalescedFlushes();
+        }
+    }
+
+    private void cycleWithCoalescedFlushes() {
         this.cycleOdd = !this.cycleOdd;
         this.cycleTimestamp = System.currentTimeMillis();
         final boolean[] foundRightHolder = {false};

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomMessagingManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomMessagingManager.java
@@ -2,6 +2,7 @@ package com.eu.habbo.habbohotel.rooms;
 
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.ServerMessageFrame;
 import com.eu.habbo.messages.outgoing.generic.alerts.GenericAlertComposer;
 
 import java.util.ArrayList;
@@ -24,6 +25,8 @@ public class RoomMessagingManager {
      * Sends a message to all Habbos in the room.
      */
     public void sendComposer(ServerMessage message) {
+        prepareBroadcast(message);
+
         for (Habbo habbo : this.room.getHabbos()) {
             if (habbo.getClient() == null) {
                 continue;
@@ -46,6 +49,7 @@ public class RoomMessagingManager {
             }
 
             responses.add(message);
+            prepareBroadcast(message);
         }
 
         if (responses.isEmpty()) {
@@ -65,6 +69,8 @@ public class RoomMessagingManager {
      * Sends a message to all Habbos with rights in the room.
      */
     public void sendComposerToHabbosWithRights(ServerMessage message) {
+        prepareBroadcast(message);
+
         for (Habbo habbo : this.room.getHabbos()) {
             if (this.room.hasRights(habbo)) {
                 habbo.getClient().sendResponse(message);
@@ -78,6 +84,8 @@ public class RoomMessagingManager {
      * Sends a pet chat message to all Habbos who don't ignore pets.
      */
     public void petChat(ServerMessage message) {
+        prepareBroadcast(message);
+
         for (Habbo habbo : this.room.getHabbos()) {
             if (!habbo.getHabboStats().ignorePets) {
                 habbo.getClient().sendResponse(message);
@@ -92,6 +100,8 @@ public class RoomMessagingManager {
         if (message == null) {
             return;
         }
+
+        prepareBroadcast(message);
 
         for (Habbo habbo : this.room.getHabbos()) {
             if (habbo == null) {
@@ -110,5 +120,11 @@ public class RoomMessagingManager {
      */
     public void alert(String message) {
         this.sendComposer(new GenericAlertComposer(message).compose());
+    }
+
+    private static void prepareBroadcast(ServerMessage message) {
+        if (message != null) {
+            ServerMessageFrame.prepareBroadcast(message);
+        }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/ServerMessage.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/ServerMessage.java
@@ -17,6 +17,8 @@ public class ServerMessage {
     private ByteBufOutputStream stream;
     private ByteBuf channelBuffer;
     private MessageComposer composer;
+    private volatile boolean broadcastPrepared;
+    private int framedWriterIndex = -1;
 
     public ServerMessage() {
 
@@ -177,10 +179,33 @@ public class ServerMessage {
         return this.header;
     }
 
-    public ByteBuf get() {
-        this.channelBuffer.setInt(0, this.channelBuffer.writerIndex() - 4);
-
+    public synchronized ByteBuf get() {
+        this.frameLength();
         return this.channelBuffer.copy();
+    }
+
+    synchronized void prepareBroadcast() {
+        this.broadcastPrepared = true;
+        this.frameLength();
+    }
+
+    synchronized ByteBuf retainedDuplicateForBroadcast() {
+        this.frameLength();
+        return this.channelBuffer.retainedDuplicate();
+    }
+
+    boolean isBroadcastPrepared() {
+        return this.broadcastPrepared;
+    }
+
+    private void frameLength() {
+        int writerIndex = this.channelBuffer.writerIndex();
+        if (this.framedWriterIndex == writerIndex) {
+            return;
+        }
+
+        this.channelBuffer.setInt(0, writerIndex - 4);
+        this.framedWriterIndex = writerIndex;
     }
 
     public MessageComposer getComposer() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/ServerMessageFrame.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/ServerMessageFrame.java
@@ -1,0 +1,29 @@
+package com.eu.habbo.messages;
+
+import io.netty.buffer.ByteBuf;
+
+import java.util.Objects;
+
+/**
+ * Prepares one packet frame for reuse across broadcast recipients while
+ * retaining independent Netty reader indexes.
+ */
+public final class ServerMessageFrame {
+
+    private ServerMessageFrame() {
+    }
+
+    public static void prepareBroadcast(ServerMessage message) {
+        Objects.requireNonNull(message, "message").prepareBroadcast();
+    }
+
+    public static boolean isBroadcastPrepared(ServerMessage message) {
+        return message != null && message.isBroadcastPrepared();
+    }
+
+    public static ByteBuf retainedDuplicate(ServerMessage message) {
+        return Objects.requireNonNull(
+                message,
+                "message").retainedDuplicateForBroadcast();
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -176,6 +177,46 @@ class GameClientOutgoingPacketCompatibilityTest {
                 java.util.List.of(
                         new ServerMessage(100),
                         new ServerMessage(101))));
+
+        assertEquals(1, this.flushCounter.flushes);
+    }
+
+    @Test
+    void flushBatchWritesAndPublishesEventsBeforeOneClosingFlush() {
+        org.mockito.Mockito.when(this.pluginManager.isRegistered(
+                OutgoingPacketEvent.class,
+                false)).thenReturn(true);
+        ServerMessage first = new ServerMessage(100);
+        ServerMessage second = new ServerMessage(101);
+
+        try (GameClientFlushBatch ignored =
+                     GameClientFlushBatch.open()) {
+            this.client.sendResponse(first);
+            this.client.sendResponse(second);
+
+            assertEquals(0, this.flushCounter.flushes);
+            verify(this.pluginManager, times(2)).fireEvent(
+                    any(OutgoingPacketEvent.class));
+        }
+
+        assertEquals(1, this.flushCounter.flushes);
+        assertSame(first, this.channel.readOutbound());
+        assertSame(second, this.channel.readOutbound());
+    }
+
+    @Test
+    void flushBatchClosesAndFlushesWhenSendingFails() {
+        assertThrows(
+                IllegalStateException.class,
+                () -> {
+                    try (GameClientFlushBatch ignored =
+                                 GameClientFlushBatch.open()) {
+                        this.client.sendResponse(
+                                new ServerMessage(100));
+                        throw new IllegalStateException(
+                                "expected");
+                    }
+                });
 
         assertEquals(1, this.flushCounter.flushes);
     }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
@@ -3,9 +3,11 @@ package com.eu.habbo.habbohotel.gameclients;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.core.CryptoConfig;
 import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.ServerMessageFrame;
 import com.eu.habbo.plugin.PluginManager;
 import com.eu.habbo.plugin.events.emulator.OutgoingPacketEvent;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.buffer.ByteBuf;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +16,7 @@ import org.mockito.ArgumentCaptor;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
@@ -152,6 +155,70 @@ class GameClientOutgoingPacketCompatibilityTest {
         assertSame(first, this.channel.readOutbound());
         assertSame(second, this.channel.readOutbound());
         assertNull(this.channel.readOutbound());
+    }
+
+    @Test
+    void preparedBroadcastWritesTheSharedFrameWithoutSubscribers() {
+        ServerMessage response =
+                new ServerMessage(100);
+        response.appendInt(77);
+        ServerMessageFrame.prepareBroadcast(response);
+        ByteBuf expected = response.get();
+
+        this.client.sendResponse(response);
+
+        ByteBuf actual = this.channel.readOutbound();
+        try {
+            assertEquals(expected, actual);
+        } finally {
+            expected.release();
+            actual.release();
+        }
+    }
+
+    @Test
+    void preparedBroadcastStillUsesPacketEventsWhenRegistered() {
+        org.mockito.Mockito.when(this.pluginManager.isRegistered(
+                OutgoingPacketEvent.class,
+                false)).thenReturn(true);
+        ServerMessage response =
+                new ServerMessage(100);
+        ServerMessageFrame.prepareBroadcast(response);
+
+        this.client.sendResponse(response);
+
+        verify(this.pluginManager).fireEvent(
+                any(OutgoingPacketEvent.class));
+        assertSame(response, this.channel.readOutbound());
+    }
+
+    @Test
+    void preparedBroadcastBatchWritesEachSharedFrame() {
+        ServerMessage first =
+                new ServerMessage(100);
+        first.appendInt(1);
+        ServerMessage second =
+                new ServerMessage(101);
+        second.appendInt(2);
+        ServerMessageFrame.prepareBroadcast(first);
+        ServerMessageFrame.prepareBroadcast(second);
+        ByteBuf expectedFirst = first.get();
+        ByteBuf expectedSecond = second.get();
+
+        this.client.sendResponses(new ArrayList<>(
+                java.util.List.of(first, second)));
+
+        ByteBuf actualFirst = this.channel.readOutbound();
+        ByteBuf actualSecond = this.channel.readOutbound();
+        try {
+            assertEquals(expectedFirst, actualFirst);
+            assertEquals(expectedSecond, actualSecond);
+        } finally {
+            expectedFirst.release();
+            expectedSecond.release();
+            actualFirst.release();
+            actualSecond.release();
+        }
     }
 
     private static Field field(String name) throws Exception {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientOutgoingPacketCompatibilityTest.java
@@ -6,8 +6,10 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.ServerMessageFrame;
 import com.eu.habbo.plugin.PluginManager;
 import com.eu.habbo.plugin.events.emulator.OutgoingPacketEvent;
-import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,7 @@ class GameClientOutgoingPacketCompatibilityTest {
     private Object originalCrypto;
     private Object originalPluginManager;
     private PluginManager pluginManager;
+    private FlushCountingHandler flushCounter;
     private EmbeddedChannel channel;
     private GameClient client;
 
@@ -52,7 +55,9 @@ class GameClientOutgoingPacketCompatibilityTest {
                 new CryptoConfig(false, "", "", ""));
         this.pluginManager = mock(PluginManager.class);
         this.pluginManagerField.set(null, this.pluginManager);
-        this.channel = new EmbeddedChannel();
+        this.flushCounter = new FlushCountingHandler();
+        this.channel = new EmbeddedChannel(
+                this.flushCounter);
         this.client = new GameClient(this.channel);
     }
 
@@ -158,6 +163,24 @@ class GameClientOutgoingPacketCompatibilityTest {
     }
 
     @Test
+    void singleResponseFlushesImmediately() {
+        this.client.sendResponse(
+                new ServerMessage(100));
+
+        assertEquals(1, this.flushCounter.flushes);
+    }
+
+    @Test
+    void responseBatchUsesOneFlush() {
+        this.client.sendResponses(new ArrayList<>(
+                java.util.List.of(
+                        new ServerMessage(100),
+                        new ServerMessage(101))));
+
+        assertEquals(1, this.flushCounter.flushes);
+    }
+
+    @Test
     void preparedBroadcastWritesTheSharedFrameWithoutSubscribers() {
         ServerMessage response =
                 new ServerMessage(100);
@@ -225,5 +248,17 @@ class GameClientOutgoingPacketCompatibilityTest {
         Field field = Emulator.class.getDeclaredField(name);
         field.setAccessible(true);
         return field;
+    }
+
+    private static final class FlushCountingHandler
+            extends ChannelOutboundHandlerAdapter {
+        private int flushes;
+
+        @Override
+        public void flush(ChannelHandlerContext context)
+                throws Exception {
+            this.flushes++;
+            context.flush();
+        }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomCycleFlushBatchTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomCycleFlushBatchTest.java
@@ -1,0 +1,103 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.CryptoConfig;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.plugin.PluginManager;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+class RoomCycleFlushBatchTest {
+    private Field runtimeField;
+    private Field cryptoField;
+    private Field pluginManagerField;
+    private Object originalRuntime;
+    private Object originalCrypto;
+    private Object originalPluginManager;
+    private EmbeddedChannel channel;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        this.runtimeField = field("polarisRuntime");
+        this.cryptoField = field("crypto");
+        this.pluginManagerField = field("pluginManager");
+        this.originalRuntime = this.runtimeField.get(null);
+        this.originalCrypto = this.cryptoField.get(null);
+        this.originalPluginManager =
+                this.pluginManagerField.get(null);
+        this.runtimeField.set(null, null);
+        this.cryptoField.set(
+                null,
+                new CryptoConfig(false, "", "", ""));
+        this.pluginManagerField.set(
+                null,
+                mock(PluginManager.class));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (this.channel != null) {
+            this.channel.finishAndReleaseAll();
+        }
+        this.pluginManagerField.set(
+                null,
+                this.originalPluginManager);
+        this.cryptoField.set(null, this.originalCrypto);
+        this.runtimeField.set(null, this.originalRuntime);
+    }
+
+    @Test
+    void cycleFlushesSequentialPacketWritesOnceAtItsBoundary() {
+        FlushCountingHandler flushCounter =
+                new FlushCountingHandler();
+        this.channel =
+                new EmbeddedChannel(flushCounter);
+        GameClient client = new GameClient(this.channel);
+        ServerMessage first = new ServerMessage(100);
+        ServerMessage second = new ServerMessage(101);
+        Room room = new Room(41, 7) {
+            @Override
+            public void sendComposer(ServerMessage ignored) {
+                client.sendResponse(first);
+                client.sendResponse(second);
+            }
+        };
+        room.scheduledComposers.add(
+                new ServerMessage(102));
+
+        new RoomCycleManager(room).cycle();
+
+        assertEquals(1, flushCounter.flushes);
+        assertSame(first, this.channel.readOutbound());
+        assertSame(second, this.channel.readOutbound());
+    }
+
+    private static Field field(String name) throws Exception {
+        Field field = Emulator.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field;
+    }
+
+    private static final class FlushCountingHandler
+            extends ChannelOutboundHandlerAdapter {
+        private int flushes;
+
+        @Override
+        public void flush(ChannelHandlerContext context)
+                throws Exception {
+            this.flushes++;
+            context.flush();
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomMessagingManagerBatchTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomMessagingManagerBatchTest.java
@@ -3,6 +3,7 @@ package com.eu.habbo.habbohotel.rooms;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.ServerMessageFrame;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -12,6 +13,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -48,6 +50,10 @@ class RoomMessagingManagerBatchTest {
         assertEquals(
                 List.of(first, second),
                 capturedBatch(secondClient));
+        assertTrue(
+                ServerMessageFrame.isBroadcastPrepared(first));
+        assertTrue(
+                ServerMessageFrame.isBroadcastPrepared(second));
     }
 
     @Test

--- a/Emulator/src/test/java/com/eu/habbo/messages/ServerMessageFrameCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/ServerMessageFrameCompatibilityTest.java
@@ -1,0 +1,144 @@
+package com.eu.habbo.messages;
+
+import com.eu.habbo.networking.gameserver.encoders.GameServerMessageEncoder;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class ServerMessageFrameCompatibilityTest {
+
+    @Test
+    void getReturnsAnIndependentDefensiveCopy() {
+        ServerMessage message = message();
+        ByteBuf first = message.get();
+        ByteBuf second = message.get();
+        try {
+            int original = second.getByte(8);
+            first.setByte(8, original + 1);
+
+            assertNotEquals(
+                    first.getByte(8),
+                    second.getByte(8));
+            ByteBuf third = message.get();
+            try {
+                assertEquals(
+                        original,
+                        third.getByte(8));
+            } finally {
+                third.release();
+            }
+        } finally {
+            first.release();
+            second.release();
+        }
+    }
+
+    @Test
+    void appendingAfterGetReframesWithoutMutatingOlderCopy() {
+        ServerMessage message =
+                new ServerMessage(321);
+        message.appendInt(7);
+        ByteBuf before = message.get();
+        try {
+            int beforeLength = before.getInt(0);
+            message.appendString("later");
+            ByteBuf after = message.get();
+            try {
+                assertEquals(
+                        beforeLength,
+                        before.getInt(0));
+                assertEquals(
+                        after.readableBytes() - 4,
+                        after.getInt(0));
+                assertEquals(
+                        beforeLength + 7,
+                        after.getInt(0));
+            } finally {
+                after.release();
+            }
+        } finally {
+            before.release();
+        }
+    }
+
+    @Test
+    void encoderWritesTheExactEstablishedFrame() {
+        ServerMessage message = message();
+        ByteBuf expected = message.get();
+        EmbeddedChannel channel =
+                new EmbeddedChannel(
+                        new GameServerMessageEncoder());
+        try {
+            channel.writeOutbound(message);
+            ByteBuf encoded = channel.readOutbound();
+            try {
+                assertEquals(expected, encoded);
+            } finally {
+                encoded.release();
+            }
+        } finally {
+            expected.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void concurrentReadsKeepLengthAndPayloadStable()
+            throws Exception {
+        ServerMessage message = message();
+        ExecutorService executor =
+                Executors.newFixedThreadPool(8);
+        try {
+            List<Callable<Void>> reads =
+                    new ArrayList<>();
+            for (int task = 0; task < 32; task++) {
+                reads.add(() -> {
+                    for (int iteration = 0;
+                         iteration < 100;
+                         iteration++) {
+                        ByteBuf frame = message.get();
+                        try {
+                            assertEquals(
+                                    frame.readableBytes() - 4,
+                                    frame.getInt(0));
+                            assertEquals(
+                                    4321,
+                                    frame.getUnsignedShort(4));
+                            assertEquals(
+                                    99,
+                                    frame.getInt(6));
+                        } finally {
+                            frame.release();
+                        }
+                    }
+                    return null;
+                });
+            }
+
+            for (Future<Void> result
+                    : executor.invokeAll(reads)) {
+                result.get();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static ServerMessage message() {
+        ServerMessage message =
+                new ServerMessage(4321);
+        message.appendInt(99);
+        message.appendString("broadcast");
+        return message;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/SharedBroadcastFrameTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/SharedBroadcastFrameTest.java
@@ -1,0 +1,76 @@
+package com.eu.habbo.messages;
+
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SharedBroadcastFrameTest {
+
+    @Test
+    void retainedRecipientFramesSharePreparedStorage()
+            throws Exception {
+        ServerMessage message =
+                new ServerMessage(456);
+        message.appendInt(123);
+
+        ServerMessageFrame.prepareBroadcast(message);
+        ByteBuf first =
+                ServerMessageFrame.retainedDuplicate(
+                        message);
+        ByteBuf second =
+                ServerMessageFrame.retainedDuplicate(
+                        message);
+        try {
+            assertTrue(
+                    ServerMessageFrame.isBroadcastPrepared(
+                            message));
+            assertSame(first.unwrap(), second.unwrap());
+            assertEquals(
+                    first.readableBytes() - 4,
+                    first.getInt(0));
+            assertEquals(456, first.getUnsignedShort(4));
+            assertEquals(123, first.getInt(6));
+
+            first.readerIndex(6);
+            assertEquals(0, second.readerIndex());
+        } finally {
+            first.release();
+            second.release();
+        }
+    }
+
+    @Test
+    void appendAfterPreparationUpdatesTheSharedFrame() {
+        ServerMessage message =
+                new ServerMessage(456);
+        ServerMessageFrame.prepareBroadcast(message);
+        message.appendString("later");
+
+        ByteBuf frame =
+                ServerMessageFrame.retainedDuplicate(
+                        message);
+        try {
+            assertEquals(
+                    frame.readableBytes() - 4,
+                    frame.getInt(0));
+            assertEquals(
+                    "later",
+                    readString(frame, 6));
+        } finally {
+            frame.release();
+        }
+    }
+
+    private static String readString(
+            ByteBuf frame,
+            int index) {
+        int length = frame.getUnsignedShort(index);
+        return frame.toString(
+                index + 2,
+                length,
+                java.nio.charset.StandardCharsets.UTF_8);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/BroadcastJfrProfileTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/BroadcastJfrProfileTest.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.networking.gameserver;
 
 import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.ServerMessageFrame;
 import com.eu.habbo.networking.gameserver.encoders.GameServerMessageEncoder;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -35,22 +36,32 @@ class BroadcastJfrProfileTest {
         Path profileDirectory =
                 Path.of("target", "profiles");
         Files.createDirectories(profileDirectory);
+        boolean sharedFrame =
+                Boolean.getBoolean(
+                        "polaris.profile.broadcast.shared");
+        String profileName = sharedFrame
+                ? "broadcast-shared-frame"
+                : "broadcast-baseline";
         Path recordingPath =
                 profileDirectory.resolve(
-                        "broadcast-baseline.jfr");
+                        profileName + ".jfr");
         Path summaryPath =
                 profileDirectory.resolve(
-                        "broadcast-baseline.txt");
+                        profileName + ".txt");
 
         EmbeddedChannel channel =
                 new EmbeddedChannel(
                         new GameServerMessageEncoder());
         ServerMessage message = representativeMessage();
+        if (sharedFrame) {
+            ServerMessageFrame.prepareBroadcast(message);
+        }
         try {
             runBroadcasts(
                     channel,
                     message,
-                    WARMUP_BROADCASTS);
+                    WARMUP_BROADCASTS,
+                    sharedFrame);
 
             long startedAt = System.nanoTime();
             try (Recording recording = new Recording()) {
@@ -66,7 +77,8 @@ class BroadcastJfrProfileTest {
                 runBroadcasts(
                         channel,
                         message,
-                        PROFILE_BROADCASTS);
+                        PROFILE_BROADCASTS,
+                        sharedFrame);
                 recording.stop();
                 recording.dump(recordingPath);
             }
@@ -108,7 +120,8 @@ class BroadcastJfrProfileTest {
     private static void runBroadcasts(
             EmbeddedChannel channel,
             ServerMessage message,
-            int broadcasts) {
+            int broadcasts,
+            boolean sharedFrame) {
         for (int broadcast = 0;
              broadcast < broadcasts;
              broadcast++) {
@@ -116,7 +129,12 @@ class BroadcastJfrProfileTest {
                  recipient < RECIPIENTS;
                  recipient++) {
                 assertTrue(
-                        channel.writeOutbound(message));
+                        channel.writeOutbound(
+                                sharedFrame
+                                        ? ServerMessageFrame
+                                                .retainedDuplicate(
+                                                        message)
+                                        : message));
                 ByteBuf encoded = channel.readOutbound();
                 blackhole += encoded.getByte(
                         encoded.readerIndex());
@@ -189,6 +207,8 @@ class BroadcastJfrProfileTest {
                             .getName();
             if (type.equals(
                     "com.eu.habbo.messages.ServerMessage")
+                    || type.equals(
+                    "com.eu.habbo.messages.ServerMessageFrame")
                     || type.equals(
                     "com.eu.habbo.networking.gameserver."
                             + "encoders.GameServerMessageEncoder")) {

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/BroadcastJfrProfileTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/BroadcastJfrProfileTest.java
@@ -1,0 +1,240 @@
+package com.eu.habbo.networking.gameserver;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.networking.gameserver.encoders.GameServerMessageEncoder;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedFrame;
+import jdk.jfr.consumer.RecordingFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIfSystemProperty(
+        named = "polaris.profile.broadcast",
+        matches = "true")
+class BroadcastJfrProfileTest {
+
+    private static final int RECIPIENTS = 50;
+    private static final int WARMUP_BROADCASTS = 500;
+    private static final int PROFILE_BROADCASTS = 5_000;
+    private static volatile long blackhole;
+
+    @Test
+    void capturesRepresentativeRoomBroadcastAllocationProfile()
+            throws Exception {
+        Path profileDirectory =
+                Path.of("target", "profiles");
+        Files.createDirectories(profileDirectory);
+        Path recordingPath =
+                profileDirectory.resolve(
+                        "broadcast-baseline.jfr");
+        Path summaryPath =
+                profileDirectory.resolve(
+                        "broadcast-baseline.txt");
+
+        EmbeddedChannel channel =
+                new EmbeddedChannel(
+                        new GameServerMessageEncoder());
+        ServerMessage message = representativeMessage();
+        try {
+            runBroadcasts(
+                    channel,
+                    message,
+                    WARMUP_BROADCASTS);
+
+            long startedAt = System.nanoTime();
+            try (Recording recording = new Recording()) {
+                recording.enable(
+                                "jdk.ObjectAllocationSample")
+                        .withStackTrace();
+                recording.enable("jdk.ExecutionSample")
+                        .withPeriod(
+                                Duration.ofMillis(10));
+                recording.enable(
+                        "jdk.GarbageCollection");
+                recording.start();
+                runBroadcasts(
+                        channel,
+                        message,
+                        PROFILE_BROADCASTS);
+                recording.stop();
+                recording.dump(recordingPath);
+            }
+            long elapsedNanos =
+                    System.nanoTime() - startedAt;
+
+            ProfileSummary summary =
+                    summarize(
+                            recordingPath,
+                            elapsedNanos);
+            Files.writeString(
+                    summaryPath,
+                    summary.format());
+
+            System.out.println(
+                    "BROADCAST_JFR "
+                            + summary.format()
+                            .replace(
+                                    System.lineSeparator(),
+                                    " "));
+            assertTrue(
+                    summary.totalSampledBytes() > 0L);
+            assertTrue(
+                    summary.serverMessageSampledBytes()
+                            > 0L);
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private static ServerMessage representativeMessage() {
+        ServerMessage message =
+                new ServerMessage(1_234);
+        message.appendString("room-cycle-broadcast");
+        message.appendRawBytes(new byte[1_024]);
+        return message;
+    }
+
+    private static void runBroadcasts(
+            EmbeddedChannel channel,
+            ServerMessage message,
+            int broadcasts) {
+        for (int broadcast = 0;
+             broadcast < broadcasts;
+             broadcast++) {
+            for (int recipient = 0;
+                 recipient < RECIPIENTS;
+                 recipient++) {
+                assertTrue(
+                        channel.writeOutbound(message));
+                ByteBuf encoded = channel.readOutbound();
+                blackhole += encoded.getByte(
+                        encoded.readerIndex());
+                encoded.release();
+            }
+        }
+    }
+
+    private static ProfileSummary summarize(
+            Path recordingPath,
+            long elapsedNanos) throws Exception {
+        long totalSampledBytes = 0L;
+        long serverMessageSampledBytes = 0L;
+        long allocationSamples = 0L;
+        long serverMessageSamples = 0L;
+        long executionSamples = 0L;
+        long serverMessageExecutionSamples = 0L;
+        long garbageCollections = 0L;
+
+        List<RecordedEvent> events =
+                RecordingFile.readAllEvents(
+                        recordingPath);
+        for (RecordedEvent event : events) {
+            switch (event.getEventType().getName()) {
+                case "jdk.ObjectAllocationSample" -> {
+                    long weight = event.getLong("weight");
+                    totalSampledBytes += weight;
+                    allocationSamples++;
+                    if (hasServerMessageFrame(event)) {
+                        serverMessageSampledBytes += weight;
+                        serverMessageSamples++;
+                    }
+                }
+                case "jdk.ExecutionSample" -> {
+                    executionSamples++;
+                    if (hasServerMessageFrame(event)) {
+                        serverMessageExecutionSamples++;
+                    }
+                }
+                case "jdk.GarbageCollection" ->
+                        garbageCollections++;
+                default -> {
+                }
+            }
+        }
+
+        return new ProfileSummary(
+                PROFILE_BROADCASTS,
+                RECIPIENTS,
+                elapsedNanos / 1_000_000D,
+                totalSampledBytes,
+                serverMessageSampledBytes,
+                allocationSamples,
+                serverMessageSamples,
+                executionSamples,
+                serverMessageExecutionSamples,
+                garbageCollections);
+    }
+
+    private static boolean hasServerMessageFrame(
+            RecordedEvent event) {
+        if (event.getStackTrace() == null) {
+            return false;
+        }
+        for (RecordedFrame frame
+                : event.getStackTrace().getFrames()) {
+            String type =
+                    frame.getMethod()
+                            .getType()
+                            .getName();
+            if (type.equals(
+                    "com.eu.habbo.messages.ServerMessage")
+                    || type.equals(
+                    "com.eu.habbo.networking.gameserver."
+                            + "encoders.GameServerMessageEncoder")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private record ProfileSummary(
+            int broadcasts,
+            int recipients,
+            double elapsedMs,
+            long totalSampledBytes,
+            long serverMessageSampledBytes,
+            long allocationSamples,
+            long serverMessageSamples,
+            long executionSamples,
+            long serverMessageExecutionSamples,
+            long garbageCollections) {
+
+        String format() {
+            return String.format(
+                    Locale.ROOT,
+                    "broadcasts=%d%n"
+                            + "recipients=%d%n"
+                            + "encodedFrames=%d%n"
+                            + "elapsedMs=%.3f%n"
+                            + "totalSampledBytes=%d%n"
+                            + "serverMessageSampledBytes=%d%n"
+                            + "allocationSamples=%d%n"
+                            + "serverMessageSamples=%d%n"
+                            + "executionSamples=%d%n"
+                            + "serverMessageExecutionSamples=%d%n"
+                            + "garbageCollections=%d%n",
+                    broadcasts,
+                    recipients,
+                    broadcasts * recipients,
+                    elapsedMs,
+                    totalSampledBytes,
+                    serverMessageSampledBytes,
+                    allocationSamples,
+                    serverMessageSamples,
+                    executionSamples,
+                    serverMessageExecutionSamples,
+                    garbageCollections);
+        }
+    }
+}

--- a/docs/performance/broadcast-jfr-profile.md
+++ b/docs/performance/broadcast-jfr-profile.md
@@ -18,6 +18,9 @@ The recording and text summary are written to:
 - `Emulator/target/profiles/broadcast-baseline.jfr`
 - `Emulator/target/profiles/broadcast-baseline.txt`
 
+Add `-Dpolaris.profile.broadcast.shared=true` to exercise the shared-frame
+broadcast path. Its artifacts use the `broadcast-shared-frame` prefix.
+
 ## Baseline
 
 Captured on 2026-07-20 from commit `d9fe1232` with Temurin 25.0.3+9:
@@ -38,3 +41,25 @@ About 66% of sampled allocation was attributed to the message/encoder stack.
 This confirms the T2.1 serialize-once candidate. The same harness must be run
 after the internal broadcast path changes; public `ServerMessage.get()`
 defensive-copy behavior is outside the optimization and must remain unchanged.
+
+## Shared-frame result
+
+Captured on 2026-07-20 with Temurin 25.0.3+9:
+
+| Measurement | Baseline | Shared frame |
+| --- | ---: | ---: |
+| Broadcasts | 5,000 | 5,000 |
+| Recipients per broadcast | 50 | 50 |
+| Encoded frames | 250,000 | 250,000 |
+| Elapsed recording window | 146.637 ms | 91.046 ms |
+| Total sampled allocation | 478,218,808 bytes | 136,879,312 bytes |
+| `ServerMessage` / encoder sampled allocation | 317,071,848 bytes | 13,438,248 bytes |
+| Allocation samples | 371 | 82 |
+| `ServerMessage` / encoder allocation samples | 322 | 19 |
+| Garbage collections | 3 | 0 |
+
+The shared-frame run reduced total sampled allocation by about 71% and
+message/encoder-attributed sampled allocation by about 96%. Room broadcasts
+prepare one frame and give each recipient an independently retained duplicate.
+Ordinary sends and plugin-observed outgoing packets keep the established
+`ServerMessage` encoder path.

--- a/docs/performance/broadcast-jfr-profile.md
+++ b/docs/performance/broadcast-jfr-profile.md
@@ -1,0 +1,40 @@
+# Broadcast JFR profile
+
+This profile measures the established room-broadcast encoding path with one
+representative 1,024-byte `ServerMessage`, 50 recipients, and 5,000 broadcasts.
+It uses the real `GameServerMessageEncoder` through Netty's
+`EmbeddedChannel`, producing 250,000 recipient frames.
+
+Run it from the repository root with JDK 25:
+
+```bash
+mvn -f Emulator/pom.xml test \
+  -Dtest=BroadcastJfrProfileTest \
+  -Dpolaris.profile.broadcast=true
+```
+
+The recording and text summary are written to:
+
+- `Emulator/target/profiles/broadcast-baseline.jfr`
+- `Emulator/target/profiles/broadcast-baseline.txt`
+
+## Baseline
+
+Captured on 2026-07-20 from commit `d9fe1232` with Temurin 25.0.3+9:
+
+| Measurement | Value |
+| --- | ---: |
+| Broadcasts | 5,000 |
+| Recipients per broadcast | 50 |
+| Encoded frames | 250,000 |
+| Elapsed recording window | 146.637 ms |
+| Total sampled allocation | 478,218,808 bytes |
+| `ServerMessage` / encoder sampled allocation | 317,071,848 bytes |
+| Allocation samples | 371 |
+| `ServerMessage` / encoder allocation samples | 322 |
+| Garbage collections | 3 |
+
+About 66% of sampled allocation was attributed to the message/encoder stack.
+This confirms the T2.1 serialize-once candidate. The same harness must be run
+after the internal broadcast path changes; public `ServerMessage.get()`
+defensive-copy behavior is outside the optimization and must remain unchanged.


### PR DESCRIPTION
Captures a representative broadcast JFR profile, freezes framing behavior, shares internal broadcast frames, and coalesces room-cycle flushes.