### PR TITLE
refactor(rooms): split room manager services

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomDirectory.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomDirectory.java
@@ -1,0 +1,96 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class RoomDirectory {
+
+    private final ConcurrentHashMap<Integer, Room> activeRooms = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, Set<Integer>> roomsByOwner = new ConcurrentHashMap<>();
+    private final AtomicInteger indexedRoomCount = new AtomicInteger();
+
+    ConcurrentHashMap<Integer, Room> activeRooms() {
+        return this.activeRooms;
+    }
+
+    ConcurrentHashMap<Integer, Set<Integer>> roomsByOwner() {
+        return this.roomsByOwner;
+    }
+
+    AtomicInteger indexedRoomCount() {
+        return this.indexedRoomCount;
+    }
+
+    void register(Room room) {
+        Room previousRoom = this.activeRooms.put(room.getId(), room);
+        if (previousRoom != null) {
+            this.untrack(previousRoom);
+        }
+
+        room.setOwnerChangeListener(this::ownerChanged);
+        this.track(room);
+    }
+
+    void track(Room room) {
+        if (this.roomsByOwner
+                .computeIfAbsent(room.getOwnerId(), ignored -> ConcurrentHashMap.newKeySet())
+                .add(room.getId())) {
+            this.indexedRoomCount.incrementAndGet();
+        }
+    }
+
+    void untrack(Room room) {
+        room.setOwnerChangeListener(null);
+        this.removeFromOwner(room.getOwnerId(), room.getId());
+    }
+
+    void removeFromOwner(int ownerId, int roomId) {
+        Set<Integer> rooms = this.roomsByOwner.get(ownerId);
+        if (rooms == null) {
+            return;
+        }
+        if (rooms.remove(roomId)) {
+            this.indexedRoomCount.decrementAndGet();
+        }
+        if (rooms.isEmpty()) {
+            this.roomsByOwner.remove(ownerId, rooms);
+        }
+    }
+
+    void reconcileOwnerIndex() {
+        for (Map.Entry<Integer, Set<Integer>> entry : this.roomsByOwner.entrySet()) {
+            int indexedOwnerId = entry.getKey();
+            for (int roomId : new HashSet<>(entry.getValue())) {
+                Room room = this.activeRooms.get(roomId);
+                if (room == null || room.getOwnerId() != indexedOwnerId) {
+                    this.removeFromOwner(indexedOwnerId, roomId);
+                }
+            }
+        }
+
+        for (Room room : this.activeRooms.values()) {
+            room.setOwnerChangeListener(this::ownerChanged);
+            this.track(room);
+        }
+    }
+
+    void clear() {
+        for (Room room : this.activeRooms.values()) {
+            room.setOwnerChangeListener(null);
+        }
+        this.roomsByOwner.clear();
+        this.indexedRoomCount.set(0);
+        this.activeRooms.clear();
+    }
+
+    private void ownerChanged(Room room, int previousOwnerId) {
+        if (this.activeRooms.get(room.getId()) != room) {
+            return;
+        }
+        this.removeFromOwner(previousOwnerId, room.getId());
+        this.track(room);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomEntryService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomEntryService.java
@@ -1,0 +1,150 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorCode;
+import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorMessagesComposer;
+import com.eu.habbo.messages.outgoing.hotelview.HotelViewComposer;
+import com.eu.habbo.messages.outgoing.rooms.DoorbellAddUserComposer;
+import com.eu.habbo.messages.outgoing.rooms.RoomAccessDeniedComposer;
+import com.eu.habbo.messages.outgoing.rooms.RoomEnterErrorComposer;
+import java.util.function.BiPredicate;
+import java.util.function.IntFunction;
+
+final class RoomEntryService {
+
+    private final IntFunction<Room> roomLoader;
+    private final IntFunction<Room> activeRooms;
+    private final BiPredicate<Habbo, Room> entryAllowed;
+    private final RoomOpener roomOpener;
+
+    RoomEntryService(
+            IntFunction<Room> roomLoader,
+            IntFunction<Room> activeRooms,
+            BiPredicate<Habbo, Room> entryAllowed,
+            RoomOpener roomOpener) {
+        this.roomLoader = roomLoader;
+        this.activeRooms = activeRooms;
+        this.entryAllowed = entryAllowed;
+        this.roomOpener = roomOpener;
+    }
+
+    void enter(
+            Habbo habbo,
+            int roomId,
+            String password,
+            boolean overrideChecks,
+            RoomTile doorLocation,
+            boolean reconnectSpawn) {
+        Room room = this.roomLoader.apply(roomId);
+        if (room == null) {
+            return;
+        }
+
+        if (habbo.getHabboInfo().getLoadingRoom() != 0
+                && room.getId() != habbo.getHabboInfo().getLoadingRoom()) {
+            this.returnToHotel(habbo);
+            return;
+        }
+
+        if (!this.entryAllowed.test(habbo, room) && habbo.getHabboInfo().getCurrentRoom() == null) {
+            this.returnToHotel(habbo);
+            return;
+        }
+
+        if (room.isBanned(habbo)
+                && !habbo.hasPermission(Permission.ACC_ANYROOMOWNER)
+                && !habbo.hasPermission(Permission.ACC_ENTERANYROOM)) {
+            habbo.getClient().sendResponse(new RoomEnterErrorComposer(RoomEnterErrorComposer.ROOM_ERROR_BANNED));
+            return;
+        }
+
+        if (room.isBuildersClubTrialLocked()
+                && habbo.getHabboInfo().getId() != room.getOwnerId()
+                && !overrideChecks
+                && !habbo.hasPermission(Permission.ACC_ANYROOMOWNER)
+                && !habbo.hasPermission(Permission.ACC_ENTERANYROOM)) {
+            BuildersClubRoomSupport.sendVisitDeniedOwnerBubble(
+                    room.getOwnerId(), habbo.getHabboInfo().getUsername());
+            BuildersClubRoomSupport.sendVisitDeniedVisitorAlert(
+                    habbo.getHabboInfo().getId());
+            this.returnToHotel(habbo);
+            return;
+        }
+
+        if (habbo.getHabboInfo().getRoomQueueId() != roomId) {
+            Room queuedRoom = this.activeRooms.apply(roomId);
+            if (queuedRoom != null) {
+                queuedRoom.removeFromQueue(habbo);
+            }
+        }
+
+        if (this.canOpen(habbo, room, overrideChecks)) {
+            this.roomOpener.open(habbo, room, doorLocation, reconnectSpawn);
+        } else if (room.getState() == RoomState.LOCKED) {
+            this.requestDoorbell(habbo, room, roomId);
+        } else if (room.getState() == RoomState.PASSWORD) {
+            this.checkPassword(habbo, room, password, doorLocation, reconnectSpawn);
+        } else {
+            this.returnToHotel(habbo);
+        }
+    }
+
+    private boolean canOpen(Habbo habbo, Room room, boolean overrideChecks) {
+        return overrideChecks
+                || room.isOwner(habbo)
+                || room.getState() == RoomState.OPEN
+                || habbo.hasPermission(Permission.ACC_ANYROOMOWNER)
+                || habbo.hasPermission(Permission.ACC_ENTERANYROOM)
+                || room.hasRights(habbo)
+                || (room.getState().equals(RoomState.INVISIBLE) && room.hasRights(habbo))
+                || (room.hasGuild() && room.getGuildRightLevel(habbo).isGreaterThan(RoomRightLevels.GUILD_RIGHTS));
+    }
+
+    private void requestDoorbell(Habbo habbo, Room room, int roomId) {
+        boolean rightsFound = false;
+        synchronized (room.roomUnitLock) {
+            for (Habbo current : room.getHabbos()) {
+                if (room.hasRights(current)
+                        || current.getHabboInfo().getId() == room.getOwnerId()
+                        || (room.hasGuild()
+                                && room.getGuildRightLevel(current)
+                                        .isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS))) {
+                    current.getClient()
+                            .sendResponse(new DoorbellAddUserComposer(
+                                    habbo.getHabboInfo().getUsername()));
+                    rightsFound = true;
+                }
+            }
+        }
+
+        if (!rightsFound) {
+            habbo.getClient().sendResponse(new RoomAccessDeniedComposer(""));
+            this.returnToHotel(habbo);
+            return;
+        }
+
+        habbo.getHabboInfo().setRoomQueueId(roomId);
+        habbo.getClient().sendResponse(new DoorbellAddUserComposer(""));
+        room.addToQueue(habbo);
+    }
+
+    private void checkPassword(Habbo habbo, Room room, String password, RoomTile doorLocation, boolean reconnectSpawn) {
+        if (room.getPassword().equalsIgnoreCase(password)) {
+            this.roomOpener.open(habbo, room, doorLocation, reconnectSpawn);
+            return;
+        }
+        habbo.getClient().sendResponse(new GenericErrorMessagesComposer(GenericErrorCode.WRONG_ROOM_PASSWORD));
+        this.returnToHotel(habbo);
+    }
+
+    private void returnToHotel(Habbo habbo) {
+        habbo.getClient().sendResponse(new HotelViewComposer());
+        habbo.getHabboInfo().setLoadingRoom(0);
+    }
+
+    @FunctionalInterface
+    interface RoomOpener {
+        void open(Habbo habbo, Room room, RoomTile doorLocation, boolean reconnectSpawn);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLifecycleService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLifecycleService.java
@@ -1,0 +1,129 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.users.Habbo;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.IntPredicate;
+import java.util.function.Predicate;
+
+final class RoomLifecycleService {
+
+    private final RoomDirectory directory;
+    private final Map<Integer, RoomCategory> categories;
+    private final IntPredicate ownerConnected;
+    private final Predicate<Room> uncacheAllowed;
+    private final Runnable directoryChanged;
+
+    RoomLifecycleService(
+            RoomDirectory directory,
+            Map<Integer, RoomCategory> categories,
+            IntPredicate ownerConnected,
+            Predicate<Room> uncacheAllowed,
+            Runnable directoryChanged) {
+        this.directory = directory;
+        this.categories = categories;
+        this.ownerConnected = ownerConnected;
+        this.uncacheAllowed = uncacheAllowed;
+        this.directoryChanged = directoryChanged;
+    }
+
+    void unloadRoomsFor(Habbo habbo) {
+        int ownerId = habbo.getHabboInfo().getId();
+        for (Room room : this.roomsToUnloadForOwner(ownerId)) {
+            if (!this.uncacheAllowed.test(room)) {
+                continue;
+            }
+            room.dispose();
+            this.remove(room);
+        }
+    }
+
+    List<Room> roomsToUnloadForOwner(int ownerId) {
+        if (this.directory.indexedRoomCount().get()
+                != this.directory.activeRooms().size()) {
+            this.directory.reconcileOwnerIndex();
+        }
+
+        List<Room> roomsToDispose = new ArrayList<>();
+        Set<Integer> roomIds = this.directory.roomsByOwner().get(ownerId);
+        if (roomIds == null) {
+            return roomsToDispose;
+        }
+
+        for (int roomId : new HashSet<>(roomIds)) {
+            Room room = this.directory.activeRooms().get(roomId);
+            if (room == null || room.getOwnerId() != ownerId) {
+                this.directory.removeFromOwner(ownerId, roomId);
+                if (room != null) {
+                    this.directory.track(room);
+                }
+                continue;
+            }
+
+            RoomCategory category = this.categories.get(room.getCategory());
+            if (!room.isPublicRoom()
+                    && !room.isStaffPromotedRoom()
+                    && room.getUserCount() == 0
+                    && (category == null || !category.isPublic())) {
+                roomsToDispose.add(room);
+            }
+        }
+        return roomsToDispose;
+    }
+
+    void clearInactiveRooms() {
+        Set<Room> roomsToDispose = new HashSet<>();
+        for (Map.Entry<Integer, Set<Integer>> entry :
+                this.directory.roomsByOwner().entrySet()) {
+            if (this.ownerConnected.test(entry.getKey())) {
+                continue;
+            }
+            for (int roomId : entry.getValue()) {
+                Room room = this.directory.activeRooms().get(roomId);
+                if (room != null && !room.isPublicRoom() && !room.isStaffPromotedRoom() && room.isPreLoaded()) {
+                    roomsToDispose.add(room);
+                }
+            }
+        }
+
+        for (Room room : roomsToDispose) {
+            room.dispose();
+            if (room.getUserCount() == 0) {
+                this.remove(room);
+            }
+        }
+    }
+
+    void unload(Room room) {
+        room.dispose();
+    }
+
+    void uncache(Room room) {
+        this.remove(room);
+    }
+
+    void quiesceRoomCycles() {
+        for (Room room : this.directory.activeRooms().values()) {
+            room.quiesceCycleTask();
+        }
+    }
+
+    void dispose() {
+        this.quiesceRoomCycles();
+        for (Room room : this.directory.activeRooms().values()) {
+            room.dispose();
+            room.setOwnerChangeListener(null);
+        }
+        this.directory.clear();
+        this.directoryChanged.run();
+    }
+
+    private void remove(Room room) {
+        this.directory.untrack(room);
+        this.directory.activeRooms().remove(room.getId());
+        this.directoryChanged.run();
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -80,6 +80,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -89,7 +90,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -147,6 +147,7 @@ public class RoomManager {
     private final List<String> mapNames;
     private final ConcurrentHashMap<String, RoomLayoutData> layoutCache;
     private final RoomDirectory roomDirectory;
+    private final RoomSearchService roomSearchService;
     private final ConcurrentHashMap<Integer, Room> activeRooms;
     private final ConcurrentHashMap<Integer, Set<Integer>> roomsByOwner;
     private final AtomicInteger indexedRoomCount;
@@ -175,6 +176,7 @@ public class RoomManager {
         this.activeRooms = this.roomDirectory.activeRooms();
         this.roomsByOwner = this.roomDirectory.roomsByOwner();
         this.indexedRoomCount = this.roomDirectory.indexedRoomCount();
+        this.roomSearchService = new RoomSearchService(this.activeRooms::values, Duration.ofSeconds(1));
 
         this.gameTypes = new ArrayList<>();
 
@@ -208,6 +210,7 @@ public class RoomManager {
 
     private void untrackRoomOwner(Room room) {
         this.roomDirectory.untrack(room);
+        this.roomSearchService.invalidate();
     }
 
     private void removeRoomFromOwner(int ownerId, int roomId) {
@@ -216,6 +219,7 @@ public class RoomManager {
 
     void registerActiveRoom(Room room) {
         this.roomDirectory.register(room);
+        this.roomSearchService.invalidate();
     }
 
     private void reconcileOwnerIndex() {
@@ -1369,94 +1373,23 @@ public class RoomManager {
     }
 
     public Set<String> getTags() {
-        Map<String, Integer> tagCount = new HashMap<>();
-
-        for (Room room : this.activeRooms.values()) {
-            for (String s : room.getTags().split(";")) {
-                int i = 0;
-                if (tagCount.get(s) != null) i++;
-
-                tagCount.put(s, i++);
-            }
-        }
-        return new TreeMap<>(tagCount).keySet();
+        return this.roomSearchService.tags();
     }
 
     public ArrayList<Room> getPublicRooms() {
-        ArrayList<Room> rooms = new ArrayList<>();
-
-        for (Room room : this.activeRooms.values()) {
-            if (room.isPublicRoom()) {
-                rooms.add(room);
-            }
-        }
-        rooms.sort(Room.SORT_ID);
-        return rooms;
+        return this.roomSearchService.publicRooms();
     }
 
     public ArrayList<Room> getPopularRooms(int count) {
-        ArrayList<Room> rooms = new ArrayList<>();
-
-        for (Room room : this.activeRooms.values()) {
-            if (room.getUserCount() > 0) {
-                if (!room.isPublicRoom() || RoomManager.SHOW_PUBLIC_IN_POPULAR_TAB) rooms.add(room);
-            }
-        }
-
-        if (rooms.isEmpty()) {
-            return rooms;
-        }
-
-        Collections.sort(rooms);
-
-        return new ArrayList<>(rooms.subList(0, (Math.min(rooms.size(), count))));
+        return this.roomSearchService.popularRooms(count, RoomManager.SHOW_PUBLIC_IN_POPULAR_TAB);
     }
 
     public ArrayList<Room> getPopularRooms(int count, int category) {
-        ArrayList<Room> rooms = new ArrayList<>();
-
-        for (Room room : this.activeRooms.values()) {
-            if (!room.isPublicRoom() && room.getCategory() == category) {
-                rooms.add(room);
-            }
-        }
-
-        if (rooms.isEmpty()) {
-            return rooms;
-        }
-
-        Collections.sort(rooms);
-
-        return new ArrayList<>(rooms.subList(0, (Math.min(rooms.size(), count))));
+        return this.roomSearchService.popularRooms(count, category);
     }
 
     public Map<Integer, List<Room>> getPopularRoomsByCategory(int count) {
-        Map<Integer, List<Room>> rooms = new HashMap<>();
-
-        for (Room room : this.activeRooms.values()) {
-            if (!room.isPublicRoom()) {
-                if (!rooms.containsKey(room.getCategory())) {
-                    rooms.put(room.getCategory(), new ArrayList<>());
-                }
-
-                rooms.get(room.getCategory()).add(room);
-            }
-        }
-
-        Map<Integer, List<Room>> result = new HashMap<>();
-
-        for (Map.Entry<Integer, List<Room>> set : rooms.entrySet()) {
-            if (set.getValue().isEmpty()) continue;
-
-            Collections.sort(set.getValue());
-
-            result.put(
-                    set.getKey(),
-                    new ArrayList<>(
-                            set.getValue().subList(0, (Math.min(set.getValue().size(), count)))));
-        }
-
-        return result;
+        return this.roomSearchService.popularRoomsByCategory(count);
     }
 
     public ArrayList<Room> getRoomsWithName(String name) {
@@ -1501,20 +1434,7 @@ public class RoomManager {
     }
 
     public ArrayList<Room> getRoomsWithTag(String tag) {
-        ArrayList<Room> rooms = new ArrayList<>();
-
-        for (Room room : this.activeRooms.values()) {
-            for (String s : room.getTags().split(";")) {
-                if (s.equalsIgnoreCase(tag)) {
-                    rooms.add(room);
-                    break;
-                }
-            }
-        }
-
-        Collections.sort(rooms);
-
-        return rooms;
+        return this.roomSearchService.roomsWithTag(tag);
     }
 
     public ArrayList<Room> getGroupRoomsWithName(String name) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -31,8 +31,6 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.messages.incoming.users.UserNuxEvent;
-import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorCode;
-import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorMessagesComposer;
 import com.eu.habbo.messages.outgoing.hotelview.HotelViewComposer;
 import com.eu.habbo.messages.outgoing.polls.PollStartComposer;
 import com.eu.habbo.messages.outgoing.polls.infobus.SimplePollAnswersComposer;
@@ -40,7 +38,6 @@ import com.eu.habbo.messages.outgoing.polls.infobus.SimplePollStartComposer;
 import com.eu.habbo.messages.outgoing.rooms.DoorbellAddUserComposer;
 import com.eu.habbo.messages.outgoing.rooms.FloodCounterComposer;
 import com.eu.habbo.messages.outgoing.rooms.HideDoorbellComposer;
-import com.eu.habbo.messages.outgoing.rooms.RoomAccessDeniedComposer;
 import com.eu.habbo.messages.outgoing.rooms.RoomDataComposer;
 import com.eu.habbo.messages.outgoing.rooms.RoomEnterErrorComposer;
 import com.eu.habbo.messages.outgoing.rooms.RoomModelComposer;
@@ -150,6 +147,7 @@ public class RoomManager {
     private final RoomSearchService roomSearchService;
     private final RoomModerationService roomModerationService;
     private final RoomLifecycleService roomLifecycleService;
+    private final RoomEntryService roomEntryService;
     private final ConcurrentHashMap<Integer, Room> activeRooms;
     private final ConcurrentHashMap<Integer, Set<Integer>> roomsByOwner;
     private final AtomicInteger indexedRoomCount;
@@ -194,6 +192,13 @@ public class RoomManager {
                 HabboManager::getOfflineHabboInfo,
                 () -> Emulator.getIntUnixTimestamp(),
                 RoomBan::insert);
+        this.roomEntryService = new RoomEntryService(
+                roomId -> this.loadRoom(roomId, true),
+                this::getRoom,
+                (habbo, room) -> !Emulator.getPluginManager()
+                        .fireEvent(new UserEnterRoomEvent(habbo, room))
+                        .isCancelled(),
+                this::openRoom);
 
         this.gameTypes = new ArrayList<>();
 
@@ -621,105 +626,7 @@ public class RoomManager {
             boolean overrideChecks,
             RoomTile doorLocation,
             boolean isReconnectSpawn) {
-        Room room = this.loadRoom(roomId, true);
-
-        if (room == null) return;
-
-        if (habbo.getHabboInfo().getLoadingRoom() != 0
-                && room.getId() != habbo.getHabboInfo().getLoadingRoom()) {
-            habbo.getClient().sendResponse(new HotelViewComposer());
-            habbo.getHabboInfo().setLoadingRoom(0);
-            return;
-        }
-
-        if (Emulator.getPluginManager()
-                .fireEvent(new UserEnterRoomEvent(habbo, room))
-                .isCancelled()) {
-            if (habbo.getHabboInfo().getCurrentRoom() == null) {
-                habbo.getClient().sendResponse(new HotelViewComposer());
-                habbo.getHabboInfo().setLoadingRoom(0);
-                return;
-            }
-        }
-
-        if (room.isBanned(habbo)
-                && !habbo.hasPermission(Permission.ACC_ANYROOMOWNER)
-                && !habbo.hasPermission(Permission.ACC_ENTERANYROOM)) {
-            habbo.getClient().sendResponse(new RoomEnterErrorComposer(RoomEnterErrorComposer.ROOM_ERROR_BANNED));
-            return;
-        }
-
-        if (room.isBuildersClubTrialLocked()
-                && habbo.getHabboInfo().getId() != room.getOwnerId()
-                && !overrideChecks
-                && !habbo.hasPermission(Permission.ACC_ANYROOMOWNER)
-                && !habbo.hasPermission(Permission.ACC_ENTERANYROOM)) {
-            BuildersClubRoomSupport.sendVisitDeniedOwnerBubble(
-                    room.getOwnerId(), habbo.getHabboInfo().getUsername());
-            BuildersClubRoomSupport.sendVisitDeniedVisitorAlert(
-                    habbo.getHabboInfo().getId());
-            habbo.getClient().sendResponse(new HotelViewComposer());
-            habbo.getHabboInfo().setLoadingRoom(0);
-            return;
-        }
-
-        if (habbo.getHabboInfo().getRoomQueueId() != roomId) {
-            Room queRoom = Emulator.getGameEnvironment().getRoomManager().getRoom(roomId);
-
-            if (queRoom != null) {
-                queRoom.removeFromQueue(habbo);
-            }
-        }
-
-        if (overrideChecks
-                || room.isOwner(habbo)
-                || room.getState() == RoomState.OPEN
-                || habbo.hasPermission(Permission.ACC_ANYROOMOWNER)
-                || habbo.hasPermission(Permission.ACC_ENTERANYROOM)
-                || room.hasRights(habbo)
-                || (room.getState().equals(RoomState.INVISIBLE) && room.hasRights(habbo))
-                || (room.hasGuild() && room.getGuildRightLevel(habbo).isGreaterThan(RoomRightLevels.GUILD_RIGHTS))) {
-            this.openRoom(habbo, room, doorLocation, isReconnectSpawn);
-        } else if (room.getState() == RoomState.LOCKED) {
-            boolean rightsFound = false;
-
-            synchronized (room.roomUnitLock) {
-                for (Habbo current : room.getHabbos()) {
-                    if (room.hasRights(current)
-                            || current.getHabboInfo().getId() == room.getOwnerId()
-                            || (room.hasGuild()
-                                    && room.getGuildRightLevel(current)
-                                            .isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS))) {
-                        current.getClient()
-                                .sendResponse(new DoorbellAddUserComposer(
-                                        habbo.getHabboInfo().getUsername()));
-                        rightsFound = true;
-                    }
-                }
-            }
-
-            if (!rightsFound) {
-                habbo.getClient().sendResponse(new RoomAccessDeniedComposer(""));
-                habbo.getClient().sendResponse(new HotelViewComposer());
-                habbo.getHabboInfo().setLoadingRoom(0);
-                return;
-            }
-
-            habbo.getHabboInfo().setRoomQueueId(roomId);
-            habbo.getClient().sendResponse(new DoorbellAddUserComposer(""));
-            room.addToQueue(habbo);
-        } else if (room.getState() == RoomState.PASSWORD) {
-            if (room.getPassword().equalsIgnoreCase(password))
-                this.openRoom(habbo, room, doorLocation, isReconnectSpawn);
-            else {
-                habbo.getClient().sendResponse(new GenericErrorMessagesComposer(GenericErrorCode.WRONG_ROOM_PASSWORD));
-                habbo.getClient().sendResponse(new HotelViewComposer());
-                habbo.getHabboInfo().setLoadingRoom(0);
-            }
-        } else {
-            habbo.getClient().sendResponse(new HotelViewComposer());
-            habbo.getHabboInfo().setLoadingRoom(0);
-        }
+        this.roomEntryService.enter(habbo, roomId, password, overrideChecks, doorLocation, isReconnectSpawn);
     }
 
     void openRoom(Habbo habbo, Room room, RoomTile doorLocation) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -141,6 +141,7 @@ public class RoomManager {
     public static boolean SHOW_PUBLIC_IN_POPULAR_TAB = false;
     private final Map<Integer, RoomCategory> roomCategories;
     private final RoomModelRepository roomModelRepository;
+    private final RoomRepository roomRepository;
     private final List<String> mapNames;
     private final ConcurrentHashMap<String, RoomLayoutData> layoutCache;
     private final RoomDirectory roomDirectory;
@@ -170,6 +171,7 @@ public class RoomManager {
         long millis = System.currentTimeMillis();
         this.persistenceExecutor = Objects.requireNonNull(persistenceExecutor, "persistenceExecutor");
         this.roomCategories = new HashMap<>();
+        this.roomRepository = new RoomRepository(this::openConnection);
         this.roomModelRepository = new RoomModelRepository(this::openConnection);
         this.mapNames = this.roomModelRepository.modelNames();
         this.layoutCache = this.roomModelRepository.layouts();
@@ -573,12 +575,9 @@ public class RoomManager {
                 h.getClient().sendResponse(new RoomScoreComposer(room.getScore(), !this.hasVotedForRoom(h, room)));
             }
 
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                    PreparedStatement statement =
-                            connection.prepareStatement("INSERT INTO room_votes (user_id, room_id) VALUES (?, ?)")) {
-                statement.setInt(1, habbo.getHabboInfo().getId());
-                statement.setInt(2, room.getId());
-                statement.execute();
+            try {
+                this.roomRepository.recordVote(
+                        room.getId(), habbo.getHabboInfo().getId());
             } catch (SQLException e) {
                 LOGGER.error("Caught SQL exception", e);
             }
@@ -1092,14 +1091,9 @@ public class RoomManager {
 
     void logEnter(Habbo habbo, Room room) {
         habbo.getHabboStats().roomEnterTimestamp = Emulator.getIntUnixTimestamp();
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                PreparedStatement statement = connection.prepareStatement(
-                        "INSERT INTO room_enter_log (room_id, user_id, timestamp) VALUES(?, ?, ?)")) {
-            statement.setInt(1, room.getId());
-            statement.setInt(2, habbo.getHabboInfo().getId());
-            statement.setInt(3, (int) (habbo.getHabboStats().roomEnterTimestamp));
-            statement.execute();
-
+        try {
+            this.roomRepository.recordEntry(
+                    room.getId(), habbo.getHabboInfo().getId(), (int) habbo.getHabboStats().roomEnterTimestamp);
             if (!habbo.getHabboStats().visitedRoom(room.getId()))
                 habbo.getHabboStats().addVisitRoom(room.getId());
         } catch (SQLException e) {
@@ -1160,13 +1154,9 @@ public class RoomManager {
 
         Room room = habbo.getHabboInfo().getCurrentRoom();
         if (room != null) {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                    PreparedStatement statement = connection.prepareStatement(
-                            "UPDATE room_enter_log SET exit_timestamp = ? WHERE user_id = ? AND room_id = ? ORDER BY timestamp DESC LIMIT 1")) {
-                statement.setInt(1, Emulator.getIntUnixTimestamp());
-                statement.setInt(2, habbo.getHabboInfo().getId());
-                statement.setInt(3, room.getId());
-                statement.execute();
+            try {
+                this.roomRepository.recordExit(
+                        room.getId(), habbo.getHabboInfo().getId(), Emulator.getIntUnixTimestamp());
             } catch (SQLException e) {
                 LOGGER.error("Caught SQL exception", e);
             }
@@ -1579,20 +1569,8 @@ public class RoomManager {
     }
 
     public CustomRoomLayout insertCustomLayout(Room room, String map, int doorX, int doorY, int doorDirection) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                PreparedStatement statement = connection.prepareStatement(
-                        "INSERT INTO room_models_custom (id, name, door_x, door_y, door_dir, heightmap) VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE door_x = ?, door_y = ?, door_dir = ?, heightmap = ?")) {
-            statement.setInt(1, room.getId());
-            statement.setString(2, "custom_" + room.getId());
-            statement.setInt(3, doorX);
-            statement.setInt(4, doorY);
-            statement.setInt(5, doorDirection);
-            statement.setString(6, map);
-            statement.setInt(7, doorX);
-            statement.setInt(8, doorY);
-            statement.setInt(9, doorDirection);
-            statement.setString(10, map);
-            statement.execute();
+        try {
+            this.roomRepository.upsertCustomLayout(room.getId(), map, doorX, doorY, doorDirection);
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -144,6 +144,7 @@ public class RoomManager {
     public static int HOME_ROOM_ID = 0;
     public static boolean SHOW_PUBLIC_IN_POPULAR_TAB = false;
     private final Map<Integer, RoomCategory> roomCategories;
+    private final RoomModelRepository roomModelRepository;
     private final List<String> mapNames;
     private final ConcurrentHashMap<String, RoomLayoutData> layoutCache;
     private final RoomDirectory roomDirectory;
@@ -170,8 +171,9 @@ public class RoomManager {
         long millis = System.currentTimeMillis();
         this.persistenceExecutor = Objects.requireNonNull(persistenceExecutor, "persistenceExecutor");
         this.roomCategories = new HashMap<>();
-        this.mapNames = new ArrayList<>();
-        this.layoutCache = new ConcurrentHashMap<>();
+        this.roomModelRepository = new RoomModelRepository(this::openConnection);
+        this.mapNames = this.roomModelRepository.modelNames();
+        this.layoutCache = this.roomModelRepository.layouts();
         this.roomDirectory = new RoomDirectory();
         this.activeRooms = this.roomDirectory.activeRooms();
         this.roomsByOwner = this.roomDirectory.roomsByOwner();
@@ -227,37 +229,11 @@ public class RoomManager {
     }
 
     public void loadRoomModels() {
-        this.mapNames.clear();
-        this.layoutCache.clear();
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                Statement statement = connection.createStatement();
-                ResultSet set = statement.executeQuery("SELECT * FROM room_models")) {
-            while (set.next()) {
-                String name = set.getString("name");
-                this.mapNames.add(name);
-                this.layoutCache.put(name, new RoomLayoutData(set));
-            }
-        } catch (SQLException e) {
-            LOGGER.error("Caught SQL exception", e);
-        }
+        this.roomModelRepository.reload();
     }
 
     public CustomRoomLayout loadCustomLayout(Room room) {
-        CustomRoomLayout layout = null;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                PreparedStatement statement =
-                        connection.prepareStatement("SELECT * FROM room_models_custom WHERE id = ? LIMIT 1")) {
-            statement.setInt(1, room.getId());
-            try (ResultSet set = statement.executeQuery()) {
-                if (set.next()) {
-                    layout = new CustomRoomLayout(set, room);
-                }
-            }
-        } catch (SQLException e) {
-            LOGGER.error("Caught SQL exception", e);
-        }
-
-        return layout;
+        return this.roomModelRepository.loadCustomLayout(room);
     }
 
     private void loadRoomCategories() {
@@ -622,31 +598,11 @@ public class RoomManager {
     }
 
     public boolean layoutExists(String name) {
-        return this.mapNames.contains(name);
+        return this.roomModelRepository.exists(name);
     }
 
     public RoomLayout loadLayout(String name, Room room) {
-        RoomLayoutData cached = this.layoutCache.get(name);
-        if (cached != null) {
-            return new RoomLayout(cached, room);
-        }
-
-        // Fallback to DB if not in cache (should not happen for standard models)
-        RoomLayout layout = null;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                PreparedStatement statement =
-                        connection.prepareStatement("SELECT * FROM room_models WHERE name = ? LIMIT 1")) {
-            statement.setString(1, name);
-            try (ResultSet set = statement.executeQuery()) {
-                if (set.next()) {
-                    layout = new RoomLayout(set, room);
-                }
-            }
-        } catch (SQLException e) {
-            LOGGER.error("Caught SQL exception", e);
-        }
-
-        return layout;
+        return this.roomModelRepository.load(name, room);
     }
 
     public void unloadRoom(Room room) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -27,7 +27,6 @@ import com.eu.habbo.habbohotel.polls.Poll;
 import com.eu.habbo.habbohotel.polls.PollManager;
 import com.eu.habbo.habbohotel.users.DanceType;
 import com.eu.habbo.habbohotel.users.Habbo;
-import com.eu.habbo.habbohotel.users.HabboInfo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
@@ -149,6 +148,7 @@ public class RoomManager {
     private final ConcurrentHashMap<String, RoomLayoutData> layoutCache;
     private final RoomDirectory roomDirectory;
     private final RoomSearchService roomSearchService;
+    private final RoomModerationService roomModerationService;
     private final ConcurrentHashMap<Integer, Room> activeRooms;
     private final ConcurrentHashMap<Integer, Set<Integer>> roomsByOwner;
     private final AtomicInteger indexedRoomCount;
@@ -179,6 +179,12 @@ public class RoomManager {
         this.roomsByOwner = this.roomDirectory.roomsByOwner();
         this.indexedRoomCount = this.roomDirectory.indexedRoomCount();
         this.roomSearchService = new RoomSearchService(this.activeRooms::values, Duration.ofSeconds(1));
+        this.roomModerationService = new RoomModerationService(
+                this::getRoom,
+                userId -> Emulator.getGameEnvironment().getHabboManager().getHabbo(userId),
+                HabboManager::getOfflineHabboInfo,
+                () -> Emulator.getIntUnixTimestamp(),
+                RoomBan::insert);
 
         this.gameTypes = new ArrayList<>();
 
@@ -1766,49 +1772,7 @@ public class RoomManager {
     }
 
     public void banUserFromRoom(Habbo rights, int userId, int roomId, RoomBanTypes length) {
-        Room room = this.getRoom(roomId);
-
-        if (room == null) return;
-
-        if (rights != null && !room.hasRights(rights)) return;
-
-        if (room.getOwnerId() == userId) return;
-
-        String name = "";
-
-        Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(userId);
-        if (habbo != null) {
-            if (habbo.hasPermission(Permission.ACC_UNKICKABLE)) {
-                return;
-            }
-
-            name = habbo.getHabboInfo().getUsername();
-        } else {
-            HabboInfo info = HabboManager.getOfflineHabboInfo(userId);
-
-            if (info != null) {
-                if (info.getRank().hasPermission(Permission.ACC_UNKICKABLE, false)) {
-                    return;
-                }
-                name = info.getUsername();
-            }
-        }
-
-        if (name.isEmpty()) {
-            return;
-        }
-
-        RoomBan roomBan = new RoomBan(roomId, userId, name, Emulator.getIntUnixTimestamp() + length.duration);
-        roomBan.insert();
-
-        room.addRoomBan(roomBan);
-
-        if (habbo != null) {
-            if (habbo.getHabboInfo().getCurrentRoom() == room) {
-                room.removeHabbo(habbo, true);
-                habbo.getClient().sendResponse(new RoomEnterErrorComposer(RoomEnterErrorComposer.ROOM_ERROR_BANNED));
-            }
-        }
+        this.roomModerationService.banUser(rights, userId, roomId, length);
     }
 
     public void registerGameType(Class<? extends Game> gameClass) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -25,23 +25,47 @@ import com.eu.habbo.habbohotel.pets.PetData;
 import com.eu.habbo.habbohotel.pets.PetTasks;
 import com.eu.habbo.habbohotel.polls.Poll;
 import com.eu.habbo.habbohotel.polls.PollManager;
-import com.eu.habbo.habbohotel.users.*;
+import com.eu.habbo.habbohotel.users.DanceType;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.messages.incoming.users.UserNuxEvent;
-import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorMessagesComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorCode;
+import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorMessagesComposer;
 import com.eu.habbo.messages.outgoing.hotelview.HotelViewComposer;
 import com.eu.habbo.messages.outgoing.polls.PollStartComposer;
 import com.eu.habbo.messages.outgoing.polls.infobus.SimplePollAnswersComposer;
 import com.eu.habbo.messages.outgoing.polls.infobus.SimplePollStartComposer;
-import com.eu.habbo.messages.outgoing.rooms.*;
+import com.eu.habbo.messages.outgoing.rooms.DoorbellAddUserComposer;
+import com.eu.habbo.messages.outgoing.rooms.FloodCounterComposer;
+import com.eu.habbo.messages.outgoing.rooms.HideDoorbellComposer;
+import com.eu.habbo.messages.outgoing.rooms.RoomAccessDeniedComposer;
+import com.eu.habbo.messages.outgoing.rooms.RoomDataComposer;
+import com.eu.habbo.messages.outgoing.rooms.RoomEnterErrorComposer;
+import com.eu.habbo.messages.outgoing.rooms.RoomModelComposer;
+import com.eu.habbo.messages.outgoing.rooms.RoomOpenComposer;
+import com.eu.habbo.messages.outgoing.rooms.RoomPaintComposer;
+import com.eu.habbo.messages.outgoing.rooms.RoomPaneComposer;
+import com.eu.habbo.messages.outgoing.rooms.RoomScoreComposer;
+import com.eu.habbo.messages.outgoing.rooms.RoomThicknessComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.ConfInvisStateComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.HanditemBlockStateComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RoomFloorItemsComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RoomWallItemsComposer;
 import com.eu.habbo.messages.outgoing.rooms.pets.RoomPetComposer;
 import com.eu.habbo.messages.outgoing.rooms.promotions.RoomPromotionMessageComposer;
-import com.eu.habbo.messages.outgoing.rooms.users.*;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUnitIdleComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserDanceComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserEffectComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserHandItemComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserIgnoredComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserRemoveComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUsersAddGuildBadgeComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUsersComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUsersGuildBadgesComposer;
 import com.eu.habbo.messages.outgoing.users.MutedWhisperComposer;
 import com.eu.habbo.messages.outgoing.users.UserBadgesComposer;
 import com.eu.habbo.plugin.events.navigator.NavigatorRoomCreatedEvent;
@@ -51,14 +75,26 @@ import com.eu.habbo.plugin.events.rooms.UserVoteRoomEvent;
 import com.eu.habbo.plugin.events.users.HabboAddedToRoomEvent;
 import com.eu.habbo.plugin.events.users.UserEnterRoomEvent;
 import com.eu.habbo.plugin.events.users.UserExitRoomEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.sql.*;
-import java.util.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RoomManager {
 
@@ -102,7 +138,7 @@ public class RoomManager {
             """;
 
     private static final int page = 0;
-    //Configuration. Loaded from database & updated accordingly.
+    // Configuration. Loaded from database & updated accordingly.
     public static int MAXIMUM_ROOMS_USER = 25;
     public static int MAXIMUM_ROOMS_HC = 35;
     public static int HOME_ROOM_ID = 0;
@@ -110,6 +146,7 @@ public class RoomManager {
     private final Map<Integer, RoomCategory> roomCategories;
     private final List<String> mapNames;
     private final ConcurrentHashMap<String, RoomLayoutData> layoutCache;
+    private final RoomDirectory roomDirectory;
     private final ConcurrentHashMap<Integer, Room> activeRooms;
     private final ConcurrentHashMap<Integer, Set<Integer>> roomsByOwner;
     private final AtomicInteger indexedRoomCount;
@@ -128,20 +165,16 @@ public class RoomManager {
         this(initialize, Runnable::run);
     }
 
-    RoomManager(
-            boolean initialize,
-            Executor persistenceExecutor) {
+    RoomManager(boolean initialize, Executor persistenceExecutor) {
         long millis = System.currentTimeMillis();
-        this.persistenceExecutor =
-                Objects.requireNonNull(
-                        persistenceExecutor,
-                        "persistenceExecutor");
+        this.persistenceExecutor = Objects.requireNonNull(persistenceExecutor, "persistenceExecutor");
         this.roomCategories = new HashMap<>();
         this.mapNames = new ArrayList<>();
         this.layoutCache = new ConcurrentHashMap<>();
-        this.activeRooms = new ConcurrentHashMap<>();
-        this.roomsByOwner = new ConcurrentHashMap<>();
-        this.indexedRoomCount = new AtomicInteger();
+        this.roomDirectory = new RoomDirectory();
+        this.activeRooms = this.roomDirectory.activeRooms();
+        this.roomsByOwner = this.roomDirectory.roomsByOwner();
+        this.indexedRoomCount = this.roomDirectory.indexedRoomCount();
 
         this.gameTypes = new ArrayList<>();
 
@@ -162,15 +195,11 @@ public class RoomManager {
     }
 
     private void trackRoomOwner(Room room) {
-        if (this.roomsByOwner.computeIfAbsent(room.getOwnerId(), k -> ConcurrentHashMap.newKeySet()).add(room.getId())) {
-            this.indexedRoomCount.incrementAndGet();
-        }
+        this.roomDirectory.track(room);
     }
 
     private RoomDependencies roomDependencies() {
-        return new RoomDependencies(
-                this::openConnection,
-                this.persistenceExecutor::execute);
+        return new RoomDependencies(this::openConnection, this.persistenceExecutor::execute);
     }
 
     private Connection openConnection() throws SQLException {
@@ -178,62 +207,27 @@ public class RoomManager {
     }
 
     private void untrackRoomOwner(Room room) {
-        room.setOwnerChangeListener(null);
-        this.removeRoomFromOwner(room.getOwnerId(), room.getId());
+        this.roomDirectory.untrack(room);
     }
 
     private void removeRoomFromOwner(int ownerId, int roomId) {
-        Set<Integer> rooms = this.roomsByOwner.get(ownerId);
-        if (rooms != null) {
-            if (rooms.remove(roomId)) {
-                this.indexedRoomCount.decrementAndGet();
-            }
-            if (rooms.isEmpty()) {
-                this.roomsByOwner.remove(ownerId, rooms);
-            }
-        }
+        this.roomDirectory.removeFromOwner(ownerId, roomId);
     }
 
     void registerActiveRoom(Room room) {
-        Room previousRoom = this.activeRooms.put(room.getId(), room);
-        if (previousRoom != null) {
-            this.untrackRoomOwner(previousRoom);
-        }
-
-        room.setOwnerChangeListener(this::roomOwnerChanged);
-        this.trackRoomOwner(room);
-    }
-
-    private void roomOwnerChanged(Room room, int previousOwnerId) {
-        if (this.activeRooms.get(room.getId()) != room) {
-            return;
-        }
-
-        this.removeRoomFromOwner(previousOwnerId, room.getId());
-        this.trackRoomOwner(room);
+        this.roomDirectory.register(room);
     }
 
     private void reconcileOwnerIndex() {
-        for (Map.Entry<Integer, Set<Integer>> entry : this.roomsByOwner.entrySet()) {
-            int indexedOwnerId = entry.getKey();
-            for (int roomId : new HashSet<>(entry.getValue())) {
-                Room room = this.activeRooms.get(roomId);
-                if (room == null || room.getOwnerId() != indexedOwnerId) {
-                    this.removeRoomFromOwner(indexedOwnerId, roomId);
-                }
-            }
-        }
-
-        for (Room room : this.activeRooms.values()) {
-            room.setOwnerChangeListener(this::roomOwnerChanged);
-            this.trackRoomOwner(room);
-        }
+        this.roomDirectory.reconcileOwnerIndex();
     }
 
     public void loadRoomModels() {
         this.mapNames.clear();
         this.layoutCache.clear();
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM room_models")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM room_models")) {
             while (set.next()) {
                 String name = set.getString("name");
                 this.mapNames.add(name);
@@ -246,7 +240,9 @@ public class RoomManager {
 
     public CustomRoomLayout loadCustomLayout(Room room) {
         CustomRoomLayout layout = null;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM room_models_custom WHERE id = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("SELECT * FROM room_models_custom WHERE id = ? LIMIT 1")) {
             statement.setInt(1, room.getId());
             try (ResultSet set = statement.executeQuery()) {
                 if (set.next()) {
@@ -263,7 +259,9 @@ public class RoomManager {
     private void loadRoomCategories() {
         this.roomCategories.clear();
 
-        try (Connection connection = this.openConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM navigator_flatcats")) {
+        try (Connection connection = this.openConnection();
+                Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM navigator_flatcats")) {
             while (set.next()) {
                 this.roomCategories.put(set.getInt("id"), new RoomCategory(set));
             }
@@ -273,7 +271,8 @@ public class RoomManager {
     }
 
     public void loadPublicRooms() {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement(PUBLIC_ROOMS_SQL)) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(PUBLIC_ROOMS_SQL)) {
             statement.setString(1, "1");
             statement.setString(2, "1");
             try (ResultSet set = statement.executeQuery()) {
@@ -288,11 +287,17 @@ public class RoomManager {
         }
     }
 
-    public Map<Integer, List<Room>> findRooms(NavigatorFilterField filterField, String value, int category, boolean showInvisible) {
+    public Map<Integer, List<Room>> findRooms(
+            NavigatorFilterField filterField, String value, int category, boolean showInvisible) {
         Map<Integer, List<Room>> rooms = new HashMap<>();
-        String query = filterField.databaseQuery + " AND rooms.state NOT LIKE " + (showInvisible ? "''" : "'invisible'") + (category >= 0 ? "AND rooms.category = '" + category + "'" : "") + "  ORDER BY rooms.users, rooms.id DESC LIMIT " + (page * NavigatorManager.MAXIMUM_RESULTS_PER_PAGE) + "" + ((page * NavigatorManager.MAXIMUM_RESULTS_PER_PAGE) + NavigatorManager.MAXIMUM_RESULTS_PER_PAGE);
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement(query)) {
-            statement.setString(1, (filterField.comparator == NavigatorFilterComparator.EQUALS ? value : "%" + value + "%"));
+        String query = filterField.databaseQuery + " AND rooms.state NOT LIKE " + (showInvisible ? "''" : "'invisible'")
+                + (category >= 0 ? "AND rooms.category = '" + category + "'" : "")
+                + "  ORDER BY rooms.users, rooms.id DESC LIMIT " + (page * NavigatorManager.MAXIMUM_RESULTS_PER_PAGE)
+                + "" + ((page * NavigatorManager.MAXIMUM_RESULTS_PER_PAGE) + NavigatorManager.MAXIMUM_RESULTS_PER_PAGE);
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(
+                    1, (filterField.comparator == NavigatorFilterComparator.EQUALS ? value : "%" + value + "%"));
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
                     Room room = this.activeRooms.get(set.getInt("id"));
@@ -343,8 +348,7 @@ public class RoomManager {
     public List<RoomCategory> roomCategoriesForHabbo(Habbo habbo) {
         List<RoomCategory> categories = new ArrayList<>();
         for (RoomCategory category : this.roomCategories.values()) {
-            if (category.getMinRank() <= habbo.getHabboInfo().getRank().getId())
-                categories.add(category);
+            if (category.getMinRank() <= habbo.getHabboInfo().getRank().getId()) categories.add(category);
         }
 
         Collections.sort(categories);
@@ -354,7 +358,8 @@ public class RoomManager {
 
     public boolean hasCategory(int categoryId, Habbo habbo) {
         RoomCategory category = this.roomCategories.get(categoryId);
-        return category != null && category.getMinRank() <= habbo.getHabboInfo().getRank().getId();
+        return category != null
+                && category.getMinRank() <= habbo.getHabboInfo().getRank().getId();
     }
 
     public Map<Integer, RoomCategory> getRoomCategories() {
@@ -371,19 +376,17 @@ public class RoomManager {
     public List<Room> getActiveRooms(int categoryId) {
         List<Room> rooms = new ArrayList<>();
         for (Room room : this.activeRooms.values()) {
-            if (categoryId == room.getCategory() || categoryId == -1)
-                rooms.add(room);
+            if (categoryId == room.getCategory() || categoryId == -1) rooms.add(room);
         }
         Collections.sort(rooms);
         return rooms;
     }
 
-    //TODO Move to HabboInfo class.
+    // TODO Move to HabboInfo class.
     public List<Room> getRoomsForHabbo(Habbo habbo) {
         List<Room> rooms = new ArrayList<>();
         for (Room room : this.activeRooms.values()) {
-            if (room.getOwnerId() == habbo.getHabboInfo().getId())
-                rooms.add(room);
+            if (room.getOwnerId() == habbo.getHabboInfo().getId()) rooms.add(room);
         }
         rooms.sort(Room.SORT_ID);
         return rooms;
@@ -397,7 +400,8 @@ public class RoomManager {
 
         List<Room> rooms = new ArrayList<>();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement(ROOM_IDS_BY_OWNER_NAME_SQL)) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(ROOM_IDS_BY_OWNER_NAME_SQL)) {
             statement.setString(1, username);
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
@@ -426,7 +430,7 @@ public class RoomManager {
     public Room loadRoom(int id, boolean loadData) {
         Room room = null;
 
-        if(id == 0) {
+        if (id == 0) {
             return null;
         }
 
@@ -445,7 +449,8 @@ public class RoomManager {
             return room;
         }
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM rooms WHERE id = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT * FROM rooms WHERE id = ? LIMIT 1")) {
             statement.setInt(1, id);
 
             try (ResultSet set = statement.executeQuery()) {
@@ -467,11 +472,21 @@ public class RoomManager {
         return room;
     }
 
-
-    public Room createRoom(int ownerId, String ownerName, String name, String description, String modelName, int usersMax, int categoryId, int tradeType) {
+    public Room createRoom(
+            int ownerId,
+            String ownerName,
+            String name,
+            String description,
+            String modelName,
+            int usersMax,
+            int categoryId,
+            int tradeType) {
         Room room = null;
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO rooms (owner_id, owner_name, name, description, model, users_max, category, trade_mode) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO rooms (owner_id, owner_name, name, description, model, users_max, category, trade_mode) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                        Statement.RETURN_GENERATED_KEYS)) {
             statement.setInt(1, ownerId);
             statement.setString(2, ownerName);
             statement.setString(3, name);
@@ -482,8 +497,7 @@ public class RoomManager {
             statement.setInt(8, tradeType);
             statement.execute();
             try (ResultSet set = statement.getGeneratedKeys()) {
-                if (set.next())
-                    room = this.loadRoom(set.getInt(1));
+                if (set.next()) room = this.loadRoom(set.getInt(1));
             }
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
@@ -492,9 +506,23 @@ public class RoomManager {
         return room;
     }
 
-
-    public Room createRoomForHabbo(Habbo habbo, String name, String description, String modelName, int usersMax, int categoryId, int tradeType) {
-        Room room = this.createRoom(habbo.getHabboInfo().getId(), habbo.getHabboInfo().getUsername(), name, description, modelName, usersMax, categoryId, tradeType);
+    public Room createRoomForHabbo(
+            Habbo habbo,
+            String name,
+            String description,
+            String modelName,
+            int usersMax,
+            int categoryId,
+            int tradeType) {
+        Room room = this.createRoom(
+                habbo.getHabboInfo().getId(),
+                habbo.getHabboInfo().getUsername(),
+                name,
+                description,
+                modelName,
+                usersMax,
+                categoryId,
+                tradeType);
 
         Emulator.getPluginManager().fireEvent(new NavigatorRoomCreatedEvent(habbo, room));
 
@@ -502,7 +530,8 @@ public class RoomManager {
     }
 
     public void loadRoomsForHabbo(Habbo habbo) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement(ROOMS_BY_OWNER_ID_SQL)) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(ROOMS_BY_OWNER_ID_SQL)) {
             statement.setInt(1, habbo.getHabboInfo().getId());
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
@@ -522,8 +551,9 @@ public class RoomManager {
         List<Room> roomsToDispose = this.roomsToUnloadForOwner(ownerId);
 
         for (Room room : roomsToDispose) {
-            if (Emulator.getPluginManager().fireEvent(new RoomUncachedEvent(room)).isCancelled())
-                continue;
+            if (Emulator.getPluginManager()
+                    .fireEvent(new RoomUncachedEvent(room))
+                    .isCancelled()) continue;
 
             room.dispose();
             this.untrackRoomOwner(room);
@@ -552,7 +582,11 @@ public class RoomManager {
                 continue;
             }
 
-            if (!room.isPublicRoom() && !room.isStaffPromotedRoom() && room.getUserCount() == 0 && (this.roomCategories.get(room.getCategory()) == null || !this.roomCategories.get(room.getCategory()).isPublic())) {
+            if (!room.isPublicRoom()
+                    && !room.isStaffPromotedRoom()
+                    && room.getUserCount() == 0
+                    && (this.roomCategories.get(room.getCategory()) == null
+                            || !this.roomCategories.get(room.getCategory()).isPublic())) {
                 roomsToDispose.add(room);
             }
         }
@@ -595,7 +629,9 @@ public class RoomManager {
 
         // Fallback to DB if not in cache (should not happen for standard models)
         RoomLayout layout = null;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM room_models WHERE name = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("SELECT * FROM room_models WHERE name = ? LIMIT 1")) {
             statement.setString(1, name);
             try (ResultSet set = statement.executeQuery()) {
                 if (set.next()) {
@@ -619,9 +655,10 @@ public class RoomManager {
     }
 
     public void voteForRoom(Habbo habbo, Room room) {
-        if (habbo.getHabboInfo().getCurrentRoom() != null && room != null && habbo.getHabboInfo().getCurrentRoom() == room) {
-            if (this.hasVotedForRoom(habbo, room))
-                return;
+        if (habbo.getHabboInfo().getCurrentRoom() != null
+                && room != null
+                && habbo.getHabboInfo().getCurrentRoom() == room) {
+            if (this.hasVotedForRoom(habbo, room)) return;
 
             UserVoteRoomEvent event = new UserVoteRoomEvent(room, habbo);
             if (Emulator.getPluginManager().fireEvent(event).isCancelled()) return;
@@ -633,7 +670,9 @@ public class RoomManager {
                 h.getClient().sendResponse(new RoomScoreComposer(room.getScore(), !this.hasVotedForRoom(h, room)));
             }
 
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO room_votes (user_id, room_id) VALUES (?, ?)")) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    PreparedStatement statement =
+                            connection.prepareStatement("INSERT INTO room_votes (user_id, room_id) VALUES (?, ?)")) {
                 statement.setInt(1, habbo.getHabboInfo().getId());
                 statement.setInt(2, room.getId());
                 statement.execute();
@@ -644,12 +683,10 @@ public class RoomManager {
     }
 
     boolean hasVotedForRoom(Habbo habbo, Room room) {
-        if (room.getOwnerId() == habbo.getHabboInfo().getId())
-            return true;
+        if (room.getOwnerId() == habbo.getHabboInfo().getId()) return true;
 
         for (int i : habbo.getHabboStats().votedRooms) {
-            if (i == room.getId())
-                return true;
+            if (i == room.getId()) return true;
         }
 
         return false;
@@ -679,19 +716,27 @@ public class RoomManager {
         this.enterRoom(habbo, roomId, password, overrideChecks, doorLocation, false);
     }
 
-    public void enterRoom(Habbo habbo, int roomId, String password, boolean overrideChecks, RoomTile doorLocation, boolean isReconnectSpawn) {
+    public void enterRoom(
+            Habbo habbo,
+            int roomId,
+            String password,
+            boolean overrideChecks,
+            RoomTile doorLocation,
+            boolean isReconnectSpawn) {
         Room room = this.loadRoom(roomId, true);
 
-        if (room == null)
-            return;
+        if (room == null) return;
 
-        if (habbo.getHabboInfo().getLoadingRoom() != 0 && room.getId() != habbo.getHabboInfo().getLoadingRoom()) {
+        if (habbo.getHabboInfo().getLoadingRoom() != 0
+                && room.getId() != habbo.getHabboInfo().getLoadingRoom()) {
             habbo.getClient().sendResponse(new HotelViewComposer());
             habbo.getHabboInfo().setLoadingRoom(0);
             return;
         }
 
-        if (Emulator.getPluginManager().fireEvent(new UserEnterRoomEvent(habbo, room)).isCancelled()) {
+        if (Emulator.getPluginManager()
+                .fireEvent(new UserEnterRoomEvent(habbo, room))
+                .isCancelled()) {
             if (habbo.getHabboInfo().getCurrentRoom() == null) {
                 habbo.getClient().sendResponse(new HotelViewComposer());
                 habbo.getHabboInfo().setLoadingRoom(0);
@@ -699,7 +744,9 @@ public class RoomManager {
             }
         }
 
-        if (room.isBanned(habbo) && !habbo.hasPermission(Permission.ACC_ANYROOMOWNER) && !habbo.hasPermission(Permission.ACC_ENTERANYROOM)) {
+        if (room.isBanned(habbo)
+                && !habbo.hasPermission(Permission.ACC_ANYROOMOWNER)
+                && !habbo.hasPermission(Permission.ACC_ENTERANYROOM)) {
             habbo.getClient().sendResponse(new RoomEnterErrorComposer(RoomEnterErrorComposer.ROOM_ERROR_BANNED));
             return;
         }
@@ -709,8 +756,10 @@ public class RoomManager {
                 && !overrideChecks
                 && !habbo.hasPermission(Permission.ACC_ANYROOMOWNER)
                 && !habbo.hasPermission(Permission.ACC_ENTERANYROOM)) {
-            BuildersClubRoomSupport.sendVisitDeniedOwnerBubble(room.getOwnerId(), habbo.getHabboInfo().getUsername());
-            BuildersClubRoomSupport.sendVisitDeniedVisitorAlert(habbo.getHabboInfo().getId());
+            BuildersClubRoomSupport.sendVisitDeniedOwnerBubble(
+                    room.getOwnerId(), habbo.getHabboInfo().getUsername());
+            BuildersClubRoomSupport.sendVisitDeniedVisitorAlert(
+                    habbo.getHabboInfo().getId());
             habbo.getClient().sendResponse(new HotelViewComposer());
             habbo.getHabboInfo().setLoadingRoom(0);
             return;
@@ -724,22 +773,28 @@ public class RoomManager {
             }
         }
 
-        if (overrideChecks ||
-                room.isOwner(habbo) ||
-                room.getState() == RoomState.OPEN ||
-                habbo.hasPermission(Permission.ACC_ANYROOMOWNER) ||
-                habbo.hasPermission(Permission.ACC_ENTERANYROOM) ||
-                room.hasRights(habbo) ||
-                (room.getState().equals(RoomState.INVISIBLE) && room.hasRights(habbo)) ||
-                (room.hasGuild() && room.getGuildRightLevel(habbo).isGreaterThan(RoomRightLevels.GUILD_RIGHTS))) {
+        if (overrideChecks
+                || room.isOwner(habbo)
+                || room.getState() == RoomState.OPEN
+                || habbo.hasPermission(Permission.ACC_ANYROOMOWNER)
+                || habbo.hasPermission(Permission.ACC_ENTERANYROOM)
+                || room.hasRights(habbo)
+                || (room.getState().equals(RoomState.INVISIBLE) && room.hasRights(habbo))
+                || (room.hasGuild() && room.getGuildRightLevel(habbo).isGreaterThan(RoomRightLevels.GUILD_RIGHTS))) {
             this.openRoom(habbo, room, doorLocation, isReconnectSpawn);
         } else if (room.getState() == RoomState.LOCKED) {
             boolean rightsFound = false;
 
             synchronized (room.roomUnitLock) {
                 for (Habbo current : room.getHabbos()) {
-                    if (room.hasRights(current) || current.getHabboInfo().getId() == room.getOwnerId() || (room.hasGuild() && room.getGuildRightLevel(current).isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS))) {
-                        current.getClient().sendResponse(new DoorbellAddUserComposer(habbo.getHabboInfo().getUsername()));
+                    if (room.hasRights(current)
+                            || current.getHabboInfo().getId() == room.getOwnerId()
+                            || (room.hasGuild()
+                                    && room.getGuildRightLevel(current)
+                                            .isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS))) {
+                        current.getClient()
+                                .sendResponse(new DoorbellAddUserComposer(
+                                        habbo.getHabboInfo().getUsername()));
                         rightsFound = true;
                     }
                 }
@@ -774,15 +829,16 @@ public class RoomManager {
     }
 
     void openRoom(Habbo habbo, Room room, RoomTile doorLocation, boolean isReconnectSpawn) {
-        if (room == null || room.getLayout() == null)
-            return;
+        if (room == null || room.getLayout() == null) return;
 
         if (Emulator.getConfig().getBoolean("hotel.room.enter.logs")) {
             this.logEnter(habbo, room);
         }
 
         if (habbo.getHabboInfo().getRoomQueueId() > 0) {
-            Room r = Emulator.getGameEnvironment().getRoomManager().getRoom(habbo.getHabboInfo().getRoomQueueId());
+            Room r = Emulator.getGameEnvironment()
+                    .getRoomManager()
+                    .getRoom(habbo.getHabboInfo().getRoomQueueId());
 
             if (r != null) {
                 r.removeFromQueue(habbo);
@@ -808,17 +864,31 @@ public class RoomManager {
 
         habbo.getRoomUnit().clearStatus();
         if (habbo.getRoomUnit().getCurrentLocation() == null) {
-            habbo.getRoomUnit().setLocation(doorLocation != null ? doorLocation : room.getLayout().getDoorTile());
-            if (habbo.getRoomUnit().getCurrentLocation() != null) habbo.getRoomUnit().setZ(habbo.getRoomUnit().getCurrentLocation().getStackHeight());
+            habbo.getRoomUnit()
+                    .setLocation(
+                            doorLocation != null
+                                    ? doorLocation
+                                    : room.getLayout().getDoorTile());
+            if (habbo.getRoomUnit().getCurrentLocation() != null)
+                habbo.getRoomUnit()
+                        .setZ(habbo.getRoomUnit().getCurrentLocation().getStackHeight());
 
             if (doorLocation == null) {
-                habbo.getRoomUnit().setBodyRotation(RoomUserRotation.values()[room.getLayout().getDoorDirection()]);
-                habbo.getRoomUnit().setHeadRotation(RoomUserRotation.values()[room.getLayout().getDoorDirection()]);
+                habbo.getRoomUnit()
+                        .setBodyRotation(
+                                RoomUserRotation.values()[room.getLayout().getDoorDirection()]);
+                habbo.getRoomUnit()
+                        .setHeadRotation(
+                                RoomUserRotation.values()[room.getLayout().getDoorDirection()]);
             } else if (isReconnectSpawn) {
                 // Reconnect spawn: place at tile but keep normal room behavior
                 // (user can still leave by door, no teleport flags)
-                habbo.getRoomUnit().setBodyRotation(RoomUserRotation.values()[room.getLayout().getDoorDirection()]);
-                habbo.getRoomUnit().setHeadRotation(RoomUserRotation.values()[room.getLayout().getDoorDirection()]);
+                habbo.getRoomUnit()
+                        .setBodyRotation(
+                                RoomUserRotation.values()[room.getLayout().getDoorDirection()]);
+                habbo.getRoomUnit()
+                        .setHeadRotation(
+                                RoomUserRotation.values()[room.getLayout().getDoorDirection()]);
             } else {
                 // Furniture teleport spawn
                 habbo.getRoomUnit().setCanLeaveRoomByDoor(false);
@@ -838,8 +908,11 @@ public class RoomManager {
             return;
         }
 
-        if (room.getUserCount() >= room.getUsersMax() && !habbo.hasPermission(Permission.ACC_FULLROOMS) && !room.hasRights(habbo)) {
-            habbo.getClient().sendResponse(new RoomEnterErrorComposer(RoomEnterErrorComposer.ROOM_ERROR_GUESTROOM_FULL));
+        if (room.getUserCount() >= room.getUsersMax()
+                && !habbo.hasPermission(Permission.ACC_FULLROOMS)
+                && !room.hasRights(habbo)) {
+            habbo.getClient()
+                    .sendResponse(new RoomEnterErrorComposer(RoomEnterErrorComposer.ROOM_ERROR_GUESTROOM_FULL));
             return;
         }
 
@@ -849,14 +922,17 @@ public class RoomManager {
         habbo.getClient().sendResponse(new RoomOpenComposer());
 
         habbo.getRoomUnit().setInRoom(true);
-        if (habbo.getHabboInfo().getCurrentRoom() != room && habbo.getHabboInfo().getCurrentRoom() != null) {
+        if (habbo.getHabboInfo().getCurrentRoom() != room
+                && habbo.getHabboInfo().getCurrentRoom() != null) {
             habbo.getHabboInfo().getCurrentRoom().removeHabbo(habbo, true);
         } else if (!habbo.getHabboStats().blockFollowing && habbo.getHabboInfo().getCurrentRoom() == null) {
             habbo.getMessenger().connectionChanged(habbo, true, true);
         }
 
         if (habbo.getHabboInfo().getLoadingRoom() != 0) {
-            Room oldRoom = Emulator.getGameEnvironment().getRoomManager().getRoom(habbo.getHabboInfo().getLoadingRoom());
+            Room oldRoom = Emulator.getGameEnvironment()
+                    .getRoomManager()
+                    .getRoom(habbo.getHabboInfo().getLoadingRoom());
             if (oldRoom != null) {
                 oldRoom.removeFromQueue(habbo);
             }
@@ -878,7 +954,9 @@ public class RoomManager {
 
         habbo.getClient().sendResponse(new RoomScoreComposer(room.getScore(), !this.hasVotedForRoom(habbo, room)));
 
-        habbo.getRoomUnit().setFastWalk(habbo.getRoomUnit().isFastWalk() && habbo.hasPermission("cmd_fastwalk", room.hasRights(habbo)));
+        habbo.getRoomUnit()
+                .setFastWalk(
+                        habbo.getRoomUnit().isFastWalk() && habbo.hasPermission("cmd_fastwalk", room.hasRights(habbo)));
 
         if (room.isPromoted()) {
             habbo.getClient().sendResponse(new RoomPromotionMessageComposer(room, room.getPromotion()));
@@ -886,8 +964,10 @@ public class RoomManager {
             habbo.getClient().sendResponse(new RoomPromotionMessageComposer(null, null));
         }
 
-        if (room.getOwnerId() != habbo.getHabboInfo().getId() && !habbo.getHabboStats().visitedRoom(room.getId())) {
-            AchievementManager.progressAchievement(habbo, Emulator.getGameEnvironment().getAchievementManager().getAchievement("RoomEntry"));
+        if (room.getOwnerId() != habbo.getHabboInfo().getId()
+                && !habbo.getHabboStats().visitedRoom(room.getId())) {
+            AchievementManager.progressAchievement(
+                    habbo, Emulator.getGameEnvironment().getAchievementManager().getAchievement("RoomEntry"));
         }
     }
 
@@ -913,20 +993,26 @@ public class RoomManager {
         habbo.getRoomUnit().isKicked = false;
 
         if (habbo.getRoomUnit().getCurrentLocation() == null && !habbo.getRoomUnit().isTeleporting) {
-            RoomTile doorTile = room.getLayout().getTile(room.getLayout().getDoorX(), room.getLayout().getDoorY());
+            RoomTile doorTile = room.getLayout()
+                    .getTile(room.getLayout().getDoorX(), room.getLayout().getDoorY());
 
             if (doorTile != null) {
                 habbo.getRoomUnit().setLocation(doorTile);
                 habbo.getRoomUnit().setZ(doorTile.getStackHeight());
             }
 
-            habbo.getRoomUnit().setBodyRotation(RoomUserRotation.values()[room.getLayout().getDoorDirection()]);
-            habbo.getRoomUnit().setHeadRotation(RoomUserRotation.values()[room.getLayout().getDoorDirection()]);
+            habbo.getRoomUnit()
+                    .setBodyRotation(RoomUserRotation.values()[room.getLayout().getDoorDirection()]);
+            habbo.getRoomUnit()
+                    .setHeadRotation(RoomUserRotation.values()[room.getLayout().getDoorDirection()]);
         }
 
         if (habbo.getRoomUnit().getCurrentLocation() == null) {
-            LOGGER.warn("Failed to resolve a valid door tile for room {} ({}) while {} was entering; sending user back to hotel view",
-                    room.getId(), room.getName(), habbo.getHabboInfo().getUsername());
+            LOGGER.warn(
+                    "Failed to resolve a valid door tile for room {} ({}) while {} was entering; sending user back to hotel view",
+                    room.getId(),
+                    room.getName(),
+                    habbo.getHabboInfo().getUsername());
             habbo.getHabboInfo().setLoadingRoom(0);
             habbo.getHabboInfo().setCurrentRoom(null);
             habbo.getClient().sendResponse(new HotelViewComposer());
@@ -941,7 +1027,10 @@ public class RoomManager {
         BuildersClubRoomSupport.sendCurrentRoomPlacementStatus(room);
         room.getUserVariableManager().restorePermanentAssignments(habbo);
 
-        habbo.getClient().sendResponse(new UserBadgesComposer(habbo.getInventory().getBadgesComponent().getWearingBadges(), habbo.getHabboInfo().getId()));
+        habbo.getClient()
+                .sendResponse(new UserBadgesComposer(
+                        habbo.getInventory().getBadgesComponent().getWearingBadges(),
+                        habbo.getHabboInfo().getId()));
 
         List<Habbo> habbos = new ArrayList<>();
         if (!room.getCurrentHabbos().isEmpty()) {
@@ -950,7 +1039,8 @@ public class RoomManager {
             Collection<Habbo> visibleHabbos = room.getHabbos();
 
             if (Emulator.getPluginManager().isRegistered(HabboAddedToRoomEvent.class, false)) {
-                HabboAddedToRoomEvent event = Emulator.getPluginManager().fireEvent(new HabboAddedToRoomEvent(habbo, room, habbosToSendEnter, visibleHabbos));
+                HabboAddedToRoomEvent event = Emulator.getPluginManager()
+                        .fireEvent(new HabboAddedToRoomEvent(habbo, room, habbosToSendEnter, visibleHabbos));
                 habbosToSendEnter = event.habbosToSendEnter;
                 visibleHabbos = event.visibleHabbos;
             }
@@ -986,15 +1076,17 @@ public class RoomManager {
             room.giveEffect(habbo.getRoomUnit(), effect, -1);
         }
 
-
-        habbo.getClient().sendResponse(new RoomUsersComposer(room.getCurrentBots().values(), true));
+        habbo.getClient()
+                .sendResponse(new RoomUsersComposer(room.getCurrentBots().values(), true));
         if (!room.getCurrentBots().isEmpty()) {
             for (Bot bot : room.getCurrentBots().values()) {
                 if (!bot.getRoomUnit().getDanceType().equals(DanceType.NONE)) {
                     habbo.getClient().sendResponse(new RoomUserDanceComposer(bot.getRoomUnit()));
                 }
 
-                habbo.getClient().sendResponse(new RoomUserStatusComposer(bot.getRoomUnit(), bot.getRoomUnit().getZ()));
+                habbo.getClient()
+                        .sendResponse(new RoomUserStatusComposer(
+                                bot.getRoomUnit(), bot.getRoomUnit().getZ()));
             }
         }
 
@@ -1002,7 +1094,8 @@ public class RoomManager {
 
         habbo.getClient().sendResponse(new RoomThicknessComposer(room));
 
-        habbo.getClient().sendResponse(new RoomDataComposer(room, habbo.getClient().getHabbo(), false, true));
+        habbo.getClient()
+                .sendResponse(new RoomDataComposer(room, habbo.getClient().getHabbo(), false, true));
 
         habbo.getClient().sendResponse(new RoomWallItemsComposer(room));
         {
@@ -1011,7 +1104,8 @@ public class RoomManager {
             Set<HabboItem> allFloorItems = new HashSet<>(room.getFloorItems());
 
             if (Emulator.getPluginManager().isRegistered(RoomFloorItemsLoadEvent.class, true)) {
-                RoomFloorItemsLoadEvent roomFloorItemsLoadEvent = Emulator.getPluginManager().fireEvent(new RoomFloorItemsLoadEvent(habbo, allFloorItems));
+                RoomFloorItemsLoadEvent roomFloorItemsLoadEvent =
+                        Emulator.getPluginManager().fireEvent(new RoomFloorItemsLoadEvent(habbo, allFloorItems));
                 if (roomFloorItemsLoadEvent.hasChangedFloorItems()) {
                     allFloorItems = roomFloorItemsLoadEvent.getFloorItems();
                 }
@@ -1040,7 +1134,8 @@ public class RoomManager {
         habbo.getClient().sendResponse(new HanditemBlockStateComposer(room).compose());
 
         if (!room.getCurrentPets().isEmpty()) {
-            habbo.getClient().sendResponse(new RoomPetComposer(room.getCurrentPets().values()));
+            habbo.getClient()
+                    .sendResponse(new RoomPetComposer(room.getCurrentPets().values()));
             for (Pet pet : room.getCurrentPets().values()) {
                 habbo.getClient().sendResponse(new RoomUserStatusComposer(pet.getRoomUnit()));
             }
@@ -1076,17 +1171,23 @@ public class RoomManager {
                 }
 
                 if (roomHabbo.getHabboStats().userIgnored(habbo.getHabboInfo().getId())) {
-                    roomHabbo.getClient().sendResponse(new RoomUserIgnoredComposer(habbo, RoomUserIgnoredComposer.IGNORED));
+                    roomHabbo
+                            .getClient()
+                            .sendResponse(new RoomUserIgnoredComposer(habbo, RoomUserIgnoredComposer.IGNORED));
                 }
 
                 if (!roomHabbo.getHabboStats().allowTalk()) {
-                    habbo.getClient().sendResponse(new RoomUserIgnoredComposer(roomHabbo, RoomUserIgnoredComposer.MUTED));
-                } else if (habbo.getHabboStats().userIgnored(roomHabbo.getHabboInfo().getId())) {
-                    habbo.getClient().sendResponse(new RoomUserIgnoredComposer(roomHabbo, RoomUserIgnoredComposer.IGNORED));
+                    habbo.getClient()
+                            .sendResponse(new RoomUserIgnoredComposer(roomHabbo, RoomUserIgnoredComposer.MUTED));
+                } else if (habbo.getHabboStats()
+                        .userIgnored(roomHabbo.getHabboInfo().getId())) {
+                    habbo.getClient()
+                            .sendResponse(new RoomUserIgnoredComposer(roomHabbo, RoomUserIgnoredComposer.IGNORED));
                 }
 
                 if (roomHabbo.getHabboStats().guild != 0 && !guildBadges.containsKey(roomHabbo.getHabboStats().guild)) {
-                    Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(roomHabbo.getHabboStats().guild);
+                    Guild guild =
+                            Emulator.getGameEnvironment().getGuildManager().getGuild(roomHabbo.getHabboStats().guild);
 
                     if (guild != null) {
                         guildBadges.put(roomHabbo.getHabboStats().guild, guild.getBadge());
@@ -1096,7 +1197,17 @@ public class RoomManager {
                 if (roomHabbo.getRoomUnit().getRoomUnitType().equals(RoomUnitType.PET)) {
                     try {
                         habbo.getClient().sendResponse(new RoomUserRemoveComposer(roomHabbo.getRoomUnit()));
-                        habbo.getClient().sendResponse(new RoomUserPetComposer(((PetData) roomHabbo.getHabboStats().cache.get("pet_type")).getType(), (Integer) roomHabbo.getHabboStats().cache.get("pet_race"), (String) roomHabbo.getHabboStats().cache.get("pet_color"), roomHabbo));
+                        habbo.getClient()
+                                .sendResponse(new RoomUserPetComposer(
+                                        ((PetData) roomHabbo
+                                                        .getHabboStats()
+                                                        .cache
+                                                        .get("pet_type"))
+                                                .getType(),
+                                        (Integer)
+                                                roomHabbo.getHabboStats().cache.get("pet_race"),
+                                        (String) roomHabbo.getHabboStats().cache.get("pet_color"),
+                                        roomHabbo));
                     } catch (Exception e) {
 
                     }
@@ -1106,10 +1217,14 @@ public class RoomManager {
 
         habbo.getClient().sendResponse(new RoomUsersGuildBadgesComposer(guildBadges));
 
-        if (room.hasRights(habbo) || (room.hasGuild() && room.getGuildRightLevel(habbo).isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS))) {
+        if (room.hasRights(habbo)
+                || (room.hasGuild()
+                        && room.getGuildRightLevel(habbo).isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS))) {
             if (!room.getHabboQueue().isEmpty()) {
                 for (Habbo waiting : room.getHabboQueue().values()) {
-                    habbo.getClient().sendResponse(new DoorbellAddUserComposer(waiting.getHabboInfo().getUsername()));
+                    habbo.getClient()
+                            .sendResponse(new DoorbellAddUserComposer(
+                                    waiting.getHabboInfo().getUsername()));
                 }
             }
         }
@@ -1125,30 +1240,42 @@ public class RoomManager {
         }
 
         if (room.hasActiveWordQuiz()) {
-            habbo.getClient().sendResponse(new SimplePollStartComposer((Emulator.getIntUnixTimestamp() - room.wordQuizEnd) * 1000, room.wordQuiz));
+            habbo.getClient()
+                    .sendResponse(new SimplePollStartComposer(
+                            (Emulator.getIntUnixTimestamp() - room.wordQuizEnd) * 1000, room.wordQuiz));
 
             if (room.hasVotedInWordQuiz(habbo)) {
                 habbo.getClient().sendResponse(new SimplePollAnswersComposer(room.noVotes, room.yesVotes));
             }
         }
 
-        habbo.getClient().sendResponse(new com.eu.habbo.messages.outgoing.rooms.youtube.YouTubeRoomSettingsComposer(
-                room.isYoutubeEnabled()).compose());
+        habbo.getClient()
+                .sendResponse(new com.eu.habbo.messages.outgoing.rooms.youtube.YouTubeRoomSettingsComposer(
+                                room.isYoutubeEnabled())
+                        .compose());
 
         if (!room.getYoutubeCurrentVideo().isEmpty()) {
-            habbo.getClient().sendResponse(new com.eu.habbo.messages.outgoing.rooms.youtube.YouTubeRoomBroadcastComposer(
-                    room.getYoutubeCurrentVideo(),
-                    room.getYoutubeSenderName(),
-                    room.getYoutubePlaylist()).compose());
+            habbo.getClient()
+                    .sendResponse(new com.eu.habbo.messages.outgoing.rooms.youtube.YouTubeRoomBroadcastComposer(
+                                    room.getYoutubeCurrentVideo(),
+                                    room.getYoutubeSenderName(),
+                                    room.getYoutubePlaylist())
+                            .compose());
         }
         if (!room.getYoutubeWatchers().isEmpty()) {
-            habbo.getClient().sendResponse(new com.eu.habbo.messages.outgoing.rooms.youtube.YouTubeRoomWatchersComposer(
-                    room.getYoutubeWatchers()).compose());
+            habbo.getClient()
+                    .sendResponse(new com.eu.habbo.messages.outgoing.rooms.youtube.YouTubeRoomWatchersComposer(
+                                    room.getYoutubeWatchers())
+                            .compose());
         }
 
-        habbo.getClient().sendResponse(new com.eu.habbo.messages.outgoing.soundboard.SoundboardSettingsComposer(
-                room.isSoundboardEnabled(),
-                Emulator.getGameEnvironment().getSoundboardManager().getSounds()).compose());
+        habbo.getClient()
+                .sendResponse(new com.eu.habbo.messages.outgoing.soundboard.SoundboardSettingsComposer(
+                                room.isSoundboardEnabled(),
+                                Emulator.getGameEnvironment()
+                                        .getSoundboardManager()
+                                        .getSounds())
+                        .compose());
 
         WiredManager.triggerUserEntersRoom(room, habbo.getRoomUnit());
         room.habboEntered(habbo);
@@ -1160,7 +1287,9 @@ public class RoomManager {
 
     void logEnter(Habbo habbo, Room room) {
         habbo.getHabboStats().roomEnterTimestamp = Emulator.getIntUnixTimestamp();
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO room_enter_log (room_id, user_id, timestamp) VALUES(?, ?, ?)")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO room_enter_log (room_id, user_id, timestamp) VALUES(?, ?, ?)")) {
             statement.setInt(1, room.getId());
             statement.setInt(2, habbo.getHabboInfo().getId());
             statement.setInt(3, (int) (habbo.getHabboStats().roomEnterTimestamp));
@@ -1178,7 +1307,8 @@ public class RoomManager {
     }
 
     public void leaveRoom(Habbo habbo, Room room, boolean redirectToHotelView) {
-        if (habbo.getHabboInfo().getCurrentRoom() != null && habbo.getHabboInfo().getCurrentRoom() == room) {
+        if (habbo.getHabboInfo().getCurrentRoom() != null
+                && habbo.getHabboInfo().getCurrentRoom() == room) {
             habbo.getRoomUnit().setPathFinderRoom(null);
 
             this.logExit(habbo);
@@ -1192,7 +1322,11 @@ public class RoomManager {
             habbo.getRoomUnit().isKicked = false;
 
             if (room.getOwnerId() != habbo.getHabboInfo().getId()) {
-                AchievementManager.progressAchievement(room.getOwnerId(), Emulator.getGameEnvironment().getAchievementManager().getAchievement("RoomDecoHosting"), (int) Math.floor((Emulator.getIntUnixTimestamp() - habbo.getHabboStats().roomEnterTimestamp) / 60000));
+                AchievementManager.progressAchievement(
+                        room.getOwnerId(),
+                        Emulator.getGameEnvironment().getAchievementManager().getAchievement("RoomDecoHosting"),
+                        (int) Math.floor(
+                                (Emulator.getIntUnixTimestamp() - habbo.getHabboStats().roomEnterTimestamp) / 60000));
             }
 
             habbo.getMessenger().connectionChanged(habbo, habbo.isOnline(), false);
@@ -1208,7 +1342,11 @@ public class RoomManager {
 
         if (habbo.getHabboInfo().getRiding() != null) {
             if (habbo.getHabboInfo().getRiding().getRoomUnit() != null) {
-                habbo.getHabboInfo().getRiding().getRoomUnit().setGoalLocation(habbo.getHabboInfo().getRiding().getRoomUnit().getCurrentLocation());
+                habbo.getHabboInfo()
+                        .getRiding()
+                        .getRoomUnit()
+                        .setGoalLocation(
+                                habbo.getHabboInfo().getRiding().getRoomUnit().getCurrentLocation());
             }
             habbo.getHabboInfo().getRiding().setTask(PetTasks.FREE);
             habbo.getHabboInfo().getRiding().setRider(null);
@@ -1217,7 +1355,9 @@ public class RoomManager {
 
         Room room = habbo.getHabboInfo().getCurrentRoom();
         if (room != null) {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE room_enter_log SET exit_timestamp = ? WHERE user_id = ? AND room_id = ? ORDER BY timestamp DESC LIMIT 1")) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    PreparedStatement statement = connection.prepareStatement(
+                            "UPDATE room_enter_log SET exit_timestamp = ? WHERE user_id = ? AND room_id = ? ORDER BY timestamp DESC LIMIT 1")) {
                 statement.setInt(1, Emulator.getIntUnixTimestamp());
                 statement.setInt(2, habbo.getHabboInfo().getId());
                 statement.setInt(3, room.getId());
@@ -1234,8 +1374,7 @@ public class RoomManager {
         for (Room room : this.activeRooms.values()) {
             for (String s : room.getTags().split(";")) {
                 int i = 0;
-                if (tagCount.get(s) != null)
-                    i++;
+                if (tagCount.get(s) != null) i++;
 
                 tagCount.put(s, i++);
             }
@@ -1307,12 +1446,14 @@ public class RoomManager {
         Map<Integer, List<Room>> result = new HashMap<>();
 
         for (Map.Entry<Integer, List<Room>> set : rooms.entrySet()) {
-            if (set.getValue().isEmpty())
-                continue;
+            if (set.getValue().isEmpty()) continue;
 
             Collections.sort(set.getValue());
 
-            result.put(set.getKey(), new ArrayList<>(set.getValue().subList(0, (Math.min(set.getValue().size(), count)))));
+            result.put(
+                    set.getKey(),
+                    new ArrayList<>(
+                            set.getValue().subList(0, (Math.min(set.getValue().size(), count)))));
         }
 
         return result;
@@ -1339,12 +1480,13 @@ public class RoomManager {
     private ArrayList<Room> getOfflineRoomsWithName(String name) {
         ArrayList<Room> rooms = new ArrayList<>();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT users.username AS owner_name, rooms.* FROM rooms INNER JOIN users ON owner_id = users.id WHERE name LIKE ? ORDER BY id DESC LIMIT 25")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT users.username AS owner_name, rooms.* FROM rooms INNER JOIN users ON owner_id = users.id WHERE name LIKE ? ORDER BY id DESC LIMIT 25")) {
             statement.setString(1, "%" + name + "%");
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
-                    if (this.activeRooms.containsKey(set.getInt("id")))
-                        continue;
+                    if (this.activeRooms.containsKey(set.getInt("id"))) continue;
 
                     Room r = new Room(set, this.roomDependencies());
                     rooms.add(r);
@@ -1379,11 +1521,9 @@ public class RoomManager {
         ArrayList<Room> rooms = new ArrayList<>();
 
         for (Room room : this.activeRooms.values()) {
-            if (room.getGuildId() == 0)
-                continue;
+            if (room.getGuildId() == 0) continue;
 
-            if (room.getName().toLowerCase().contains(name.toLowerCase()))
-                rooms.add(room);
+            if (room.getName().toLowerCase().contains(name.toLowerCase())) rooms.add(room);
         }
 
         if (rooms.size() < 25) {
@@ -1398,12 +1538,13 @@ public class RoomManager {
     private ArrayList<Room> getOfflineGroupRoomsWithName(String name) {
         ArrayList<Room> rooms = new ArrayList<>();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT users.username AS owner_name, rooms.* FROM rooms INNER JOIN users ON rooms.owner_id = users.id WHERE name LIKE ? AND guild_id != 0 ORDER BY id DESC LIMIT 25")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT users.username AS owner_name, rooms.* FROM rooms INNER JOIN users ON rooms.owner_id = users.id WHERE name LIKE ? AND guild_id != 0 ORDER BY id DESC LIMIT 25")) {
             statement.setString(1, "%" + name + "%");
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
-                    if (this.activeRooms.containsKey(set.getInt("id")))
-                        continue;
+                    if (this.activeRooms.containsKey(set.getInt("id"))) continue;
 
                     Room r = new Room(set, this.roomDependencies());
                     rooms.add(r);
@@ -1422,12 +1563,10 @@ public class RoomManager {
         ArrayList<Room> rooms = new ArrayList<>();
 
         for (MessengerBuddy buddy : habbo.getMessenger().getFriends().values()) {
-            if (buddy.getOnline() == 0)
-                continue;
+            if (buddy.getOnline() == 0) continue;
 
             Habbo friend = Emulator.getGameEnvironment().getHabboManager().getHabbo(buddy.getId());
-            if (friend == null || friend.getHabboInfo().getCurrentRoom() == null)
-                continue;
+            if (friend == null || friend.getHabboInfo().getCurrentRoom() == null) continue;
 
             rooms.add(friend.getHabboInfo().getCurrentRoom());
         }
@@ -1441,13 +1580,11 @@ public class RoomManager {
         ArrayList<Room> rooms = new ArrayList<>();
 
         for (MessengerBuddy buddy : habbo.getMessenger().getFriends().values()) {
-            if (buddy.getOnline() == 0)
-                continue;
+            if (buddy.getOnline() == 0) continue;
 
             Habbo friend = Emulator.getGameEnvironment().getHabboManager().getHabbo(buddy.getId());
 
-            if (friend == null)
-                continue;
+            if (friend == null) continue;
 
             rooms.addAll(this.getRoomsForHabbo(friend));
         }
@@ -1460,7 +1597,10 @@ public class RoomManager {
     public ArrayList<Room> getRoomsVisited(Habbo habbo, boolean includeSelf, int limit) {
         ArrayList<Room> rooms = new ArrayList<>();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT rooms.* FROM room_enter_log INNER JOIN rooms ON room_enter_log.room_id = rooms.id WHERE user_id = ? AND timestamp >= ? AND rooms.owner_id != ? GROUP BY rooms.id ORDER BY MAX(timestamp) DESC LIMIT " + limit)) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT rooms.* FROM room_enter_log INNER JOIN rooms ON room_enter_log.room_id = rooms.id WHERE user_id = ? AND timestamp >= ? AND rooms.owner_id != ? GROUP BY rooms.id ORDER BY MAX(timestamp) DESC LIMIT "
+                                + limit)) {
             statement.setInt(1, habbo.getHabboInfo().getId());
             statement.setInt(2, Emulator.getIntUnixTimestamp() - 259200);
             statement.setInt(3, (includeSelf ? 0 : habbo.getHabboInfo().getId()));
@@ -1508,7 +1648,8 @@ public class RoomManager {
         final ArrayList<Room> rooms = new ArrayList<>();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT rooms.* FROM rooms INNER JOIN guilds_members ON guilds_members.guild_id = rooms.guild_id WHERE guilds_members.user_id = ? AND level_id != 3")) {
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT rooms.* FROM rooms INNER JOIN guilds_members ON guilds_members.guild_id = rooms.guild_id WHERE guilds_members.user_id = ? AND level_id != 3")) {
             statement.setInt(1, habbo.getHabboInfo().getId());
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
@@ -1531,7 +1672,9 @@ public class RoomManager {
     public ArrayList<Room> getRoomsWithRights(Habbo habbo) {
         ArrayList<Room> rooms = new ArrayList<>();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT rooms.* FROM rooms INNER JOIN room_rights ON room_rights.room_id = rooms.id WHERE room_rights.user_id = ? ORDER BY rooms.id DESC LIMIT 30")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT rooms.* FROM rooms INNER JOIN room_rights ON room_rights.room_id = rooms.id WHERE room_rights.user_id = ? ORDER BY rooms.id DESC LIMIT 30")) {
             statement.setInt(1, habbo.getHabboInfo().getId());
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
@@ -1572,7 +1715,8 @@ public class RoomManager {
         final ArrayList<Room> rooms = new ArrayList<>();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT * FROM rooms ORDER BY score DESC LIMIT ?")) {
+                PreparedStatement statement =
+                        connection.prepareStatement("SELECT * FROM rooms ORDER BY score DESC LIMIT ?")) {
             statement.setInt(1, limit);
 
             try (ResultSet set = statement.executeQuery()) {
@@ -1595,7 +1739,8 @@ public class RoomManager {
         ArrayList<Room> rooms = new ArrayList<>();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT * FROM rooms INNER JOIN guilds_members ON guilds_members.guild_id = rooms.guild_id WHERE guilds_members.user_id = ? AND level_id = 0")) {
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT * FROM rooms INNER JOIN guilds_members ON guilds_members.guild_id = rooms.guild_id WHERE guilds_members.user_id = ? AND level_id = 0")) {
             statement.setInt(1, habbo.getHabboInfo().getId());
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
@@ -1645,8 +1790,7 @@ public class RoomManager {
         ArrayList<Room> r = new ArrayList<>();
 
         for (Room room : rooms) {
-            if (room.getOwnerName().equalsIgnoreCase(filter))
-                r.add(room);
+            if (room.getOwnerName().equalsIgnoreCase(filter)) r.add(room);
         }
 
         return r;
@@ -1656,8 +1800,7 @@ public class RoomManager {
         ArrayList<Room> r = new ArrayList<>();
 
         for (Room room : rooms) {
-            if (room.getName().toLowerCase().contains(filter.toLowerCase()))
-                r.add(room);
+            if (room.getName().toLowerCase().contains(filter.toLowerCase())) r.add(room);
         }
 
         return r;
@@ -1667,8 +1810,8 @@ public class RoomManager {
         ArrayList<Room> r = new ArrayList<>();
 
         for (Room room : rooms) {
-            if (room.getName().toLowerCase().contains(filter.toLowerCase()) || room.getDescription().toLowerCase().contains(filter.toLowerCase()))
-                r.add(room);
+            if (room.getName().toLowerCase().contains(filter.toLowerCase())
+                    || room.getDescription().toLowerCase().contains(filter.toLowerCase())) r.add(room);
         }
 
         return r;
@@ -1678,12 +1821,10 @@ public class RoomManager {
         ArrayList<Room> r = new ArrayList<>();
 
         for (Room room : rooms) {
-            if (room.getTags().split(";").length == 0)
-                continue;
+            if (room.getTags().split(";").length == 0) continue;
 
             for (String s : room.getTags().split(";")) {
-                if (s.equalsIgnoreCase(filter))
-                    r.add(room);
+                if (s.equalsIgnoreCase(filter)) r.add(room);
             }
         }
 
@@ -1694,11 +1835,14 @@ public class RoomManager {
         ArrayList<Room> r = new ArrayList<>();
 
         for (Room room : rooms) {
-            if (room.getGuildId() == 0)
-                continue;
+            if (room.getGuildId() == 0) continue;
 
-            if (Emulator.getGameEnvironment().getGuildManager().getGuild(room.getGuildId()).getName().toLowerCase().contains(filter.toLowerCase()))
-                r.add(room);
+            if (Emulator.getGameEnvironment()
+                    .getGuildManager()
+                    .getGuild(room.getGuildId())
+                    .getName()
+                    .toLowerCase()
+                    .contains(filter.toLowerCase())) r.add(room);
         }
 
         return r;
@@ -1712,9 +1856,7 @@ public class RoomManager {
             room.setOwnerChangeListener(null);
         }
 
-        this.roomsByOwner.clear();
-        this.indexedRoomCount.set(0);
-        this.activeRooms.clear();
+        this.roomDirectory.clear();
 
         LOGGER.info("Room Manager -> Disposed!");
     }
@@ -1726,7 +1868,9 @@ public class RoomManager {
     }
 
     public CustomRoomLayout insertCustomLayout(Room room, String map, int doorX, int doorY, int doorDirection) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO room_models_custom (id, name, door_x, door_y, door_dir, heightmap) VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE door_x = ?, door_y = ?, door_dir = ?, heightmap = ?")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO room_models_custom (id, name, door_x, door_y, door_dir, heightmap) VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE door_x = ?, door_y = ?, door_dir = ?, heightmap = ?")) {
             statement.setInt(1, room.getId());
             statement.setString(2, "custom_" + room.getId());
             statement.setInt(3, doorX);
@@ -1748,14 +1892,11 @@ public class RoomManager {
     public void banUserFromRoom(Habbo rights, int userId, int roomId, RoomBanTypes length) {
         Room room = this.getRoom(roomId);
 
-        if (room == null)
-            return;
+        if (room == null) return;
 
-        if (rights != null && !room.hasRights(rights))
-            return;
+        if (rights != null && !room.hasRights(rights)) return;
 
-        if (room.getOwnerId() == userId)
-            return;
+        if (room.getOwnerId() == userId) return;
 
         String name = "";
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -149,6 +149,7 @@ public class RoomManager {
     private final RoomDirectory roomDirectory;
     private final RoomSearchService roomSearchService;
     private final RoomModerationService roomModerationService;
+    private final RoomLifecycleService roomLifecycleService;
     private final ConcurrentHashMap<Integer, Room> activeRooms;
     private final ConcurrentHashMap<Integer, Set<Integer>> roomsByOwner;
     private final AtomicInteger indexedRoomCount;
@@ -179,6 +180,14 @@ public class RoomManager {
         this.roomsByOwner = this.roomDirectory.roomsByOwner();
         this.indexedRoomCount = this.roomDirectory.indexedRoomCount();
         this.roomSearchService = new RoomSearchService(this.activeRooms::values, Duration.ofSeconds(1));
+        this.roomLifecycleService = new RoomLifecycleService(
+                this.roomDirectory,
+                this.roomCategories,
+                ownerId -> Emulator.getGameServer().getGameClientManager().containsHabbo(ownerId),
+                room -> !Emulator.getPluginManager()
+                        .fireEvent(new RoomUncachedEvent(room))
+                        .isCancelled(),
+                this.roomSearchService::invalidate);
         this.roomModerationService = new RoomModerationService(
                 this::getRoom,
                 userId -> Emulator.getGameEnvironment().getHabboManager().getHabbo(userId),
@@ -204,10 +213,6 @@ public class RoomManager {
         }
     }
 
-    private void trackRoomOwner(Room room) {
-        this.roomDirectory.track(room);
-    }
-
     private RoomDependencies roomDependencies() {
         return new RoomDependencies(this::openConnection, this.persistenceExecutor::execute);
     }
@@ -216,22 +221,9 @@ public class RoomManager {
         return Emulator.getDatabase().getDataSource().getConnection();
     }
 
-    private void untrackRoomOwner(Room room) {
-        this.roomDirectory.untrack(room);
-        this.roomSearchService.invalidate();
-    }
-
-    private void removeRoomFromOwner(int ownerId, int roomId) {
-        this.roomDirectory.removeFromOwner(ownerId, roomId);
-    }
-
     void registerActiveRoom(Room room) {
         this.roomDirectory.register(room);
         this.roomSearchService.invalidate();
-    }
-
-    private void reconcileOwnerIndex() {
-        this.roomDirectory.reconcileOwnerIndex();
     }
 
     public void loadRoomModels() {
@@ -533,74 +525,15 @@ public class RoomManager {
     }
 
     public void unloadRoomsForHabbo(Habbo habbo) {
-        int ownerId = habbo.getHabboInfo().getId();
-        List<Room> roomsToDispose = this.roomsToUnloadForOwner(ownerId);
-
-        for (Room room : roomsToDispose) {
-            if (Emulator.getPluginManager()
-                    .fireEvent(new RoomUncachedEvent(room))
-                    .isCancelled()) continue;
-
-            room.dispose();
-            this.untrackRoomOwner(room);
-            this.activeRooms.remove(room.getId());
-        }
+        this.roomLifecycleService.unloadRoomsFor(habbo);
     }
 
     List<Room> roomsToUnloadForOwner(int ownerId) {
-        if (this.indexedRoomCount.get() != this.activeRooms.size()) {
-            this.reconcileOwnerIndex();
-        }
-
-        List<Room> roomsToDispose = new ArrayList<>();
-        Set<Integer> roomIds = this.roomsByOwner.get(ownerId);
-        if (roomIds == null) {
-            return roomsToDispose;
-        }
-
-        for (int roomId : new HashSet<>(roomIds)) {
-            Room room = this.activeRooms.get(roomId);
-            if (room == null || room.getOwnerId() != ownerId) {
-                this.removeRoomFromOwner(ownerId, roomId);
-                if (room != null) {
-                    this.trackRoomOwner(room);
-                }
-                continue;
-            }
-
-            if (!room.isPublicRoom()
-                    && !room.isStaffPromotedRoom()
-                    && room.getUserCount() == 0
-                    && (this.roomCategories.get(room.getCategory()) == null
-                            || !this.roomCategories.get(room.getCategory()).isPublic())) {
-                roomsToDispose.add(room);
-            }
-        }
-
-        return roomsToDispose;
+        return this.roomLifecycleService.roomsToUnloadForOwner(ownerId);
     }
 
     public void clearInactiveRooms() {
-        Set<Room> roomsToDispose = new HashSet<>();
-        for (Map.Entry<Integer, Set<Integer>> entry : this.roomsByOwner.entrySet()) {
-            int ownerId = entry.getKey();
-            if (!Emulator.getGameServer().getGameClientManager().containsHabbo(ownerId)) {
-                for (int roomId : entry.getValue()) {
-                    Room room = this.activeRooms.get(roomId);
-                    if (room != null && !room.isPublicRoom() && !room.isStaffPromotedRoom() && room.isPreLoaded()) {
-                        roomsToDispose.add(room);
-                    }
-                }
-            }
-        }
-
-        for (Room room : roomsToDispose) {
-            room.dispose();
-            if (room.getUserCount() == 0) {
-                this.untrackRoomOwner(room);
-                this.activeRooms.remove(room.getId());
-            }
-        }
+        this.roomLifecycleService.clearInactiveRooms();
     }
 
     public boolean layoutExists(String name) {
@@ -612,12 +545,11 @@ public class RoomManager {
     }
 
     public void unloadRoom(Room room) {
-        room.dispose();
+        this.roomLifecycleService.unload(room);
     }
 
     public void uncacheRoom(Room room) {
-        this.untrackRoomOwner(room);
-        this.activeRooms.remove(room.getId());
+        this.roomLifecycleService.uncache(room);
     }
 
     public void voteForRoom(Habbo habbo, Room room) {
@@ -1731,22 +1663,12 @@ public class RoomManager {
     }
 
     public synchronized void dispose() {
-        this.quiesceRoomCycles();
-
-        for (Room room : this.activeRooms.values()) {
-            room.dispose();
-            room.setOwnerChangeListener(null);
-        }
-
-        this.roomDirectory.clear();
-
+        this.roomLifecycleService.dispose();
         LOGGER.info("Room Manager -> Disposed!");
     }
 
     public void quiesceRoomCycles() {
-        for (Room room : this.activeRooms.values()) {
-            room.quiesceCycleTask();
-        }
+        this.roomLifecycleService.quiesceRoomCycles();
     }
 
     public CustomRoomLayout insertCustomLayout(Room room, String map, int doorX, int doorY, int doorDirection) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomModelRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomModelRepository.java
@@ -1,0 +1,91 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class RoomModelRepository {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RoomModelRepository.class);
+    private final RoomDependencies.ConnectionProvider database;
+    private final List<String> modelNames = new ArrayList<>();
+    private final ConcurrentHashMap<String, RoomManager.RoomLayoutData> layouts = new ConcurrentHashMap<>();
+
+    RoomModelRepository(RoomDependencies.ConnectionProvider database) {
+        this.database = database;
+    }
+
+    List<String> modelNames() {
+        return this.modelNames;
+    }
+
+    ConcurrentHashMap<String, RoomManager.RoomLayoutData> layouts() {
+        return this.layouts;
+    }
+
+    void reload() {
+        this.modelNames.clear();
+        this.layouts.clear();
+        try (Connection connection = this.database.openConnection();
+                Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM room_models")) {
+            while (set.next()) {
+                String name = set.getString("name");
+                this.modelNames.add(name);
+                this.layouts.put(name, new RoomManager.RoomLayoutData(set));
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+    }
+
+    CustomRoomLayout loadCustomLayout(Room room) {
+        CustomRoomLayout layout = null;
+        try (Connection connection = this.database.openConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("SELECT * FROM room_models_custom WHERE id = ? LIMIT 1")) {
+            statement.setInt(1, room.getId());
+            try (ResultSet set = statement.executeQuery()) {
+                if (set.next()) {
+                    layout = new CustomRoomLayout(set, room);
+                }
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+        return layout;
+    }
+
+    boolean exists(String name) {
+        return this.modelNames.contains(name);
+    }
+
+    RoomLayout load(String name, Room room) {
+        RoomManager.RoomLayoutData cached = this.layouts.get(name);
+        if (cached != null) {
+            return new RoomLayout(cached, room);
+        }
+
+        RoomLayout layout = null;
+        try (Connection connection = this.database.openConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("SELECT * FROM room_models WHERE name = ? LIMIT 1")) {
+            statement.setString(1, name);
+            try (ResultSet set = statement.executeQuery()) {
+                if (set.next()) {
+                    layout = new RoomLayout(set, room);
+                }
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+        return layout;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomModerationService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomModerationService.java
@@ -1,0 +1,73 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.messages.outgoing.rooms.RoomEnterErrorComposer;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+import java.util.function.IntSupplier;
+
+final class RoomModerationService {
+
+    private final IntFunction<Room> rooms;
+    private final IntFunction<Habbo> onlineUsers;
+    private final IntFunction<HabboInfo> offlineUsers;
+    private final IntSupplier unixTime;
+    private final Consumer<RoomBan> banStore;
+
+    RoomModerationService(
+            IntFunction<Room> rooms,
+            IntFunction<Habbo> onlineUsers,
+            IntFunction<HabboInfo> offlineUsers,
+            IntSupplier unixTime,
+            Consumer<RoomBan> banStore) {
+        this.rooms = rooms;
+        this.onlineUsers = onlineUsers;
+        this.offlineUsers = offlineUsers;
+        this.unixTime = unixTime;
+        this.banStore = banStore;
+    }
+
+    void banUser(Habbo rights, int userId, int roomId, RoomManager.RoomBanTypes length) {
+        Room room = this.rooms.apply(roomId);
+        if (room == null) {
+            return;
+        }
+        if (rights != null && !room.hasRights(rights)) {
+            return;
+        }
+        if (room.getOwnerId() == userId) {
+            return;
+        }
+
+        Habbo habbo = this.onlineUsers.apply(userId);
+        String name = this.bannableUsername(userId, habbo);
+        if (name.isEmpty()) {
+            return;
+        }
+
+        RoomBan roomBan = new RoomBan(roomId, userId, name, this.unixTime.getAsInt() + length.duration);
+        this.banStore.accept(roomBan);
+        room.addRoomBan(roomBan);
+
+        if (habbo != null && habbo.getHabboInfo().getCurrentRoom() == room) {
+            room.removeHabbo(habbo, true);
+            habbo.getClient().sendResponse(new RoomEnterErrorComposer(RoomEnterErrorComposer.ROOM_ERROR_BANNED));
+        }
+    }
+
+    private String bannableUsername(int userId, Habbo habbo) {
+        if (habbo != null) {
+            return habbo.hasPermission(Permission.ACC_UNKICKABLE)
+                    ? ""
+                    : habbo.getHabboInfo().getUsername();
+        }
+
+        HabboInfo info = this.offlineUsers.apply(userId);
+        if (info == null || info.getRank().hasPermission(Permission.ACC_UNKICKABLE, false)) {
+            return "";
+        }
+        return info.getUsername();
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRepository.java
@@ -9,10 +9,18 @@ import java.util.Objects;
 final class RoomRepository {
 
     private static final String FIND_WIRED_SETTINGS_SQL =
-            "SELECT inspect_mask, modify_mask FROM room_wired_settings "
-                    + "WHERE room_id = ? LIMIT 1";
-    private static final String UPDATE_USER_COUNT_SQL =
-            "UPDATE rooms SET users = ? WHERE id = ? LIMIT 1";
+            "SELECT inspect_mask, modify_mask FROM room_wired_settings " + "WHERE room_id = ? LIMIT 1";
+    private static final String UPDATE_USER_COUNT_SQL = "UPDATE rooms SET users = ? WHERE id = ? LIMIT 1";
+    private static final String UPSERT_CUSTOM_LAYOUT_SQL = "INSERT INTO room_models_custom "
+            + "(id, name, door_x, door_y, door_dir, heightmap) "
+            + "VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE "
+            + "door_x = ?, door_y = ?, door_dir = ?, heightmap = ?";
+    private static final String RECORD_ENTRY_SQL =
+            "INSERT INTO room_enter_log (room_id, user_id, timestamp) VALUES(?, ?, ?)";
+    private static final String RECORD_EXIT_SQL = "UPDATE room_enter_log SET exit_timestamp = ? "
+            + "WHERE user_id = ? AND room_id = ? "
+            + "ORDER BY timestamp DESC LIMIT 1";
+    private static final String RECORD_VOTE_SQL = "INSERT INTO room_votes (user_id, room_id) VALUES (?, ?)";
 
     private final RoomDependencies.ConnectionProvider database;
 
@@ -22,15 +30,12 @@ final class RoomRepository {
 
     WiredSettings findWiredSettings(int roomId) throws SQLException {
         try (Connection connection = this.database.openConnection();
-             PreparedStatement statement =
-                     connection.prepareStatement(FIND_WIRED_SETTINGS_SQL)) {
+                PreparedStatement statement = connection.prepareStatement(FIND_WIRED_SETTINGS_SQL)) {
             statement.setInt(1, roomId);
 
             try (ResultSet resultSet = statement.executeQuery()) {
                 if (resultSet.next()) {
-                    return new WiredSettings(
-                            resultSet.getInt("inspect_mask"),
-                            resultSet.getInt("modify_mask"));
+                    return new WiredSettings(resultSet.getInt("inspect_mask"), resultSet.getInt("modify_mask"));
                 }
             }
         }
@@ -40,20 +45,63 @@ final class RoomRepository {
 
     void updateUserCount(int roomId, int userCount) throws SQLException {
         try (Connection connection = this.database.openConnection();
-             PreparedStatement statement =
-                     connection.prepareStatement(UPDATE_USER_COUNT_SQL)) {
+                PreparedStatement statement = connection.prepareStatement(UPDATE_USER_COUNT_SQL)) {
             statement.setInt(1, userCount);
             statement.setInt(2, roomId);
             statement.executeUpdate();
         }
     }
 
+    void upsertCustomLayout(int roomId, String map, int doorX, int doorY, int doorDirection) throws SQLException {
+        try (Connection connection = this.database.openConnection();
+                PreparedStatement statement = connection.prepareStatement(UPSERT_CUSTOM_LAYOUT_SQL)) {
+            statement.setInt(1, roomId);
+            statement.setString(2, "custom_" + roomId);
+            statement.setInt(3, doorX);
+            statement.setInt(4, doorY);
+            statement.setInt(5, doorDirection);
+            statement.setString(6, map);
+            statement.setInt(7, doorX);
+            statement.setInt(8, doorY);
+            statement.setInt(9, doorDirection);
+            statement.setString(10, map);
+            statement.execute();
+        }
+    }
+
+    void recordEntry(int roomId, int userId, int timestamp) throws SQLException {
+        try (Connection connection = this.database.openConnection();
+                PreparedStatement statement = connection.prepareStatement(RECORD_ENTRY_SQL)) {
+            statement.setInt(1, roomId);
+            statement.setInt(2, userId);
+            statement.setInt(3, timestamp);
+            statement.execute();
+        }
+    }
+
+    void recordExit(int roomId, int userId, int timestamp) throws SQLException {
+        try (Connection connection = this.database.openConnection();
+                PreparedStatement statement = connection.prepareStatement(RECORD_EXIT_SQL)) {
+            statement.setInt(1, timestamp);
+            statement.setInt(2, userId);
+            statement.setInt(3, roomId);
+            statement.execute();
+        }
+    }
+
+    void recordVote(int roomId, int userId) throws SQLException {
+        try (Connection connection = this.database.openConnection();
+                PreparedStatement statement = connection.prepareStatement(RECORD_VOTE_SQL)) {
+            statement.setInt(1, userId);
+            statement.setInt(2, roomId);
+            statement.execute();
+        }
+    }
+
     record WiredSettings(int inspectMask, int modifyMask) {
 
         static WiredSettings defaults() {
-            return new WiredSettings(
-                    Room.WIRED_ACCESS_DEFAULT_INSPECT_MASK,
-                    Room.WIRED_ACCESS_DEFAULT_MODIFY_MASK);
+            return new WiredSettings(Room.WIRED_ACCESS_DEFAULT_INSPECT_MASK, Room.WIRED_ACCESS_DEFAULT_MODIFY_MASK);
         }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomSearchService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomSearchService.java
@@ -1,0 +1,142 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+final class RoomSearchService {
+
+    private final Supplier<? extends Collection<Room>> rooms;
+    private final LongSupplier nanoTime;
+    private final long ttlNanos;
+    private final Map<SearchKey, CacheEntry> cache = new ConcurrentHashMap<>();
+
+    RoomSearchService(Supplier<? extends Collection<Room>> rooms, Duration ttl) {
+        this(rooms, ttl, System::nanoTime);
+    }
+
+    RoomSearchService(Supplier<? extends Collection<Room>> rooms, Duration ttl, LongSupplier nanoTime) {
+        this.rooms = rooms;
+        this.ttlNanos = ttl.toNanos();
+        this.nanoTime = nanoTime;
+    }
+
+    Set<String> tags() {
+        return new TreeSet<>(this.cached(new SearchKey("tags", 0, false), () -> {
+            Set<String> tags = new TreeSet<>();
+            for (Room room : this.rooms.get()) {
+                Collections.addAll(tags, room.getTags().split(";"));
+            }
+            return List.copyOf(tags);
+        }));
+    }
+
+    ArrayList<Room> publicRooms() {
+        return new ArrayList<>(this.cached(new SearchKey("public", 0, false), () -> {
+            ArrayList<Room> result = new ArrayList<>();
+            for (Room room : this.rooms.get()) {
+                if (room.isPublicRoom()) {
+                    result.add(room);
+                }
+            }
+            result.sort(Room.SORT_ID);
+            return List.copyOf(result);
+        }));
+    }
+
+    ArrayList<Room> popularRooms(int count, boolean showPublicRooms) {
+        return new ArrayList<>(this.cached(new SearchKey("popular", count, showPublicRooms), () -> {
+            ArrayList<Room> result = new ArrayList<>();
+            for (Room room : this.rooms.get()) {
+                if (room.getUserCount() > 0 && (!room.isPublicRoom() || showPublicRooms)) {
+                    result.add(room);
+                }
+            }
+            Collections.sort(result);
+            return List.copyOf(result.subList(0, Math.min(result.size(), count)));
+        }));
+    }
+
+    ArrayList<Room> popularRooms(int count, int category) {
+        return new ArrayList<>(this.cached(new SearchKey("popular-category-" + category, count, false), () -> {
+            ArrayList<Room> result = new ArrayList<>();
+            for (Room room : this.rooms.get()) {
+                if (!room.isPublicRoom() && room.getCategory() == category) {
+                    result.add(room);
+                }
+            }
+            Collections.sort(result);
+            return List.copyOf(result.subList(0, Math.min(result.size(), count)));
+        }));
+    }
+
+    Map<Integer, List<Room>> popularRoomsByCategory(int count) {
+        Map<Integer, List<Room>> cached = this.cached(new SearchKey("popular-by-category", count, false), () -> {
+            Map<Integer, List<Room>> grouped = new HashMap<>();
+            for (Room room : this.rooms.get()) {
+                if (!room.isPublicRoom()) {
+                    grouped.computeIfAbsent(room.getCategory(), ignored -> new ArrayList<>())
+                            .add(room);
+                }
+            }
+
+            Map<Integer, List<Room>> result = new HashMap<>();
+            for (Map.Entry<Integer, List<Room>> entry : grouped.entrySet()) {
+                List<Room> rooms = entry.getValue();
+                Collections.sort(rooms);
+                result.put(entry.getKey(), List.copyOf(rooms.subList(0, Math.min(rooms.size(), count))));
+            }
+            return Map.copyOf(result);
+        });
+
+        Map<Integer, List<Room>> result = new HashMap<>();
+        cached.forEach((category, rooms) -> result.put(category, new ArrayList<>(rooms)));
+        return result;
+    }
+
+    ArrayList<Room> roomsWithTag(String tag) {
+        return new ArrayList<>(this.cached(new SearchKey("tag-" + tag.toLowerCase(), 0, false), () -> {
+            ArrayList<Room> result = new ArrayList<>();
+            for (Room room : this.rooms.get()) {
+                for (String roomTag : room.getTags().split(";")) {
+                    if (roomTag.equalsIgnoreCase(tag)) {
+                        result.add(room);
+                        break;
+                    }
+                }
+            }
+            Collections.sort(result);
+            return List.copyOf(result);
+        }));
+    }
+
+    void invalidate() {
+        this.cache.clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T cached(SearchKey key, Supplier<T> loader) {
+        long now = this.nanoTime.getAsLong();
+        CacheEntry existing = this.cache.get(key);
+        if (existing != null && now - existing.createdAtNanos() < this.ttlNanos) {
+            return (T) existing.value();
+        }
+
+        T value = loader.get();
+        this.cache.put(key, new CacheEntry(now, value));
+        return value;
+    }
+
+    private record SearchKey(String kind, int limit, boolean option) {}
+
+    private record CacheEntry(long createdAtNanos, Object value) {}
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomSearchService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomSearchService.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -104,7 +105,7 @@ final class RoomSearchService {
     }
 
     ArrayList<Room> roomsWithTag(String tag) {
-        return new ArrayList<>(this.cached(new SearchKey("tag-" + tag.toLowerCase(), 0, false), () -> {
+        return new ArrayList<>(this.cached(new SearchKey("tag-" + tag.toLowerCase(Locale.ROOT), 0, false), () -> {
             ArrayList<Room> result = new ArrayList<>();
             for (Room room : this.rooms.get()) {
                 for (String roomTag : room.getTags().split(";")) {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomDirectoryCharacterizationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomDirectoryCharacterizationTest.java
@@ -1,0 +1,45 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+class RoomDirectoryCharacterizationTest {
+
+    @Test
+    void registrationPreservesRoomIdentityForLegacyLookup() {
+        RoomManager manager = new RoomManager(false);
+        Room room = new Room(41, 7);
+
+        manager.registerActiveRoom(room);
+
+        assertSame(room, manager.getRoom(41));
+    }
+
+    @Test
+    void activeRoomListRemainsADetachedMutableSnapshot() {
+        RoomManager manager = new RoomManager(false);
+        Room room = new Room(41, 7);
+        manager.registerActiveRoom(room);
+
+        ArrayList<Room> snapshot = manager.getActiveRooms();
+        snapshot.clear();
+
+        assertEquals(0, snapshot.size());
+        assertSame(room, manager.getRoom(41));
+    }
+
+    @Test
+    void uncachingRemovesTheRoomFromLegacyLookup() {
+        RoomManager manager = new RoomManager(false);
+        Room room = new Room(41, 7);
+        manager.registerActiveRoom(room);
+
+        manager.uncacheRoom(room);
+
+        assertNull(manager.getRoom(41));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomEntryPolicyBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomEntryPolicyBehaviorTest.java
@@ -1,0 +1,118 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorMessagesComposer;
+import com.eu.habbo.messages.outgoing.hotelview.HotelViewComposer;
+import com.eu.habbo.messages.outgoing.rooms.RoomEnterErrorComposer;
+import com.eu.habbo.plugin.PluginManager;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RoomEntryPolicyBehaviorTest {
+
+    private PluginManager originalPlugins;
+
+    @BeforeEach
+    void installPlugins() throws Exception {
+        Field field = Emulator.class.getDeclaredField("pluginManager");
+        field.setAccessible(true);
+        this.originalPlugins = (PluginManager) field.get(null);
+        PluginManager plugins = mock(PluginManager.class);
+        doAnswer(invocation -> invocation.getArgument(0)).when(plugins).fireEvent(any());
+        field.set(null, plugins);
+    }
+
+    @AfterEach
+    void restorePlugins() throws Exception {
+        Field field = Emulator.class.getDeclaredField("pluginManager");
+        field.setAccessible(true);
+        field.set(null, this.originalPlugins);
+    }
+
+    @Test
+    void bannedUserIsRejectedBeforeRoomOpening() {
+        RecordingRoomManager manager = new RecordingRoomManager();
+        Room room = room(41, RoomState.OPEN);
+        Habbo habbo = habbo(41);
+        when(room.isBanned(habbo)).thenReturn(true);
+        manager.registerActiveRoom(room);
+
+        manager.enterRoom(habbo, 41, "");
+
+        verify(habbo.getClient()).sendResponse(any(RoomEnterErrorComposer.class));
+        assertSame(null, manager.openedRoom);
+    }
+
+    @Test
+    void wrongPasswordReturnsTheEstablishedErrorAndHotelView() {
+        RecordingRoomManager manager = new RecordingRoomManager();
+        Room room = room(41, RoomState.PASSWORD);
+        Habbo habbo = habbo(41);
+        when(room.getPassword()).thenReturn("secret");
+        manager.registerActiveRoom(room);
+
+        manager.enterRoom(habbo, 41, "wrong");
+
+        verify(habbo.getClient()).sendResponse(any(GenericErrorMessagesComposer.class));
+        verify(habbo.getClient()).sendResponse(any(HotelViewComposer.class));
+        assertSame(null, manager.openedRoom);
+    }
+
+    @Test
+    void openRoomPolicyPreservesTheRequestedSpawnInputs() {
+        RecordingRoomManager manager = new RecordingRoomManager();
+        Room room = room(41, RoomState.OPEN);
+        Habbo habbo = habbo(41);
+        RoomTile door = mock(RoomTile.class);
+        manager.registerActiveRoom(room);
+
+        manager.enterRoom(habbo, 41, "", false, door, true);
+
+        assertSame(room, manager.openedRoom);
+        assertSame(door, manager.openedDoor);
+    }
+
+    private static Room room(int id, RoomState state) {
+        Room room = mock(Room.class);
+        when(room.getId()).thenReturn(id);
+        when(room.getState()).thenReturn(state);
+        return room;
+    }
+
+    private static Habbo habbo(int queuedRoomId) {
+        Habbo habbo = mock(Habbo.class);
+        HabboInfo info = mock(HabboInfo.class);
+        GameClient client = mock(GameClient.class);
+        when(info.getRoomQueueId()).thenReturn(queuedRoomId);
+        when(habbo.getHabboInfo()).thenReturn(info);
+        when(habbo.getClient()).thenReturn(client);
+        return habbo;
+    }
+
+    private static final class RecordingRoomManager extends RoomManager {
+        private Room openedRoom;
+        private RoomTile openedDoor;
+
+        private RecordingRoomManager() {
+            super(false);
+        }
+
+        @Override
+        void openRoom(Habbo habbo, Room room, RoomTile doorLocation, boolean isReconnectSpawn) {
+            this.openedRoom = room;
+            this.openedDoor = doorLocation;
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomLifecycleBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomLifecycleBehaviorTest.java
@@ -1,0 +1,95 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.plugin.Event;
+import com.eu.habbo.plugin.PluginManager;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RoomLifecycleBehaviorTest {
+
+    private PluginManager originalPlugins;
+    private PluginManager plugins;
+
+    @BeforeEach
+    void installPlugins() throws Exception {
+        Field field = Emulator.class.getDeclaredField("pluginManager");
+        field.setAccessible(true);
+        this.originalPlugins = (PluginManager) field.get(null);
+        this.plugins = mock(PluginManager.class);
+        field.set(null, this.plugins);
+    }
+
+    @AfterEach
+    void restorePlugins() throws Exception {
+        Field field = Emulator.class.getDeclaredField("pluginManager");
+        field.setAccessible(true);
+        field.set(null, this.originalPlugins);
+    }
+
+    @Test
+    void cancelledUncacheEventRetainsTheRoomWithoutDisposal() {
+        RoomManager manager = new RoomManager(false);
+        TrackingRoom room = new TrackingRoom(41, 7);
+        manager.registerActiveRoom(room);
+        doAnswer(invocation -> {
+                    Event event = invocation.getArgument(0);
+                    event.setCancelled(true);
+                    return event;
+                })
+                .when(this.plugins)
+                .fireEvent(any());
+
+        manager.unloadRoomsForHabbo(owner(7));
+
+        assertSame(room, manager.getRoom(41));
+        assertEquals(0, room.disposeCalls);
+    }
+
+    @Test
+    void acceptedUncacheEventDisposesBeforeRemovingTheRoom() {
+        RoomManager manager = new RoomManager(false);
+        TrackingRoom room = new TrackingRoom(41, 7);
+        manager.registerActiveRoom(room);
+        doAnswer(invocation -> invocation.getArgument(0))
+                .when(this.plugins)
+                .fireEvent(any());
+
+        manager.unloadRoomsForHabbo(owner(7));
+
+        assertEquals(1, room.disposeCalls);
+        assertEquals(null, manager.getRoom(41));
+    }
+
+    private static Habbo owner(int id) {
+        Habbo habbo = mock(Habbo.class);
+        HabboInfo info = mock(HabboInfo.class);
+        when(info.getId()).thenReturn(id);
+        when(habbo.getHabboInfo()).thenReturn(info);
+        return habbo;
+    }
+
+    private static final class TrackingRoom extends Room {
+        private int disposeCalls;
+
+        private TrackingRoom(int id, int ownerId) {
+            super(id, ownerId);
+        }
+
+        @Override
+        public synchronized void dispose() {
+            this.disposeCalls++;
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomLifecycleBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomLifecycleBehaviorTest.java
@@ -62,9 +62,7 @@ class RoomLifecycleBehaviorTest {
         RoomManager manager = new RoomManager(false);
         TrackingRoom room = new TrackingRoom(41, 7);
         manager.registerActiveRoom(room);
-        doAnswer(invocation -> invocation.getArgument(0))
-                .when(this.plugins)
-                .fireEvent(any());
+        doAnswer(invocation -> invocation.getArgument(0)).when(this.plugins).fireEvent(any());
 
         manager.unloadRoomsForHabbo(owner(7));
 

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomManagerModerationContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomManagerModerationContractTest.java
@@ -1,20 +1,20 @@
 package com.eu.habbo.habbohotel.rooms;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class RoomManagerModerationContractTest {
     @Test
     void roomBanCannotTargetRoomOwner() throws Exception {
-        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java"));
+        String source =
+                Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/RoomModerationService.java"));
 
         int rightsGuard = source.indexOf("rights != null && !room.hasRights(rights)");
         int ownerGuard = source.indexOf("room.getOwnerId() == userId");
-        int banCreate = source.indexOf("new RoomBan(roomId, userId");
+        int banCreate = source.indexOf("new RoomBan(");
 
         assertTrue(rightsGuard > -1, "room bans must require rights");
         assertTrue(ownerGuard > rightsGuard, "room bans must guard owner targets after rights are checked");

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomManagerPersistenceBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomManagerPersistenceBehaviorTest.java
@@ -1,0 +1,72 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.habbohotel.users.HabboStats;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RoomManagerPersistenceBehaviorTest {
+
+    @Test
+    void customLayoutUpsertPreservesEveryCoordinateAndHeightmapParameter() throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource = new RoomJdbcTestSupport.RecordingDataSource();
+        try (RoomJdbcTestSupport.InstalledDatabase ignored = RoomJdbcTestSupport.install(dataSource)) {
+            RoomManager manager = new RoomManager(false);
+            Room room = mock(Room.class);
+            when(room.getId()).thenReturn(41);
+
+            manager.insertCustomLayout(room, "0\r00", 2, 3, 4);
+
+            RoomJdbcTestSupport.SqlCall insert = dataSource.calls().stream()
+                    .filter(call -> call.sql().startsWith("INSERT INTO room_models_custom"))
+                    .findFirst()
+                    .orElseThrow();
+            assertEquals(
+                    Map.of(
+                            1, 41,
+                            2, "custom_41",
+                            3, 2,
+                            4, 3,
+                            5, 4,
+                            6, "0\r00",
+                            7, 2,
+                            8, 3,
+                            9, 4,
+                            10, "0\r00"),
+                    insert.parameters());
+        }
+    }
+
+    @Test
+    void entryLoggingPersistsTheRoomAndUserBeforeRecordingTheVisit() throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource = new RoomJdbcTestSupport.RecordingDataSource();
+        try (RoomJdbcTestSupport.InstalledDatabase ignored = RoomJdbcTestSupport.install(dataSource)) {
+            RoomManager manager = new RoomManager(false);
+            Room room = mock(Room.class);
+            Habbo habbo = mock(Habbo.class);
+            HabboInfo info = mock(HabboInfo.class);
+            HabboStats stats = mock(HabboStats.class);
+            when(room.getId()).thenReturn(41);
+            when(info.getId()).thenReturn(8);
+            when(habbo.getHabboInfo()).thenReturn(info);
+            when(habbo.getHabboStats()).thenReturn(stats);
+
+            manager.logEnter(habbo, room);
+
+            assertEquals(
+                    List.of(Map.of(1, 41, 2, 8)),
+                    dataSource.calls().stream()
+                            .filter(call -> call.sql().startsWith("INSERT INTO room_enter_log"))
+                            .map(call -> Map.of(1, call.parameters().get(1), 2, call.parameters().get(2)))
+                            .toList());
+            verify(stats).addVisitRoom(41);
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomManagerPersistenceBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomManagerPersistenceBehaviorTest.java
@@ -64,7 +64,11 @@ class RoomManagerPersistenceBehaviorTest {
                     List.of(Map.of(1, 41, 2, 8)),
                     dataSource.calls().stream()
                             .filter(call -> call.sql().startsWith("INSERT INTO room_enter_log"))
-                            .map(call -> Map.of(1, call.parameters().get(1), 2, call.parameters().get(2)))
+                            .map(call -> Map.of(
+                                    1,
+                                    call.parameters().get(1),
+                                    2,
+                                    call.parameters().get(2)))
                             .toList());
             verify(stats).addVisitRoom(41);
         }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomModelRepositoryCharacterizationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomModelRepositoryCharacterizationTest.java
@@ -1,0 +1,93 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RoomModelRepositoryCharacterizationTest {
+
+    private ConfigurationManager originalConfig;
+
+    @TempDir
+    Path tempDirectory;
+
+    @BeforeEach
+    void installConfiguration() throws Exception {
+        Field field = Emulator.class.getDeclaredField("config");
+        field.setAccessible(true);
+        this.originalConfig = (ConfigurationManager) field.get(null);
+        Path config = this.tempDirectory.resolve("config.ini");
+        Files.writeString(config, "");
+        field.set(null, new ConfigurationManager(config.toString()));
+    }
+
+    @AfterEach
+    void restoreConfiguration() throws Exception {
+        Field field = Emulator.class.getDeclaredField("config");
+        field.setAccessible(true);
+        field.set(null, this.originalConfig);
+    }
+
+    @Test
+    void layoutNamesReflectTheLoadedModelCache() throws Exception {
+        RoomManager manager = new RoomManager(false);
+
+        assertFalse(manager.layoutExists("model_a"));
+        modelNames(manager).add("model_a");
+
+        assertTrue(manager.layoutExists("model_a"));
+    }
+
+    @Test
+    void cachedModelDataCreatesAnIndependentLayoutPerRoom() throws Exception {
+        RoomManager manager = new RoomManager(false);
+        layoutCache(manager).put("model_a", layoutData("model_a"));
+
+        RoomLayout first = manager.loadLayout("model_a", mock(Room.class));
+        RoomLayout second = manager.loadLayout("model_a", mock(Room.class));
+
+        assertNotSame(first, second);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> modelNames(RoomManager manager) throws Exception {
+        Field field = RoomManager.class.getDeclaredField("mapNames");
+        field.setAccessible(true);
+        return (List<String>) field.get(manager);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ConcurrentHashMap<String, RoomManager.RoomLayoutData> layoutCache(RoomManager manager)
+            throws Exception {
+        Field field = RoomManager.class.getDeclaredField("layoutCache");
+        field.setAccessible(true);
+        return (ConcurrentHashMap<String, RoomManager.RoomLayoutData>) field.get(manager);
+    }
+
+    private static RoomManager.RoomLayoutData layoutData(String name) throws Exception {
+        ResultSet row = (ResultSet) Proxy.newProxyInstance(
+                ResultSet.class.getClassLoader(),
+                new Class<?>[] {ResultSet.class},
+                (ignored, method, arguments) -> switch (method.getName()) {
+                    case "getString" -> "name".equals(arguments[0]) ? name : "0\r0";
+                    case "getInt" -> 0;
+                    default -> null;
+                });
+        return new RoomManager.RoomLayoutData(row);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomModerationBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomModerationBehaviorTest.java
@@ -1,0 +1,110 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.GameEnvironment;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.habbohotel.users.HabboManager;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RoomModerationBehaviorTest {
+
+    private GameEnvironment originalEnvironment;
+    private GameEnvironment environment;
+    private HabboManager habbos;
+
+    @BeforeEach
+    void installEnvironment() throws Exception {
+        Field field = Emulator.class.getDeclaredField("gameEnvironment");
+        field.setAccessible(true);
+        this.originalEnvironment = (GameEnvironment) field.get(null);
+        this.environment = mock(GameEnvironment.class);
+        this.habbos = mock(HabboManager.class);
+        when(this.environment.getHabboManager()).thenReturn(this.habbos);
+        field.set(null, this.environment);
+    }
+
+    @AfterEach
+    void restoreEnvironment() throws Exception {
+        Field field = Emulator.class.getDeclaredField("gameEnvironment");
+        field.setAccessible(true);
+        field.set(null, this.originalEnvironment);
+    }
+
+    @Test
+    void rejectsMissingRightsAndOwnerTargetsBeforeUserLookup() {
+        RoomManager manager = new RoomManager(false);
+        Room room = activeRoom(manager, 41, 7);
+        Habbo moderator = mock(Habbo.class);
+        when(room.hasRights(moderator)).thenReturn(false);
+
+        manager.banUserFromRoom(moderator, 8, 41, RoomManager.RoomBanTypes.RWUAM_BAN_USER_HOUR);
+        manager.banUserFromRoom(null, 7, 41, RoomManager.RoomBanTypes.RWUAM_BAN_USER_HOUR);
+
+        verify(this.environment, never()).getHabboManager();
+        verify(room, never()).addRoomBan(any());
+    }
+
+    @Test
+    void rejectsOnlineUnkickableUsersWithoutPersistingABan() {
+        RoomManager manager = new RoomManager(false);
+        Room room = activeRoom(manager, 41, 7);
+        Habbo target = onlineTarget(8, "protected");
+        when(target.hasPermission(Permission.ACC_UNKICKABLE)).thenReturn(true);
+
+        manager.banUserFromRoom(null, 8, 41, RoomManager.RoomBanTypes.RWUAM_BAN_USER_HOUR);
+
+        verify(room, never()).addRoomBan(any());
+    }
+
+    @Test
+    void persistsAndPublishesAnAuthorizedOnlineBan() throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource = new RoomJdbcTestSupport.RecordingDataSource();
+        try (RoomJdbcTestSupport.InstalledDatabase ignored = RoomJdbcTestSupport.install(dataSource)) {
+            RoomManager manager = new RoomManager(false);
+            Room room = activeRoom(manager, 41, 7);
+            onlineTarget(8, "target");
+
+            manager.banUserFromRoom(null, 8, 41, RoomManager.RoomBanTypes.RWUAM_BAN_USER_HOUR);
+
+            verify(room).addRoomBan(any(RoomBan.class));
+            assertEquals(
+                    List.of(Map.of(1, 41, 2, 8)),
+                    dataSource.calls().stream()
+                            .filter(call -> call.sql().startsWith("INSERT INTO room_bans"))
+                            .map(call -> Map.of(1, call.parameters().get(1), 2, call.parameters().get(2)))
+                            .toList());
+        }
+    }
+
+    private Room activeRoom(RoomManager manager, int id, int ownerId) {
+        Room room = mock(Room.class);
+        when(room.getId()).thenReturn(id);
+        when(room.getOwnerId()).thenReturn(ownerId);
+        manager.registerActiveRoom(room);
+        return room;
+    }
+
+    private Habbo onlineTarget(int id, String username) {
+        Habbo target = mock(Habbo.class);
+        HabboInfo info = mock(HabboInfo.class);
+        when(info.getId()).thenReturn(id);
+        when(info.getUsername()).thenReturn(username);
+        when(target.getHabboInfo()).thenReturn(info);
+        when(this.habbos.getHabbo(id)).thenReturn(target);
+        return target;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomModerationBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomModerationBehaviorTest.java
@@ -85,7 +85,11 @@ class RoomModerationBehaviorTest {
                     List.of(Map.of(1, 41, 2, 8)),
                     dataSource.calls().stream()
                             .filter(call -> call.sql().startsWith("INSERT INTO room_bans"))
-                            .map(call -> Map.of(1, call.parameters().get(1), 2, call.parameters().get(2)))
+                            .map(call -> Map.of(
+                                    1,
+                                    call.parameters().get(1),
+                                    2,
+                                    call.parameters().get(2)))
                             .toList());
         }
     }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomOwnerIndexTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomOwnerIndexTest.java
@@ -1,6 +1,9 @@
 package com.eu.habbo.habbohotel.rooms;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Proxy;
@@ -11,11 +14,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class RoomOwnerIndexTest {
 
@@ -95,20 +94,18 @@ class RoomOwnerIndexTest {
 
     @Test
     void unloadKeepsCancellationAndDisposalOrdering() throws Exception {
-        String source = Files.readString(Path.of(
-                "src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java"));
-        int unload = source.indexOf("public void unloadRoomsForHabbo");
+        String source =
+                Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/RoomLifecycleService.java"));
+        int unload = source.indexOf("void unloadRoomsFor");
         int selection = source.indexOf("roomsToUnloadForOwner(ownerId)", unload);
-        int callback = source.indexOf("fireEvent(new RoomUncachedEvent(room))", selection);
+        int callback = source.indexOf("this.uncacheAllowed.test(room)", selection);
         int disposal = source.indexOf("room.dispose()", callback);
-        int untrack = source.indexOf("this.untrackRoomOwner(room)", disposal);
-        int removal = source.indexOf("this.activeRooms.remove(room.getId())", untrack);
+        int removal = source.indexOf("this.remove(room)", disposal);
 
         assertTrue(unload >= 0 && unload < selection);
         assertTrue(selection < callback);
         assertTrue(callback < disposal);
-        assertTrue(disposal < untrack);
-        assertTrue(untrack < removal);
+        assertTrue(disposal < removal);
     }
 
     private static TestRoom eligibleRoom(int id, int ownerId) {
@@ -118,7 +115,7 @@ class RoomOwnerIndexTest {
     private static RoomCategory publicCategory() throws Exception {
         ResultSet row = (ResultSet) Proxy.newProxyInstance(
                 ResultSet.class.getClassLoader(),
-                new Class<?>[]{ResultSet.class},
+                new Class<?>[] {ResultSet.class},
                 (proxy, method, arguments) -> switch (method.getName()) {
                     case "getInt" -> 0;
                     case "getBoolean" -> false;

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSearchCharacterizationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSearchCharacterizationTest.java
@@ -1,0 +1,83 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class RoomSearchCharacterizationTest {
+
+    @Test
+    void tagsRemainSortedAndDeduplicatedAcrossActiveRooms() {
+        RoomManager manager = new RoomManager(false);
+        Room first = room(41, false, 0, "retro;polaris");
+        Room second = room(42, false, 0, "polaris;java");
+        manager.registerActiveRoom(first);
+        manager.registerActiveRoom(second);
+
+        assertEquals(List.of("java", "polaris", "retro"), List.copyOf(manager.getTags()));
+    }
+
+    @Test
+    void publicRoomsRemainSortedByDescendingRoomId() {
+        RoomManager manager = new RoomManager(false);
+        Room lower = room(41, true, 0, "");
+        Room higher = room(42, true, 0, "");
+        manager.registerActiveRoom(lower);
+        manager.registerActiveRoom(higher);
+
+        assertEquals(List.of(higher, lower), manager.getPublicRooms());
+    }
+
+    @Test
+    void popularRoomsExcludeEmptyAndPublicRoomsByDefault() {
+        RoomManager manager = new RoomManager(false);
+        TestRoom occupied = room(41, false, 1, "");
+        TestRoom empty = room(42, false, 0, "");
+        TestRoom publicRoom = room(43, true, 1, "");
+        manager.registerActiveRoom(occupied);
+        manager.registerActiveRoom(empty);
+        manager.registerActiveRoom(publicRoom);
+        boolean previous = RoomManager.SHOW_PUBLIC_IN_POPULAR_TAB;
+
+        try {
+            RoomManager.SHOW_PUBLIC_IN_POPULAR_TAB = false;
+            assertEquals(List.of(occupied), manager.getPopularRooms(10));
+        } finally {
+            RoomManager.SHOW_PUBLIC_IN_POPULAR_TAB = previous;
+        }
+    }
+
+    @Test
+    void tagSearchMatchesWholeTagsWithoutCaseSensitivity() {
+        RoomManager manager = new RoomManager(false);
+        Room matching = room(41, false, 0, "retro;polaris");
+        Room partial = room(42, false, 0, "retrospective");
+        manager.registerActiveRoom(matching);
+        manager.registerActiveRoom(partial);
+
+        assertEquals(Set.of(matching), Set.copyOf(manager.getRoomsWithTag("RETRO")));
+    }
+
+    private static TestRoom room(int id, boolean publicRoom, int users, String tags) {
+        TestRoom room = new TestRoom(id, users);
+        room.setPublicRoom(publicRoom);
+        room.setTags(tags);
+        return room;
+    }
+
+    private static final class TestRoom extends Room {
+        private final int users;
+
+        private TestRoom(int id, int users) {
+            super(id, 7);
+            this.users = users;
+        }
+
+        @Override
+        public int getUserCount() {
+            return this.users;
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSearchServiceCacheTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSearchServiceCacheTest.java
@@ -1,0 +1,66 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+class RoomSearchServiceCacheTest {
+
+    @Test
+    void popularSearchRefreshesAfterTheShortTtl() {
+        ArrayList<Room> rooms = new ArrayList<>();
+        AtomicLong time = new AtomicLong();
+        RoomSearchService service = new RoomSearchService(() -> rooms, Duration.ofSeconds(1), time::get);
+        Room first = occupiedRoom(41);
+        Room second = occupiedRoom(42);
+        rooms.add(first);
+
+        assertEquals(List.of(first), service.popularRooms(10, false));
+        rooms.add(second);
+        assertEquals(List.of(first), service.popularRooms(10, false));
+
+        time.addAndGet(Duration.ofSeconds(1).toNanos());
+
+        assertEquals(Set.of(first, second), Set.copyOf(service.popularRooms(10, false)));
+    }
+
+    @Test
+    void invalidationPublishesDirectoryChangesImmediately() {
+        ArrayList<Room> rooms = new ArrayList<>();
+        RoomSearchService service = new RoomSearchService(() -> rooms, Duration.ofSeconds(1), () -> 0);
+        Room first = occupiedRoom(41);
+        Room second = occupiedRoom(42);
+        rooms.add(first);
+        service.popularRooms(10, false);
+        rooms.add(second);
+
+        service.invalidate();
+
+        assertEquals(Set.of(first, second), Set.copyOf(service.popularRooms(10, false)));
+    }
+
+    @Test
+    void callersCannotMutateCachedLists() {
+        Room room = occupiedRoom(41);
+        RoomSearchService service = new RoomSearchService(() -> List.of(room), Duration.ofSeconds(1), () -> 0);
+
+        ArrayList<Room> result = service.popularRooms(10, false);
+        result.clear();
+
+        assertEquals(List.of(room), service.popularRooms(10, false));
+    }
+
+    private static Room occupiedRoom(int id) {
+        return new Room(id, 7) {
+            @Override
+            public int getUserCount() {
+                return 1;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Splits RoomManager internals into focused directory, search, entry policy, lifecycle, moderation, model, and persistence services while retaining the existing facade and behavior. Adds bounded navigator caching with explicit invalidation.

Manual testing:
- Enter open, password, and locked rooms and confirm the existing access responses.
- Browse public, popular, category, and tag navigator results.
- Leave and re-enter a room, then unload an inactive owned room.
- Ban a user from a room and confirm the existing permission protections.