### PR TITLE
refactor(users): offload disconnect persistence

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java
@@ -102,7 +102,7 @@ public class GameEnvironment {
                 PermissionsManager::new);
         this.habboManager = this.services.create(
                 "habbo manager",
-                HabboManager::new,
+                () -> new HabboManager(this.persistenceExecutor),
                 HabboManager::dispose);
         this.hotelViewManager = this.services.create(
                 "hotel view manager",

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/DisconnectPersistenceGate.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/DisconnectPersistenceGate.java
@@ -1,0 +1,93 @@
+package com.eu.habbo.habbohotel.users;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+
+final class DisconnectPersistenceGate {
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(DisconnectPersistenceGate.class);
+
+    private final Executor executor;
+    private final ConcurrentHashMap<Integer, CompletableFuture<Void>> pending =
+            new ConcurrentHashMap<>();
+
+    DisconnectPersistenceGate(Executor executor) {
+        this.executor = Objects.requireNonNull(executor, "executor");
+    }
+
+    Registration begin(int userId) {
+        if (userId <= 0) {
+            throw new IllegalArgumentException("userId must be positive");
+        }
+        CompletableFuture<Void> completion = new CompletableFuture<>();
+        if (this.pending.putIfAbsent(userId, completion) != null) {
+            throw new IllegalStateException(
+                    "disconnect persistence already pending for user " + userId);
+        }
+        return new Registration(userId, completion);
+    }
+
+    void submit(Registration registration, Runnable persistence) {
+        Objects.requireNonNull(registration, "registration");
+        Objects.requireNonNull(persistence, "persistence");
+        Runnable guarded = () -> {
+            try {
+                persistence.run();
+            } catch (Exception exception) {
+                LOGGER.error(
+                        "Disconnect persistence failed for user {}",
+                        registration.userId(),
+                        exception);
+            } finally {
+                this.complete(registration);
+            }
+        };
+        try {
+            this.executor.execute(guarded);
+        } catch (RuntimeException exception) {
+            LOGGER.error(
+                    "Unable to queue disconnect persistence for user {}; running inline",
+                    registration.userId(),
+                    exception);
+            guarded.run();
+        }
+    }
+
+    void cancel(Registration registration) {
+        Objects.requireNonNull(registration, "registration");
+        this.complete(registration);
+    }
+
+    boolean await(int userId) {
+        CompletableFuture<Void> completion = this.pending.get(userId);
+        if (completion == null) {
+            return true;
+        }
+        try {
+            completion.get();
+            return true;
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            return false;
+        } catch (java.util.concurrent.ExecutionException exception) {
+            return true;
+        }
+    }
+
+    private void complete(Registration registration) {
+        this.pending.remove(
+                registration.userId(),
+                registration.completion());
+        registration.completion().complete(null);
+    }
+
+    record Registration(
+            int userId,
+            CompletableFuture<Void> completion) {
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.habbohotel.users;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.GameEnvironment;
 import com.eu.habbo.habbohotel.achievements.AchievementManager;
 import com.eu.habbo.habbohotel.bots.Bot;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
@@ -206,52 +207,95 @@ public class Habbo implements Runnable {
     }
 
 
-    public synchronized void disconnect() {
-        if (!Emulator.isShuttingDown) {
-            if (Emulator.getPluginManager().fireEvent(new UserDisconnectEvent(this)).isCancelled()) return;
-        }
-
-        if (this.disconnected || this.disconnecting)
-            return;
-
-        this.disconnecting = true;
-
-        try {
-            if (this.getHabboInfo().getCurrentRoom() != null) {
-                Emulator.getGameEnvironment().getRoomManager().leaveRoom(this, this.getHabboInfo().getCurrentRoom());
-            }
-            if (this.getHabboInfo().getRoomQueueId() > 0) {
-                Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getHabboInfo().getRoomQueueId());
-
-                if (room != null) {
-                    room.removeFromQueue(this);
+    public void disconnect() {
+        GameEnvironment environment = Emulator.getGameEnvironment();
+        HabboManager habboManager = environment.getHabboManager();
+        boolean shuttingDown = Emulator.isShuttingDown;
+        var pluginManager = Emulator.getPluginManager();
+        DisconnectPersistenceGate.Registration persistenceRegistration;
+        synchronized (this) {
+            if (this.disconnected || this.disconnecting) {
+                if (!shuttingDown) {
+                    pluginManager.fireEvent(
+                            new UserDisconnectEvent(this));
                 }
+                return;
             }
-        } catch (Exception e) {
-            LOGGER.error("Caught exception", e);
+
+            persistenceRegistration =
+                    habboManager.beginDisconnectPersistence(
+                            this.habboInfo.getId());
+            boolean cancelled;
+            try {
+                cancelled = !shuttingDown
+                        && pluginManager
+                        .fireEvent(new UserDisconnectEvent(this))
+                        .isCancelled();
+            } catch (RuntimeException exception) {
+                habboManager.cancelDisconnectPersistence(
+                        persistenceRegistration);
+                throw exception;
+            }
+            if (cancelled) {
+                habboManager.cancelDisconnectPersistence(
+                        persistenceRegistration);
+                return;
+            }
+            this.disconnecting = true;
+
+            try {
+                if (this.getHabboInfo().getCurrentRoom() != null) {
+                    environment.getRoomManager().leaveRoom(
+                            this,
+                            this.getHabboInfo().getCurrentRoom());
+                }
+                if (this.getHabboInfo().getRoomQueueId() > 0) {
+                    Room room = environment.getRoomManager().getRoom(
+                            this.getHabboInfo().getRoomQueueId());
+
+                    if (room != null) {
+                        room.removeFromQueue(this);
+                    }
+                }
+            } catch (Exception e) {
+                LOGGER.error("Caught exception", e);
+            }
+
+            try {
+                environment.getGuideManager().userLogsOut(this);
+                this.habboInfo.setOnline(false);
+                this.needsUpdate(true);
+                this.messenger.connectionChanged(this, false, false);
+                this.messenger.dispose();
+            } catch (Exception e) {
+                LOGGER.error("Caught exception", e);
+            } finally {
+                this.disconnected = true;
+                try {
+                    environment.getRoomManager().unloadRoomsForHabbo(this);
+                } catch (Exception e) {
+                    LOGGER.error("Unable to unload owned rooms during disconnect", e);
+                }
+                try {
+                    habboManager.removeHabbo(this);
+                } catch (Exception e) {
+                    LOGGER.error("Unable to remove disconnected user", e);
+                }
+                this.client = null;
+            }
         }
 
-        try {
-            Emulator.getGameEnvironment().getGuideManager().userLogsOut(this);
-            this.isOnline(false);
-            this.needsUpdate(true);
-            this.run();
-            this.getInventory().dispose();
-            this.messenger.connectionChanged(this, false, false);
-            this.messenger.dispose();
-            this.disconnected = true;
-            AchievementManager.saveAchievements(this);
+        habboManager.submitDisconnectPersistence(
+                persistenceRegistration,
+                this::persistDisconnect);
+    }
 
-            this.habboStats.dispose();
-        } catch (Exception e) {
-            LOGGER.error("Caught exception", e);
-            return;
-        } finally {
-            Emulator.getGameEnvironment().getRoomManager().unloadRoomsForHabbo(this);
-            Emulator.getGameEnvironment().getHabboManager().removeHabbo(this);
-        }
+    private void persistDisconnect() {
+        this.run();
+        this.getInventory().dispose();
+        AchievementManager.saveAchievements(this);
+        this.habboStats.dispose();
         LOGGER.info("{} disconnected.", this.habboInfo.getUsername());
-        this.client = null;
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboManager.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 
 public class HabboManager {
 
@@ -42,12 +43,19 @@ public class HabboManager {
     private final ConcurrentHashMap<Integer, Habbo> onlineHabbos;
     private final ConcurrentHashMap<String, Habbo> onlineHabbosByName;
     private final ConcurrentHashMap<Integer, String> usernameCache = new ConcurrentHashMap<>();
+    private final DisconnectPersistenceGate disconnectPersistence;
 
     public HabboManager() {
+        this(Runnable::run);
+    }
+
+    public HabboManager(Executor persistenceExecutor) {
         long millis = System.currentTimeMillis();
 
         this.onlineHabbos = new ConcurrentHashMap<>();
         this.onlineHabbosByName = new ConcurrentHashMap<>();
+        this.disconnectPersistence =
+                new DisconnectPersistenceGate(persistenceExecutor);
 
         LOGGER.info("Habbo Manager -> Loaded! ({} MS)", System.currentTimeMillis() - millis);
     }
@@ -111,11 +119,19 @@ public class HabboManager {
             LOGGER.error("Caught SQL exception", e);
         }
 
+        if (!this.awaitDisconnectPersistence(userId)) {
+            return null;
+        }
+
         habbo = this.cloneCheck(userId);
         if (habbo != null) {
             habbo.alert(Emulator.getTexts().getValue("loggedin.elsewhere"));
             Emulator.getGameServer().getGameClientManager().forceDisposeClient(habbo.getClient());
             habbo = null;
+        }
+
+        if (!this.awaitDisconnectPersistence(userId)) {
+            return null;
         }
 
         ModToolBan ban = Emulator.getGameEnvironment().getModToolManager().checkForBan(userId);
@@ -150,6 +166,32 @@ public class HabboManager {
         }
 
         return habbo;
+    }
+
+    private boolean awaitDisconnectPersistence(int userId) {
+        if (this.disconnectPersistence.await(userId)) {
+            return true;
+        }
+        LOGGER.warn(
+                "Interrupted while waiting for disconnect persistence for user {}",
+                userId);
+        return false;
+    }
+
+    DisconnectPersistenceGate.Registration beginDisconnectPersistence(
+            int userId) {
+        return this.disconnectPersistence.begin(userId);
+    }
+
+    void submitDisconnectPersistence(
+            DisconnectPersistenceGate.Registration registration,
+            Runnable persistence) {
+        this.disconnectPersistence.submit(registration, persistence);
+    }
+
+    void cancelDisconnectPersistence(
+            DisconnectPersistenceGate.Registration registration) {
+        this.disconnectPersistence.cancel(registration);
     }
 
     public HabboInfo getHabboInfo(int id) {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/users/AsyncDisconnectPersistenceContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/users/AsyncDisconnectPersistenceContractTest.java
@@ -1,0 +1,68 @@
+package com.eu.habbo.habbohotel.users;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AsyncDisconnectPersistenceContractTest {
+
+    @Test
+    void disconnectReleasesItsMonitorBeforeDurableSaves() throws Exception {
+        String source = source("Habbo.java");
+        int disconnect = source.indexOf("public void disconnect()");
+        int monitor = source.indexOf("synchronized (this)", disconnect);
+        int leaveRoom = source.indexOf(".leaveRoom(", monitor);
+        int removeHabbo = source.indexOf("habboManager.removeHabbo(this)", leaveRoom);
+        int submit = source.indexOf("submitDisconnectPersistence(", removeHabbo);
+        int persistence = source.indexOf("private void persistDisconnect()", submit);
+        int userSave = source.indexOf("this.run()", persistence);
+        int inventorySave = source.indexOf("this.getInventory().dispose()", userSave);
+        int achievementSave = source.indexOf(
+                "AchievementManager.saveAchievements(this)",
+                inventorySave);
+        int statsSave = source.indexOf("this.habboStats.dispose()", achievementSave);
+
+        assertTrue(disconnect > -1);
+        assertFalse(source.contains("public synchronized void disconnect()"));
+        assertTrue(monitor > disconnect);
+        assertTrue(leaveRoom > monitor);
+        assertTrue(submit > removeHabbo);
+        assertTrue(userSave > persistence);
+        assertTrue(inventorySave > userSave);
+        assertTrue(achievementSave > inventorySave);
+        assertTrue(statsSave > achievementSave);
+    }
+
+    @Test
+    void loginWaitsAgainAfterItDisposesADuplicateSession() throws Exception {
+        String source = source("HabboManager.java");
+        int load = source.indexOf("public Habbo loadHabbo(");
+        int firstWait = source.indexOf(
+                "awaitDisconnectPersistence(userId)",
+                load);
+        int cloneCheck = source.indexOf("this.cloneCheck(userId)", firstWait);
+        int forceDispose = source.indexOf("forceDisposeClient(", cloneCheck);
+        int secondWait = source.indexOf(
+                "awaitDisconnectPersistence(userId)",
+                forceDispose);
+        int reload = source.indexOf(
+                "SELECT * FROM users WHERE auth_ticket",
+                secondWait);
+
+        assertTrue(firstWait > load);
+        assertTrue(cloneCheck > firstWait);
+        assertTrue(forceDispose > cloneCheck);
+        assertTrue(secondWait > forceDispose);
+        assertTrue(reload > secondWait);
+    }
+
+    private static String source(String file) throws Exception {
+        return Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/users",
+                file));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/users/DisconnectPersistenceGateTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/users/DisconnectPersistenceGateTest.java
@@ -1,0 +1,75 @@
+package com.eu.habbo.habbohotel.users;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DisconnectPersistenceGateTest {
+
+    @Test
+    void replacementSessionWaitsUntilQueuedPersistenceCompletes() {
+        List<Runnable> queued = new ArrayList<>();
+        DisconnectPersistenceGate gate =
+                new DisconnectPersistenceGate(queued::add);
+        DisconnectPersistenceGate.Registration registration =
+                gate.begin(42);
+        AtomicBoolean persisted = new AtomicBoolean();
+        gate.submit(registration, () -> persisted.set(true));
+
+        CompletableFuture<Boolean> waiting =
+                CompletableFuture.supplyAsync(() -> gate.await(42));
+
+        assertThrows(
+                java.util.concurrent.TimeoutException.class,
+                () -> waiting.get(
+                        100,
+                        java.util.concurrent.TimeUnit.MILLISECONDS));
+        assertFalse(persisted.get());
+
+        queued.removeFirst().run();
+
+        assertTrue(waiting.join());
+        assertTrue(persisted.get());
+    }
+
+    @Test
+    void persistenceFailureStillReleasesReplacementSession() {
+        List<Runnable> queued = new ArrayList<>();
+        DisconnectPersistenceGate gate =
+                new DisconnectPersistenceGate(queued::add);
+        DisconnectPersistenceGate.Registration registration =
+                gate.begin(42);
+        gate.submit(registration, () -> {
+            throw new IllegalStateException("expected");
+        });
+
+        queued.removeFirst().run();
+
+        assertTimeoutPreemptively(
+                Duration.ofSeconds(1),
+                () -> assertTrue(gate.await(42)));
+    }
+
+    @Test
+    void cancelledDisconnectRemovesItsGateWithoutSchedulingWork() {
+        List<Runnable> queued = new ArrayList<>();
+        DisconnectPersistenceGate gate =
+                new DisconnectPersistenceGate(queued::add);
+        DisconnectPersistenceGate.Registration registration =
+                gate.begin(42);
+
+        gate.cancel(registration);
+
+        assertTrue(gate.await(42));
+        assertTrue(queued.isEmpty());
+    }
+}


### PR DESCRIPTION
Moves disconnect account, inventory, achievement, and stats saves onto the bounded persistence executor after in-memory teardown.

Adds a pending-disconnect gate so replacement logins wait for the old session's saves before loading, preventing stale offline state from overwriting a fast reconnect.
