### PR TITLE
fix(db): explain missing migration backup executable

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/database/backup/MariaDbMigrationBackup.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/backup/MariaDbMigrationBackup.java
@@ -91,6 +91,8 @@ public final class MariaDbMigrationBackup implements MigrationBackup {
         List<String> pending = List.copyOf(pendingVersions);
         if (!options.enabled() || pending.isEmpty()) return;
 
+        requireResolvableExecutable();
+
         Path credentials = null;
         Path archivePart = null;
         Path archive = null;
@@ -120,7 +122,7 @@ public final class MariaDbMigrationBackup implements MigrationBackup {
             manifestPart = options.directory().resolve(baseName + ".sql.gz.json.part");
 
             List<String> command = command(credentials);
-            Process process = processStarter.start(command);
+            Process process = startDump(command);
             ProcessResult result = collect(process, archivePart);
             if (result.exitCode() != 0) {
                 throw new MigrationBackupException(
@@ -187,6 +189,34 @@ public final class MariaDbMigrationBackup implements MigrationBackup {
             deleteQuietly(checksumPart);
             deleteQuietly(manifestPart);
         }
+    }
+
+    private void requireResolvableExecutable() {
+        String executable = options.executable();
+        boolean explicitPath = executable.indexOf('/') >= 0 || executable.indexOf('\\') >= 0;
+        if (!explicitPath) return;
+        try {
+            if (Files.isRegularFile(Path.of(executable))) return;
+        } catch (java.nio.file.InvalidPathException ignored) {
+            // Fall through to the unavailable-executable failure below.
+        }
+        throw new MigrationBackupException(executableUnavailableMessage());
+    }
+
+    private Process startDump(List<String> command) {
+        try {
+            return processStarter.start(command);
+        } catch (IOException launchFailure) {
+            throw new MigrationBackupException(executableUnavailableMessage(), launchFailure);
+        }
+    }
+
+    private String executableUnavailableMessage() {
+        return "The migration backup tool '" + options.executable() + "' could not be found or executed. "
+                + "Polaris takes a fail-closed database backup before applying pending migrations, so startup stops here. "
+                + "Fix one of: (1) install the MariaDB client tools so 'mariadb-dump' is on PATH, "
+                + "(2) set db.migrations.backup.executable=<full path to mariadb-dump> in config.ini, or "
+                + "(3) take a manual database backup first and set db.migrations.backup.enabled=0.";
     }
 
     private ProcessResult collect(Process process, Path archivePart) throws IOException {

--- a/Emulator/src/test/java/com/eu/habbo/database/backup/MariaDbMigrationBackupTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/backup/MariaDbMigrationBackupTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -155,6 +156,56 @@ class MariaDbMigrationBackupTest {
         assertEquals(List.of(), files(".part"));
         assertEquals(List.of(), files(".cnf"));
         assertEquals(List.of(), files(".sql.gz"));
+    }
+
+    @Test
+    void missingExplicitExecutableFailsBeforeLaunchWithRemedies() throws Exception {
+        String executable = tempDir.resolve("tools").resolve("mariadb-dump").toString();
+        DatabaseBackupOptions options = new DatabaseBackupOptions(
+                true, tempDir, 3, Duration.ofSeconds(30), executable);
+        MariaDbMigrationBackup backup = new MariaDbMigrationBackup(
+                options,
+                new DatabaseBackupRequest("localhost", 3306, "polaris", "user", "password"),
+                command -> {
+                    throw new AssertionError("the dump process must not be launched");
+                },
+                Clock.systemUTC());
+
+        MigrationBackupException error = assertThrows(
+                MigrationBackupException.class,
+                () -> backup.beforeMigrations(migrations()));
+
+        assertTrue(error.getMessage().contains(executable));
+        assertTrue(error.getMessage().contains("MariaDB client tools"));
+        assertTrue(error.getMessage().contains("db.migrations.backup.executable"));
+        assertTrue(error.getMessage().contains("db.migrations.backup.enabled=0"));
+        assertEquals(List.of(), files(".cnf"));
+        assertEquals(List.of(), files(".part"));
+    }
+
+    @Test
+    void unresolvableCommandLaunchFailureExplainsRemedies() {
+        DatabaseBackupOptions options = new DatabaseBackupOptions(
+                true, tempDir, 3, Duration.ofSeconds(30), "mariadb-dump");
+        IOException launchFailure = new IOException(
+                "Cannot run program \"mariadb-dump\": CreateProcess error=2");
+        MariaDbMigrationBackup backup = new MariaDbMigrationBackup(
+                options,
+                new DatabaseBackupRequest("localhost", 3306, "polaris", "user", "password"),
+                command -> {
+                    throw launchFailure;
+                },
+                Clock.systemUTC());
+
+        MigrationBackupException error = assertThrows(
+                MigrationBackupException.class,
+                () -> backup.beforeMigrations(migrations()));
+
+        assertTrue(error.getMessage().contains("'mariadb-dump'"));
+        assertTrue(error.getMessage().contains("MariaDB client tools"));
+        assertTrue(error.getMessage().contains("db.migrations.backup.executable"));
+        assertTrue(error.getMessage().contains("db.migrations.backup.enabled=0"));
+        assertEquals(launchFailure, error.getCause());
     }
 
     private List<String> migrations() {


### PR DESCRIPTION
## Context

A real support report (Windows, MariaDB 12.2, adopting an existing hotel DB): startup aborted with a deeply nested `IOException: Cannot run program "mariadb-dump": CreateProcess error=2`. Root cause: the fail-closed pre-migration backup shells out to `db.migrations.backup.executable` (default `mariadb-dump`), and the MariaDB MSI on Windows does not put its `bin` directory on PATH. The failure was correct-by-design but the real cause sat two `Caused by` levels deep with no remediation guidance.

## Change

- `test(db)`: two reproductions, verified failing on unmodified code — an explicit-but-missing executable path must fail before any process launch or credential write; a bare-name launch failure (the reporter's exact case) must surface remedies.
- `fix(db)`: preflight in `MariaDbMigrationBackup.beforeMigrations` — explicit paths are checked for existence before anything runs; bare-name launch `IOException`s are translated. Both paths produce one clear `MigrationBackupException` naming the three remedies: install the MariaDB client tools / set `db.migrations.backup.executable=<full path>` / take a manual backup and set `db.migrations.backup.enabled=0`.

Deliberately **no** home-grown PATH scan for bare names: the OS's own resolution is authoritative (Windows searches beyond PATH), so a scan could reject working setups. Fail-closed semantics, backup coverage, and all public signatures are unchanged. The `db.migrations.backup.*` keys were already documented in `config example/config.ini.example`.