### PR TITLE
refactor(catalog): introduce purchase command

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java
@@ -1,9 +1,25 @@
 package com.eu.habbo.messages.incoming.catalog;
 
+import static com.eu.habbo.messages.incoming.catalog.CheckPetNameEvent.PET_NAME_LENGTH_MAXIMUM;
+import static com.eu.habbo.messages.incoming.catalog.CheckPetNameEvent.PET_NAME_LENGTH_MINIMUM;
+
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.bots.BotManager;
-import com.eu.habbo.habbohotel.catalog.*;
-import com.eu.habbo.habbohotel.catalog.layouts.*;
+import com.eu.habbo.habbohotel.catalog.CatalogItem;
+import com.eu.habbo.habbohotel.catalog.CatalogManager;
+import com.eu.habbo.habbohotel.catalog.CatalogPage;
+import com.eu.habbo.habbohotel.catalog.CatalogPageAccessPolicy;
+import com.eu.habbo.habbohotel.catalog.CatalogPageLayouts;
+import com.eu.habbo.habbohotel.catalog.CatalogPaymentService;
+import com.eu.habbo.habbohotel.catalog.CatalogPurchaseMath;
+import com.eu.habbo.habbohotel.catalog.ClubOffer;
+import com.eu.habbo.habbohotel.catalog.layouts.BuildersClubAddonsLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.BuildersClubFrontPageLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.BuildersClubLoyaltyLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.ClubBuyLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.RecentPurchasesLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.RoomBundleLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.VipBuyLayout;
 import com.eu.habbo.habbohotel.items.FurnitureType;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.permissions.Permission;
@@ -14,7 +30,11 @@ import com.eu.habbo.habbohotel.users.HabboBadge;
 import com.eu.habbo.habbohotel.users.HabboInventory;
 import com.eu.habbo.habbohotel.users.subscriptions.Subscription;
 import com.eu.habbo.messages.incoming.MessageHandler;
-import com.eu.habbo.messages.outgoing.catalog.*;
+import com.eu.habbo.messages.outgoing.catalog.AlertPurchaseFailedComposer;
+import com.eu.habbo.messages.outgoing.catalog.AlertPurchaseUnavailableComposer;
+import com.eu.habbo.messages.outgoing.catalog.BuildersClubFurniCountComposer;
+import com.eu.habbo.messages.outgoing.catalog.BuildersClubSubscriptionStatusComposer;
+import com.eu.habbo.messages.outgoing.catalog.PurchaseOKComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.generic.alerts.HotelWillCloseInMinutesComposer;
@@ -22,13 +42,9 @@ import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.navigator.CanCreateRoomComposer;
 import com.eu.habbo.messages.outgoing.users.AddUserBadgeComposer;
 import com.eu.habbo.threading.runnables.ShutdownEmulator;
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.HashMap;
 import java.util.Map;
-
-import static com.eu.habbo.messages.incoming.catalog.CheckPetNameEvent.PET_NAME_LENGTH_MAXIMUM;
-import static com.eu.habbo.messages.incoming.catalog.CheckPetNameEvent.PET_NAME_LENGTH_MINIMUM;
+import org.apache.commons.lang3.StringUtils;
 
 public class CatalogBuyItemEvent extends MessageHandler {
 
@@ -44,50 +60,61 @@ public class CatalogBuyItemEvent extends MessageHandler {
 
     @Override
     public void handle() throws Exception {
-        if (Emulator.getIntUnixTimestamp() - this.client.getHabbo().getHabboStats().lastPurchaseTimestamp >= CatalogManager.PURCHASE_COOLDOWN) {
+        if (Emulator.getIntUnixTimestamp() - this.client.getHabbo().getHabboStats().lastPurchaseTimestamp
+                >= CatalogManager.PURCHASE_COOLDOWN) {
             this.client.getHabbo().getHabboStats().lastPurchaseTimestamp = Emulator.getIntUnixTimestamp();
             if (ShutdownEmulator.timestamp > 0) {
-                this.client.sendResponse(new HotelWillCloseInMinutesComposer((ShutdownEmulator.timestamp - Emulator.getIntUnixTimestamp()) / 60));
+                this.client.sendResponse(new HotelWillCloseInMinutesComposer(
+                        (ShutdownEmulator.timestamp - Emulator.getIntUnixTimestamp()) / 60));
                 return;
             }
 
-            int pageId = this.packet.readInt();
-            int itemId = this.packet.readInt();
-            String extraData = this.packet.readString();
-            int count = this.packet.readInt();
-            if (count < 1) count = 1;
-            if (count > 100) count = 100;
+            CatalogPurchaseCommand command = CatalogPurchaseCommand.readFrom(this.packet);
+            int pageId = command.pageId();
+            int itemId = command.itemId();
+            String extraData = command.extraData();
+            int count = command.count();
 
             try {
-                if (this.client.getHabbo().getInventory().getItemsComponent().itemCount() > HabboInventory.MAXIMUM_ITEMS) {
-                    this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                if (this.client.getHabbo().getInventory().getItemsComponent().itemCount()
+                        > HabboInventory.MAXIMUM_ITEMS) {
+                    this.client.sendResponse(
+                            new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                     this.client.getHabbo().alert(Emulator.getTexts().getValue("inventory.full"));
                     return;
                 }
             } catch (Exception e) {
-                this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                this.client.sendResponse(
+                        new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
             }
 
             CatalogPage page = null;
 
             if (pageId == -12345678 || pageId == -1) {
-                CatalogItem searchedItem = Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(itemId);
+                CatalogItem searchedItem =
+                        Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(itemId);
 
                 if (searchedItem != null && searchedItem.getOfferId() > 0) {
                     page = Emulator.getGameEnvironment().getCatalogManager().getCatalogPage(searchedItem.getPageId());
 
-                    if(page != null) {
+                    if (page != null) {
                         if (!this.canAccessPage(page)) {
                             page = null;
-                        } else if (page.getLayout() != null && page.getLayout().equalsIgnoreCase(CatalogPageLayouts.club_gift.name())) {
+                        } else if (page.getLayout() != null
+                                && page.getLayout().equalsIgnoreCase(CatalogPageLayouts.club_gift.name())) {
                             page = null;
                         }
                     }
                 }
             } else {
-                page = Emulator.getGameEnvironment().getCatalogManager().catalogPages.get(pageId);
+                page = Emulator.getGameEnvironment()
+                        .getCatalogManager()
+                        .catalogPages
+                        .get(pageId);
 
-                if(page != null && page.getLayout() != null && page.getLayout().equalsIgnoreCase(CatalogPageLayouts.club_gift.name())) {
+                if (page != null
+                        && page.getLayout() != null
+                        && page.getLayout().equalsIgnoreCase(CatalogPageLayouts.club_gift.name())) {
                     page = null;
                 }
 
@@ -104,136 +131,198 @@ public class CatalogBuyItemEvent extends MessageHandler {
 
                     CatalogItem roomBundleItem = item[0];
                     if (roomBundleItem == null) {
-                        this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                        this.client.sendResponse(
+                                new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
                         return;
                     }
 
                     int roomCredits;
                     int roomPoints;
                     try {
-                        roomCredits = CatalogPurchaseMath.requireNonNegative(roomBundleItem.getCredits(), "room bundle credit price");
-                        roomPoints = CatalogPurchaseMath.requireNonNegative(roomBundleItem.getPoints(), "room bundle points price");
+                        roomCredits = CatalogPurchaseMath.requireNonNegative(
+                                roomBundleItem.getCredits(), "room bundle credit price");
+                        roomPoints = CatalogPurchaseMath.requireNonNegative(
+                                roomBundleItem.getPoints(), "room bundle points price");
                     } catch (IllegalArgumentException e) {
-                        this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                        this.client.sendResponse(
+                                new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                         return;
                     }
 
                     if (roomCredits > this.client.getHabbo().getHabboInfo().getCredits()
-                            || roomPoints > this.client.getHabbo().getHabboInfo().getCurrencyAmount(roomBundleItem.getPointsType())) {
-                        this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                            || roomPoints
+                                    > this.client
+                                            .getHabbo()
+                                            .getHabboInfo()
+                                            .getCurrencyAmount(roomBundleItem.getPointsType())) {
+                        this.client.sendResponse(
+                                new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
                         return;
                     }
-                    int roomCount = Emulator.getGameEnvironment().getRoomManager().getRoomsForHabbo(this.client.getHabbo()).size();
-                    int maxRooms = this.client.getHabbo().getHabboStats().hasActiveClub() ? RoomManager.MAXIMUM_ROOMS_HC : RoomManager.MAXIMUM_ROOMS_USER;
+                    int roomCount = Emulator.getGameEnvironment()
+                            .getRoomManager()
+                            .getRoomsForHabbo(this.client.getHabbo())
+                            .size();
+                    int maxRooms = this.client.getHabbo().getHabboStats().hasActiveClub()
+                            ? RoomManager.MAXIMUM_ROOMS_HC
+                            : RoomManager.MAXIMUM_ROOMS_USER;
 
                     if (roomCount >= maxRooms) { // checks if a user has the maximum rooms
-                        this.client.sendResponse(new CanCreateRoomComposer(roomCount, maxRooms)); // if so throws the max room error.
-                        this.client.sendResponse(new PurchaseOKComposer(null)); // Send this so the alert disappears, not sure if this is how it should be handled :S
+                        this.client.sendResponse(
+                                new CanCreateRoomComposer(roomCount, maxRooms)); // if so throws the max room error.
+                        this.client.sendResponse(new PurchaseOKComposer(
+                                null)); // Send this so the alert disappears, not sure if this is how it should be
+                        // handled :S
                         return;
                     }
                     ((RoomBundleLayout) page).buyRoom(this.client.getHabbo());
-                    if (!this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS)) { //if the player has this perm disabled
+                    if (!this.client
+                            .getHabbo()
+                            .hasPermission(Permission.ACC_INFINITE_CREDITS)) { // if the player has this perm disabled
                         this.client.getHabbo().giveCredits(-roomCredits); // takes their credits away
                     }
-                    if (!this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS)) { //if the player has this perm disabled
-                        this.client.getHabbo().givePoints(roomBundleItem.getPointsType(), -roomPoints); // takes their points away
+                    if (!this.client
+                            .getHabbo()
+                            .hasPermission(Permission.ACC_INFINITE_POINTS)) { // if the player has this perm disabled
+                        this.client
+                                .getHabbo()
+                                .givePoints(roomBundleItem.getPointsType(), -roomPoints); // takes their points away
                     }
                     this.client.sendResponse(new PurchaseOKComposer()); // Sends the composer to close the window.
 
-                    item[0].getBaseItems().stream().filter(i -> i.getType() == FurnitureType.BADGE).forEach(i -> {
-                        if (!this.client.getHabbo().getInventory().getBadgesComponent().hasBadge(i.getName())) {
-                            HabboBadge badge = new HabboBadge(0, i.getName(), 0, this.client.getHabbo());
-                            Emulator.getThreading().run(badge);
-                            this.client.getHabbo().getInventory().getBadgesComponent().addBadge(badge);
-                            this.client.sendResponse(new AddUserBadgeComposer(badge));
-                            Map<String, String> keys = new HashMap<>();
-                            keys.put("display", "BUBBLE");
-                            keys.put("image", "${image.library.url}album1584/" + badge.getCode() + ".gif");
-                            keys.put("message", Emulator.getTexts().getValue("commands.generic.cmd_badge.received"));
-                            this.client.sendResponse(new BubbleAlertComposer(BubbleAlertKeys.RECEIVED_BADGE.key, keys));
-                        }
-                    });
+                    item[0].getBaseItems().stream()
+                            .filter(i -> i.getType() == FurnitureType.BADGE)
+                            .forEach(i -> {
+                                if (!this.client
+                                        .getHabbo()
+                                        .getInventory()
+                                        .getBadgesComponent()
+                                        .hasBadge(i.getName())) {
+                                    HabboBadge badge = new HabboBadge(0, i.getName(), 0, this.client.getHabbo());
+                                    Emulator.getThreading().run(badge);
+                                    this.client
+                                            .getHabbo()
+                                            .getInventory()
+                                            .getBadgesComponent()
+                                            .addBadge(badge);
+                                    this.client.sendResponse(new AddUserBadgeComposer(badge));
+                                    Map<String, String> keys = new HashMap<>();
+                                    keys.put("display", "BUBBLE");
+                                    keys.put("image", "${image.library.url}album1584/" + badge.getCode() + ".gif");
+                                    keys.put(
+                                            "message",
+                                            Emulator.getTexts().getValue("commands.generic.cmd_badge.received"));
+                                    this.client.sendResponse(
+                                            new BubbleAlertComposer(BubbleAlertKeys.RECEIVED_BADGE.key, keys));
+                                }
+                            });
 
                     return;
                 }
             }
 
             if (page == null) {
-                this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                this.client.sendResponse(
+                        new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                 return;
             }
 
             if (page.getRank() > this.client.getHabbo().getHabboInfo().getRank().getId()) {
-                this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                this.client.sendResponse(
+                        new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                 return;
             }
 
             if (this.isClubOfferPage(page)) {
                 synchronized (this.client.getHabbo().getHabboStats()) {
                     if (this.client.getHabbo().getHabboStats().isPurchasingFurniture) {
-                        this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                        this.client.sendResponse(
+                                new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
                         return;
                     }
                     this.client.getHabbo().getHabboStats().isPurchasingFurniture = true;
                 }
 
                 try {
-                    ClubOffer item = Emulator.getGameEnvironment().getCatalogManager().clubOffers.get(itemId);
+                    ClubOffer item = Emulator.getGameEnvironment()
+                            .getCatalogManager()
+                            .clubOffers
+                            .get(itemId);
 
-                if (item == null || !item.belongsToWindow(this.getClubOfferWindowId(page))) {
-                    this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
-                    return;
-                }
-
-                int totalDays;
-                int totalCredits;
-                int totalDuckets;
-                int subscriptionSeconds;
-                try {
-                    totalDays = CatalogPurchaseMath.checkedPrice(item.getDays(), count);
-                    totalCredits = CatalogPurchaseMath.checkedPrice(item.getCredits(), count);
-                    totalDuckets = CatalogPurchaseMath.checkedPrice(item.getPoints(), count);
-                    subscriptionSeconds = item.isBuildersClubAddon()
-                            ? 0
-                            : CatalogPurchaseMath.checkedSubscriptionSeconds(totalDays);
-                } catch (IllegalArgumentException e) {
-                    this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
-                    return;
-                }
-
-                if (totalDays > 0) {
-                    if (this.client.getHabbo().getHabboInfo().getCurrencyAmount(item.getPointsType()) < totalDuckets)
-                        return;
-
-                    if (this.client.getHabbo().getHabboInfo().getCredits() < totalCredits)
-                        return;
-
-                    int paidCredits = this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS) ? 0 : totalCredits;
-                    int paidPoints = this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS) ? 0 : totalDuckets;
-                    if (!CatalogPaymentService.tryTake(this.client.getHabbo(), paidCredits, item.getPointsType(), paidPoints)) {
-                        this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                    if (item == null || !item.belongsToWindow(this.getClubOfferWindowId(page))) {
+                        this.client.sendResponse(
+                                new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                         return;
                     }
 
-                    if (item.isBuildersClubAddon()) {
-                        this.client.getHabbo().getHabboStats().addBuildersClubBonusFurni(totalDays);
-                        this.client.sendResponse(new BuildersClubFurniCountComposer(BuildersClubRoomSupport.getTrackedFurniCount(this.client.getHabbo().getHabboInfo().getId())));
-                        this.client.sendResponse(new BuildersClubSubscriptionStatusComposer(this.client.getHabbo()));
-                    } else {
-                        String subscriptionType = item.isBuildersClubSubscription() ? Subscription.BUILDERS_CLUB : Subscription.HABBO_CLUB;
+                    int totalDays;
+                    int totalCredits;
+                    int totalDuckets;
+                    int subscriptionSeconds;
+                    try {
+                        totalDays = CatalogPurchaseMath.checkedPrice(item.getDays(), count);
+                        totalCredits = CatalogPurchaseMath.checkedPrice(item.getCredits(), count);
+                        totalDuckets = CatalogPurchaseMath.checkedPrice(item.getPoints(), count);
+                        subscriptionSeconds = item.isBuildersClubAddon()
+                                ? 0
+                                : CatalogPurchaseMath.checkedSubscriptionSeconds(totalDays);
+                    } catch (IllegalArgumentException e) {
+                        this.client.sendResponse(
+                                new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                        return;
+                    }
 
-                        if (this.client.getHabbo().getHabboStats().createSubscription(subscriptionType, subscriptionSeconds) == null) {
-                            CatalogPaymentService.refund(this.client.getHabbo(), paidCredits, item.getPointsType(), paidPoints);
-                            this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                    if (totalDays > 0) {
+                        if (this.client.getHabbo().getHabboInfo().getCurrencyAmount(item.getPointsType())
+                                < totalDuckets) return;
+
+                        if (this.client.getHabbo().getHabboInfo().getCredits() < totalCredits) return;
+
+                        int paidCredits = this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS)
+                                ? 0
+                                : totalCredits;
+                        int paidPoints =
+                                this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS) ? 0 : totalDuckets;
+                        if (!CatalogPaymentService.tryTake(
+                                this.client.getHabbo(), paidCredits, item.getPointsType(), paidPoints)) {
+                            this.client.sendResponse(
+                                    new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                             return;
                         }
+
+                        if (item.isBuildersClubAddon()) {
+                            this.client.getHabbo().getHabboStats().addBuildersClubBonusFurni(totalDays);
+                            this.client.sendResponse(new BuildersClubFurniCountComposer(
+                                    BuildersClubRoomSupport.getTrackedFurniCount(this.client
+                                            .getHabbo()
+                                            .getHabboInfo()
+                                            .getId())));
+                            this.client.sendResponse(
+                                    new BuildersClubSubscriptionStatusComposer(this.client.getHabbo()));
+                        } else {
+                            String subscriptionType = item.isBuildersClubSubscription()
+                                    ? Subscription.BUILDERS_CLUB
+                                    : Subscription.HABBO_CLUB;
+
+                            if (this.client
+                                            .getHabbo()
+                                            .getHabboStats()
+                                            .createSubscription(subscriptionType, subscriptionSeconds)
+                                    == null) {
+                                CatalogPaymentService.refund(
+                                        this.client.getHabbo(), paidCredits, item.getPointsType(), paidPoints);
+                                this.client.sendResponse(
+                                        new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR)
+                                                .compose());
+                                return;
+                            }
+                        }
+
+                        this.client.sendResponse(new PurchaseOKComposer(null));
+                        this.client.sendResponse(new InventoryRefreshComposer());
+
+                        this.client.getHabbo().getHabboStats().run();
                     }
-
-                    this.client.sendResponse(new PurchaseOKComposer(null));
-                    this.client.sendResponse(new InventoryRefreshComposer());
-
-                    this.client.getHabbo().getHabboStats().run();
-                }
                     return;
                 } finally {
                     synchronized (this.client.getHabbo().getHabboStats()) {
@@ -245,10 +334,12 @@ public class CatalogBuyItemEvent extends MessageHandler {
             CatalogItem item;
 
             if (page instanceof RecentPurchasesLayout)
-                item = this.client.getHabbo().getHabboStats().getRecentPurchases().get(itemId);
-
-            else
-                item = page.getCatalogItem(itemId);
+                item = this.client
+                        .getHabbo()
+                        .getHabboStats()
+                        .getRecentPurchases()
+                        .get(itemId);
+            else item = page.getCatalogItem(itemId);
 
             if (item == null && !(page instanceof RecentPurchasesLayout)) {
                 for (CatalogItem candidate : page.getCatalogItems().values()) {
@@ -270,28 +361,55 @@ public class CatalogBuyItemEvent extends MessageHandler {
                 }
             }
 
-            if (itemHasBot && !this.client.getHabbo().hasPermission(Permission.ACC_UNLIMITED_BOTS)
-                    && this.client.getHabbo().getInventory().getBotsComponent().getBots().size() >= BotManager.MAXIMUM_BOT_INVENTORY_SIZE) {
-                this.client.getHabbo().alert(Emulator.getTexts().getValue("error.bots.max.inventory").replace("%amount%", BotManager.MAXIMUM_BOT_INVENTORY_SIZE + ""));
+            if (itemHasBot
+                    && !this.client.getHabbo().hasPermission(Permission.ACC_UNLIMITED_BOTS)
+                    && this.client
+                                    .getHabbo()
+                                    .getInventory()
+                                    .getBotsComponent()
+                                    .getBots()
+                                    .size()
+                            >= BotManager.MAXIMUM_BOT_INVENTORY_SIZE) {
+                this.client
+                        .getHabbo()
+                        .alert(Emulator.getTexts()
+                                .getValue("error.bots.max.inventory")
+                                .replace("%amount%", BotManager.MAXIMUM_BOT_INVENTORY_SIZE + ""));
                 return;
             }
 
             if (itemHasPet) {
                 if (!this.client.getHabbo().hasPermission(Permission.ACC_UNLIMITED_PETS)
-                        && this.client.getHabbo().getInventory().getPetsComponent().getPets().size() >= PetManager.MAXIMUM_PET_INVENTORY_SIZE) {
-                    this.client.getHabbo().alert(Emulator.getTexts().getValue("error.pets.max.inventory").replace("%amount%", PetManager.MAXIMUM_PET_INVENTORY_SIZE + ""));
+                        && this.client
+                                        .getHabbo()
+                                        .getInventory()
+                                        .getPetsComponent()
+                                        .getPets()
+                                        .size()
+                                >= PetManager.MAXIMUM_PET_INVENTORY_SIZE) {
+                    this.client
+                            .getHabbo()
+                            .alert(Emulator.getTexts()
+                                    .getValue("error.pets.max.inventory")
+                                    .replace("%amount%", PetManager.MAXIMUM_PET_INVENTORY_SIZE + ""));
                     return;
                 }
                 String[] check = extraData.split("\n");
-                if ((check.length != 3) || (check[0].length() < PET_NAME_LENGTH_MINIMUM) || (check[0].length() > PET_NAME_LENGTH_MAXIMUM) || (!StringUtils.isAlphanumeric(check[0]))) {
+                if ((check.length != 3)
+                        || (check[0].length() < PET_NAME_LENGTH_MINIMUM)
+                        || (check[0].length() > PET_NAME_LENGTH_MAXIMUM)
+                        || (!StringUtils.isAlphanumeric(check[0]))) {
                     return;
                 }
             }
 
-            Emulator.getGameEnvironment().getCatalogManager().purchaseItem(page, item, this.client.getHabbo(), count, extraData, false);
+            Emulator.getGameEnvironment()
+                    .getCatalogManager()
+                    .purchaseItem(page, item, this.client.getHabbo(), count, extraData, false);
 
         } else {
-            this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+            this.client.sendResponse(
+                    new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogPurchaseCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogPurchaseCommand.java
@@ -1,0 +1,15 @@
+package com.eu.habbo.messages.incoming.catalog;
+
+import com.eu.habbo.messages.ClientMessage;
+
+record CatalogPurchaseCommand(int pageId, int itemId, String extraData, int count) {
+
+    static CatalogPurchaseCommand readFrom(ClientMessage packet) {
+        int pageId = packet.readInt();
+        int itemId = packet.readInt();
+        String extraData = packet.readString();
+        int requestedCount = packet.readInt();
+        int count = Math.clamp(requestedCount, 1, 100);
+        return new CatalogPurchaseCommand(pageId, itemId, extraData, count);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseAtomicityContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseAtomicityContractTest.java
@@ -1,15 +1,18 @@
 package com.eu.habbo.habbohotel.catalog;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class CatalogPurchaseAtomicityContractTest {
     private static String source(String relativePath) throws Exception {
         return Files.readString(Path.of("src/main/java", relativePath));
+    }
+
+    private static String withoutWhitespace(String source) {
+        return source.replaceAll("\\s+", "");
     }
 
     @Test
@@ -17,19 +20,24 @@ class CatalogPurchaseAtomicityContractTest {
         String manager = source("com/eu/habbo/habbohotel/catalog/CatalogManager.java");
         String transaction = source("com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java");
 
-        assertTrue(manager.contains("synchronized (habbo.getHabboStats())"),
+        assertTrue(
+                manager.contains("synchronized (habbo.getHabboStats())"),
                 "normal catalog purchases must acquire the per-user purchase gate atomically");
-        assertTrue(manager.contains("CatalogPurchaseTransaction.execute("),
+        assertTrue(
+                manager.contains("CatalogPurchaseTransaction.execute("),
                 "normal catalog assets and payment must use the transaction coordinator");
         assertTrue(transaction.contains("connection.setAutoCommit(false)"));
-        assertTrue(transaction.contains("EconomyLedger.apply(connection"),
+        assertTrue(
+                transaction.contains("EconomyLedger.apply(connection"),
                 "credit debit must use the locked, audited economy ledger");
         String ledger = source("com/eu/habbo/habbohotel/economy/EconomyLedger.java");
-        assertTrue(ledger.contains("int balanceAfter = checkedBalance(balanceBefore, operation.delta())"),
+        assertTrue(
+                ledger.contains("int balanceAfter = checkedBalance(balanceBefore, operation.delta())"),
                 "the ledger must reject insufficient concurrent balances");
         assertTrue(transaction.contains("connection.commit()"));
         assertTrue(transaction.contains("connection.rollback()"));
-        assertTrue(manager.contains("limitedConfiguration.restoreNumber(item.getId(), limitedNumber)"),
+        assertTrue(
+                manager.contains("limitedConfiguration.restoreNumber(item.getId(), limitedNumber)"),
                 "a failed legacy limited purchase must return its reserved number to the pool");
     }
 
@@ -37,23 +45,28 @@ class CatalogPurchaseAtomicityContractTest {
     void giftsDebitBeforeCreationAndCompensateOnFailure() throws Exception {
         String gift = source("com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java");
 
-        int debit = gift.indexOf("CatalogPaymentService.tryTake(this.client.getHabbo(), chargeCredits, item.getPointsType(), chargePoints)");
+        int debit = gift.indexOf(
+                "CatalogPaymentService.tryTake(this.client.getHabbo(), chargeCredits, item.getPointsType(), chargePoints)");
         int create = gift.indexOf("getItemManager().createItem(userId", debit);
-        assertTrue(debit > -1 && create > debit,
-                "gift payment must be reserved before recipient-owned rows are created");
-        assertTrue(gift.contains("if (!giftDelivered)"),
-                "failed gift delivery must enter compensating cleanup");
-        assertTrue(gift.contains("CatalogPaymentService.refund(this.client.getHabbo(), paidCredits, paidPointsType, paidPoints)"),
+        assertTrue(
+                debit > -1 && create > debit, "gift payment must be reserved before recipient-owned rows are created");
+        assertTrue(gift.contains("if (!giftDelivered)"), "failed gift delivery must enter compensating cleanup");
+        assertTrue(
+                gift.contains(
+                        "CatalogPaymentService.refund(this.client.getHabbo(), paidCredits, paidPointsType, paidPoints)"),
                 "failed gift delivery must restore the exact reserved payment");
     }
 
     @Test
     void clubPurchasesUseTheSamePurchaseGateAndWalletDebit() throws Exception {
-        String buy = source("com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java");
+        String buy = withoutWhitespace(source("com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java"));
 
-        assertTrue(buy.contains("isPurchasingFurniture = true"));
-        assertTrue(buy.contains("CatalogPaymentService.tryTake(this.client.getHabbo(), paidCredits, item.getPointsType(), paidPoints)"));
-        assertTrue(buy.contains("CatalogPaymentService.refund(this.client.getHabbo(), paidCredits, item.getPointsType(), paidPoints)"),
+        assertTrue(buy.contains("isPurchasingFurniture=true"));
+        assertTrue(buy.contains(
+                "CatalogPaymentService.tryTake(this.client.getHabbo(),paidCredits,item.getPointsType(),paidPoints)"));
+        assertTrue(
+                buy.contains(
+                        "CatalogPaymentService.refund(this.client.getHabbo(),paidCredits,item.getPointsType(),paidPoints)"),
                 "a rejected subscription grant must restore its payment");
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/catalog/CatalogPurchaseCommandTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/catalog/CatalogPurchaseCommandTest.java
@@ -1,0 +1,52 @@
+package com.eu.habbo.messages.incoming.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.eu.habbo.messages.ClientMessage;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class CatalogPurchaseCommandTest {
+
+    @Test
+    void readsPurchaseFieldsInProtocolOrder() {
+        CatalogPurchaseCommand command = CatalogPurchaseCommand.readFrom(packet(17, 42, "blue\npet", 3));
+
+        assertAll(
+                () -> assertEquals(17, command.pageId()),
+                () -> assertEquals(42, command.itemId()),
+                () -> assertEquals("blue\npet", command.extraData()),
+                () -> assertEquals(3, command.count()));
+    }
+
+    @Test
+    void clampsRequestedCountToLegacyRange() {
+        assertAll(
+                () -> assertEquals(
+                        1, CatalogPurchaseCommand.readFrom(packet(1, 2, "", -5)).count()),
+                () -> assertEquals(
+                        1, CatalogPurchaseCommand.readFrom(packet(1, 2, "", 0)).count()),
+                () -> assertEquals(
+                        1, CatalogPurchaseCommand.readFrom(packet(1, 2, "", 1)).count()),
+                () -> assertEquals(
+                        100,
+                        CatalogPurchaseCommand.readFrom(packet(1, 2, "", 100)).count()),
+                () -> assertEquals(
+                        100,
+                        CatalogPurchaseCommand.readFrom(packet(1, 2, "", 101)).count()));
+    }
+
+    private static ClientMessage packet(int pageId, int itemId, String extraData, int count) {
+        byte[] extraDataBytes = extraData.getBytes(StandardCharsets.UTF_8);
+        ByteBuf buffer = Unpooled.buffer();
+        buffer.writeInt(pageId);
+        buffer.writeInt(itemId);
+        buffer.writeShort(extraDataBytes.length);
+        buffer.writeBytes(extraDataBytes);
+        buffer.writeInt(count);
+        return new ClientMessage(0, buffer);
+    }
+}


### PR DESCRIPTION
Adds a typed catalog purchase command at the packet boundary while preserving field order and legacy count clamping. This establishes the tested seam for extracting purchase orchestration from the incoming handler.