### PR TITLE
refactor(rooms): coalesce user count persistence

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
+++ b/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
@@ -176,7 +176,8 @@ final class PolarisBootstrap {
 
     private boolean initializeHotel() throws Exception {
         new CleanerThread();
-        GameEnvironment environment = new GameEnvironment();
+        GameEnvironment environment = new GameEnvironment(
+                runtime.persistenceExecutor()::execute);
         runtime.installGameEnvironment(environment);
         Emulator.synchronizeLegacyFacade(runtime);
         environment.load();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java
@@ -37,12 +37,15 @@ import org.slf4j.LoggerFactory;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executor;
 
 public class GameEnvironment {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GameEnvironment.class);
     private final HotelServiceRegistry services =
             new HotelServiceRegistry();
+    private final Executor persistenceExecutor;
 
     public CreditsScheduler creditsScheduler;
     public PixelScheduler pixelScheduler;
@@ -79,6 +82,17 @@ public class GameEnvironment {
     private SoundboardManager soundboardManager;
     private TraxEditorManager traxEditorManager;
     private MentionManager mentionManager;
+
+    public GameEnvironment() {
+        this(Runnable::run);
+    }
+
+    public GameEnvironment(Executor persistenceExecutor) {
+        this.persistenceExecutor =
+                Objects.requireNonNull(
+                        persistenceExecutor,
+                        "persistenceExecutor");
+    }
 
     public void load() throws Exception {
         LOGGER.info("GameEnvironment -> Loading...");
@@ -120,7 +134,7 @@ public class GameEnvironment {
                 CatalogManager::dispose);
         this.roomManager = this.services.create(
                 "room manager",
-                RoomManager::new,
+                () -> new RoomManager(this.persistenceExecutor),
                 RoomManager::dispose);
         this.services.beforeDispose(
                 "room cycles",

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -134,6 +134,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
   private final RoomItemPersistence itemPersistence;
   private final RoomPersistence persistence;
   private final RoomRepository repository;
+  private final RoomUserCountPersistence userCountPersistence;
   public volatile double lastCycleCpuMs = 0.0;
   public volatile String lastCycleThread = "N/A";
 
@@ -250,6 +251,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     this.repository = new RoomRepository(this.dependencies.database());
     this.id = id;
     this.ownerId = ownerId;
+    this.userCountPersistence = this.createUserCountPersistence();
     this.bannedHabbos = new Int2ObjectOpenHashMap<>();
     this.moodlightData = new Int2ObjectOpenHashMap<>(defaultMoodData);
     this.mutedHabbos = new Int2IntOpenHashMap();
@@ -276,6 +278,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     RoomSnapshot.Initial initial = RoomSnapshot.readInitial(set);
     this.id = initial.id();
     this.ownerId = initial.ownerId();
+    this.userCountPersistence = this.createUserCountPersistence();
     this.ownerName = initial.ownerName();
     this.name = initial.name();
     this.description = initial.description();
@@ -1268,6 +1271,17 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     } catch (SQLException e) {
       LOGGER.error("Caught SQL exception", e);
     }
+  }
+
+  void scheduleDatabaseUserCountUpdate() {
+    this.userCountPersistence.schedule();
+  }
+
+  private RoomUserCountPersistence createUserCountPersistence() {
+    return new RoomUserCountPersistence(
+        this::getUserCount,
+        userCount -> this.repository.updateUserCount(this.id, userCount),
+        this.dependencies.persistence()::execute);
   }
 
   private void cycle() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomDependencies.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomDependencies.java
@@ -6,10 +6,17 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Objects;
 
-record RoomDependencies(ConnectionProvider database) {
+record RoomDependencies(
+        ConnectionProvider database,
+        PersistenceScheduler persistence) {
 
     RoomDependencies {
         Objects.requireNonNull(database, "database");
+        Objects.requireNonNull(persistence, "persistence");
+    }
+
+    RoomDependencies(ConnectionProvider database) {
+        this(database, Runnable::run);
     }
 
     static RoomDependencies runtime() {
@@ -20,5 +27,10 @@ record RoomDependencies(ConnectionProvider database) {
     @FunctionalInterface
     interface ConnectionProvider {
         Connection openConnection() throws SQLException;
+    }
+
+    @FunctionalInterface
+    interface PersistenceScheduler {
+        void execute(Runnable task);
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 import java.sql.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class RoomManager {
@@ -76,13 +77,28 @@ public class RoomManager {
     private final ConcurrentHashMap<Integer, Set<Integer>> roomsByOwner;
     private final AtomicInteger indexedRoomCount;
     private final ArrayList<Class<? extends Game>> gameTypes;
+    private final Executor persistenceExecutor;
 
     public RoomManager() {
-        this(true);
+        this(true, Runnable::run);
+    }
+
+    public RoomManager(Executor persistenceExecutor) {
+        this(true, persistenceExecutor);
     }
 
     RoomManager(boolean initialize) {
+        this(initialize, Runnable::run);
+    }
+
+    RoomManager(
+            boolean initialize,
+            Executor persistenceExecutor) {
         long millis = System.currentTimeMillis();
+        this.persistenceExecutor =
+                Objects.requireNonNull(
+                        persistenceExecutor,
+                        "persistenceExecutor");
         this.roomCategories = new HashMap<>();
         this.mapNames = new ArrayList<>();
         this.layoutCache = new ConcurrentHashMap<>();
@@ -112,6 +128,16 @@ public class RoomManager {
         if (this.roomsByOwner.computeIfAbsent(room.getOwnerId(), k -> ConcurrentHashMap.newKeySet()).add(room.getId())) {
             this.indexedRoomCount.incrementAndGet();
         }
+    }
+
+    private RoomDependencies roomDependencies() {
+        return new RoomDependencies(
+                this::openConnection,
+                this.persistenceExecutor::execute);
+    }
+
+    private Connection openConnection() throws SQLException {
+        return Emulator.getDatabase().getDataSource().getConnection();
     }
 
     private void untrackRoomOwner(Room room) {
@@ -200,7 +226,7 @@ public class RoomManager {
     private void loadRoomCategories() {
         this.roomCategories.clear();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM navigator_flatcats")) {
+        try (Connection connection = this.openConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM navigator_flatcats")) {
             while (set.next()) {
                 this.roomCategories.put(set.getInt("id"), new RoomCategory(set));
             }
@@ -215,7 +241,7 @@ public class RoomManager {
             statement.setString(2, "1");
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
-                    Room room = new Room(set);
+                    Room room = new Room(set, this.roomDependencies());
                     room.preventUncaching = true;
                     this.registerActiveRoom(room);
                 }
@@ -235,7 +261,7 @@ public class RoomManager {
                     Room room = this.activeRooms.get(set.getInt("id"));
 
                     if (room == null) {
-                        room = new Room(set);
+                        room = new Room(set, this.roomDependencies());
                         this.registerActiveRoom(room);
                     }
 
@@ -387,7 +413,7 @@ public class RoomManager {
 
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
-                    room = new Room(set);
+                    room = new Room(set, this.roomDependencies());
                     if (loadData) {
                         room.loadData();
                     }
@@ -444,7 +470,7 @@ public class RoomManager {
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
                     if (!this.activeRooms.containsKey(set.getInt("id"))) {
-                        Room room = new Room(set);
+                        Room room = new Room(set, this.roomDependencies());
                         this.registerActiveRoom(room);
                     }
                 }
@@ -1283,7 +1309,7 @@ public class RoomManager {
                     if (this.activeRooms.containsKey(set.getInt("id")))
                         continue;
 
-                    Room r = new Room(set);
+                    Room r = new Room(set, this.roomDependencies());
                     rooms.add(r);
                     this.registerActiveRoom(r);
                 }
@@ -1342,7 +1368,7 @@ public class RoomManager {
                     if (this.activeRooms.containsKey(set.getInt("id")))
                         continue;
 
-                    Room r = new Room(set);
+                    Room r = new Room(set, this.roomDependencies());
                     rooms.add(r);
 
                     this.registerActiveRoom(r);
@@ -1406,7 +1432,7 @@ public class RoomManager {
                     Room room = this.activeRooms.get(set.getInt("id"));
 
                     if (room == null) {
-                        room = new Room(set);
+                        room = new Room(set, this.roomDependencies());
 
                         this.registerActiveRoom(room);
                     }
@@ -1452,7 +1478,7 @@ public class RoomManager {
                     if (this.activeRooms.containsKey(set.getInt("id"))) {
                         rooms.add(this.activeRooms.get(set.getInt("id")));
                     } else {
-                        rooms.add(new Room(set));
+                        rooms.add(new Room(set, this.roomDependencies()));
                     }
                 }
             }
@@ -1475,7 +1501,7 @@ public class RoomManager {
                     if (this.activeRooms.containsKey(set.getInt("id"))) {
                         rooms.add(this.activeRooms.get(set.getInt("id")));
                     } else {
-                        rooms.add(new Room(set));
+                        rooms.add(new Room(set, this.roomDependencies()));
                     }
                 }
             }
@@ -1517,7 +1543,7 @@ public class RoomManager {
                     if (this.activeRooms.containsKey(set.getInt("id"))) {
                         rooms.add(this.activeRooms.get(set.getInt("id")));
                     } else {
-                        rooms.add(new Room(set));
+                        rooms.add(new Room(set, this.roomDependencies()));
                     }
                 }
             }
@@ -1539,7 +1565,7 @@ public class RoomManager {
                     if (this.activeRooms.containsKey(set.getInt("id"))) {
                         rooms.add(this.activeRooms.get(set.getInt("id")));
                     } else {
-                        rooms.add(new Room(set));
+                        rooms.add(new Room(set, this.roomDependencies()));
                     }
                 }
             }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitManager.java
@@ -159,8 +159,8 @@ public class RoomUnitManager {
             habbo.getRoomUnit().setId(this.unitCounter);
             this.currentHabbos.put(habbo.getHabboInfo().getId(), habbo);
             this.unitCounter++;
-            this.room.updateDatabaseUserCount();
         }
+        this.room.scheduleDatabaseUserCountUpdate();
     }
 
     public void removeHabbo(Habbo habbo) {
@@ -223,7 +223,7 @@ public class RoomUnitManager {
             this.pickupPetsForHabbo(habbo);
         }
 
-        this.room.updateDatabaseUserCount();
+        this.room.scheduleDatabaseUserCountUpdate();
     }
 
      public void kickHabbo(Habbo habbo, boolean alert) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserCountPersistence.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserCountPersistence.java
@@ -1,0 +1,58 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.IntSupplier;
+
+final class RoomUserCountPersistence {
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(RoomUserCountPersistence.class);
+
+    private final IntSupplier userCount;
+    private final CountWriter writer;
+    private final Executor executor;
+    private final AtomicBoolean dirty = new AtomicBoolean();
+    private final AtomicBoolean scheduled = new AtomicBoolean();
+
+    RoomUserCountPersistence(
+            IntSupplier userCount,
+            CountWriter writer,
+            Executor executor) {
+        this.userCount = Objects.requireNonNull(userCount, "userCount");
+        this.writer = Objects.requireNonNull(writer, "writer");
+        this.executor = Objects.requireNonNull(executor, "executor");
+    }
+
+    void schedule() {
+        this.dirty.set(true);
+        if (this.scheduled.compareAndSet(false, true)) {
+            this.executor.execute(this::flush);
+        }
+    }
+
+    private void flush() {
+        try {
+            while (this.dirty.getAndSet(false)) {
+                this.writer.write(this.userCount.getAsInt());
+            }
+        } catch (SQLException exception) {
+            LOGGER.error("Unable to persist room user count", exception);
+        } finally {
+            this.scheduled.set(false);
+            if (this.dirty.get()
+                    && this.scheduled.compareAndSet(false, true)) {
+                this.executor.execute(this::flush);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface CountWriter {
+        void write(int userCount) throws SQLException;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomPersistenceBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomPersistenceBehaviorTest.java
@@ -1,11 +1,18 @@
 package com.eu.habbo.habbohotel.rooms;
 
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class RoomPersistenceBehaviorTest {
 
@@ -78,5 +85,44 @@ class RoomPersistenceBehaviorTest {
                 call.sql());
         assertEquals(Map.of(1, 0, 2, 41), call.parameters());
         assertEquals("update", call.operation());
+    }
+
+    @Test
+    void roomJoinSchedulesOneUserCountWriteOutsideTheRoomUnitLock()
+            throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource =
+                new RoomJdbcTestSupport.RecordingDataSource();
+        List<Runnable> queued = new ArrayList<>();
+        AtomicBoolean scheduledUnderRoomUnitLock = new AtomicBoolean();
+        Room[] holder = new Room[1];
+        Room room = new Room(
+                41,
+                7,
+                new RoomDependencies(
+                        dataSource::getConnection,
+                        task -> {
+                            scheduledUnderRoomUnitLock.set(
+                                    Thread.holdsLock(holder[0].roomUnitLock));
+                            queued.add(task);
+                        }));
+        holder[0] = room;
+        Habbo habbo = mock(Habbo.class);
+        HabboInfo info = mock(HabboInfo.class);
+        RoomUnit roomUnit = mock(RoomUnit.class);
+        when(habbo.getHabboInfo()).thenReturn(info);
+        when(info.getId()).thenReturn(9);
+        when(habbo.getRoomUnit()).thenReturn(roomUnit);
+
+        room.getUnitManager().addHabbo(habbo);
+
+        assertFalse(scheduledUnderRoomUnitLock.get());
+        assertEquals(1, queued.size());
+        assertEquals(List.of(), dataSource.calls());
+
+        queued.removeFirst().run();
+        assertEquals(1, dataSource.calls().size());
+        assertEquals(
+                Map.of(1, 1, 2, 41),
+                dataSource.calls().getFirst().parameters());
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomUserCountPersistenceTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomUserCountPersistenceTest.java
@@ -1,0 +1,78 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RoomUserCountPersistenceTest {
+
+    @Test
+    void repeatedChangesQueueOneWriteWithTheLatestCount() {
+        AtomicInteger userCount = new AtomicInteger(1);
+        List<Integer> persistedCounts = new ArrayList<>();
+        List<Runnable> queued = new ArrayList<>();
+        RoomUserCountPersistence persistence =
+                new RoomUserCountPersistence(
+                        userCount::get,
+                        persistedCounts::add,
+                        queued::add);
+
+        persistence.schedule();
+        userCount.set(2);
+        persistence.schedule();
+        userCount.set(3);
+        persistence.schedule();
+
+        assertEquals(1, queued.size());
+        queued.removeFirst().run();
+        assertEquals(List.of(3), persistedCounts);
+    }
+
+    @Test
+    void aChangeDuringWriteFlushesAgainBeforeTheWorkerExits() {
+        AtomicInteger userCount = new AtomicInteger(1);
+        List<Integer> persistedCounts = new ArrayList<>();
+        List<Runnable> queued = new ArrayList<>();
+        RoomUserCountPersistence[] holder = new RoomUserCountPersistence[1];
+        holder[0] = new RoomUserCountPersistence(
+                userCount::get,
+                count -> {
+                    persistedCounts.add(count);
+                    if (count == 1) {
+                        userCount.set(2);
+                        holder[0].schedule();
+                    }
+                },
+                queued::add);
+
+        holder[0].schedule();
+        queued.removeFirst().run();
+
+        assertEquals(List.of(1, 2), persistedCounts);
+        assertEquals(List.of(), queued);
+    }
+
+    @Test
+    void aLaterChangeCanScheduleAfterTheWorkerCompletes() {
+        AtomicInteger userCount = new AtomicInteger(1);
+        List<Integer> persistedCounts = new ArrayList<>();
+        List<Runnable> queued = new ArrayList<>();
+        RoomUserCountPersistence persistence =
+                new RoomUserCountPersistence(
+                        userCount::get,
+                        persistedCounts::add,
+                        queued::add);
+
+        persistence.schedule();
+        queued.removeFirst().run();
+        userCount.set(0);
+        persistence.schedule();
+        queued.removeFirst().run();
+
+        assertEquals(List.of(1, 0), persistedCounts);
+    }
+}


### PR DESCRIPTION
Coalesces room join and leave user-count writes on the bounded persistence executor while retaining the synchronous public update method for compatibility and final disposal.

Wires the executor from bootstrap and schedules persistence after releasing `roomUnitLock`.
