### PR TITLE
feat(db): summarize integrity audit findings

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/database/indexing/DatabaseIndexAuditor.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/indexing/DatabaseIndexAuditor.java
@@ -49,7 +49,10 @@ public final class DatabaseIndexAuditor {
             }
             if (!report.redundantCandidates().isEmpty()) {
                 LOGGER.info(
-                        "Database indexes -> redundant candidates (never removed automatically): {}",
+                        "Database indexes -> {} redundant candidate(s) identified (never removed automatically; enable debug.mode to list them)",
+                        report.redundantCandidates().size());
+                LOGGER.debug(
+                        "Database indexes -> redundant candidates: {}",
                         report.redundantCandidates());
             }
         } catch (SQLException | RuntimeException error) {

--- a/Emulator/src/main/java/com/eu/habbo/database/integrity/DatabaseIntegrityAudit.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/integrity/DatabaseIntegrityAudit.java
@@ -1,16 +1,29 @@
 package com.eu.habbo.database.integrity;
 
 import com.eu.habbo.core.ConfigurationManager;
+import com.google.gson.Gson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Connection;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 
 public final class DatabaseIntegrityAudit {
     private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseIntegrityAudit.class);
+    private static final Gson GSON = new Gson();
+    private static final Path REPORT_PATH = Path.of("logging", "database-integrity-audit.json");
+    private static final int MAX_LOGGED_SAMPLES = 3;
 
     private DatabaseIntegrityAudit() {
     }
@@ -74,22 +87,116 @@ public final class DatabaseIntegrityAudit {
 
     private static void log(IntegrityAuditReport report, IntegrityAuditMode mode) {
         if (report.isHealthy()) {
+            clearReport(REPORT_PATH);
             LOGGER.info(
                     "Database integrity audit -> clean, relations={}, duplicates={}, durationMs={}, mode={}",
                     report.relationChecks(), report.duplicateChecks(), report.elapsedMillis(), mode);
             return;
         }
+        String reportNote = writeReport(report, REPORT_PATH) ? "; full report: " + REPORT_PATH : "";
+        int total = report.findings().size();
         LOGGER.warn(
-                "Database integrity audit -> findings={}, errors={}, affectedRows={}, durationMs={}, mode={}",
-                report.findings().size(), report.errors().size(), report.affectedRows(),
-                report.elapsedMillis(), mode);
-        report.findings().forEach(finding -> LOGGER.warn(
-                "Database integrity finding -> check={}, type={}, source={}, affectedRows={}, groups={}, samples={}, description={}",
-                finding.checkId(), finding.type(), finding.source(), finding.affectedRows(),
-                finding.groups(), finding.samples(), finding.description()));
+                "Database integrity audit -> {} finding(s) affecting {} row(s) ({} ms, mode {}){}",
+                total, report.affectedRows(), report.elapsedMillis(), mode, reportNote);
+        int index = 0;
+        for (IntegrityFinding finding : report.findings()) {
+            LOGGER.warn("{}", findingLine(++index, total, finding));
+            LOGGER.debug(
+                    "Database integrity finding detail -> check={}, type={}, source={}, affectedRows={}, groups={}, samples={}",
+                    finding.checkId(), finding.type(), finding.source(), finding.affectedRows(),
+                    finding.groups(), finding.samples());
+        }
         report.errors().forEach(error -> LOGGER.warn(
-                "Database integrity error -> check={}, error={}",
-                error.checkId(), error.message()));
+                "  audit error {}: {}", error.checkId(), error.message()));
+    }
+
+    static String findingLine(int index, int total, IntegrityFinding finding) {
+        StringBuilder line = new StringBuilder()
+                .append("  [").append(index).append('/').append(total).append("] ")
+                .append(finding.checkId())
+                .append(" (").append(finding.type().name().toLowerCase(Locale.ROOT)).append("): ")
+                .append(finding.affectedRows()).append(" rows - ")
+                .append(finding.description());
+        String samples = compactSamples(finding.samples());
+        if (!samples.isEmpty()) line.append("; e.g. ").append(samples);
+        return line.toString();
+    }
+
+    static String compactSamples(List<IntegritySample> samples) {
+        Map<String, Long> distinct = new LinkedHashMap<>();
+        for (IntegritySample sample : samples) {
+            StringBuilder values = new StringBuilder();
+            sample.values().forEach((column, value) -> {
+                if (!values.isEmpty()) values.append(' ');
+                values.append(column).append('=').append(value);
+            });
+            distinct.merge(values.toString(), sample.occurrences(), Long::max);
+        }
+        StringBuilder out = new StringBuilder();
+        int shown = 0;
+        for (Map.Entry<String, Long> entry : distinct.entrySet()) {
+            if (shown == MAX_LOGGED_SAMPLES) {
+                out.append("; ...");
+                break;
+            }
+            if (shown > 0) out.append("; ");
+            out.append(entry.getKey());
+            if (entry.getValue() > 1) out.append(" x").append(entry.getValue());
+            shown++;
+        }
+        return out.toString();
+    }
+
+    static boolean writeReport(IntegrityAuditReport report, Path path) {
+        try {
+            if (path.getParent() != null) Files.createDirectories(path.getParent());
+            Map<String, Object> document = new LinkedHashMap<>();
+            document.put("generatedAt", Instant.now().toString());
+            document.put("contractVersion", report.contractVersion());
+            document.put("durationMs", report.elapsedMillis());
+            document.put("affectedRows", report.affectedRows());
+            List<Map<String, Object>> findings = new ArrayList<>();
+            for (IntegrityFinding finding : report.findings()) {
+                Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("check", finding.checkId());
+                entry.put("type", finding.type().name());
+                entry.put("source", finding.source().name());
+                entry.put("affectedRows", finding.affectedRows());
+                entry.put("groups", finding.groups());
+                entry.put("description", finding.description());
+                List<Map<String, Object>> sampleEntries = new ArrayList<>();
+                for (IntegritySample sample : finding.samples()) {
+                    Map<String, Object> sampleEntry = new LinkedHashMap<>();
+                    sampleEntry.put("values", sample.values());
+                    sampleEntry.put("occurrences", sample.occurrences());
+                    sampleEntries.add(sampleEntry);
+                }
+                entry.put("samples", sampleEntries);
+                findings.add(entry);
+            }
+            document.put("findings", findings);
+            List<Map<String, String>> errors = new ArrayList<>();
+            for (IntegrityAuditError error : report.errors()) {
+                Map<String, String> entry = new LinkedHashMap<>();
+                entry.put("check", error.checkId());
+                entry.put("error", error.message());
+                errors.add(entry);
+            }
+            document.put("errors", errors);
+            Files.writeString(path, GSON.toJson(document) + System.lineSeparator(), StandardCharsets.UTF_8);
+            return true;
+        } catch (IOException | RuntimeException error) {
+            LOGGER.debug("Unable to write the database integrity report", error);
+            return false;
+        }
+    }
+
+    static void clearReport(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException error) {
+            LOGGER.debug("Unable to remove the previous database integrity report", error);
+        }
     }
 
     private static String bounded(Throwable error) {

--- a/Emulator/src/main/java/com/eu/habbo/database/integrity/DatabaseIntegrityAudit.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/integrity/DatabaseIntegrityAudit.java
@@ -128,7 +128,9 @@ public final class DatabaseIntegrityAudit {
             StringBuilder values = new StringBuilder();
             sample.values().forEach((column, value) -> {
                 if (!values.isEmpty()) values.append(' ');
-                values.append(column).append('=').append(value);
+                values.append(singleLine(column))
+                        .append('=')
+                        .append(singleLine(value));
             });
             distinct.merge(values.toString(), sample.occurrences(), Long::max);
         }
@@ -145,6 +147,15 @@ public final class DatabaseIntegrityAudit {
             shown++;
         }
         return out.toString();
+    }
+
+    private static String singleLine(String value) {
+        if (value == null) {
+            return "null";
+        }
+        return value.replace("\\", "\\\\")
+                .replace("\r", "\\r")
+                .replace("\n", "\\n");
     }
 
     static boolean writeReport(IntegrityAuditReport report, Path path) {
@@ -194,7 +205,7 @@ public final class DatabaseIntegrityAudit {
     static void clearReport(Path path) {
         try {
             Files.deleteIfExists(path);
-        } catch (IOException error) {
+        } catch (IOException | RuntimeException error) {
             LOGGER.debug("Unable to remove the previous database integrity report", error);
         }
     }

--- a/Emulator/src/test/java/com/eu/habbo/database/integrity/DatabaseIntegrityAuditLogFormatTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/integrity/DatabaseIntegrityAuditLogFormatTest.java
@@ -1,0 +1,112 @@
+package com.eu.habbo.database.integrity;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DatabaseIntegrityAuditLogFormatTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void findingLineIsCompactAndHumanReadable() {
+        IntegrityFinding finding = new IntegrityFinding(
+                "items.owner",
+                IntegrityFindingType.ORPHAN,
+                IntegrityCheckSource.LOGICAL_CONTRACT,
+                280,
+                280,
+                List.of(sample(Map.of("user_id", "5"), 1), sample(Map.of("user_id", "5"), 1)),
+                "Every item must retain an existing owner");
+
+        assertEquals(
+                "  [1/4] items.owner (orphan): 280 rows - Every item must retain an existing owner; e.g. user_id=5",
+                DatabaseIntegrityAudit.findingLine(1, 4, finding));
+    }
+
+    @Test
+    void identicalSamplesCollapseWithOccurrenceMultiplier() {
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put("user_id", "2");
+        values.put("badge_code", "ACH_PetRespectGiver3");
+
+        String compact = DatabaseIntegrityAudit.compactSamples(List.of(
+                sample(values, 12),
+                sample(values, 12)));
+
+        assertEquals("user_id=2 badge_code=ACH_PetRespectGiver3 x12", compact);
+    }
+
+    @Test
+    void atMostThreeDistinctSamplesAreListed() {
+        String compact = DatabaseIntegrityAudit.compactSamples(List.of(
+                sample(Map.of("room_id", "1"), 1),
+                sample(Map.of("room_id", "2"), 1),
+                sample(Map.of("room_id", "3"), 1),
+                sample(Map.of("room_id", "4"), 1)));
+
+        assertEquals("room_id=1; room_id=2; room_id=3; ...", compact);
+    }
+
+    @Test
+    void unhealthyReportIsWrittenAsJsonAndClearedAgain() throws Exception {
+        Path reportPath = tempDir.resolve("logging").resolve("database-integrity-audit.json");
+        IntegrityAuditReport report = new IntegrityAuditReport(
+                1, 10, 5, 39,
+                List.of(new IntegrityFinding(
+                        "items.owner",
+                        IntegrityFindingType.ORPHAN,
+                        IntegrityCheckSource.LOGICAL_CONTRACT,
+                        280,
+                        280,
+                        List.of(sample(Map.of("user_id", "5"), 1)),
+                        "Every item must retain an existing owner")),
+                List.of(new IntegrityAuditError("audit-startup", "boom")));
+
+        assertTrue(DatabaseIntegrityAudit.writeReport(report, reportPath));
+
+        String json = Files.readString(reportPath);
+        assertTrue(json.contains("\"check\":\"items.owner\""));
+        assertTrue(json.contains("\"type\":\"ORPHAN\""));
+        assertTrue(json.contains("\"user_id\":\"5\""));
+        assertTrue(json.contains("\"occurrences\":1"));
+        assertTrue(json.contains("Every item must retain an existing owner"));
+        assertTrue(json.contains("\"error\":\"boom\""));
+
+        DatabaseIntegrityAudit.clearReport(reportPath);
+        assertFalse(Files.exists(reportPath));
+    }
+
+    @Test
+    void unwritableReportPathNeverThrows() throws Exception {
+        Path blocking = tempDir.resolve("logging");
+        Files.writeString(blocking, "a plain file where the directory should be");
+        IntegrityAuditReport report = new IntegrityAuditReport(
+                1, 1, 1, 1,
+                List.of(new IntegrityFinding(
+                        "items.owner",
+                        IntegrityFindingType.ORPHAN,
+                        IntegrityCheckSource.LOGICAL_CONTRACT,
+                        1,
+                        1,
+                        List.of(sample(Map.of("user_id", "5"), 1)),
+                        "Every item must retain an existing owner")),
+                List.of());
+
+        assertFalse(DatabaseIntegrityAudit.writeReport(
+                report, blocking.resolve("database-integrity-audit.json")));
+    }
+
+    private static IntegritySample sample(Map<String, String> values, long occurrences) {
+        return new IntegritySample(values, occurrences);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/integrity/DatabaseIntegrityAuditLogFormatTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/integrity/DatabaseIntegrityAuditLogFormatTest.java
@@ -62,6 +62,7 @@ class DatabaseIntegrityAuditLogFormatTest {
         String compact = DatabaseIntegrityAudit.compactSamples(List.of(
                 sample(Map.of("username", "first\r\nforged warning"), 1)));
 
+        assertEquals("username=first\\r\\nforged warning", compact);
         assertFalse(compact.contains("\r"));
         assertFalse(compact.contains("\n"));
     }

--- a/Emulator/src/test/java/com/eu/habbo/database/integrity/DatabaseIntegrityAuditLogFormatTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/integrity/DatabaseIntegrityAuditLogFormatTest.java
@@ -58,6 +58,15 @@ class DatabaseIntegrityAuditLogFormatTest {
     }
 
     @Test
+    void sampleValuesCannotBreakTheSingleLineLogContract() {
+        String compact = DatabaseIntegrityAudit.compactSamples(List.of(
+                sample(Map.of("username", "first\r\nforged warning"), 1)));
+
+        assertFalse(compact.contains("\r"));
+        assertFalse(compact.contains("\n"));
+    }
+
+    @Test
     void unhealthyReportIsWrittenAsJsonAndClearedAgain() throws Exception {
         Path reportPath = tempDir.resolve("logging").resolve("database-integrity-audit.json");
         IntegrityAuditReport report = new IntegrityAuditReport(


### PR DESCRIPTION
Replaces verbose startup integrity findings with compact operator-facing summaries while retaining full details in logging/database-integrity-audit.json. Sample values are escaped to keep each finding on one line, stale reports are removed after a clean audit, and redundant index candidates move to DEBUG while the INFO count remains. Audit checks, WARN/STRICT enforcement, and public contracts are unchanged.