### PR TITLE
feat(persistence): add bounded JDBC executor

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -6,6 +6,7 @@ import ch.qos.logback.core.ConsoleAppender;
 import com.eu.habbo.core.*;
 import com.eu.habbo.core.consolecommands.ConsoleCommand;
 import com.eu.habbo.database.Database;
+import com.eu.habbo.database.PersistenceExecutor;
 import com.eu.habbo.database.integrity.DatabaseIntegrityAudit;
 import com.eu.habbo.database.integrity.IntegrityAuditOptions;
 import com.eu.habbo.database.migration.MigrationRunner;
@@ -629,6 +630,13 @@ public final class Emulator {
         return polarisRuntime != null && polarisRuntime.threading() != null
                 ? polarisRuntime.threading()
                 : threading;
+    }
+
+    public static PersistenceExecutor getPersistenceExecutor() {
+        return polarisRuntime != null
+                && polarisRuntime.persistenceExecutor() != null
+                ? polarisRuntime.persistenceExecutor()
+                : null;
     }
 
     public static GameEnvironment getGameEnvironment() {

--- a/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
+++ b/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
@@ -7,6 +7,7 @@ import com.eu.habbo.core.DatabaseLogger;
 import com.eu.habbo.core.Logging;
 import com.eu.habbo.core.TextsManager;
 import com.eu.habbo.database.Database;
+import com.eu.habbo.database.PersistenceExecutor;
 import com.eu.habbo.database.indexing.DatabaseIndexAuditor;
 import com.eu.habbo.database.integrity.DatabaseIntegrityAudit;
 import com.eu.habbo.database.integrity.IntegrityAuditOptions;
@@ -129,6 +130,9 @@ final class PolarisBootstrap {
 
         int runtimeThreads = configuration.getInt("runtime.threads");
         runtime.installThreading(new ThreadPooling(runtimeThreads));
+        runtime.installPersistenceExecutor(
+                PersistenceExecutor.forRuntimeThreads(
+                        runtimeThreads));
         Emulator.synchronizeLegacyFacade(runtime);
         database.getDataSource().setMaximumPoolSize(runtimeThreads * 2);
         database.getDataSource().setMinimumIdle(10);

--- a/Emulator/src/main/java/com/eu/habbo/PolarisRuntime.java
+++ b/Emulator/src/main/java/com/eu/habbo/PolarisRuntime.java
@@ -6,6 +6,7 @@ import com.eu.habbo.core.DatabaseLogger;
 import com.eu.habbo.core.Logging;
 import com.eu.habbo.core.TextsManager;
 import com.eu.habbo.database.Database;
+import com.eu.habbo.database.PersistenceExecutor;
 import com.eu.habbo.habbohotel.GameEnvironment;
 import com.eu.habbo.networking.gameserver.GameServer;
 import com.eu.habbo.networking.rconserver.RCONServer;
@@ -33,6 +34,7 @@ final class PolarisRuntime {
     private RCONServer rconServer;
     private Logging logging;
     private ThreadPooling threading;
+    private PersistenceExecutor persistenceExecutor;
     private GameEnvironment gameEnvironment;
     private PluginManager pluginManager;
     private BadgeImager badgeImager;
@@ -115,6 +117,16 @@ final class PolarisRuntime {
 
     void installThreading(ThreadPooling threading) {
         this.threading = Objects.requireNonNull(threading);
+    }
+
+    PersistenceExecutor persistenceExecutor() {
+        return persistenceExecutor;
+    }
+
+    void installPersistenceExecutor(
+            PersistenceExecutor persistenceExecutor) {
+        this.persistenceExecutor =
+                Objects.requireNonNull(persistenceExecutor);
     }
 
     GameEnvironment gameEnvironment() {

--- a/Emulator/src/main/java/com/eu/habbo/RuntimeLifecycle.java
+++ b/Emulator/src/main/java/com/eu/habbo/RuntimeLifecycle.java
@@ -92,6 +92,11 @@ final class RuntimeLifecycle {
                     "stop scheduler",
                     () -> services.threading().shutDown());
         }
+        if (services.persistenceExecutor() != null) {
+            run(
+                    "drain persistence executor",
+                    () -> services.persistenceExecutor().shutDown());
+        }
         run("save configuration", () -> {
             if (canPersistConfiguration()) {
                 services.configuration().saveToDatabase();

--- a/Emulator/src/main/java/com/eu/habbo/database/PersistenceExecutor.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/PersistenceExecutor.java
@@ -1,0 +1,143 @@
+package com.eu.habbo.database;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Bounded executor for blocking database writes that must not compete with
+ * room and wired scheduling.
+ */
+public final class PersistenceExecutor {
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(
+                    PersistenceExecutor.class);
+    private static final int DEFAULT_QUEUE_CAPACITY = 2_048;
+
+    private final ThreadPoolExecutor executor;
+    private final AtomicBoolean accepting =
+            new AtomicBoolean(true);
+
+    public PersistenceExecutor(
+            int threads,
+            int queueCapacity) {
+        if (threads < 1) {
+            throw new IllegalArgumentException(
+                    "threads must be positive");
+        }
+        if (queueCapacity < 1) {
+            throw new IllegalArgumentException(
+                    "queueCapacity must be positive");
+        }
+
+        ThreadFactory threadFactory =
+                Thread.ofPlatform()
+                        .name("Polaris-JDBC-", 0)
+                        .factory();
+        this.executor = new ThreadPoolExecutor(
+                threads,
+                threads,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new ArrayBlockingQueue<>(queueCapacity),
+                threadFactory,
+                (task, ignored) -> task.run());
+        this.executor.prestartAllCoreThreads();
+    }
+
+    public static PersistenceExecutor forRuntimeThreads(
+            int runtimeThreads) {
+        int threads = Math.max(
+                2,
+                Math.min(8, runtimeThreads));
+        return new PersistenceExecutor(
+                threads,
+                DEFAULT_QUEUE_CAPACITY);
+    }
+
+    public void execute(Runnable task) {
+        Runnable guarded = guard(
+                Objects.requireNonNull(task, "task"));
+        if (!this.accepting.get()) {
+            guarded.run();
+            return;
+        }
+
+        this.executor.execute(guarded);
+    }
+
+    public int getQueueDepth() {
+        return this.executor.getQueue().size();
+    }
+
+    public int getActiveCount() {
+        return this.executor.getActiveCount();
+    }
+
+    public void shutDown() {
+        this.shutDown(35, TimeUnit.SECONDS);
+    }
+
+    void shutDown(long timeout, TimeUnit unit) {
+        this.accepting.set(false);
+        this.executor.shutdown();
+
+        boolean interrupted = false;
+        boolean terminated = false;
+        try {
+            terminated = this.executor.awaitTermination(
+                    Math.max(0L, timeout),
+                    unit);
+        } catch (InterruptedException exception) {
+            interrupted = true;
+        }
+
+        if (!terminated) {
+            List<Runnable> queued =
+                    this.executor.shutdownNow();
+            for (Runnable task : queued) {
+                task.run();
+            }
+            if (!interrupted) {
+                try {
+                    terminated =
+                            this.executor.awaitTermination(
+                                    Math.max(0L, timeout),
+                                    unit);
+                } catch (InterruptedException exception) {
+                    interrupted = true;
+                }
+            }
+        }
+
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+        if (terminated) {
+            LOGGER.info(
+                    "Persistence executor stopped after draining accepted work");
+        } else {
+            LOGGER.error(
+                    "Persistence executor workers remained active during shutdown");
+        }
+    }
+
+    private static Runnable guard(Runnable task) {
+        return () -> {
+            try {
+                task.run();
+            } catch (Exception exception) {
+                LOGGER.error(
+                        "Persistence task failed",
+                        exception);
+            }
+        };
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/PolarisRuntimeTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/PolarisRuntimeTest.java
@@ -6,6 +6,7 @@ import com.eu.habbo.core.DatabaseLogger;
 import com.eu.habbo.core.Logging;
 import com.eu.habbo.core.TextsManager;
 import com.eu.habbo.database.Database;
+import com.eu.habbo.database.PersistenceExecutor;
 import com.eu.habbo.habbohotel.GameEnvironment;
 import com.eu.habbo.networking.gameserver.GameServer;
 import com.eu.habbo.networking.rconserver.RCONServer;
@@ -60,6 +61,11 @@ class PolarisRuntimeTest {
         services.put(
                 ThreadPooling.class,
                 service(runtime::installThreading, Emulator::getThreading));
+        services.put(
+                PersistenceExecutor.class,
+                service(
+                        runtime::installPersistenceExecutor,
+                        Emulator::getPersistenceExecutor));
         services.put(
                 GameEnvironment.class,
                 service(

--- a/Emulator/src/test/java/com/eu/habbo/RuntimeLifecycleTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/RuntimeLifecycleTest.java
@@ -2,6 +2,7 @@ package com.eu.habbo;
 
 import com.eu.habbo.core.ConfigurationManager;
 import com.eu.habbo.database.Database;
+import com.eu.habbo.database.PersistenceExecutor;
 import com.eu.habbo.habbohotel.GameEnvironment;
 import com.eu.habbo.networking.gameserver.GameServer;
 import com.eu.habbo.networking.rconserver.RCONServer;
@@ -38,6 +39,8 @@ class RuntimeLifecycleTest {
         GameServer gameServer = mock(GameServer.class);
         RCONServer rconServer = mock(RCONServer.class);
         ThreadPooling threading = mock(ThreadPooling.class);
+        PersistenceExecutor persistence =
+                mock(PersistenceExecutor.class);
         GameEnvironment environment = mock(GameEnvironment.class);
         PluginManager plugins = mock(PluginManager.class);
 
@@ -77,6 +80,10 @@ class RuntimeLifecycleTest {
             return null;
         }).when(threading).shutDown();
         doAnswer(invocation -> {
+            calls.add("persistence.shutdown");
+            return null;
+        }).when(persistence).shutDown();
+        doAnswer(invocation -> {
             calls.add("configuration.save");
             return null;
         }).when(configuration).saveToDatabase();
@@ -88,6 +95,7 @@ class RuntimeLifecycleTest {
         runtime.installConfiguration(configuration);
         runtime.installDatabase(database);
         runtime.installThreading(threading);
+        runtime.installPersistenceExecutor(persistence);
         runtime.installPluginManager(plugins);
         runtime.installGameEnvironment(environment);
         runtime.installGameServer(gameServer);
@@ -106,6 +114,7 @@ class RuntimeLifecycleTest {
                 "plugins.after-hotel",
                 "plugins.dispose",
                 "threading.shutdown",
+                "persistence.shutdown",
                 "configuration.save",
                 "database.dispose"), calls);
     }

--- a/Emulator/src/test/java/com/eu/habbo/database/PersistenceExecutorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/PersistenceExecutorTest.java
@@ -1,0 +1,95 @@
+package com.eu.habbo.database;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PersistenceExecutorTest {
+
+    @Test
+    void databaseWorkRunsOnDedicatedNamedWorkers()
+            throws Exception {
+        PersistenceExecutor executor =
+                new PersistenceExecutor(2, 8);
+        CountDownLatch completed = new CountDownLatch(1);
+        AtomicReference<String> threadName =
+                new AtomicReference<>();
+        try {
+            executor.execute(() -> {
+                threadName.set(
+                        Thread.currentThread().getName());
+                completed.countDown();
+            });
+
+            assertTrue(completed.await(
+                    2,
+                    TimeUnit.SECONDS));
+            assertTrue(threadName.get().startsWith(
+                    "Polaris-JDBC-"));
+        } finally {
+            executor.shutDown(2, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void saturationAppliesCallerBackpressureWithoutDroppingWork()
+            throws Exception {
+        PersistenceExecutor executor =
+                new PersistenceExecutor(1, 1);
+        CountDownLatch workerStarted =
+                new CountDownLatch(1);
+        CountDownLatch releaseWorker =
+                new CountDownLatch(1);
+        AtomicReference<Thread> saturatedTaskThread =
+                new AtomicReference<>();
+        try {
+            executor.execute(() -> {
+                workerStarted.countDown();
+                await(releaseWorker);
+            });
+            assertTrue(workerStarted.await(
+                    2,
+                    TimeUnit.SECONDS));
+            executor.execute(() -> {
+            });
+
+            Thread caller = Thread.currentThread();
+            executor.execute(() ->
+                    saturatedTaskThread.set(
+                            Thread.currentThread()));
+
+            assertEquals(
+                    caller,
+                    saturatedTaskThread.get());
+        } finally {
+            releaseWorker.countDown();
+            executor.shutDown(2, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void shutdownDrainsAcceptedTasks() {
+        PersistenceExecutor executor =
+                new PersistenceExecutor(1, 8);
+        CountDownLatch completed = new CountDownLatch(2);
+        executor.execute(completed::countDown);
+        executor.execute(completed::countDown);
+
+        executor.shutDown(2, TimeUnit.SECONDS);
+
+        assertEquals(0L, completed.getCount());
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}


### PR DESCRIPTION
Adds a fixed-width bounded executor for database writes with caller backpressure and queue metrics.

The runtime drains accepted persistence work after hotel teardown and before closing the database.