### PR TITLE
refactor(persistence): isolate durable writes

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -6,6 +6,7 @@ import ch.qos.logback.core.ConsoleAppender;
 import com.eu.habbo.core.*;
 import com.eu.habbo.core.consolecommands.ConsoleCommand;
 import com.eu.habbo.database.Database;
+import com.eu.habbo.database.PersistenceExecutor;
 import com.eu.habbo.database.integrity.DatabaseIntegrityAudit;
 import com.eu.habbo.database.integrity.IntegrityAuditOptions;
 import com.eu.habbo.database.migration.MigrationRunner;
@@ -629,6 +630,13 @@ public final class Emulator {
         return polarisRuntime != null && polarisRuntime.threading() != null
                 ? polarisRuntime.threading()
                 : threading;
+    }
+
+    public static PersistenceExecutor getPersistenceExecutor() {
+        return polarisRuntime != null
+                && polarisRuntime.persistenceExecutor() != null
+                ? polarisRuntime.persistenceExecutor()
+                : null;
     }
 
     public static GameEnvironment getGameEnvironment() {

--- a/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
+++ b/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
@@ -7,6 +7,7 @@ import com.eu.habbo.core.DatabaseLogger;
 import com.eu.habbo.core.Logging;
 import com.eu.habbo.core.TextsManager;
 import com.eu.habbo.database.Database;
+import com.eu.habbo.database.PersistenceExecutor;
 import com.eu.habbo.database.indexing.DatabaseIndexAuditor;
 import com.eu.habbo.database.integrity.DatabaseIntegrityAudit;
 import com.eu.habbo.database.integrity.IntegrityAuditOptions;
@@ -129,6 +130,9 @@ final class PolarisBootstrap {
 
         int runtimeThreads = configuration.getInt("runtime.threads");
         runtime.installThreading(new ThreadPooling(runtimeThreads));
+        runtime.installPersistenceExecutor(
+                PersistenceExecutor.forRuntimeThreads(
+                        runtimeThreads));
         Emulator.synchronizeLegacyFacade(runtime);
         database.getDataSource().setMaximumPoolSize(runtimeThreads * 2);
         database.getDataSource().setMinimumIdle(10);

--- a/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
+++ b/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
@@ -129,10 +129,13 @@ final class PolarisBootstrap {
         configuration.loadFromDatabase();
 
         int runtimeThreads = configuration.getInt("runtime.threads");
-        runtime.installThreading(new ThreadPooling(runtimeThreads));
-        runtime.installPersistenceExecutor(
+        PersistenceExecutor persistenceExecutor =
                 PersistenceExecutor.forRuntimeThreads(
-                        runtimeThreads));
+                        runtimeThreads);
+        runtime.installPersistenceExecutor(persistenceExecutor);
+        runtime.installThreading(new ThreadPooling(
+                runtimeThreads,
+                persistenceExecutor));
         Emulator.synchronizeLegacyFacade(runtime);
         database.getDataSource().setMaximumPoolSize(runtimeThreads * 2);
         database.getDataSource().setMinimumIdle(10);

--- a/Emulator/src/main/java/com/eu/habbo/PolarisRuntime.java
+++ b/Emulator/src/main/java/com/eu/habbo/PolarisRuntime.java
@@ -6,6 +6,7 @@ import com.eu.habbo.core.DatabaseLogger;
 import com.eu.habbo.core.Logging;
 import com.eu.habbo.core.TextsManager;
 import com.eu.habbo.database.Database;
+import com.eu.habbo.database.PersistenceExecutor;
 import com.eu.habbo.habbohotel.GameEnvironment;
 import com.eu.habbo.networking.gameserver.GameServer;
 import com.eu.habbo.networking.rconserver.RCONServer;
@@ -33,6 +34,7 @@ final class PolarisRuntime {
     private RCONServer rconServer;
     private Logging logging;
     private ThreadPooling threading;
+    private PersistenceExecutor persistenceExecutor;
     private GameEnvironment gameEnvironment;
     private PluginManager pluginManager;
     private BadgeImager badgeImager;
@@ -115,6 +117,16 @@ final class PolarisRuntime {
 
     void installThreading(ThreadPooling threading) {
         this.threading = Objects.requireNonNull(threading);
+    }
+
+    PersistenceExecutor persistenceExecutor() {
+        return persistenceExecutor;
+    }
+
+    void installPersistenceExecutor(
+            PersistenceExecutor persistenceExecutor) {
+        this.persistenceExecutor =
+                Objects.requireNonNull(persistenceExecutor);
     }
 
     GameEnvironment gameEnvironment() {

--- a/Emulator/src/main/java/com/eu/habbo/RuntimeLifecycle.java
+++ b/Emulator/src/main/java/com/eu/habbo/RuntimeLifecycle.java
@@ -92,6 +92,11 @@ final class RuntimeLifecycle {
                     "stop scheduler",
                     () -> services.threading().shutDown());
         }
+        if (services.persistenceExecutor() != null) {
+            run(
+                    "drain persistence executor",
+                    () -> services.persistenceExecutor().shutDown());
+        }
         run("save configuration", () -> {
             if (canPersistConfiguration()) {
                 services.configuration().saveToDatabase();

--- a/Emulator/src/main/java/com/eu/habbo/database/PersistenceExecutor.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/PersistenceExecutor.java
@@ -1,0 +1,143 @@
+package com.eu.habbo.database;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Bounded executor for blocking database writes that must not compete with
+ * room and wired scheduling.
+ */
+public final class PersistenceExecutor {
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(
+                    PersistenceExecutor.class);
+    private static final int DEFAULT_QUEUE_CAPACITY = 2_048;
+
+    private final ThreadPoolExecutor executor;
+    private final AtomicBoolean accepting =
+            new AtomicBoolean(true);
+
+    public PersistenceExecutor(
+            int threads,
+            int queueCapacity) {
+        if (threads < 1) {
+            throw new IllegalArgumentException(
+                    "threads must be positive");
+        }
+        if (queueCapacity < 1) {
+            throw new IllegalArgumentException(
+                    "queueCapacity must be positive");
+        }
+
+        ThreadFactory threadFactory =
+                Thread.ofPlatform()
+                        .name("Polaris-JDBC-", 0)
+                        .factory();
+        this.executor = new ThreadPoolExecutor(
+                threads,
+                threads,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new ArrayBlockingQueue<>(queueCapacity),
+                threadFactory,
+                (task, ignored) -> task.run());
+        this.executor.prestartAllCoreThreads();
+    }
+
+    public static PersistenceExecutor forRuntimeThreads(
+            int runtimeThreads) {
+        int threads = Math.max(
+                2,
+                Math.min(8, runtimeThreads));
+        return new PersistenceExecutor(
+                threads,
+                DEFAULT_QUEUE_CAPACITY);
+    }
+
+    public void execute(Runnable task) {
+        Runnable guarded = guard(
+                Objects.requireNonNull(task, "task"));
+        if (!this.accepting.get()) {
+            guarded.run();
+            return;
+        }
+
+        this.executor.execute(guarded);
+    }
+
+    public int getQueueDepth() {
+        return this.executor.getQueue().size();
+    }
+
+    public int getActiveCount() {
+        return this.executor.getActiveCount();
+    }
+
+    public void shutDown() {
+        this.shutDown(35, TimeUnit.SECONDS);
+    }
+
+    void shutDown(long timeout, TimeUnit unit) {
+        this.accepting.set(false);
+        this.executor.shutdown();
+
+        boolean interrupted = false;
+        boolean terminated = false;
+        try {
+            terminated = this.executor.awaitTermination(
+                    Math.max(0L, timeout),
+                    unit);
+        } catch (InterruptedException exception) {
+            interrupted = true;
+        }
+
+        if (!terminated) {
+            List<Runnable> queued =
+                    this.executor.shutdownNow();
+            for (Runnable task : queued) {
+                task.run();
+            }
+            if (!interrupted) {
+                try {
+                    terminated =
+                            this.executor.awaitTermination(
+                                    Math.max(0L, timeout),
+                                    unit);
+                } catch (InterruptedException exception) {
+                    interrupted = true;
+                }
+            }
+        }
+
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+        if (terminated) {
+            LOGGER.info(
+                    "Persistence executor stopped after draining accepted work");
+        } else {
+            LOGGER.error(
+                    "Persistence executor workers remained active during shutdown");
+        }
+    }
+
+    private static Runnable guard(Runnable task) {
+        return () -> {
+            try {
+                task.run();
+            } catch (Exception exception) {
+                LOGGER.error(
+                        "Persistence task failed",
+                        exception);
+            }
+        };
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -1539,7 +1539,7 @@ public class CatalogManager {
         String operationId = EconomyOperationId.create(
                 "catalog:" + habbo.getHabboInfo().getId() + ":" + item.getId());
         SpecialCompanionPurchase purchase = CatalogPurchaseTransaction.execute(
-                habbo.getHabboInfo().getId(), operationId, connection -> {
+                habbo, operationId, connection -> {
                     List<Bot> bots = new ArrayList<>();
                     List<Pet> pets = new ArrayList<>();
                     for (int index = 0; index < amount; index++) {
@@ -1638,7 +1638,7 @@ public class CatalogManager {
         String operationId = EconomyOperationId.create(
                 "catalog:" + habbo.getHabboInfo().getId() + ":" + item.getId());
         EntitlementPurchase purchase = CatalogPurchaseTransaction.execute(
-                habbo.getHabboInfo().getId(), operationId, connection -> {
+                habbo, operationId, connection -> {
             UserCatalogItemPurchasedEvent event = new UserCatalogItemPurchasedEvent(
                     habbo, item, new HashSet<>(), totalCredits, totalPoints, new ArrayList<>(requestedBadges));
             Emulator.getPluginManager().fireEvent(event);
@@ -1699,7 +1699,8 @@ public class CatalogManager {
         int userId = habbo.getHabboInfo().getId();
         try {
             String operationId = EconomyOperationId.create("catalog:" + userId + ":" + item.getId());
-            AtomicFurniturePurchase purchase = CatalogPurchaseTransaction.execute(userId, operationId, connection -> {
+            AtomicFurniturePurchase purchase = CatalogPurchaseTransaction.execute(
+                    habbo, operationId, connection -> {
                 Set<HabboItem> createdItems = new HashSet<>();
                 Map<InteractionGuildFurni, Guild> guildFurniture = new HashMap<>();
                 boolean includesMusicDisc = false;
@@ -1894,11 +1895,9 @@ public class CatalogManager {
 
     private void publishCommittedCharges(Habbo habbo, int credits, int points, int pointsType) {
         if (credits > 0) {
-            habbo.getHabboInfo().addCredits(-credits);
             habbo.getClient().sendResponse(new UserCreditsComposer(habbo));
         }
         if (points > 0) {
-            habbo.getHabboInfo().addCurrencyAmount(pointsType, -points);
             habbo.getClient().sendResponse(new UserPointsComposer(
                     habbo.getHabboInfo().getCurrencyAmount(pointsType), -points, pointsType));
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPaymentService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPaymentService.java
@@ -1,14 +1,25 @@
 package com.eu.habbo.habbohotel.catalog;
 
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyMutationResult;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.LedgerWalletMutation;
 import com.eu.habbo.messages.outgoing.users.UserCreditsComposer;
 import com.eu.habbo.messages.outgoing.users.UserPointsComposer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Catalog-only facade for one atomic credits-plus-points wallet mutation.
  *
- * <p>Note: this deliberately debits (and refunds) directly rather than through
- * {@code Habbo.giveCredits}/{@code givePoints}, so it does NOT fire
+ * <p>Note: this deliberately records ledger debits and refunds without routing
+ * through {@code Habbo.giveCredits}/{@code givePoints}, so it does NOT fire
  * {@code UserCreditsEvent}/{@code UserPointsEvent}. That is intentional: a plugin
  * cancelling or reducing the debit event previously let a buyer keep the items
  * without paying. The trade-off is that plugins observing those events no longer
@@ -16,33 +27,163 @@ import com.eu.habbo.messages.outgoing.users.UserPointsComposer;
  * {@code UserCatalogItemPurchasedEvent} instead.
  */
 public final class CatalogPaymentService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CatalogPaymentService.class);
+
     private CatalogPaymentService() {
     }
 
     public static boolean tryTake(Habbo habbo, int credits, int pointsType, int points) {
-        if (habbo == null || !habbo.getHabboInfo().tryDebitCatalogPayment(credits, pointsType, points)) {
+        if (habbo == null || credits < 0 || points < 0) {
             return false;
         }
 
-        if (habbo.getClient() != null) {
-            if (credits > 0) habbo.getClient().sendResponse(new UserCreditsComposer(habbo));
-            if (points > 0) {
-                habbo.getClient().sendResponse(new UserPointsComposer(
-                        habbo.getHabboInfo().getCurrencyAmount(pointsType), -points, pointsType));
-            }
+        try {
+            LedgerWalletMutation.coordinated(
+                    habbo,
+                    () -> {
+                        WalletCommit result = mutate(
+                                habbo,
+                                -credits,
+                                pointsType,
+                                -points,
+                                "catalog_payment_reserve",
+                                "catalog.payment.reserve");
+                        applyCommittedBalances(
+                                habbo,
+                                pointsType,
+                                result);
+                        return result;
+                    });
+        } catch (IllegalArgumentException exception) {
+            return false;
+        } catch (SQLException exception) {
+            LOGGER.error("Unable to reserve catalog payment for user {}",
+                    habbo.getHabboInfo().getId(), exception);
+            return false;
         }
+
+        publish(habbo, credits, pointsType, -points);
         return true;
     }
 
     public static void refund(Habbo habbo, int credits, int pointsType, int points) {
-        habbo.getHabboInfo().refundCatalogPayment(credits, pointsType, points);
+        if (habbo == null || credits < 0 || points < 0) {
+            throw new IllegalArgumentException("catalog refund cannot be negative");
+        }
 
+        try {
+            LedgerWalletMutation.coordinated(
+                    habbo,
+                    () -> {
+                        WalletCommit result = mutate(
+                                habbo,
+                                credits,
+                                pointsType,
+                                points,
+                                "catalog_payment_refund",
+                                "catalog.payment.refund");
+                        applyCommittedBalances(
+                                habbo,
+                                pointsType,
+                                result);
+                        return result;
+                    });
+        } catch (SQLException | IllegalArgumentException exception) {
+            LOGGER.error("Unable to refund catalog payment for user {}",
+                    habbo.getHabboInfo().getId(), exception);
+            return;
+        }
+
+        publish(habbo, credits, pointsType, points);
+    }
+
+    private static WalletCommit mutate(
+            Habbo habbo,
+            int creditDelta,
+            int pointsType,
+            int pointsDelta,
+            String operation,
+            String reason) throws SQLException {
+        int userId = habbo.getHabboInfo().getId();
+        String operationId = EconomyOperationId.create(
+                "catalog-payment:" + userId);
+        List<EconomyOperation> operations = new ArrayList<>(2);
+        if (creditDelta != 0) {
+            operations.add(new EconomyOperation(
+                    operationId + ":credits",
+                    userId,
+                    userId,
+                    operation,
+                    reason,
+                    EconomyLedger.CREDITS,
+                    creditDelta,
+                    null,
+                    operationId));
+        }
+        if (pointsDelta != 0) {
+            operations.add(new EconomyOperation(
+                    operationId + ":points",
+                    userId,
+                    userId,
+                    operation,
+                    reason,
+                    pointsType,
+                    pointsDelta,
+                    null,
+                    operationId));
+        }
+        if (operations.isEmpty()) {
+            return new WalletCommit(null, null);
+        }
+
+        List<EconomyMutationResult> results =
+                EconomyLedger.executeBatch(operations);
+        int resultIndex = 0;
+        EconomyMutationResult creditMutation =
+                creditDelta == 0 ? null : results.get(resultIndex++);
+        EconomyMutationResult pointsMutation =
+                pointsDelta == 0 ? null : results.get(resultIndex);
+        return new WalletCommit(creditMutation, pointsMutation);
+    }
+
+    private static void publish(
+            Habbo habbo,
+            int credits,
+            int pointsType,
+            int pointsDelta) {
         if (habbo.getClient() != null) {
-            if (credits > 0) habbo.getClient().sendResponse(new UserCreditsComposer(habbo));
-            if (points > 0) {
+            if (credits > 0) {
+                habbo.getClient().sendResponse(new UserCreditsComposer(habbo));
+            }
+            if (pointsDelta != 0) {
                 habbo.getClient().sendResponse(new UserPointsComposer(
-                        habbo.getHabboInfo().getCurrencyAmount(pointsType), points, pointsType));
+                        habbo.getHabboInfo().getCurrencyAmount(pointsType),
+                        pointsDelta,
+                        pointsType));
             }
         }
+    }
+
+    private static void applyCommittedBalances(
+            Habbo habbo,
+            int pointsType,
+            WalletCommit commit) {
+        if (commit.creditMutation() != null) {
+            LedgerWalletMutation.applyCommitted(
+                    habbo,
+                    EconomyLedger.CREDITS,
+                    commit.creditMutation().balanceAfter());
+        }
+        if (commit.pointsMutation() != null) {
+            LedgerWalletMutation.applyCommitted(
+                    habbo,
+                    pointsType,
+                    commit.pointsMutation().balanceAfter());
+        }
+    }
+
+    private record WalletCommit(
+            EconomyMutationResult creditMutation,
+            EconomyMutationResult pointsMutation) {
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java
@@ -2,7 +2,10 @@ package com.eu.habbo.habbohotel.catalog;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyMutationResult;
 import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.LedgerWalletMutation;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -11,15 +14,45 @@ final class CatalogPurchaseTransaction {
     private CatalogPurchaseTransaction() {
     }
 
-    static <T> T execute(int userId, String operationId, PurchaseWork<T> work) throws SQLException {
+    static <T> T execute(
+            Habbo habbo,
+            String operationId,
+            PurchaseWork<T> work) throws SQLException {
+        return LedgerWalletMutation.coordinated(habbo, () -> {
+            Commit<PreparedPurchase<T>> commit = commit(
+                    habbo.getHabboInfo().getId(),
+                    operationId,
+                    work);
+            if (commit.creditMutation() != null) {
+                LedgerWalletMutation.applyCommitted(
+                        habbo,
+                        EconomyLedger.CREDITS,
+                        commit.creditMutation().balanceAfter());
+            }
+            if (commit.pointsMutation() != null) {
+                LedgerWalletMutation.applyCommitted(
+                        habbo,
+                        commit.value().pointsType(),
+                        commit.pointsMutation().balanceAfter());
+            }
+            return commit.value().value();
+        });
+    }
+
+    private static <T> Commit<PreparedPurchase<T>> commit(
+            int userId,
+            String operationId,
+            PurchaseWork<T> work) throws SQLException {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
             connection.setAutoCommit(false);
             try {
                 PreparedPurchase<T> purchase = work.persist(connection);
-                chargeCredits(connection, operationId, userId, purchase.credits());
-                chargePoints(connection, operationId, userId, purchase.pointsType(), purchase.points());
+                EconomyMutationResult creditMutation =
+                        chargeCredits(connection, operationId, userId, purchase.credits());
+                EconomyMutationResult pointsMutation =
+                        chargePoints(connection, operationId, userId, purchase.pointsType(), purchase.points());
                 connection.commit();
-                return purchase.value();
+                return new Commit<>(purchase, creditMutation, pointsMutation);
             } catch (Exception exception) {
                 try {
                     connection.rollback();
@@ -32,18 +65,27 @@ final class CatalogPurchaseTransaction {
         }
     }
 
-    private static void chargeCredits(Connection connection, String operationId, int userId, int credits)
+    private static EconomyMutationResult chargeCredits(
+            Connection connection,
+            String operationId,
+            int userId,
+            int credits)
             throws SQLException {
-        if (credits == 0) return;
-        EconomyLedger.apply(connection, new EconomyOperation(
+        if (credits == 0) return null;
+        return EconomyLedger.apply(connection, new EconomyOperation(
                 operationId + ":credits", userId, userId, "catalog_purchase", "catalog.purchase",
                 EconomyLedger.CREDITS, -credits, null, operationId));
     }
 
-    private static void chargePoints(Connection connection, String operationId, int userId, int pointsType, int points)
+    private static EconomyMutationResult chargePoints(
+            Connection connection,
+            String operationId,
+            int userId,
+            int pointsType,
+            int points)
             throws SQLException {
-        if (points == 0) return;
-        EconomyLedger.apply(connection, new EconomyOperation(
+        if (points == 0) return null;
+        return EconomyLedger.apply(connection, new EconomyOperation(
                 operationId + ":points", userId, userId, "catalog_purchase", "catalog.purchase",
                 pointsType, -points, null, operationId));
     }
@@ -57,5 +99,11 @@ final class CatalogPurchaseTransaction {
         PreparedPurchase {
             if (credits < 0 || points < 0) throw new IllegalArgumentException("Catalog charges cannot be negative");
         }
+    }
+
+    private record Commit<T>(
+            T value,
+            EconomyMutationResult creditMutation,
+            EconomyMutationResult pointsMutation) {
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlace.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlace.java
@@ -1,9 +1,11 @@
 package com.eu.habbo.habbohotel.catalog.marketplace;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyMutationResult;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.users.LedgerWalletMutation;
 import com.eu.habbo.habbohotel.users.WalletBalanceMath;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.catalog.marketplace.RequestOffersEvent;
@@ -308,13 +310,27 @@ public class MarketPlace {
                                         PreparedCharge charge = prepareMarketplaceCharge(client.getHabbo(), event.price);
                                         if (charge == null) return;
 
-                                        if (!MarketPlacePurchaseTransaction.commit(
-                                                offerId,
-                                                item.getId(),
-                                                client.getHabbo().getHabboInfo().getId(),
-                                                charge.currencyType(),
-                                                -charge.delta(),
-                                                soldTimestamp)) {
+                                        EconomyMutationResult walletMutation =
+                                                LedgerWalletMutation.coordinated(
+                                                        client.getHabbo(),
+                                                        () -> {
+                                                            EconomyMutationResult mutation =
+                                                                    MarketPlacePurchaseTransaction.commit(
+                                                                            offerId,
+                                                                            item.getId(),
+                                                                            client.getHabbo().getHabboInfo().getId(),
+                                                                            charge.currencyType(),
+                                                                            -charge.delta(),
+                                                                            soldTimestamp);
+                                                            if (mutation != null) {
+                                                                LedgerWalletMutation.applyCommitted(
+                                                                        client.getHabbo(),
+                                                                        charge.currencyType(),
+                                                                        mutation.balanceAfter());
+                                                            }
+                                                            return mutation;
+                                                        });
+                                        if (walletMutation == null) {
                                             sendErrorMessage(client, item.getBaseItem().getId(), offerId);
                                             return;
                                         }
@@ -325,7 +341,7 @@ public class MarketPlace {
 
                                         client.getHabbo().getInventory().getItemsComponent().addItem(item);
 
-                                        applyMarketplaceCharge(client, charge);
+                                        publishMarketplaceCharge(client, charge);
 
                                         client.sendResponse(new AddHabboItemComposer(item));
                                         client.sendResponse(new InventoryRefreshComposer());
@@ -499,14 +515,14 @@ public class MarketPlace {
         return new PreparedCharge(event.type, event.points);
     }
 
-    private static void applyMarketplaceCharge(GameClient client, PreparedCharge charge) {
+    private static void publishMarketplaceCharge(
+            GameClient client,
+            PreparedCharge charge) {
         if (charge.currencyType() < 0) {
-            client.getHabbo().getHabboInfo().addCredits(charge.delta());
             client.sendResponse(new UserCreditsComposer(client.getHabbo()));
             return;
         }
 
-        client.getHabbo().getHabboInfo().addCurrencyAmount(charge.currencyType(), charge.delta());
         client.sendResponse(new UserPointsComposer(
                 client.getHabbo().getHabboInfo().getCurrencyAmount(charge.currencyType()),
                 charge.delta(),

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlacePurchaseTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlacePurchaseTransaction.java
@@ -2,6 +2,7 @@ package com.eu.habbo.habbohotel.catalog.marketplace;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyMutationResult;
 import com.eu.habbo.habbohotel.economy.EconomyOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,8 +20,14 @@ final class MarketPlacePurchaseTransaction {
     private MarketPlacePurchaseTransaction() {
     }
 
-    static boolean commit(int offerId, int itemId, int buyerId, int currencyType, int charge, int soldTimestamp) {
-        if (offerId <= 0 || itemId <= 0 || buyerId <= 0 || charge <= 0) return false;
+    static EconomyMutationResult commit(
+            int offerId,
+            int itemId,
+            int buyerId,
+            int currencyType,
+            int charge,
+            int soldTimestamp) {
+        if (offerId <= 0 || itemId <= 0 || buyerId <= 0 || charge <= 0) return null;
 
         Connection connection = null;
         try {
@@ -30,10 +37,10 @@ final class MarketPlacePurchaseTransaction {
             if (!executeOfferSale(connection, offerId, soldTimestamp)
                     || !executeItemTransfer(connection, itemId, buyerId)) {
                 connection.rollback();
-                return false;
+                return null;
             }
 
-            EconomyLedger.apply(connection, new EconomyOperation(
+            EconomyMutationResult walletMutation = EconomyLedger.apply(connection, new EconomyOperation(
                     "marketplace:offer:" + offerId + ":buyer",
                     buyerId,
                     buyerId,
@@ -45,13 +52,13 @@ final class MarketPlacePurchaseTransaction {
                     "offerId=" + offerId));
 
             connection.commit();
-            return true;
+            return walletMutation;
         } catch (SQLException e) {
             if (connection != null) {
                 try { connection.rollback(); } catch (SQLException rollbackError) { e.addSuppressed(rollbackError); }
             }
             LOGGER.error("Atomic marketplace purchase failed for offer {}", offerId, e);
-            return false;
+            return null;
         } finally {
             if (connection != null) {
                 try { connection.setAutoCommit(true); connection.close(); }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EmptyInventoryCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EmptyInventoryCommand.java
@@ -39,7 +39,7 @@ public class EmptyInventoryCommand extends Command {
             if (habbo != null) {
                 List<HabboItem> items = new ArrayList<>(habbo.getInventory().getItemsComponent().getItems().values());
                 habbo.getInventory().getItemsComponent().getItems().clear();
-                Emulator.getThreading().run(new QueryDeleteHabboItems(items));
+                Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(items));
 
                 habbo.getClient().sendResponse(new InventoryRefreshComposer());
                 habbo.getClient().sendResponse(new InventoryItemsComposer(0, 1, gameClient.getHabbo().getInventory().getItemsComponent().getItems()));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/RedeemCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/RedeemCommand.java
@@ -80,7 +80,7 @@ public class RedeemCommand extends Command {
             deleted.add(item);
         }
 
-        Emulator.getThreading().run(new QueryDeleteHabboItems(deleted));
+        Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(deleted));
 
         gameClient.sendResponse(new InventoryRefreshComposer());
         gameClient.getHabbo().giveCredits(credits);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyLedger.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyLedger.java
@@ -6,6 +6,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class EconomyLedger {
     public static final int CREDITS = -1;
@@ -25,12 +27,20 @@ public final class EconomyLedger {
     }
 
     public static EconomyMutationResult execute(EconomyOperation operation) throws SQLException {
+        return executeBatch(List.of(operation)).getFirst();
+    }
+
+    public static List<EconomyMutationResult> executeBatch(
+            List<EconomyOperation> operations) throws SQLException {
+        validateBatch(operations);
+
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
             connection.setAutoCommit(false);
             try {
-                EconomyMutationResult result = apply(connection, operation);
+                List<EconomyMutationResult> results =
+                        applyBatch(connection, operations);
                 connection.commit();
-                return result;
+                return List.copyOf(results);
             } catch (SQLException | RuntimeException exception) {
                 try {
                     connection.rollback();
@@ -39,6 +49,36 @@ public final class EconomyLedger {
                 }
                 throw exception;
             }
+        }
+    }
+
+    public static List<EconomyMutationResult> applyBatch(
+            Connection connection,
+            List<EconomyOperation> operations) throws SQLException {
+        if (connection == null) {
+            throw new IllegalArgumentException("connection must not be null");
+        }
+        validateBatch(operations);
+        List<EconomyMutationResult> results =
+                new ArrayList<>(operations.size());
+        for (EconomyOperation operation : operations) {
+            results.add(apply(connection, operation));
+        }
+        return List.copyOf(results);
+    }
+
+    private static void validateBatch(List<EconomyOperation> operations) {
+        if (operations == null
+                || operations.isEmpty()
+                || operations.stream().anyMatch(operation -> operation == null)) {
+            throw new IllegalArgumentException(
+                    "economy operation batch must not be empty");
+        }
+        int userId = operations.getFirst().userId();
+        if (operations.stream().anyMatch(
+                operation -> operation.userId() != userId)) {
+            throw new IllegalArgumentException(
+                    "economy operation batch must target one user");
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/games/Game.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/games/Game.java
@@ -242,7 +242,7 @@ public abstract class Game implements Runnable {
         teamsCopy.putAll(this.teams);
 
         for (Map.Entry<GameTeamColors, GameTeam> teamEntry : teamsCopy.entrySet()) {
-            Emulator.getThreading().run(new SaveScoreForTeam(teamEntry.getValue(), this));
+            Emulator.getThreading().runPersistence(new SaveScoreForTeam(teamEntry.getValue(), this));
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -971,7 +971,7 @@ public class ItemManager {
     }
 
     public HabboItem handleOpenRecycleBox(Habbo habbo, HabboItem box) {
-        Emulator.getThreading().run(new QueryDeleteHabboItem(box.getId()));
+        Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(box.getId()));
         HabboItem item = null;
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM items_presents WHERE item_id = ? LIMIT 1")) {
             statement.setInt(1, box.getId());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/pets/InteractionPetBreedingNest.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/pets/InteractionPetBreedingNest.java
@@ -198,7 +198,7 @@ public class InteractionPetBreedingNest extends HabboItem {
             return;
         }
 
-        Emulator.getThreading().run(new QueryDeleteHabboItem(this.getId()));
+        Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(this.getId()));
 
         this.setExtradata("2");
         habbo.getHabboInfo().getCurrentRoom().updateItem(this);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniDepositHelper.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniDepositHelper.java
@@ -48,7 +48,7 @@ public final class ChestFurniDepositHelper {
 
         habbo.getClient().sendResponse(new RemoveHabboItemComposer(removed.getGiftAdjustedId()));
         habbo.getClient().sendResponse(new InventoryRefreshComposer());
-        Emulator.getThreading().run(new QueryDeleteHabboItems(List.of(removed)));
+        Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(List.of(removed)));
 
         habbo.getClient().sendResponse(new ChestDataComposer(chest));
         ChestFurniPackets.sendDelta(habbo.getClient(), chest.getId(), List.of(), List.of(stored));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestWiredCurrencyUtil.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestWiredCurrencyUtil.java
@@ -1,11 +1,19 @@
 package com.eu.habbo.habbohotel.items.interactions.wired.chest;
 
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.LedgerWalletMutation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Currency helpers shared by wired chest effects and contract transactions.
  */
 public final class ChestWiredCurrencyUtil {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChestWiredCurrencyUtil.class);
+
     private ChestWiredCurrencyUtil() {
     }
 
@@ -30,10 +38,24 @@ public final class ChestWiredCurrencyUtil {
         if (!has(habbo, currencyType, amount)) {
             return false;
         }
-        if (currencyType < 0) {
-            habbo.getHabboInfo().addCredits(-amount);
-        } else {
-            habbo.getHabboInfo().addCurrencyAmount(currencyType, -amount);
+        int ledgerCurrencyType =
+                currencyType < 0 ? EconomyLedger.CREDITS : currencyType;
+        try {
+            LedgerWalletMutation.execute(habbo, new EconomyOperation(
+                    EconomyOperationId.create(
+                            "wired-contract:" + habbo.getHabboInfo().getId()),
+                    habbo.getHabboInfo().getId(),
+                    habbo.getHabboInfo().getId(),
+                    "wired_contract_debit",
+                    "wired.contract.currency",
+                    ledgerCurrencyType,
+                    -amount,
+                    null,
+                    ""));
+        } catch (Exception exception) {
+            LOGGER.error("Unable to debit wired contract currency for user {}",
+                    habbo.getHabboInfo().getId(), exception);
+            return false;
         }
         return true;
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestWiredFurniUtil.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestWiredFurniUtil.java
@@ -107,7 +107,7 @@ public final class ChestWiredFurniUtil {
                 habbo.getClient().sendResponse(new RemoveHabboItemComposer(removed.getGiftAdjustedId()));
             }
             habbo.getClient().sendResponse(new InventoryRefreshComposer());
-            Emulator.getThreading().run(new QueryDeleteHabboItems(removedItems));
+            Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(removedItems));
         }
 
         return taken;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveOrTakeFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveOrTakeFurni.java
@@ -125,7 +125,7 @@ public class WiredEffectGiveOrTakeFurni extends InteractionWiredEffect {
         }
 
         habbo.getClient().sendResponse(new InventoryRefreshComposer());
-        Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove.values()));
+        Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(toRemove.values()));
     }
 
     @Deprecated

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolIssue.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolIssue.java
@@ -106,6 +106,6 @@ public class ModToolIssue implements ISerialize {
     }
 
     public void updateInDatabase() {
-        Emulator.getThreading().run(new UpdateModToolIssue(this));
+        Emulator.getThreading().runPersistence(new UpdateModToolIssue(this));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTrade.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTrade.java
@@ -3,6 +3,7 @@ package com.eu.habbo.habbohotel.rooms;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.users.LedgerWalletMutation;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
@@ -217,13 +218,31 @@ public class RoomTrade {
 
         creditsForUserOne = resolveCredits(userOne.getHabbo(), creditsForUserOne);
         creditsForUserTwo = resolveCredits(userTwo.getHabbo(), creditsForUserTwo);
+        final int committedCreditsForUserOne = creditsForUserOne;
+        final int committedCreditsForUserTwo = creditsForUserTwo;
 
         try {
-            if (!RoomTradeTransaction.execute(userOne.getHabbo(), userTwo.getHabbo(),
-                    userOne.getItems(), userTwo.getItems(), creditsForUserOne, creditsForUserTwo,
-                    Emulator.getConfig().getBoolean("hotel.log.trades"))) {
-                return false;
-            }
+            LedgerWalletMutation.coordinated(
+                    userOne.getHabbo(),
+                    userTwo.getHabbo(),
+                    () -> {
+                        RoomTradeTransaction.CommitResult commit =
+                                RoomTradeTransaction.execute(
+                                        userOne.getHabbo(),
+                                        userTwo.getHabbo(),
+                                        userOne.getItems(),
+                                        userTwo.getItems(),
+                                        committedCreditsForUserOne,
+                                        committedCreditsForUserTwo,
+                                        Emulator.getConfig().getBoolean("hotel.log.trades"));
+                        applyCommittedCreditBalance(
+                                userOne.getHabbo(),
+                                commit.userOneCreditBalance());
+                        applyCommittedCreditBalance(
+                                userTwo.getHabbo(),
+                                commit.userTwoCreditBalance());
+                        return commit;
+                    });
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
             this.sendMessageToUsers(new TradeClosedComposer(userOne.getHabbo().getRoomUnit().getId(), TradeClosedComposer.ITEMS_NOT_FOUND));
@@ -236,8 +255,8 @@ public class RoomTrade {
         userOne.clearItems();
         userTwo.clearItems();
 
-        applyCommittedCredits(userOne.getHabbo(), creditsForUserOne);
-        applyCommittedCredits(userTwo.getHabbo(), creditsForUserTwo);
+        publishCommittedCredits(userOne.getHabbo(), committedCreditsForUserOne);
+        publishCommittedCredits(userTwo.getHabbo(), committedCreditsForUserTwo);
 
         userOne.getHabbo().getInventory().getItemsComponent().addItems(itemsUserTwo);
         userTwo.getHabbo().getInventory().getItemsComponent().addItems(itemsUserOne);
@@ -256,9 +275,18 @@ public class RoomTrade {
         return Emulator.getPluginManager().fireEvent(event).isCancelled() ? 0 : Math.max(0, event.credits);
     }
 
-    private static void applyCommittedCredits(Habbo habbo, int credits) {
+    private static void applyCommittedCreditBalance(
+            Habbo habbo,
+            Integer committedBalance) {
+        if (committedBalance == null) return;
+        LedgerWalletMutation.applyCommitted(
+                habbo,
+                com.eu.habbo.habbohotel.economy.EconomyLedger.CREDITS,
+                committedBalance);
+    }
+
+    private static void publishCommittedCredits(Habbo habbo, int credits) {
         if (credits <= 0) return;
-        habbo.getHabboInfo().addCredits(credits);
         if (habbo.getClient() != null) habbo.getClient().sendResponse(new UserCreditsComposer(habbo));
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTradeTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTradeTransaction.java
@@ -4,6 +4,7 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.economy.EconomyLedger;
 import com.eu.habbo.habbohotel.economy.EconomyOperation;
 import com.eu.habbo.habbohotel.economy.EconomyOperationId;
+import com.eu.habbo.habbohotel.economy.EconomyMutationResult;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 
@@ -21,9 +22,14 @@ final class RoomTradeTransaction {
     private RoomTradeTransaction() {
     }
 
-    static boolean execute(Habbo userOne, Habbo userTwo,
-                           Collection<HabboItem> userOneItems, Collection<HabboItem> userTwoItems,
-                           int creditsForUserOne, int creditsForUserTwo, boolean logTrades) throws SQLException {
+    static CommitResult execute(
+            Habbo userOne,
+            Habbo userTwo,
+            Collection<HabboItem> userOneItems,
+            Collection<HabboItem> userTwoItems,
+            int creditsForUserOne,
+            int creditsForUserTwo,
+            boolean logTrades) throws SQLException {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
             connection.setAutoCommit(false);
             try {
@@ -36,13 +42,15 @@ final class RoomTradeTransaction {
                         userOneItems, logTrades);
                 persistItems(connection, tradeId, userTwo.getHabboInfo().getId(), userOne.getHabboInfo().getId(),
                         userTwoItems, logTrades);
-                creditUser(connection, operationId, userOne.getHabboInfo().getId(), creditsForUserOne,
+                Integer userOneBalance = creditUser(connection,
+                        operationId, userOne.getHabboInfo().getId(), creditsForUserOne,
                         userTwo.getHabboInfo().getId(), tradeId);
-                creditUser(connection, operationId, userTwo.getHabboInfo().getId(), creditsForUserTwo,
+                Integer userTwoBalance = creditUser(connection,
+                        operationId, userTwo.getHabboInfo().getId(), creditsForUserTwo,
                         userOne.getHabboInfo().getId(), tradeId);
 
                 connection.commit();
-                return true;
+                return new CommitResult(userOneBalance, userTwoBalance);
             } catch (SQLException | RuntimeException exception) {
                 connection.rollback();
                 throw exception;
@@ -104,10 +112,15 @@ final class RoomTradeTransaction {
         }
     }
 
-    private static void creditUser(Connection connection, String operationId, int userId, int credits,
-                                   int actorId, int tradeId) throws SQLException {
-        if (credits <= 0) return;
-        EconomyLedger.apply(connection, new EconomyOperation(
+    private static Integer creditUser(
+            Connection connection,
+            String operationId,
+            int userId,
+            int credits,
+            int actorId,
+            int tradeId) throws SQLException {
+        if (credits <= 0) return null;
+        EconomyMutationResult mutation = EconomyLedger.apply(connection, new EconomyOperation(
                 operationId + ":recipient:" + userId,
                 userId,
                 actorId,
@@ -117,5 +130,9 @@ final class RoomTradeTransaction {
                 credits,
                 null,
                 "tradeId=" + tradeId));
+        return mutation.balanceAfter();
+    }
+
+    record CommitResult(Integer userOneCreditBalance, Integer userTwoCreditBalance) {
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/traxeditor/TraxEditorManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/traxeditor/TraxEditorManager.java
@@ -223,7 +223,7 @@ public class TraxEditorManager {
         for (HabboItem disc : discs) {
             habbo.getInventory().getItemsComponent().removeHabboItem(disc);
             habbo.getClient().sendResponse(new RemoveHabboItemComposer(disc.getId()));
-            Emulator.getThreading().run(new QueryDeleteHabboItem(disc.getId()));
+            Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(disc.getId()));
         }
 
         habbo.getClient().sendResponse(new InventoryRefreshComposer());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -5,7 +5,6 @@ import com.eu.habbo.habbohotel.achievements.AchievementManager;
 import com.eu.habbo.habbohotel.bots.Bot;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.economy.EconomyLedger;
-import com.eu.habbo.habbohotel.economy.EconomyMutationResult;
 import com.eu.habbo.habbohotel.economy.EconomyOperation;
 import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.messenger.Messenger;
@@ -293,7 +292,7 @@ public class Habbo implements Runnable {
             return;
 
         try {
-            EconomyMutationResult result = EconomyLedger.execute(new EconomyOperation(
+            LedgerWalletMutation.execute(this, new EconomyOperation(
                     operationId,
                     this.getHabboInfo().getId(),
                     actorId,
@@ -303,7 +302,6 @@ public class Habbo implements Runnable {
                     event.credits,
                     null,
                     ""));
-            this.getHabboInfo().setCredits(result.balanceAfter());
         } catch (Exception exception) {
             LOGGER.error("Unable to apply audited credit mutation for user {}", this.getHabboInfo().getId(), exception);
             return;
@@ -313,6 +311,18 @@ public class Habbo implements Runnable {
     }
 
     public boolean tryTakeCredits(int credits) {
+        return this.tryTakeCredits(
+                credits,
+                "economy.api.credits",
+                EconomyOperationId.create("credits:" + this.getHabboInfo().getId()),
+                this.getHabboInfo().getId());
+    }
+
+    public boolean tryTakeCredits(
+            int credits,
+            String reason,
+            String operationId,
+            Integer actorId) {
         if (credits <= 0) {
             return false;
         }
@@ -322,7 +332,21 @@ public class Habbo implements Runnable {
             return false;
         }
 
-        if (!this.getHabboInfo().tryAddCredits(event.credits)) {
+        try {
+            LedgerWalletMutation.execute(this, new EconomyOperation(
+                    operationId,
+                    this.getHabboInfo().getId(),
+                    actorId,
+                    "credit_debit",
+                    reason,
+                    EconomyLedger.CREDITS,
+                    event.credits,
+                    null,
+                    ""));
+        } catch (IllegalArgumentException exception) {
+            return false;
+        } catch (Exception exception) {
+            LOGGER.error("Unable to apply audited credit debit for user {}", this.getHabboInfo().getId(), exception);
             return false;
         }
 
@@ -364,7 +388,7 @@ public class Habbo implements Runnable {
             return;
 
         try {
-            EconomyMutationResult result = EconomyLedger.execute(new EconomyOperation(
+            LedgerWalletMutation.execute(this, new EconomyOperation(
                     operationId,
                     this.getHabboInfo().getId(),
                     actorId,
@@ -374,7 +398,6 @@ public class Habbo implements Runnable {
                     event.points,
                     null,
                     ""));
-            this.getHabboInfo().setCurrencyAmount(event.type, result.balanceAfter());
         } catch (Exception exception) {
             LOGGER.error("Unable to apply audited currency mutation for user {}", this.getHabboInfo().getId(), exception);
             return;
@@ -387,6 +410,21 @@ public class Habbo implements Runnable {
     }
 
     public boolean tryTakePoints(int type, int points) {
+        return this.tryTakePoints(
+                type,
+                points,
+                "economy.api.currency",
+                EconomyOperationId.create(
+                        "currency:" + this.getHabboInfo().getId() + ":" + type),
+                this.getHabboInfo().getId());
+    }
+
+    public boolean tryTakePoints(
+            int type,
+            int points,
+            String reason,
+            String operationId,
+            Integer actorId) {
         if (points <= 0) {
             return false;
         }
@@ -397,7 +435,22 @@ public class Habbo implements Runnable {
             return false;
         }
 
-        if (!this.getHabboInfo().tryAddCurrencyAmount(event.type, event.points)) {
+        try {
+            LedgerWalletMutation.execute(this, new EconomyOperation(
+                    operationId,
+                    this.getHabboInfo().getId(),
+                    actorId,
+                    "currency_debit",
+                    reason,
+                    event.type,
+                    event.points,
+                    null,
+                    ""));
+        } catch (IllegalArgumentException exception) {
+            return false;
+        } catch (Exception exception) {
+            LOGGER.error("Unable to apply audited currency debit for user {}",
+                    this.getHabboInfo().getId(), exception);
             return false;
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInfo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInfo.java
@@ -115,6 +115,13 @@ public class HabboInfo implements Runnable {
         this.loadMessengerCategories();
     }
 
+    HabboInfo(int id, int credits) {
+        this.id = id;
+        this.credits = WalletBalanceMath.requireValidBalance(credits);
+        this.gender = HabboGender.M;
+        this.currencies = new Int2IntOpenHashMap();
+    }
+
     private void loadCurrencies() {
         this.currencies = new Int2IntOpenHashMap();
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInfo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInfo.java
@@ -61,6 +61,7 @@ public class HabboInfo implements Runnable {
     // can't lose updates or rehash the Trove map mid-iteration. Never held
     // across run()'s DB I/O.
     private final Object currencyLock = new Object();
+    private final Object ledgerMutationLock = new Object();
     private GamePlayer gamePlayer;
     private int photoRoomId;
     private int photoTimestamp;
@@ -523,6 +524,22 @@ public class HabboInfo implements Runnable {
             this.credits = updated;
         }
         this.run();
+    }
+
+    void applyPersistedCredits(int credits) {
+        synchronized (this.currencyLock) {
+            this.credits = WalletBalanceMath.requireValidBalance(credits);
+        }
+    }
+
+    void applyPersistedCurrencyAmount(int type, int amount) {
+        synchronized (this.currencyLock) {
+            this.currencies.put(type, WalletBalanceMath.requireValidBalance(amount));
+        }
+    }
+
+    Object ledgerMutationLock() {
+        return this.ledgerMutationLock;
     }
 
     public boolean tryAddCredits(int credits) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/LedgerWalletMutation.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/LedgerWalletMutation.java
@@ -1,0 +1,114 @@
+package com.eu.habbo.habbohotel.users;
+
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyMutationResult;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Applies durable ledger results to an online wallet without invoking the
+ * legacy whole-user snapshot save.
+ */
+public final class LedgerWalletMutation {
+    private LedgerWalletMutation() {
+    }
+
+    public static EconomyMutationResult execute(Habbo habbo, EconomyOperation operation)
+            throws SQLException {
+        return executeBatch(habbo, List.of(operation)).getFirst();
+    }
+
+    public static List<EconomyMutationResult> executeBatch(
+            Habbo habbo,
+            List<EconomyOperation> operations) throws SQLException {
+        return coordinated(
+                habbo,
+                () -> executeBatchWhileCoordinated(habbo, operations));
+    }
+
+    private static List<EconomyMutationResult> executeBatchWhileCoordinated(
+            Habbo habbo,
+            List<EconomyOperation> operations) throws SQLException {
+        if (habbo == null || operations == null || operations.isEmpty()) {
+            throw new IllegalArgumentException("online ledger operation batch must not be empty");
+        }
+        int userId = habbo.getHabboInfo().getId();
+        if (operations.stream().anyMatch(
+                operation -> operation == null || operation.userId() != userId)) {
+            throw new IllegalArgumentException(
+                    "ledger operation user does not match the online wallet");
+        }
+
+        List<EconomyMutationResult> results =
+                EconomyLedger.executeBatch(operations);
+        for (int index = 0; index < operations.size(); index++) {
+            EconomyOperation operation = operations.get(index);
+            applyCommitted(
+                    habbo,
+                    operation.currencyType(),
+                    results.get(index).balanceAfter());
+        }
+        return results;
+    }
+
+    public static void applyCommitted(Habbo habbo, int currencyType, int balance) {
+        if (habbo == null) {
+            throw new IllegalArgumentException("habbo must not be null");
+        }
+        synchronized (habbo.getHabboInfo().ledgerMutationLock()) {
+            if (currencyType == EconomyLedger.CREDITS) {
+                habbo.getHabboInfo().applyPersistedCredits(balance);
+                return;
+            }
+            habbo.getHabboInfo().applyPersistedCurrencyAmount(
+                    currencyType,
+                    balance);
+        }
+    }
+
+    public static <T, E extends Exception> T coordinated(
+            Habbo habbo,
+            CoordinatedWork<T, E> work) throws E {
+        if (habbo == null || work == null) {
+            throw new IllegalArgumentException(
+                    "coordinated wallet work must not be null");
+        }
+        synchronized (habbo.getHabboInfo().ledgerMutationLock()) {
+            return work.execute();
+        }
+    }
+
+    public static <T, E extends Exception> T coordinated(
+            Habbo firstHabbo,
+            Habbo secondHabbo,
+            CoordinatedWork<T, E> work) throws E {
+        if (firstHabbo == null || secondHabbo == null || work == null) {
+            throw new IllegalArgumentException(
+                    "coordinated wallet work must not be null");
+        }
+        HabboInfo first = firstHabbo.getHabboInfo();
+        HabboInfo second = secondHabbo.getHabboInfo();
+        if (first == second) {
+            synchronized (first.ledgerMutationLock()) {
+                return work.execute();
+            }
+        }
+        if (first.getId() > second.getId()) {
+            HabboInfo swap = first;
+            first = second;
+            second = swap;
+        }
+        synchronized (first.ledgerMutationLock()) {
+            synchronized (second.ledgerMutationLock()) {
+                return work.execute();
+            }
+        }
+    }
+
+    @FunctionalInterface
+    public interface CoordinatedWork<T, E extends Exception> {
+        T execute() throws E;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/recycler/RecycleEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/recycler/RecycleEvent.java
@@ -59,7 +59,7 @@ public class RecycleEvent extends MessageHandler {
             for (HabboItem item : items) {
                 this.client.getHabbo().getInventory().getItemsComponent().removeHabboItem(item);
                 this.client.sendResponse(new RemoveHabboItemComposer(item.getGiftAdjustedId()));
-                Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
             }
 
             this.client.sendResponse(new AddHabboItemComposer(reward));

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftItemEvent.java
@@ -84,7 +84,7 @@ public class CraftingCraftItemEvent extends MessageHandler {
                 });
                 this.client.sendResponse(new InventoryRefreshComposer());
 
-                Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove.values()));
+                Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(toRemove.values()));
                 return;
             }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftSecretEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/crafting/CraftingCraftSecretEvent.java
@@ -95,7 +95,7 @@ public class CraftingCraftSecretEvent extends MessageHandler {
                         for (HabboItem item : habboItems) {
                             this.client.getHabbo().getInventory().getItemsComponent().removeHabboItem(item);
                             this.client.sendResponse(new RemoveHabboItemComposer(item.getGiftAdjustedId()));
-                            Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                            Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
                         }
                         this.client.sendResponse(new InventoryRefreshComposer());
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/inventory/RequestInventoryItemsDelete.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/inventory/RequestInventoryItemsDelete.java
@@ -47,7 +47,7 @@ public class RequestInventoryItemsDelete extends MessageHandler {
             habbo.getClient().sendResponse(new RemoveHabboItemComposer(object.getGiftAdjustedId()));
         });
         habbo.getClient().sendResponse(new InventoryRefreshComposer());
-        Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove.values()));
+        Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(toRemove.values()));
     }
 
     private boolean hasFurnitureInInventory(Habbo habbo, Item item, Integer amount) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/inventory/nickicons/PurchaseNickIconEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/inventory/nickicons/PurchaseNickIconEvent.java
@@ -1,7 +1,10 @@
 package com.eu.habbo.messages.incoming.inventory.nickicons;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.LedgerWalletMutation;
 import com.eu.habbo.habbohotel.users.UserNickIcon;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
@@ -63,7 +66,25 @@ public class PurchaseNickIconEvent extends MessageHandler {
                 }
 
                 if (points > 0) {
-                    habbo.getHabboInfo().addCurrencyAmount(pointsType, -points);
+                    try {
+                        LedgerWalletMutation.execute(habbo, new EconomyOperation(
+                                EconomyOperationId.create(
+                                        "nick-icon:" + habbo.getHabboInfo().getId()
+                                                + ":" + requestedIconKey),
+                                habbo.getHabboInfo().getId(),
+                                habbo.getHabboInfo().getId(),
+                                "nick_icon_purchase",
+                                "inventory.nick_icon.purchase",
+                                pointsType,
+                                -points,
+                                null,
+                                requestedIconKey));
+                    } catch (IllegalArgumentException exception) {
+                        this.client.sendResponse(new BubbleAlertComposer(
+                                BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key,
+                                "Not enough points."));
+                        return;
+                    }
                     this.client.sendResponse(new UserCurrencyComposer(habbo));
                 }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/inventory/prefixes/PurchaseCatalogPrefixEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/inventory/prefixes/PurchaseCatalogPrefixEvent.java
@@ -1,7 +1,10 @@
 package com.eu.habbo.messages.incoming.inventory.prefixes;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.LedgerWalletMutation;
 import com.eu.habbo.habbohotel.users.UserPrefix;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
@@ -57,7 +60,25 @@ public class PurchaseCatalogPrefixEvent extends MessageHandler {
                 }
 
                 if (points > 0) {
-                    habbo.getHabboInfo().addCurrencyAmount(pointsType, -points);
+                    try {
+                        LedgerWalletMutation.execute(habbo, new EconomyOperation(
+                                EconomyOperationId.create(
+                                        "catalog-prefix:" + habbo.getHabboInfo().getId()
+                                                + ":" + catalogPrefixId),
+                                habbo.getHabboInfo().getId(),
+                                habbo.getHabboInfo().getId(),
+                                "catalog_prefix_purchase",
+                                "inventory.catalog_prefix.purchase",
+                                pointsType,
+                                -points,
+                                null,
+                                "catalogPrefixId=" + catalogPrefixId));
+                    } catch (IllegalArgumentException exception) {
+                        this.client.sendResponse(new BubbleAlertComposer(
+                                BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key,
+                                "Not enough points."));
+                        return;
+                    }
                     this.client.sendResponse(new UserCurrencyComposer(habbo));
                 }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/inventory/prefixes/PurchasePrefixEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/inventory/prefixes/PurchasePrefixEvent.java
@@ -1,8 +1,12 @@
 package com.eu.habbo.messages.incoming.inventory.prefixes;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.modtool.WordFilterWord;
 import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.LedgerWalletMutation;
 import com.eu.habbo.habbohotel.users.UserPrefix;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
@@ -22,7 +26,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class PurchasePrefixEvent extends MessageHandler {
@@ -147,18 +153,65 @@ public class PurchasePrefixEvent extends MessageHandler {
             return;
         }
 
+        String operationId = EconomyOperationId.create(
+                "prefix-purchase:" + habbo.getHabboInfo().getId());
+        List<EconomyOperation> paymentOperations = new ArrayList<>(3);
         if (totalPriceCredits > 0) {
-            habbo.getHabboInfo().addCredits(-totalPriceCredits);
+            paymentOperations.add(new EconomyOperation(
+                    operationId + ":credits",
+                    habbo.getHabboInfo().getId(),
+                    habbo.getHabboInfo().getId(),
+                    "prefix_purchase",
+                    "inventory.prefix.purchase",
+                    EconomyLedger.CREDITS,
+                    -totalPriceCredits,
+                    null,
+                    operationId));
+        }
+        if (totalPricePointsSameType > 0) {
+            paymentOperations.add(new EconomyOperation(
+                    operationId + ":points",
+                    habbo.getHabboInfo().getId(),
+                    habbo.getHabboInfo().getId(),
+                    "prefix_purchase",
+                    "inventory.prefix.purchase",
+                    pointsType,
+                    -totalPricePointsSameType,
+                    null,
+                    operationId));
+        }
+        if (!font.isEmpty() && fontPricePoints > 0 && fontPointsType != pointsType) {
+            paymentOperations.add(new EconomyOperation(
+                    operationId + ":font-points",
+                    habbo.getHabboInfo().getId(),
+                    habbo.getHabboInfo().getId(),
+                    "prefix_purchase",
+                    "inventory.prefix.purchase",
+                    fontPointsType,
+                    -fontPricePoints,
+                    null,
+                    operationId));
+        }
+        try {
+            if (!paymentOperations.isEmpty()) {
+                LedgerWalletMutation.executeBatch(habbo, paymentOperations);
+            }
+        } catch (IllegalArgumentException exception) {
+            this.fail(habbo, "Not enough currency.");
+            return;
+        } catch (SQLException exception) {
+            LOGGER.error("Unable to debit prefix purchase for user {}",
+                    habbo.getHabboInfo().getId(), exception);
+            this.fail(habbo, "Unable to complete the purchase.");
+            return;
+        }
+        if (totalPriceCredits > 0) {
             this.client.sendResponse(new UserCreditsComposer(habbo));
         }
-
-        if (totalPricePointsSameType > 0) {
-            habbo.getHabboInfo().addCurrencyAmount(pointsType, -totalPricePointsSameType);
-            this.client.sendResponse(new UserCurrencyComposer(habbo));
-        }
-
-        if (!font.isEmpty() && fontPricePoints > 0 && fontPointsType != pointsType) {
-            habbo.getHabboInfo().addCurrencyAmount(fontPointsType, -fontPricePoints);
+        if (totalPricePointsSameType > 0
+                || (!font.isEmpty()
+                && fontPricePoints > 0
+                && fontPointsType != pointsType)) {
             this.client.sendResponse(new UserCurrencyComposer(habbo));
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestDepositFurniEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestDepositFurniEvent.java
@@ -92,7 +92,7 @@ public class ChestDepositFurniEvent extends MessageHandler {
             habbo.getClient().sendResponse(new RemoveHabboItemComposer(removed.getGiftAdjustedId()));
         }
         habbo.getClient().sendResponse(new InventoryRefreshComposer());
-        Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove));
+        Emulator.getThreading().runPersistence(new QueryDeleteHabboItems(toRemove));
 
         this.client.sendResponse(new ChestDataComposer(chest));
         ChestFurniPackets.sendDelta(this.client, chest.getId(), List.of(), added);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/PostItDeleteEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/PostItDeleteEvent.java
@@ -30,7 +30,7 @@ public class PostItDeleteEvent extends MessageHandler {
                 item.setRoomId(0);
                 room.removeHabboItem(item);
                 room.sendComposer(new RemoveWallItemComposer(item).compose());
-                Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
             }
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemClothingEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemClothingEvent.java
@@ -53,7 +53,7 @@ public class RedeemClothingEvent extends MessageHandler {
                             this.client.getHabbo().getHabboInfo().getCurrentRoom().updateTile(tile);
                             this.client.getHabbo().getHabboInfo().getCurrentRoom().sendComposer(new UpdateStackHeightComposer(tile.x, tile.y, tile.z, tile.relativeHeight()).compose());
                             this.client.getHabbo().getHabboInfo().getCurrentRoom().sendComposer(new RemoveFloorItemComposer(item, true).compose());
-                            Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                            Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
 
                             this.client.getHabbo().getInventory().getWardrobeComponent().getClothing().add(clothing.id);
                             for (int setId : clothing.setId) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java
@@ -1,9 +1,11 @@
 package com.eu.habbo.messages.incoming.rooms.items;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyMutationResult;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.users.LedgerWalletMutation;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.rooms.UpdateStackHeightComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RemoveFloorItemComposer;
@@ -107,12 +109,26 @@ public class RedeemItemEvent extends MessageHandler {
                     if (room.getHabboItem(item.getId()) == null) // plugins may cause a lag between which time the item can be removed from the room
                         return;
 
-                    if (!RedeemItemTransaction.commit(
-                            item.getId(),
-                            this.client.getHabbo().getHabboInfo().getId(),
-                            currencyGrant.currencyType(),
-                            currencyGrant.amount(),
-                            item.getBaseItem().getName()))
+                    EconomyMutationResult walletMutation =
+                            LedgerWalletMutation.coordinated(
+                                    this.client.getHabbo(),
+                                    () -> {
+                                        EconomyMutationResult mutation =
+                                                RedeemItemTransaction.commit(
+                                                        item.getId(),
+                                                        this.client.getHabbo().getHabboInfo().getId(),
+                                                        currencyGrant.currencyType(),
+                                                        currencyGrant.amount(),
+                                                        item.getBaseItem().getName());
+                                        if (mutation != null) {
+                                            LedgerWalletMutation.applyCommitted(
+                                                    this.client.getHabbo(),
+                                                    currencyGrant.currencyType(),
+                                                    mutation.balanceAfter());
+                                        }
+                                        return mutation;
+                                    });
+                    if (walletMutation == null)
                         return;
 
                     room.removeHabboItem(item);
@@ -124,7 +140,7 @@ public class RedeemItemEvent extends MessageHandler {
                     t.setStackHeight(room.getStackHeight(item.getX(), item.getY(), false));
                     room.updateTile(t);
                     room.sendComposer(new UpdateStackHeightComposer(item.getX(), item.getY(), t.z, t.relativeHeight()).compose());
-                    applyCurrencyGrant(currencyGrant);
+                    publishCurrencyGrant(currencyGrant);
                 }
             }
         }
@@ -142,14 +158,12 @@ public class RedeemItemEvent extends MessageHandler {
         return new PreparedCurrencyGrant(event.type, event.points);
     }
 
-    private void applyCurrencyGrant(PreparedCurrencyGrant grant) {
+    private void publishCurrencyGrant(PreparedCurrencyGrant grant) {
         if (grant.currencyType() == FurnitureRedeemedEvent.CREDITS) {
-            this.client.getHabbo().getHabboInfo().addCredits(grant.amount());
             this.client.sendResponse(new UserCreditsComposer(this.client.getHabbo()));
             return;
         }
 
-        this.client.getHabbo().getHabboInfo().addCurrencyAmount(grant.currencyType(), grant.amount());
         if (grant.currencyType() == FurnitureRedeemedEvent.PIXELS) {
             this.client.sendResponse(new UserCurrencyComposer(this.client.getHabbo()));
         } else {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemTransaction.java
@@ -2,6 +2,7 @@ package com.eu.habbo.messages.incoming.rooms.items;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyMutationResult;
 import com.eu.habbo.habbohotel.economy.EconomyOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,8 +18,13 @@ final class RedeemItemTransaction {
     private RedeemItemTransaction() {
     }
 
-    static boolean commit(int itemId, int userId, int currencyType, int amount, String itemName) {
-        if (itemId <= 0 || userId <= 0 || amount <= 0) return false;
+    static EconomyMutationResult commit(
+            int itemId,
+            int userId,
+            int currencyType,
+            int amount,
+            String itemName) {
+        if (itemId <= 0 || userId <= 0 || amount <= 0) return null;
 
         Connection connection = null;
         try {
@@ -30,11 +36,11 @@ final class RedeemItemTransaction {
                 delete.setInt(2, userId);
                 if (delete.executeUpdate() != 1) {
                     connection.rollback();
-                    return false;
+                    return null;
                 }
             }
 
-            EconomyLedger.apply(connection, new EconomyOperation(
+            EconomyMutationResult walletMutation = EconomyLedger.apply(connection, new EconomyOperation(
                     "furniture-redeem:" + itemId,
                     userId,
                     userId,
@@ -46,7 +52,7 @@ final class RedeemItemTransaction {
                     itemName));
 
             connection.commit();
-            return true;
+            return walletMutation;
         } catch (SQLException e) {
             if (connection != null) {
                 try {
@@ -56,7 +62,7 @@ final class RedeemItemTransaction {
                 }
             }
             LOGGER.error("Atomic redemption failed for item {} and user {}", itemId, userId, e);
-            return false;
+            return null;
         } finally {
             if (connection != null) {
                 try {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ToggleFloorItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ToggleFloorItemEvent.java
@@ -116,7 +116,7 @@ public class ToggleFloorItemEvent extends MessageHandler {
                     return;
                 }
 
-                Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
 
                 boolean isRare = item.getBaseItem().getName().contains("rare");
                 int rarity = 0;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/pets/PetPackageNameEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/pets/PetPackageNameEvent.java
@@ -71,7 +71,7 @@ public class PetPackageNameEvent extends MessageHandler {
                             pet.needsUpdate = true;
                             pet.getRoomUnit().setLocation(tile);
                             pet.getRoomUnit().setZ(item.getZ());
-                            Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                            Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
                             room.removeHabboItem(item);
                             room.sendComposer(new RemoveFloorItemComposer(item).compose());
                             room.updateTile(tile);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/pets/PetUseItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/pets/PetUseItemEvent.java
@@ -115,7 +115,7 @@ public class PetUseItemEvent extends MessageHandler {
                     this.client.getHabbo().getHabboInfo().getCurrentRoom().updateTiles(room.getLayout().getTilesAt(room.getLayout().getTile(item.getX(), item.getY()), item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation()));
                     AchievementManager.progressAchievement(this.client.getHabbo(), Emulator.getGameEnvironment().getAchievementManager().getAchievement("MonsterPlantHealer"));
                     pet.getRoomUnit().removeStatus(RoomUnitStatus.GESTURE);
-                    Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                    Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
                 }
             } else if (item.getBaseItem().getName().equalsIgnoreCase("mnstr_fert")) {
                 if (!monsterplant.isFullyGrown()) {
@@ -136,7 +136,7 @@ public class PetUseItemEvent extends MessageHandler {
                     this.client.getHabbo().getHabboInfo().getCurrentRoom().updateTiles(room.getLayout().getTilesAt(room.getLayout().getTile(item.getX(), item.getY()), item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation()));
                     pet.getRoomUnit().removeStatus(RoomUnitStatus.GESTURE);
                     pet.cycle();
-                    Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                    Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
                 }
             } else if (item.getBaseItem().getName().startsWith("mnstr_rebreed")) {
                 if (monsterplant.isFullyGrown() && !monsterplant.canBreed() && !monsterplant.isDead()) {
@@ -160,7 +160,7 @@ public class PetUseItemEvent extends MessageHandler {
                         this.client.getHabbo().getHabboInfo().getCurrentRoom().sendComposer(new PetStatusUpdateComposer(pet).compose());
                         this.client.getHabbo().getHabboInfo().getCurrentRoom().updateTiles(room.getLayout().getTilesAt(room.getLayout().getTile(item.getX(), item.getY()), item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation()));
                         pet.getRoomUnit().removeStatus(RoomUnitStatus.GESTURE);
-                        Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
+                        Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
                     }
                 }
             }

--- a/Emulator/src/main/java/com/eu/habbo/threading/ThreadPooling.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/ThreadPooling.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.threading;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.database.PersistenceExecutor;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,11 +17,19 @@ public class ThreadPooling {
 
     public final int threads;
     private final ScheduledExecutorService scheduledPool;
+    private final PersistenceExecutor persistenceExecutor;
     private volatile boolean canAdd;
 
     public ThreadPooling(Integer threads) {
+        this(threads, null);
+    }
+
+    public ThreadPooling(
+            Integer threads,
+            PersistenceExecutor persistenceExecutor) {
         this.threads = threads;
         this.scheduledPool = new HabboExecutorService(this.threads, new DefaultThreadFactory("HabExec"));
+        this.persistenceExecutor = persistenceExecutor;
         this.canAdd = true;
         LOGGER.info("Thread Pool -> Loaded!");
     }
@@ -62,6 +71,15 @@ public class ThreadPooling {
         }
 
         return null;
+    }
+
+    public void runPersistence(Runnable task) {
+        if (this.persistenceExecutor == null) {
+            this.run(task);
+            return;
+        }
+
+        this.persistenceExecutor.execute(task);
     }
 
     public void shutDown() {

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/OpenGift.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/OpenGift.java
@@ -56,7 +56,7 @@ public class OpenGift implements Runnable {
                 this.room.updateTile(tile);
             }
 
-            Emulator.getThreading().run(new QueryDeleteHabboItem(this.item.getId()));
+            Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(this.item.getId()));
             Emulator.getThreading().run(new RemoveFloorItemTask(this.room, this.item), this.item.getBaseItem().getName().contains("present_wrap") ? 5000 : 0);
 
             this.habbo.getClient().sendResponse(new InventoryRefreshComposer());

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/PetEatAction.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/PetEatAction.java
@@ -61,7 +61,12 @@ public class PetEatAction implements Runnable {
             } else {
                 // Food is empty - remove it
                 if (this.food != null && currentState >= this.food.getBaseItem().getStateCount()) {
-                    Emulator.getThreading().run(new QueryDeleteHabboItem(this.food.getId()), 250);
+                    var threading = Emulator.getThreading();
+                    threading.run(
+                            () -> threading.runPersistence(
+                                    new QueryDeleteHabboItem(
+                                            this.food.getId())),
+                            250);
                     if (this.pet.getRoom() != null) {
                         this.pet.getRoom().removeHabboItem(this.food);
                         this.pet.getRoom().sendComposer(new RemoveFloorItemComposer(this.food, true).compose());

--- a/Emulator/src/main/resources/db/migration/V20260719235220__users_currency_innodb.sql
+++ b/Emulator/src/main/resources/db/migration/V20260719235220__users_currency_innodb.sql
@@ -1,0 +1,17 @@
+SET @polaris_users_currency_engine := (
+    SELECT ENGINE
+    FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'users_currency'
+);
+
+SET @polaris_users_currency_engine_sql := IF(
+    @polaris_users_currency_engine = 'InnoDB',
+    'DO 0',
+    'ALTER TABLE `users_currency` ENGINE=InnoDB ROW_FORMAT=DYNAMIC'
+);
+
+PREPARE polaris_users_currency_engine_stmt
+    FROM @polaris_users_currency_engine_sql;
+EXECUTE polaris_users_currency_engine_stmt;
+DEALLOCATE PREPARE polaris_users_currency_engine_stmt;

--- a/Emulator/src/test/java/com/eu/habbo/PolarisRuntimeTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/PolarisRuntimeTest.java
@@ -6,6 +6,7 @@ import com.eu.habbo.core.DatabaseLogger;
 import com.eu.habbo.core.Logging;
 import com.eu.habbo.core.TextsManager;
 import com.eu.habbo.database.Database;
+import com.eu.habbo.database.PersistenceExecutor;
 import com.eu.habbo.habbohotel.GameEnvironment;
 import com.eu.habbo.networking.gameserver.GameServer;
 import com.eu.habbo.networking.rconserver.RCONServer;
@@ -60,6 +61,11 @@ class PolarisRuntimeTest {
         services.put(
                 ThreadPooling.class,
                 service(runtime::installThreading, Emulator::getThreading));
+        services.put(
+                PersistenceExecutor.class,
+                service(
+                        runtime::installPersistenceExecutor,
+                        Emulator::getPersistenceExecutor));
         services.put(
                 GameEnvironment.class,
                 service(

--- a/Emulator/src/test/java/com/eu/habbo/RuntimeLifecycleTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/RuntimeLifecycleTest.java
@@ -2,6 +2,7 @@ package com.eu.habbo;
 
 import com.eu.habbo.core.ConfigurationManager;
 import com.eu.habbo.database.Database;
+import com.eu.habbo.database.PersistenceExecutor;
 import com.eu.habbo.habbohotel.GameEnvironment;
 import com.eu.habbo.networking.gameserver.GameServer;
 import com.eu.habbo.networking.rconserver.RCONServer;
@@ -38,6 +39,8 @@ class RuntimeLifecycleTest {
         GameServer gameServer = mock(GameServer.class);
         RCONServer rconServer = mock(RCONServer.class);
         ThreadPooling threading = mock(ThreadPooling.class);
+        PersistenceExecutor persistence =
+                mock(PersistenceExecutor.class);
         GameEnvironment environment = mock(GameEnvironment.class);
         PluginManager plugins = mock(PluginManager.class);
 
@@ -77,6 +80,10 @@ class RuntimeLifecycleTest {
             return null;
         }).when(threading).shutDown();
         doAnswer(invocation -> {
+            calls.add("persistence.shutdown");
+            return null;
+        }).when(persistence).shutDown();
+        doAnswer(invocation -> {
             calls.add("configuration.save");
             return null;
         }).when(configuration).saveToDatabase();
@@ -88,6 +95,7 @@ class RuntimeLifecycleTest {
         runtime.installConfiguration(configuration);
         runtime.installDatabase(database);
         runtime.installThreading(threading);
+        runtime.installPersistenceExecutor(persistence);
         runtime.installPluginManager(plugins);
         runtime.installGameEnvironment(environment);
         runtime.installGameServer(gameServer);
@@ -106,6 +114,7 @@ class RuntimeLifecycleTest {
                 "plugins.after-hotel",
                 "plugins.dispose",
                 "threading.shutdown",
+                "persistence.shutdown",
                 "configuration.save",
                 "database.dispose"), calls);
     }

--- a/Emulator/src/test/java/com/eu/habbo/database/PersistenceExecutorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/PersistenceExecutorTest.java
@@ -1,0 +1,95 @@
+package com.eu.habbo.database;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PersistenceExecutorTest {
+
+    @Test
+    void databaseWorkRunsOnDedicatedNamedWorkers()
+            throws Exception {
+        PersistenceExecutor executor =
+                new PersistenceExecutor(2, 8);
+        CountDownLatch completed = new CountDownLatch(1);
+        AtomicReference<String> threadName =
+                new AtomicReference<>();
+        try {
+            executor.execute(() -> {
+                threadName.set(
+                        Thread.currentThread().getName());
+                completed.countDown();
+            });
+
+            assertTrue(completed.await(
+                    2,
+                    TimeUnit.SECONDS));
+            assertTrue(threadName.get().startsWith(
+                    "Polaris-JDBC-"));
+        } finally {
+            executor.shutDown(2, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void saturationAppliesCallerBackpressureWithoutDroppingWork()
+            throws Exception {
+        PersistenceExecutor executor =
+                new PersistenceExecutor(1, 1);
+        CountDownLatch workerStarted =
+                new CountDownLatch(1);
+        CountDownLatch releaseWorker =
+                new CountDownLatch(1);
+        AtomicReference<Thread> saturatedTaskThread =
+                new AtomicReference<>();
+        try {
+            executor.execute(() -> {
+                workerStarted.countDown();
+                await(releaseWorker);
+            });
+            assertTrue(workerStarted.await(
+                    2,
+                    TimeUnit.SECONDS));
+            executor.execute(() -> {
+            });
+
+            Thread caller = Thread.currentThread();
+            executor.execute(() ->
+                    saturatedTaskThread.set(
+                            Thread.currentThread()));
+
+            assertEquals(
+                    caller,
+                    saturatedTaskThread.get());
+        } finally {
+            releaseWorker.countDown();
+            executor.shutDown(2, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void shutdownDrainsAcceptedTasks() {
+        PersistenceExecutor executor =
+                new PersistenceExecutor(1, 8);
+        CountDownLatch completed = new CountDownLatch(2);
+        executor.execute(completed::countDown);
+        executor.execute(completed::countDown);
+
+        executor.shutDown(2, TimeUnit.SECONDS);
+
+        assertEquals(0L, completed.getCount());
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/PersistenceTaskRoutingContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/PersistenceTaskRoutingContractTest.java
@@ -1,0 +1,45 @@
+package com.eu.habbo.database;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class PersistenceTaskRoutingContractTest {
+
+    @Test
+    void sqlOnlyRunnablesDoNotUseTheGameScheduler()
+            throws Exception {
+        Path sourceRoot =
+                Path.of("src", "main", "java");
+        List<Path> sources;
+        try (var paths = Files.walk(sourceRoot)) {
+            sources = paths
+                    .filter(path ->
+                            path.toString().endsWith(".java"))
+                    .toList();
+        }
+
+        for (Path source : sources) {
+            String code = Files.readString(source);
+            assertFalse(
+                    code.contains(
+                            "Emulator.getThreading().run("
+                                    + "new QueryDeleteHabboItem"),
+                    source.toString());
+            assertFalse(
+                    code.contains(
+                            "Emulator.getThreading().run("
+                                    + "new SaveScoreForTeam"),
+                    source.toString());
+            assertFalse(
+                    code.contains(
+                            "Emulator.getThreading().run("
+                                    + "new UpdateModToolIssue"),
+                    source.toString());
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/migration/MigrationRunnerIT.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/migration/MigrationRunnerIT.java
@@ -80,6 +80,8 @@ class MigrationRunnerIT {
             // The engine conversion took effect.
             assertEquals("InnoDB", tableEngine(ds, "marketplace_items"),
                     "marketplace_items must be InnoDB after migration");
+            assertEquals("InnoDB", tableEngine(ds, "users_currency"),
+                    "wallet currency rows must support ledger transaction rollback");
 
             // The dynamic Arc permissions conversion must produce usable Polaris
             // rows, not merely empty marker tables.

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
@@ -82,7 +82,7 @@ class EconomyAuditCoverageContractTest {
         String service = Files.readString(SOURCES.resolve(
                 "com/eu/habbo/habbohotel/catalog/CatalogPaymentService.java"));
 
-        assertTrue(service.contains("EconomyLedger.apply(connection"),
+        assertTrue(service.contains("EconomyLedger.executeBatch(operations)"),
                 "catalog payment reservations and refunds must be durable ledger operations");
         assertTrue(service.contains("LedgerWalletMutation.applyCommitted("),
                 "online balances must publish the committed ledger result without a second snapshot save");

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
@@ -51,7 +51,8 @@ class EconomyAuditCoverageContractTest {
         String housekeepingCurrency = Files.readString(SOURCES.resolve(
                 "com/eu/habbo/messages/incoming/housekeeping/HousekeepingGiveCurrencyEvent.java"));
 
-        assertTrue(habbo.contains("EconomyLedger.execute(new EconomyOperation("));
+        assertTrue(habbo.contains(
+                "LedgerWalletMutation.execute(this, new EconomyOperation("));
         assertTrue(housekeepingCredits.contains("\"housekeeping.user.give_credits\""));
         assertTrue(housekeepingCurrency.contains("\"housekeeping.user.give_currency\""));
     }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
@@ -57,7 +57,7 @@ class EconomyAuditCoverageContractTest {
     }
 
     @Test
-    void firstPartyCodeDoesNotUseLegacyDirectCreditMutators() throws Exception {
+    void firstPartyCodeDoesNotUseLegacyDirectWalletMutators() throws Exception {
         Set<String> callers = new HashSet<>();
         try (var paths = Files.walk(SOURCES)) {
             for (Path path : paths.filter(file -> file.toString().endsWith(".java")).toList()) {
@@ -67,14 +67,17 @@ class EconomyAuditCoverageContractTest {
                 String source = Files.readString(path);
                 if (source.contains(".addCredits(")
                         || source.contains(".setCredits(")
-                        || source.contains(".tryAddCredits(")) {
+                        || source.contains(".tryAddCredits(")
+                        || source.contains(".addCurrencyAmount(")
+                        || source.contains(".setCurrencyAmount(")
+                        || source.contains(".tryAddCurrencyAmount(")) {
                     callers.add(SOURCES.relativize(path).toString());
                 }
             }
         }
 
         assertEquals(Set.of(), callers,
-                "first-party credit changes must use explicit ledger operations or committed-balance publication");
+                "first-party wallet changes must use explicit ledger operations or committed-balance publication");
     }
 
     @Test

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
@@ -55,4 +55,23 @@ class EconomyAuditCoverageContractTest {
         assertTrue(housekeepingCredits.contains("\"housekeeping.user.give_credits\""));
         assertTrue(housekeepingCurrency.contains("\"housekeeping.user.give_currency\""));
     }
+
+    @Test
+    void firstPartyCodeDoesNotUseLegacyDirectCreditMutators() throws Exception {
+        Set<String> callers = new HashSet<>();
+        try (var paths = Files.walk(SOURCES)) {
+            for (Path path : paths.filter(file -> file.toString().endsWith(".java")).toList()) {
+                if (path.getFileName().toString().equals("HabboInfo.java")) {
+                    continue;
+                }
+                String source = Files.readString(path);
+                if (source.contains(".addCredits(") || source.contains(".setCredits(")) {
+                    callers.add(SOURCES.relativize(path).toString());
+                }
+            }
+        }
+
+        assertEquals(Set.of(), callers,
+                "first-party credit changes must use explicit ledger operations or committed-balance publication");
+    }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
@@ -65,7 +65,9 @@ class EconomyAuditCoverageContractTest {
                     continue;
                 }
                 String source = Files.readString(path);
-                if (source.contains(".addCredits(") || source.contains(".setCredits(")) {
+                if (source.contains(".addCredits(")
+                        || source.contains(".setCredits(")
+                        || source.contains(".tryAddCredits(")) {
                     callers.add(SOURCES.relativize(path).toString());
                 }
             }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
@@ -76,4 +76,17 @@ class EconomyAuditCoverageContractTest {
         assertEquals(Set.of(), callers,
                 "first-party credit changes must use explicit ledger operations or committed-balance publication");
     }
+
+    @Test
+    void catalogPaymentReservationsUseAuditedLedgerMutations() throws Exception {
+        String service = Files.readString(SOURCES.resolve(
+                "com/eu/habbo/habbohotel/catalog/CatalogPaymentService.java"));
+
+        assertTrue(service.contains("EconomyLedger.apply(connection"),
+                "catalog payment reservations and refunds must be durable ledger operations");
+        assertTrue(service.contains("LedgerWalletMutation.applyCommitted("),
+                "online balances must publish the committed ledger result without a second snapshot save");
+        assertTrue(!service.contains(".tryDebitCatalogPayment("));
+        assertTrue(!service.contains(".refundCatalogPayment("));
+    }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyLedgerIT.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyLedgerIT.java
@@ -1,0 +1,123 @@
+package com.eu.habbo.habbohotel.economy;
+
+import com.eu.habbo.database.TestDatabase;
+import com.eu.habbo.database.migration.MigrationRunner;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class EconomyLedgerIT {
+    @Test
+    void walletBatchCommitsTogetherAndRollsBackAcrossCurrencyTypes()
+            throws Exception {
+        requireDocker();
+        try (HikariDataSource dataSource =
+                     TestDatabase.freshDatabase("economy_ledger")) {
+            MigrationRunner.migrate(dataSource);
+            seedWallet(dataSource);
+
+            try (Connection connection = dataSource.getConnection()) {
+                connection.setAutoCommit(false);
+                List<EconomyMutationResult> results =
+                        EconomyLedger.applyBatch(connection, List.of(
+                                operation("commit:credits", EconomyLedger.CREDITS, -100),
+                                operation("commit:points", 5, -20)));
+                connection.commit();
+
+                assertEquals(900, results.get(0).balanceAfter());
+                assertEquals(180, results.get(1).balanceAfter());
+            }
+            assertEquals(900, value(dataSource,
+                    "SELECT credits FROM users WHERE id = 910001"));
+            assertEquals(180, value(dataSource, """
+                    SELECT amount FROM users_currency
+                    WHERE user_id = 910001 AND type = 5
+                    """));
+            assertEquals(2, value(dataSource, """
+                    SELECT COUNT(*) FROM logs_economy
+                    WHERE user_id = 910001
+                    """));
+
+            try (Connection connection = dataSource.getConnection()) {
+                connection.setAutoCommit(false);
+                assertThrows(IllegalArgumentException.class, () ->
+                        EconomyLedger.applyBatch(connection, List.of(
+                                operation("rollback:points", 5, -10),
+                                operation("rollback:credits", EconomyLedger.CREDITS, -1000))));
+                connection.rollback();
+            }
+            assertEquals(900, value(dataSource,
+                    "SELECT credits FROM users WHERE id = 910001"));
+            assertEquals(180, value(dataSource, """
+                    SELECT amount FROM users_currency
+                    WHERE user_id = 910001 AND type = 5
+                    """));
+            assertEquals(0, value(dataSource, """
+                    SELECT COUNT(*) FROM logs_economy
+                    WHERE operation_id LIKE 'rollback:%'
+                    """));
+        }
+    }
+
+    private static EconomyOperation operation(
+            String operationId,
+            int currencyType,
+            int delta) {
+        return new EconomyOperation(
+                operationId,
+                910001,
+                910001,
+                "integration_test",
+                "test.economy.ledger",
+                currencyType,
+                delta,
+                null,
+                "");
+    }
+
+    private static void seedWallet(HikariDataSource dataSource)
+            throws Exception {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    INSERT INTO users
+                        (id, username, password, ip_register, ip_current, credits)
+                    VALUES
+                        (910001, 'ledger_it', '!', '127.0.0.1', '127.0.0.1', 1000)
+                    """);
+            statement.executeUpdate("""
+                    INSERT INTO users_currency (user_id, type, amount)
+                    VALUES (910001, 5, 200)
+                    """);
+        }
+    }
+
+    private static int value(HikariDataSource dataSource, String sql)
+            throws Exception {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery(sql)) {
+            result.next();
+            return result.getInt(1);
+        }
+    }
+
+    private static void requireDocker() {
+        if (!TestDatabase.dockerAvailable()) {
+            if ("true".equalsIgnoreCase(System.getenv("CI"))) {
+                throw new AssertionError(
+                        "Docker/Testcontainers is required in CI");
+            }
+            assumeTrue(false,
+                    "Docker/Testcontainers not available - skipping DB integration test");
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyOperationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyOperationTest.java
@@ -2,6 +2,8 @@ package com.eu.habbo.habbohotel.economy;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -45,5 +47,32 @@ class EconomyOperationTest {
         assertThrows(IllegalArgumentException.class, () -> EconomyLedger.checkedBalance(10, -11));
         assertThrows(IllegalArgumentException.class,
                 () -> EconomyLedger.checkedBalance(Integer.MAX_VALUE, 1));
+    }
+
+    @Test
+    void walletBatchCannotSpanUsersWithAnAmbiguousLockOrder() {
+        EconomyOperation first = new EconomyOperation(
+                "batch:user:1",
+                1,
+                1,
+                "test",
+                "test.batch",
+                EconomyLedger.CREDITS,
+                1,
+                null,
+                "");
+        EconomyOperation second = new EconomyOperation(
+                "batch:user:2",
+                2,
+                2,
+                "test",
+                "test.batch",
+                EconomyLedger.CREDITS,
+                1,
+                null,
+                "");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> EconomyLedger.executeBatch(List.of(first, second)));
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/users/HabboInfoCreditCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/users/HabboInfoCreditCompatibilityTest.java
@@ -1,0 +1,59 @@
+package com.eu.habbo.habbohotel.users;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class HabboInfoCreditCompatibilityTest {
+    @Test
+    void setCreditsIsAnAbsoluteSynchronousSave() {
+        RecordingHabboInfo info = new RecordingHabboInfo(100);
+
+        info.setCredits(250);
+
+        assertEquals(250, info.getCredits());
+        assertEquals(1, info.saveCount);
+    }
+
+    @Test
+    void setCreditsRejectsNegativeBalancesBeforeSaving() {
+        RecordingHabboInfo info = new RecordingHabboInfo(100);
+
+        assertThrows(IllegalArgumentException.class, () -> info.setCredits(-1));
+
+        assertEquals(100, info.getCredits());
+        assertEquals(0, info.saveCount);
+    }
+
+    @Test
+    void addCreditsAppliesADeltaClampsAndSavesSynchronously() {
+        RecordingHabboInfo info = new RecordingHabboInfo(100);
+
+        info.addCredits(50);
+        assertEquals(150, info.getCredits());
+        assertEquals(1, info.saveCount);
+
+        info.addCredits(-200);
+        assertEquals(0, info.getCredits());
+        assertEquals(2, info.saveCount);
+
+        info.setCredits(Integer.MAX_VALUE);
+        info.addCredits(1);
+        assertEquals(Integer.MAX_VALUE, info.getCredits());
+        assertEquals(4, info.saveCount);
+    }
+
+    private static final class RecordingHabboInfo extends HabboInfo {
+        private int saveCount;
+
+        private RecordingHabboInfo(int credits) {
+            super(42, credits);
+        }
+
+        @Override
+        public void run() {
+            this.saveCount++;
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/users/HabboInfoCreditCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/users/HabboInfoCreditCompatibilityTest.java
@@ -44,6 +44,19 @@ class HabboInfoCreditCompatibilityTest {
         assertEquals(4, info.saveCount);
     }
 
+    @Test
+    void committedLedgerBalanceUpdatesMemoryWithoutRunningLegacyPersistence() {
+        RecordingHabboInfo info = new RecordingHabboInfo(100);
+
+        info.applyPersistedCredits(275);
+
+        assertEquals(275, info.getCredits());
+        assertEquals(0, info.saveCount);
+        assertThrows(IllegalArgumentException.class, () -> info.applyPersistedCredits(-1));
+        assertEquals(275, info.getCredits());
+        assertEquals(0, info.saveCount);
+    }
+
     private static final class RecordingHabboInfo extends HabboInfo {
         private int saveCount;
 

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/users/LedgerWalletMutationCoordinationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/users/LedgerWalletMutationCoordinationTest.java
@@ -37,9 +37,12 @@ class LedgerWalletMutationCoordinationTest {
                     habbo,
                     () -> 2));
 
-            assertThrows(TimeoutException.class,
-                    () -> second.get(100, TimeUnit.MILLISECONDS));
-            releaseFirst.countDown();
+            try {
+                assertThrows(TimeoutException.class,
+                        () -> second.get(100, TimeUnit.MILLISECONDS));
+            } finally {
+                releaseFirst.countDown();
+            }
 
             assertEquals(1, first.get());
             assertEquals(2, second.get());

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/users/LedgerWalletMutationCoordinationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/users/LedgerWalletMutationCoordinationTest.java
@@ -1,0 +1,48 @@
+package com.eu.habbo.habbohotel.users;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LedgerWalletMutationCoordinationTest {
+    @Test
+    void serializesDurableMutationAndMemoryPublicationForOneOnlineWallet()
+            throws Exception {
+        HabboInfo info = new HabboInfo(42, 100);
+        Habbo habbo = mock(Habbo.class);
+        when(habbo.getHabboInfo()).thenReturn(info);
+
+        CountDownLatch firstEntered = new CountDownLatch(1);
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var first = executor.submit(() -> LedgerWalletMutation.coordinated(
+                    habbo,
+                    () -> {
+                        firstEntered.countDown();
+                        releaseFirst.await();
+                        return 1;
+                    }));
+            firstEntered.await();
+
+            var second = executor.submit(() -> LedgerWalletMutation.coordinated(
+                    habbo,
+                    () -> 2));
+
+            assertThrows(TimeoutException.class,
+                    () -> second.get(100, TimeUnit.MILLISECONDS));
+            releaseFirst.countDown();
+
+            assertEquals(1, first.get());
+            assertEquals(2, second.get());
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/AtomicRedeemItemContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/AtomicRedeemItemContractTest.java
@@ -17,12 +17,14 @@ class AtomicRedeemItemContractTest {
         String source = read("src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java");
         int prepare = source.indexOf("prepareCurrencyGrant(");
         int commit = source.indexOf("RedeemItemTransaction.commit(");
+        int apply = source.indexOf("LedgerWalletMutation.applyCommitted(", commit);
         int roomRemoval = source.indexOf("room.removeHabboItem(item)");
-        int apply = source.indexOf("applyCurrencyGrant(");
+        int publish = source.indexOf("publishCurrencyGrant(", roomRemoval);
 
         assertTrue(prepare > -1 && prepare < commit, "plugin currency events must resolve before the transaction");
-        assertTrue(commit < roomRemoval, "database commit must precede room removal");
-        assertTrue(roomRemoval < apply, "memory balance must be synchronized only after commit");
+        assertTrue(commit < apply, "memory balance must use the committed transaction result");
+        assertTrue(apply < roomRemoval, "wallet memory must synchronize before later room publication");
+        assertTrue(roomRemoval < publish, "client balance publication must follow room removal");
         assertTrue(!source.contains("EconomyAuditLogger.record("),
                 "redemption audit must be committed inside the database transaction, not afterwards");
         assertTrue(source.contains("currencyGrant.currencyType()"),

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemCurrencyContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemCurrencyContractTest.java
@@ -19,13 +19,17 @@ class RedeemItemCurrencyContractTest {
         int diamondType = source.indexOf("FurnitureRedeemedEvent.DIAMONDS", diamondFurniture);
         int transaction = source.indexOf("RedeemItemTransaction.commit(", diamondType);
         int transactionType = source.indexOf("currencyGrant.currencyType()", transaction);
-        int apply = source.indexOf("applyCurrencyGrant(currencyGrant)", transactionType);
+        int apply = source.indexOf("LedgerWalletMutation.applyCommitted(", transactionType);
+        int committedBalance = source.indexOf("mutation.balanceAfter()", apply);
+        int publish = source.indexOf("publishCurrencyGrant(currencyGrant)", committedBalance);
 
         assertTrue(diamondFurniture > -1 && diamondType > diamondFurniture,
                 "diamond furniture must resolve explicitly to the diamond currency type");
         assertTrue(transactionType > transaction,
                 "the resolved diamond type must be persisted by the atomic transaction");
         assertTrue(apply > transactionType,
-                "the client balance must use the same committed currency grant");
+                "the client balance must use the transaction's committed wallet result");
+        assertTrue(committedBalance > apply);
+        assertTrue(publish > committedBalance);
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/threading/ThreadPoolingPersistenceRoutingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/threading/ThreadPoolingPersistenceRoutingTest.java
@@ -1,0 +1,28 @@
+package com.eu.habbo.threading;
+
+import com.eu.habbo.database.PersistenceExecutor;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.verify;
+
+class ThreadPoolingPersistenceRoutingTest {
+
+    @Test
+    void persistenceTasksUseTheInjectedDatabaseExecutor() {
+        PersistenceExecutor persistence =
+                mock(PersistenceExecutor.class);
+        ThreadPooling threading =
+                new ThreadPooling(1, persistence);
+        Runnable task = () -> {
+        };
+        try {
+            threading.runPersistence(task);
+
+            verify(persistence).execute(same(task));
+        } finally {
+            threading.shutDown();
+        }
+    }
+}


### PR DESCRIPTION
Adds a bounded JDBC executor, routes persistence tasks away from game scheduling, and completes first-party wallet mutations through the economy ledger.