### PR TITLE
refactor(persistence): route SQL tasks to JDBC pool

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
+++ b/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
@@ -129,10 +129,13 @@ final class PolarisBootstrap {
         configuration.loadFromDatabase();
 
         int runtimeThreads = configuration.getInt("runtime.threads");
-        runtime.installThreading(new ThreadPooling(runtimeThreads));
-        runtime.installPersistenceExecutor(
+        PersistenceExecutor persistenceExecutor =
                 PersistenceExecutor.forRuntimeThreads(
-                        runtimeThreads));
+                        runtimeThreads);
+        runtime.installPersistenceExecutor(persistenceExecutor);
+        runtime.installThreading(new ThreadPooling(
+                runtimeThreads,
+                persistenceExecutor));
         Emulator.synchronizeLegacyFacade(runtime);
         database.getDataSource().setMaximumPoolSize(runtimeThreads * 2);
         database.getDataSource().setMinimumIdle(10);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EmptyInventoryCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EmptyInventoryCommand.java
@@ -39,7 +39,7 @@ public class EmptyInventoryCommand extends Command {
             if (habbo != null) {
                 List<HabboItem> items = new ArrayList<>(habbo.getInventory().getItemsComponent().getItems().values());
                 habbo.getInventory().getItemsComponent().getItems().clear();
-                Emulator.getThreading().run(new QueryDeleteHabboItems(items));
+                Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(items));
 
                 habbo.getClient().sendResponse(new InventoryRefreshComposer());
                 habbo.getClient().sendResponse(new InventoryItemsComposer(0, 1, gameClient.getHabbo().getInventory().getItemsComponent().getItems()));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/RedeemCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/RedeemCommand.java
@@ -80,7 +80,7 @@ public class RedeemCommand extends Command {
             deleted.add(item);
         }
 
-        Emulator.getThreading().run(new QueryDeleteHabboItems(deleted));
+        Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(deleted));
 
         gameClient.sendResponse(new InventoryRefreshComposer());
         gameClient.getHabbo().giveCredits(credits);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/games/Game.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/games/Game.java
@@ -242,7 +242,7 @@ public abstract class Game implements Runnable {
         teamsCopy.putAll(this.teams);
 
         for (Map.Entry<GameTeamColors, GameTeam> teamEntry : teamsCopy.entrySet()) {
-            Emulator.getThreading().run(new SaveScoreForTeam(teamEntry.getValue(), this));
+            Emulator.getThreading().runPersistence(new SaveScoreForTeam(teamEntry.getValue(), this));
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -971,7 +971,7 @@ public class ItemManager {
     }
 
     public HabboItem handleOpenRecycleBox(Habbo habbo, HabboItem box) {
-        Emulator.getThreading().run(new QueryDeleteHabboItem(box.getId()));
+        Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(box.getId()));
         HabboItem item = null;
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM items_presents WHERE item_id = ? LIMIT 1")) {
             statement.setInt(1, box.getId());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/pets/InteractionPetBreedingNest.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/pets/InteractionPetBreedingNest.java
@@ -198,7 +198,7 @@ public class InteractionPetBreedingNest extends HabboItem {
             return;
         }
 
-        Emulator.getThreading().run(new QueryDeleteHabboItem(this.getId()));
+        Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(this.getId()));
 
         this.setExtradata("2");
         habbo.getHabboInfo().getCurrentRoom().updateItem(this);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniDepositHelper.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniDepositHelper.java
@@ -48,7 +48,7 @@ public final class ChestFurniDepositHelper {
 
         habbo.getClient().sendResponse(new RemoveHabboItemComposer(removed.getGiftAdjustedId()));
         habbo.getClient().sendResponse(new InventoryRefreshComposer());
-        Emulator.getThreading().run(new QueryDeleteHabboItems(List.of(removed)));
+        Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(List.of(removed)));
 
         habbo.getClient().sendResponse(new ChestDataComposer(chest));
         ChestFurniPackets.sendDelta(habbo.getClient(), chest.getId(), List.of(), List.of(stored));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestWiredFurniUtil.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestWiredFurniUtil.java
@@ -107,7 +107,7 @@ public final class ChestWiredFurniUtil {
                 habbo.getClient().sendResponse(new RemoveHabboItemComposer(removed.getGiftAdjustedId()));
             }
             habbo.getClient().sendResponse(new InventoryRefreshComposer());
-            Emulator.getThreading().run(new QueryDeleteHabboItems(removedItems));
+            Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(removedItems));
         }
 
         return taken;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveOrTakeFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveOrTakeFurni.java
@@ -125,7 +125,7 @@ public class WiredEffectGiveOrTakeFurni extends InteractionWiredEffect {
         }
 
         habbo.getClient().sendResponse(new InventoryRefreshComposer());
-        Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove.values()));
+        Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(toRemove.values()));
     }
 
     @Deprecated

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolIssue.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolIssue.java
@@ -106,6 +106,6 @@ public class ModToolIssue implements ISerialize {
     }
 
     public void updateInDatabase() {
-        Emulator.getThreading().run(new UpdateModToolIssue(this));
+        Emulator.getThreading().runPersistence(new UpdateModToolIssue(this));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/traxeditor/TraxEditorManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/traxeditor/TraxEditorManager.java
@@ -223,7 +223,7 @@ public class TraxEditorManager {
         for (HabboItem disc : discs) {
             habbo.getInventory().getItemsComponent().removeHabboItem(disc);
             habbo.getClient().sendResponse(new RemoveHabboItemComposer(disc.getId()));
-            Emulator.getThreading().run(new QueryDeleteHabboItem(disc.getId()));
+            Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(disc.getId()));
         }
 
         habbo.getClient().sendResponse(new InventoryRefreshComposer());

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/recycler/RecycleEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/recycler/RecycleEvent.java
@@ -59,7 +59,7 @@ public class RecycleEvent extends MessageHandler {
             for (HabboItem item : items) {
                 this.client.getHabbo().getInventory().getItemsComponent().removeHabboItem(item);
                 this.client.sendResponse(new RemoveHabboItemComposer(item.getGiftAdjustedId()));
-                Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
             }
 
             this.client.sendResponse(new AddHabboItemComposer(reward));

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftItemEvent.java
@@ -84,7 +84,7 @@ public class CraftingCraftItemEvent extends MessageHandler {
                 });
                 this.client.sendResponse(new InventoryRefreshComposer());
 
-                Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove.values()));
+                Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(toRemove.values()));
                 return;
             }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftSecretEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftSecretEvent.java
@@ -95,7 +95,7 @@ public class CraftingCraftSecretEvent extends MessageHandler {
                         for (HabboItem item : habboItems) {
                             this.client.getHabbo().getInventory().getItemsComponent().removeHabboItem(item);
                             this.client.sendResponse(new RemoveHabboItemComposer(item.getGiftAdjustedId()));
-                            Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                            Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
                         }
                         this.client.sendResponse(new InventoryRefreshComposer());
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/inventory/RequestInventoryItemsDelete.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/inventory/RequestInventoryItemsDelete.java
@@ -47,7 +47,7 @@ public class RequestInventoryItemsDelete extends MessageHandler {
             habbo.getClient().sendResponse(new RemoveHabboItemComposer(object.getGiftAdjustedId()));
         });
         habbo.getClient().sendResponse(new InventoryRefreshComposer());
-        Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove.values()));
+        Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(toRemove.values()));
     }
 
     private boolean hasFurnitureInInventory(Habbo habbo, Item item, Integer amount) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestDepositFurniEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestDepositFurniEvent.java
@@ -92,7 +92,7 @@ public class ChestDepositFurniEvent extends MessageHandler {
             habbo.getClient().sendResponse(new RemoveHabboItemComposer(removed.getGiftAdjustedId()));
         }
         habbo.getClient().sendResponse(new InventoryRefreshComposer());
-        Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove));
+        Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(toRemove));
 
         this.client.sendResponse(new ChestDataComposer(chest));
         ChestFurniPackets.sendDelta(this.client, chest.getId(), List.of(), added);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/PostItDeleteEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/PostItDeleteEvent.java
@@ -30,7 +30,7 @@ public class PostItDeleteEvent extends MessageHandler {
                 item.setRoomId(0);
                 room.removeHabboItem(item);
                 room.sendComposer(new RemoveWallItemComposer(item).compose());
-                Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
             }
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemClothingEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemClothingEvent.java
@@ -53,7 +53,7 @@ public class RedeemClothingEvent extends MessageHandler {
                             this.client.getHabbo().getHabboInfo().getCurrentRoom().updateTile(tile);
                             this.client.getHabbo().getHabboInfo().getCurrentRoom().sendComposer(new UpdateStackHeightComposer(tile.x, tile.y, tile.z, tile.relativeHeight()).compose());
                             this.client.getHabbo().getHabboInfo().getCurrentRoom().sendComposer(new RemoveFloorItemComposer(item, true).compose());
-                            Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                            Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
 
                             this.client.getHabbo().getInventory().getWardrobeComponent().getClothing().add(clothing.id);
                             for (int setId : clothing.setId) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ToggleFloorItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ToggleFloorItemEvent.java
@@ -116,7 +116,7 @@ public class ToggleFloorItemEvent extends MessageHandler {
                     return;
                 }
 
-                Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
 
                 boolean isRare = item.getBaseItem().getName().contains("rare");
                 int rarity = 0;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/pets/PetPackageNameEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/pets/PetPackageNameEvent.java
@@ -71,7 +71,7 @@ public class PetPackageNameEvent extends MessageHandler {
                             pet.needsUpdate = true;
                             pet.getRoomUnit().setLocation(tile);
                             pet.getRoomUnit().setZ(item.getZ());
-                            Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                            Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
                             room.removeHabboItem(item);
                             room.sendComposer(new RemoveFloorItemComposer(item).compose());
                             room.updateTile(tile);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/pets/PetUseItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/pets/PetUseItemEvent.java
@@ -115,7 +115,7 @@ public class PetUseItemEvent extends MessageHandler {
                     this.client.getHabbo().getHabboInfo().getCurrentRoom().updateTiles(room.getLayout().getTilesAt(room.getLayout().getTile(item.getX(), item.getY()), item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation()));
                     AchievementManager.progressAchievement(this.client.getHabbo(), Emulator.getGameEnvironment().getAchievementManager().getAchievement("MonsterPlantHealer"));
                     pet.getRoomUnit().removeStatus(RoomUnitStatus.GESTURE);
-                    Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                    Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
                 }
             } else if (item.getBaseItem().getName().equalsIgnoreCase("mnstr_fert")) {
                 if (!monsterplant.isFullyGrown()) {
@@ -136,7 +136,7 @@ public class PetUseItemEvent extends MessageHandler {
                     this.client.getHabbo().getHabboInfo().getCurrentRoom().updateTiles(room.getLayout().getTilesAt(room.getLayout().getTile(item.getX(), item.getY()), item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation()));
                     pet.getRoomUnit().removeStatus(RoomUnitStatus.GESTURE);
                     pet.cycle();
-                    Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                    Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
                 }
             } else if (item.getBaseItem().getName().startsWith("mnstr_rebreed")) {
                 if (monsterplant.isFullyGrown() && !monsterplant.canBreed() && !monsterplant.isDead()) {
@@ -160,7 +160,7 @@ public class PetUseItemEvent extends MessageHandler {
                         this.client.getHabbo().getHabboInfo().getCurrentRoom().sendComposer(new PetStatusUpdateComposer(pet).compose());
                         this.client.getHabbo().getHabboInfo().getCurrentRoom().updateTiles(room.getLayout().getTilesAt(room.getLayout().getTile(item.getX(), item.getY()), item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation()));
                         pet.getRoomUnit().removeStatus(RoomUnitStatus.GESTURE);
-                        Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                        Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
                     }
                 }
             }

--- a/Emulator/src/main/java/com/eu/habbo/threading/ThreadPooling.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/ThreadPooling.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.threading;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.database.PersistenceExecutor;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,11 +17,19 @@ public class ThreadPooling {
 
     public final int threads;
     private final ScheduledExecutorService scheduledPool;
+    private final PersistenceExecutor persistenceExecutor;
     private volatile boolean canAdd;
 
     public ThreadPooling(Integer threads) {
+        this(threads, null);
+    }
+
+    public ThreadPooling(
+            Integer threads,
+            PersistenceExecutor persistenceExecutor) {
         this.threads = threads;
         this.scheduledPool = new HabboExecutorService(this.threads, new DefaultThreadFactory("HabExec"));
+        this.persistenceExecutor = persistenceExecutor;
         this.canAdd = true;
         LOGGER.info("Thread Pool -> Loaded!");
     }
@@ -62,6 +71,15 @@ public class ThreadPooling {
         }
 
         return null;
+    }
+
+    public void runPersistence(Runnable task) {
+        if (this.persistenceExecutor == null) {
+            this.run(task);
+            return;
+        }
+
+        this.persistenceExecutor.execute(task);
     }
 
     public void shutDown() {

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/OpenGift.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/OpenGift.java
@@ -56,7 +56,7 @@ public class OpenGift implements Runnable {
                 this.room.updateTile(tile);
             }
 
-            Emulator.getThreading().run(new QueryDeleteHabboItem(this.item.getId()));
+            Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(this.item.getId()));
             Emulator.getThreading().run(new RemoveFloorItemTask(this.room, this.item), this.item.getBaseItem().getName().contains("present_wrap") ? 5000 : 0);
 
             this.habbo.getClient().sendResponse(new InventoryRefreshComposer());

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/PetEatAction.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/PetEatAction.java
@@ -61,7 +61,12 @@ public class PetEatAction implements Runnable {
             } else {
                 // Food is empty - remove it
                 if (this.food != null && currentState >= this.food.getBaseItem().getStateCount()) {
-                    Emulator.getThreading().run(new QueryDeleteHabboItem(this.food.getId()), 250);
+                    var threading = Emulator.getThreading();
+                    threading.run(
+                            () -> threading.runPersistence(
+                                    new QueryDeleteHabboItem(
+                                            this.food.getId())),
+                            250);
                     if (this.pet.getRoom() != null) {
                         this.pet.getRoom().removeHabboItem(this.food);
                         this.pet.getRoom().sendComposer(new RemoveFloorItemComposer(this.food, true).compose());

--- a/Emulator/src/test/java/com/eu/habbo/database/PersistenceTaskRoutingContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/PersistenceTaskRoutingContractTest.java
@@ -1,0 +1,45 @@
+package com.eu.habbo.database;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class PersistenceTaskRoutingContractTest {
+
+    @Test
+    void sqlOnlyRunnablesDoNotUseTheGameScheduler()
+            throws Exception {
+        Path sourceRoot =
+                Path.of("src", "main", "java");
+        List<Path> sources;
+        try (var paths = Files.walk(sourceRoot)) {
+            sources = paths
+                    .filter(path ->
+                            path.toString().endsWith(".java"))
+                    .toList();
+        }
+
+        for (Path source : sources) {
+            String code = Files.readString(source);
+            assertFalse(
+                    code.contains(
+                            "Emulator.getThreading().run("
+                                    + "new QueryDeleteHabboItem"),
+                    source.toString());
+            assertFalse(
+                    code.contains(
+                            "Emulator.getThreading().run("
+                                    + "new SaveScoreForTeam"),
+                    source.toString());
+            assertFalse(
+                    code.contains(
+                            "Emulator.getThreading().run("
+                                    + "new UpdateModToolIssue"),
+                    source.toString());
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/threading/ThreadPoolingPersistenceRoutingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/threading/ThreadPoolingPersistenceRoutingTest.java
@@ -1,0 +1,28 @@
+package com.eu.habbo.threading;
+
+import com.eu.habbo.database.PersistenceExecutor;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.verify;
+
+class ThreadPoolingPersistenceRoutingTest {
+
+    @Test
+    void persistenceTasksUseTheInjectedDatabaseExecutor() {
+        PersistenceExecutor persistence =
+                mock(PersistenceExecutor.class);
+        ThreadPooling threading =
+                new ThreadPooling(1, persistence);
+        Runnable task = () -> {
+        };
+        try {
+            threading.runPersistence(task);
+
+            verify(persistence).execute(same(task));
+        } finally {
+            threading.shutDown();
+        }
+    }
+}


### PR DESCRIPTION
Routes already-asynchronous item deletion, moderation update, and game-score writes through the bounded persistence executor.

Preserves delayed pet-item deletion timing and the legacy scheduler fallback.