### PR TITLE
fix(config): isolate reload publication

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/core/ConfigurationManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/ConfigurationManager.java
@@ -1,19 +1,25 @@
 package com.eu.habbo.core;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.core.config.ConfigRegistry;
 import com.eu.habbo.plugin.events.emulator.EmulatorConfigUpdatedEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ConfigurationManager {
 
@@ -23,6 +29,7 @@ public class ConfigurationManager {
 
     private final Properties properties;
     private final Properties wiredProperties;
+    private final Set<String> dirtyKeys = ConcurrentHashMap.newKeySet();
     private final String configurationPath;
     public boolean loaded = false;
     public boolean isLoading = false;
@@ -38,6 +45,7 @@ public class ConfigurationManager {
         this.isLoading = true;
         this.properties.clear();
         this.wiredProperties.clear();
+        this.dirtyKeys.clear();
 
         InputStream input = null;
 
@@ -45,8 +53,7 @@ public class ConfigurationManager {
 
         boolean useEnvVarsForDbConnection = false;
 
-        if(envDbHostname != null)
-        {
+        if (envDbHostname != null) {
             useEnvVarsForDbConnection = envDbHostname.length() > 1;
         }
 
@@ -111,6 +118,13 @@ public class ConfigurationManager {
         }
 
         this.isLoading = false;
+        for (ConfigRegistry.ValidationIssue issue : ConfigRegistry.standard().validate(this)) {
+            LOGGER.error(
+                    "Invalid first-party configuration key {} with value '{}': {}",
+                    issue.key(),
+                    issue.value(),
+                    issue.reason());
+        }
         LOGGER.info("Configuration Manager -> Loaded!");
 
         if (Emulator.getPluginManager() != null) {
@@ -128,24 +142,21 @@ public class ConfigurationManager {
         LOGGER.info("Configuration -> loaded! ({} MS)", System.currentTimeMillis() - millis);
     }
 
-    public void saveToDatabase() {
-        this.saveSettingsTable(EMULATOR_SETTINGS_TABLE, this.properties);
-        this.saveSettingsTable(WIRED_SETTINGS_TABLE, this.wiredProperties);
+    public synchronized void saveToDatabase() {
+        this.saveSettingsTable(EMULATOR_SETTINGS_TABLE, this.properties, false);
+        this.saveSettingsTable(WIRED_SETTINGS_TABLE, this.wiredProperties, true);
     }
-
 
     public String getValue(String key) {
         return this.getValue(key, "", true);
     }
-
 
     public String getValue(String key, String defaultValue) {
         return this.getValue(key, defaultValue, false);
     }
 
     private String getValue(String key, String defaultValue, boolean logMissing) {
-        if (this.isLoading)
-            return defaultValue;
+        if (this.isLoading) return defaultValue;
 
         String value = this.getValueIfPresent(key);
         if (value != null) return value;
@@ -176,8 +187,7 @@ public class ConfigurationManager {
     }
 
     public boolean getBoolean(String key, boolean defaultValue) {
-        if (this.isLoading)
-            return defaultValue;
+        if (this.isLoading) return defaultValue;
 
         String value = this.getValueIfPresent(key);
         if (value == null) return defaultValue;
@@ -196,8 +206,7 @@ public class ConfigurationManager {
     }
 
     public int getInt(String key, Integer defaultValue) {
-        if (this.isLoading)
-            return defaultValue;
+        if (this.isLoading) return defaultValue;
 
         try {
             return Integer.parseInt(this.getValue(key, defaultValue.toString()));
@@ -212,8 +221,7 @@ public class ConfigurationManager {
     }
 
     public double getDouble(String key, Double defaultValue) {
-        if (this.isLoading)
-            return defaultValue;
+        if (this.isLoading) return defaultValue;
 
         try {
             return Double.parseDouble(this.getValue(key, defaultValue.toString()));
@@ -224,8 +232,9 @@ public class ConfigurationManager {
         return defaultValue;
     }
 
-    public void update(String key, String value) {
+    public synchronized void update(String key, String value) {
         this.resolveProperties(key).setProperty(key, value);
+        this.dirtyKeys.add(key);
     }
 
     public void register(String key, String value) {
@@ -235,8 +244,7 @@ public class ConfigurationManager {
     public void register(String key, String value, String comment) {
         Properties targetProperties = this.resolveProperties(key);
 
-        if (targetProperties.getProperty(key, null) != null)
-            return;
+        if (targetProperties.getProperty(key, null) != null) return;
 
         this.insertSetting(key, value, comment);
         this.update(key, value);
@@ -244,7 +252,7 @@ public class ConfigurationManager {
 
     private void loadSettingsTable(String tableName, Properties targetProperties, boolean optional) {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             Statement statement = connection.createStatement()) {
+                Statement statement = connection.createStatement()) {
             if (statement.execute("SELECT * FROM " + tableName)) {
                 try (ResultSet set = statement.getResultSet()) {
                     while (set.next()) {
@@ -261,15 +269,26 @@ public class ConfigurationManager {
         }
     }
 
-    private void saveSettingsTable(String tableName, Properties sourceProperties) {
+    private void saveSettingsTable(String tableName, Properties sourceProperties, boolean wired) {
+        Map<String, String> changes = new HashMap<>();
+        for (String key : this.dirtyKeys) {
+            if (this.isWiredSettingKey(key) == wired && sourceProperties.containsKey(key)) {
+                changes.put(key, sourceProperties.getProperty(key));
+            }
+        }
+        if (changes.isEmpty()) {
+            return;
+        }
+
         String sql = "UPDATE " + tableName + " SET `value` = ? WHERE `key` = ? LIMIT 1";
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement(sql)) {
-            for (Map.Entry<Object, Object> entry : sourceProperties.entrySet()) {
-                statement.setString(1, entry.getValue().toString());
-                statement.setString(2, entry.getKey().toString());
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            for (Map.Entry<String, String> entry : changes.entrySet()) {
+                statement.setString(1, entry.getValue());
+                statement.setString(2, entry.getKey());
                 statement.executeUpdate();
+                this.dirtyKeys.remove(entry.getKey());
             }
         } catch (SQLException e) {
             if (WIRED_SETTINGS_TABLE.equals(tableName)) {
@@ -287,7 +306,7 @@ public class ConfigurationManager {
                 : "INSERT INTO " + tableName + " (`key`, `value`) VALUES (?, ?)";
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement(sql)) {
+                PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, key);
             statement.setString(2, value);
 

--- a/Emulator/src/main/java/com/eu/habbo/core/config/ConfigKey.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/config/ConfigKey.java
@@ -1,0 +1,55 @@
+package com.eu.habbo.core.config;
+
+import java.util.List;
+
+public record ConfigKey(
+        String name,
+        ValueType type,
+        String defaultValue,
+        String environmentAlias,
+        Source source,
+        boolean restartRequired,
+        boolean liveReload,
+        List<String> deprecatedAliases,
+        String description) {
+
+    public ConfigKey {
+        deprecatedAliases = List.copyOf(deprecatedAliases);
+    }
+
+    public void validate(String value) {
+        switch (this.type) {
+            case BOOLEAN -> {
+                String normalized = value.trim().toLowerCase(java.util.Locale.ROOT);
+                if (!normalized.equals("true")
+                        && !normalized.equals("false")
+                        && !normalized.equals("1")
+                        && !normalized.equals("0")) {
+                    throw new IllegalArgumentException("expected true, false, 1, or 0");
+                }
+            }
+            case INTEGER -> Integer.parseInt(value.trim());
+            case LONG -> Long.parseLong(value.trim());
+            case DOUBLE -> Double.parseDouble(value.trim());
+            case STRING -> {
+                // Every string is valid; subsystem binders may impose a
+                // narrower domain validator.
+            }
+        }
+    }
+
+    public enum ValueType {
+        STRING,
+        BOOLEAN,
+        INTEGER,
+        LONG,
+        DOUBLE
+    }
+
+    public enum Source {
+        STARTUP,
+        DATABASE,
+        ENVIRONMENT,
+        PLUGIN
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/core/config/ConfigRegistry.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/config/ConfigRegistry.java
@@ -1,0 +1,242 @@
+package com.eu.habbo.core.config;
+
+import com.eu.habbo.core.ConfigurationManager;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class ConfigRegistry {
+
+    private static final ConfigRegistry STANDARD = new ConfigRegistry(standardDefinitions());
+    private final Map<String, ConfigKey> keys;
+
+    public ConfigRegistry(List<ConfigKey> definitions) {
+        Map<String, ConfigKey> indexed = new LinkedHashMap<>();
+        for (ConfigKey definition : definitions) {
+            if (indexed.putIfAbsent(definition.name(), definition) != null) {
+                throw new IllegalArgumentException("Duplicate configuration key " + definition.name());
+            }
+        }
+        this.keys = Map.copyOf(indexed);
+    }
+
+    public static ConfigRegistry standard() {
+        return STANDARD;
+    }
+
+    public Set<String> names() {
+        return this.keys.keySet();
+    }
+
+    public List<ValidationIssue> validate(ConfigurationManager configuration) {
+        List<ValidationIssue> issues = new ArrayList<>();
+        for (ConfigKey key : this.keys.values()) {
+            String value = configuration.getValueIfPresent(key.name());
+            if (value == null) {
+                continue;
+            }
+            try {
+                key.validate(value);
+            } catch (RuntimeException exception) {
+                issues.add(new ValidationIssue(key.name(), value, exception.getMessage()));
+            }
+        }
+        return List.copyOf(issues);
+    }
+
+    public String renderMarkdown() {
+        StringBuilder reference = new StringBuilder();
+        reference.append("# Polaris startup configuration reference\n\n");
+        reference.append(
+                "Unknown keys remain allowed for plugins. Database-backed hotel settings are documented separately from this startup-file registry.\n\n");
+        reference.append("| Key | Type | Default | Environment | Restart | Live reload | Description |\n");
+        reference.append("| --- | --- | --- | --- | --- | --- | --- |\n");
+        this.keys.values().stream()
+                .sorted(java.util.Comparator.comparing(ConfigKey::name))
+                .forEach(key -> reference
+                        .append("| `")
+                        .append(key.name())
+                        .append("` | ")
+                        .append(key.type().name().toLowerCase(java.util.Locale.ROOT))
+                        .append(" | `")
+                        .append(escape(key.defaultValue()))
+                        .append("` | ")
+                        .append(key.environmentAlias().isBlank() ? "—" : "`" + key.environmentAlias() + "`")
+                        .append(" | ")
+                        .append(key.restartRequired() ? "yes" : "no")
+                        .append(" | ")
+                        .append(key.liveReload() ? "yes" : "no")
+                        .append(" | ")
+                        .append(key.description())
+                        .append(" |\n"));
+        return reference.toString();
+    }
+
+    private static String escape(String value) {
+        return value.replace("|", "\\|").replace("`", "\\`");
+    }
+
+    private static List<ConfigKey> standardDefinitions() {
+        List<ConfigKey> keys = new ArrayList<>();
+        add(
+                keys,
+                ConfigKey.ValueType.STRING,
+                "",
+                true,
+                "db.hostname",
+                "db.database",
+                "db.username",
+                "db.password",
+                "db.params",
+                "db.migrations.backup.directory",
+                "db.migrations.backup.executable",
+                "game.host",
+                "rcon.host",
+                "rcon.allowed",
+                "enc.e",
+                "enc.n",
+                "enc.d",
+                "nitro.secure.config.root",
+                "nitro.secure.gamedata.root",
+                "nitro.secure.master_key",
+                "login.remember.jwt.secret",
+                "ws.host",
+                "ws.whitelist",
+                "client.release.allowed",
+                "habbo.console.style");
+        add(
+                keys,
+                ConfigKey.ValueType.INTEGER,
+                "0",
+                true,
+                "db.port",
+                "db.migrations.backup.keep",
+                "db.migrations.backup.timeout_seconds",
+                "db.pool.minsize",
+                "db.pool.maxsize",
+                "db.integrity.audit.sample_limit",
+                "db.integrity.audit.query_timeout_seconds",
+                "db.integrity.audit.max_duration_seconds",
+                "game.port",
+                "rcon.port",
+                "nitro.secure.session_ttl_sec",
+                "login.remember.duration.days",
+                "login.sso.ticket.ttl.seconds",
+                "login.news.limit",
+                "db.slow_query.threshold_ms",
+                "db.slow_query.max_sql_length",
+                "ws.port",
+                "session.reconnect.grace.seconds");
+        add(
+                keys,
+                ConfigKey.ValueType.LONG,
+                "0",
+                true,
+                "db.pool.connection_timeout_ms",
+                "db.pool.idle_timeout_ms",
+                "db.pool.max_lifetime_ms",
+                "db.pool.validation_timeout_ms",
+                "db.pool.leak_detection_ms");
+        add(
+                keys,
+                ConfigKey.ValueType.BOOLEAN,
+                "false",
+                true,
+                "db.migrate.on_startup",
+                "db.migrations.backup.enabled",
+                "enc.enabled",
+                "nitro.secure.assets.enabled",
+                "nitro.secure.api.enabled",
+                "login.remember.enabled",
+                "db.slow_query.enabled",
+                "ws.enabled",
+                "crypto.ws.enabled",
+                "e2e.enabled");
+        keys.add(definition("db.integrity.audit.mode", ConfigKey.ValueType.STRING, "warn", true));
+        return List.copyOf(keys);
+    }
+
+    private static void add(
+            List<ConfigKey> keys,
+            ConfigKey.ValueType type,
+            String defaultValue,
+            boolean restartRequired,
+            String... names) {
+        for (String name : names) {
+            keys.add(definition(name, type, defaultValue, restartRequired));
+        }
+    }
+
+    private static ConfigKey definition(
+            String name, ConfigKey.ValueType type, String defaultValue, boolean restartRequired) {
+        return new ConfigKey(
+                name,
+                type,
+                defaultValue,
+                environmentAlias(name),
+                ConfigKey.Source.STARTUP,
+                restartRequired,
+                false,
+                List.of(),
+                description(name));
+    }
+
+    private static String environmentAlias(String name) {
+        return switch (name) {
+            case "db.hostname" -> "DB_HOSTNAME";
+            case "db.port" -> "DB_PORT";
+            case "db.database" -> "DB_DATABASE";
+            case "db.username" -> "DB_USERNAME";
+            case "db.password" -> "DB_PASSWORD";
+            case "db.params" -> "DB_PARAMS";
+            case "db.migrate.on_startup" -> "DB_MIGRATE_ON_STARTUP";
+            case "game.host" -> "EMU_HOST";
+            case "game.port" -> "EMU_PORT";
+            case "rcon.host" -> "RCON_HOST";
+            case "rcon.port" -> "RCON_PORT";
+            case "rcon.allowed" -> "RCON_ALLOWED";
+            default -> "";
+        };
+    }
+
+    private static String description(String name) {
+        if (name.startsWith("db.pool.")) {
+            return "Database connection-pool setting.";
+        }
+        if (name.startsWith("db.migrations.")) {
+            return "Migration backup setting.";
+        }
+        if (name.startsWith("db.integrity.")) {
+            return "Startup integrity-audit setting.";
+        }
+        if (name.startsWith("db.slow_query.")) {
+            return "Sanitized slow-query diagnostic setting.";
+        }
+        if (name.startsWith("db.")) {
+            return "Database startup setting.";
+        }
+        if (name.startsWith("nitro.secure.")) {
+            return "Nitro secure-asset runtime setting.";
+        }
+        if (name.startsWith("login.")) {
+            return "Built-in login endpoint setting.";
+        }
+        if (name.startsWith("rcon.")) {
+            return "RCON listener setting.";
+        }
+        if (name.startsWith("game.")) {
+            return "Game listener setting.";
+        }
+        if (name.startsWith("ws.") || name.startsWith("crypto.ws.")) {
+            return "WebSocket listener setting.";
+        }
+        if (name.startsWith("enc.")) {
+            return "Legacy transport encryption setting.";
+        }
+        return "Polaris startup setting.";
+    }
+
+    public record ValidationIssue(String key, String value, String reason) {}
+}

--- a/Emulator/src/main/java/com/eu/habbo/core/config/ConfigurationBinder.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/config/ConfigurationBinder.java
@@ -1,0 +1,26 @@
+package com.eu.habbo.core.config;
+
+import com.eu.habbo.core.ConfigurationManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class ConfigurationBinder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationBinder.class);
+    protected final ConfigurationManager configuration;
+
+    protected ConfigurationBinder(ConfigurationManager configuration) {
+        this.configuration = configuration;
+    }
+
+    protected final void apply(String key, Runnable assignment) {
+        try {
+            assignment.run();
+        } catch (RuntimeException exception) {
+            LOGGER.error(
+                    "Configuration key {} was not applied; retaining the previous value: {}",
+                    key,
+                    exception.getMessage());
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/AchievementManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/AchievementManager.java
@@ -16,18 +16,21 @@ import com.eu.habbo.messages.outgoing.users.UserBadgesComposer;
 import com.eu.habbo.plugin.Event;
 import com.eu.habbo.plugin.events.users.achievements.UserAchievementLeveledEvent;
 import com.eu.habbo.plugin.events.users.achievements.UserAchievementProgressEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AchievementManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(AchievementManager.class);
 
-    public static boolean TALENTTRACK_ENABLED = false;
+    public static volatile boolean TALENTTRACK_ENABLED = false;
 
     private final Map<String, Achievement> achievements;
     private final Map<TalentTrackType, LinkedHashMap<Integer, TalentTrackLevel>> talentTrackLevels;
@@ -48,10 +51,11 @@ public class AchievementManager {
             if (habbo != null) {
                 progressAchievement(habbo, achievement, amount);
             } else {
-                try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                     PreparedStatement statement = connection.prepareStatement("" +
-                             "INSERT INTO users_achievements_queue (user_id, achievement_id, amount) VALUES (?, ?, ?) " +
-                             "ON DUPLICATE KEY UPDATE amount = amount + ?")) {
+                try (Connection connection =
+                                Emulator.getDatabase().getDataSource().getConnection();
+                        PreparedStatement statement = connection.prepareStatement(""
+                                + "INSERT INTO users_achievements_queue (user_id, achievement_id, amount) VALUES (?, ?, ?) "
+                                + "ON DUPLICATE KEY UPDATE amount = amount + ?")) {
                     statement.setInt(1, habboId);
                     statement.setInt(2, achievement.id);
                     statement.setInt(3, amount);
@@ -69,14 +73,11 @@ public class AchievementManager {
     }
 
     public static void progressAchievement(Habbo habbo, Achievement achievement, int amount) {
-        if (achievement == null)
-            return;
+        if (achievement == null) return;
 
-        if (habbo == null)
-            return;
+        if (habbo == null) return;
 
-        if (!habbo.isOnline())
-            return;
+        if (!habbo.isOnline()) return;
 
         int currentProgress = habbo.getHabboStats().getAchievementProgress(achievement);
 
@@ -90,14 +91,15 @@ public class AchievementManager {
             Event userAchievementProgressedEvent = new UserAchievementProgressEvent(habbo, achievement, amount);
             Emulator.getPluginManager().fireEvent(userAchievementProgressedEvent);
 
-            if (userAchievementProgressedEvent.isCancelled())
-                return;
+            if (userAchievementProgressedEvent.isCancelled()) return;
         }
 
         AchievementLevel oldLevel = achievement.getLevelForProgress(currentProgress);
 
-        if (oldLevel != null && (oldLevel.level == achievement.levels.size() && currentProgress >= oldLevel.progress)) //Maximum achievement gotten.
-            return;
+        if (oldLevel != null
+                && (oldLevel.level == achievement.levels.size()
+                        && currentProgress >= oldLevel.progress)) // Maximum achievement gotten.
+        return;
 
         int newProgress = habbo.getHabboStats().incrementProgress(achievement, amount);
 
@@ -105,10 +107,19 @@ public class AchievementManager {
 
         if (AchievementManager.TALENTTRACK_ENABLED) {
             for (TalentTrackType type : TalentTrackType.values()) {
-                if (Emulator.getGameEnvironment().getAchievementManager().talentTrackLevels.containsKey(type)) {
-                    for (Map.Entry<Integer, TalentTrackLevel> entry : Emulator.getGameEnvironment().getAchievementManager().talentTrackLevels.get(type).entrySet()) {
+                if (Emulator.getGameEnvironment()
+                        .getAchievementManager()
+                        .talentTrackLevels
+                        .containsKey(type)) {
+                    for (Map.Entry<Integer, TalentTrackLevel> entry : Emulator.getGameEnvironment()
+                            .getAchievementManager()
+                            .talentTrackLevels
+                            .get(type)
+                            .entrySet()) {
                         if (entry.getValue().achievements.containsKey(achievement)) {
-                            Emulator.getGameEnvironment().getAchievementManager().handleTalentTrackAchievement(habbo, type, achievement);
+                            Emulator.getGameEnvironment()
+                                    .getAchievementManager()
+                                    .handleTalentTrackAchievement(habbo, type, achievement);
                             break;
                         }
                     }
@@ -116,29 +127,32 @@ public class AchievementManager {
             }
         }
 
-        if (newLevel == null ||
-                (oldLevel != null && (oldLevel.level == newLevel.level && newLevel.level < achievement.levels.size()))) {
+        if (newLevel == null
+                || (oldLevel != null
+                        && (oldLevel.level == newLevel.level && newLevel.level < achievement.levels.size()))) {
             habbo.getClient().sendResponse(new AchievementProgressComposer(habbo, achievement));
         } else {
             if (Emulator.getPluginManager().isRegistered(UserAchievementLeveledEvent.class, true)) {
-                Event userAchievementLeveledEvent = new UserAchievementLeveledEvent(habbo, achievement, oldLevel, newLevel);
+                Event userAchievementLeveledEvent =
+                        new UserAchievementLeveledEvent(habbo, achievement, oldLevel, newLevel);
                 Emulator.getPluginManager().fireEvent(userAchievementLeveledEvent);
 
-                if (userAchievementLeveledEvent.isCancelled())
-                    return;
+                if (userAchievementLeveledEvent.isCancelled()) return;
             }
 
             habbo.getClient().sendResponse(new AchievementProgressComposer(habbo, achievement));
             habbo.getClient().sendResponse(new AchievementUnlockedComposer(habbo, achievement));
 
-            //Exception could possibly arise when the user disconnects while being in tour.
-            //The achievement is then progressed but the user is already disposed so fetching
-            //the badge would result in an nullpointer exception. This is normal behaviour.
+            // Exception could possibly arise when the user disconnects while being in tour.
+            // The achievement is then progressed but the user is already disposed so fetching
+            // the badge would result in an nullpointer exception. This is normal behaviour.
             HabboBadge badge = null;
 
             if (oldLevel != null) {
                 try {
-                    badge = habbo.getInventory().getBadgesComponent().getBadge(("ACH_" + achievement.name + oldLevel.level).toLowerCase());
+                    badge = habbo.getInventory()
+                            .getBadgesComponent()
+                            .getBadge(("ACH_" + achievement.name + oldLevel.level).toLowerCase());
                 } catch (Exception e) {
                     LOGGER.error("Caught exception", e);
                     return;
@@ -152,8 +166,7 @@ public class AchievementManager {
                 badge.needsInsert(false);
                 badge.needsUpdate(true);
             } else {
-                if (habbo.getInventory().getBadgesComponent().hasBadge(newBadgCode))
-                    return;
+                if (habbo.getInventory().getBadgesComponent().hasBadge(newBadgCode)) return;
 
                 badge = new HabboBadge(0, newBadgCode, 0, habbo);
                 habbo.getClient().sendResponse(new AddUserBadgeComposer(badge));
@@ -166,11 +179,20 @@ public class AchievementManager {
 
             if (badge.getSlot() > 0) {
                 if (habbo.getHabboInfo().getCurrentRoom() != null) {
-                    habbo.getHabboInfo().getCurrentRoom().sendComposer(new UserBadgesComposer(habbo.getInventory().getBadgesComponent().getWearingBadges(), habbo.getHabboInfo().getId()).compose());
+                    habbo.getHabboInfo()
+                            .getCurrentRoom()
+                            .sendComposer(new UserBadgesComposer(
+                                            habbo.getInventory()
+                                                    .getBadgesComponent()
+                                                    .getWearingBadges(),
+                                            habbo.getHabboInfo().getId())
+                                    .compose());
                 }
             }
 
-            habbo.getClient().sendResponse(new AddHabboItemComposer(badge.getId(), AddHabboItemComposer.AddHabboItemCategory.BADGE));
+            habbo.getClient()
+                    .sendResponse(
+                            new AddHabboItemComposer(badge.getId(), AddHabboItemComposer.AddHabboItemCategory.BADGE));
 
             habbo.getHabboStats().addAchievementScore(newLevel.points);
 
@@ -193,8 +215,7 @@ public class AchievementManager {
 
         AchievementLevel level = achievement.getLevelForProgress(currentProgress);
 
-        if (level == null)
-            return false;
+        if (level == null) return false;
 
         AchievementLevel nextLevel = achievement.levels.get(level.level + 1);
 
@@ -202,7 +223,9 @@ public class AchievementManager {
     }
 
     public static void createUserEntry(Habbo habbo, Achievement achievement) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO users_achievements (user_id, achievement_name, progress) VALUES (?, ?, ?)")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO users_achievements (user_id, achievement_name, progress) VALUES (?, ?, ?)")) {
             statement.setInt(1, habbo.getHabboInfo().getId());
             statement.setString(2, achievement.name);
             statement.setInt(3, 1);
@@ -213,9 +236,12 @@ public class AchievementManager {
     }
 
     public static void saveAchievements(Habbo habbo) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE users_achievements SET progress = ? WHERE achievement_name = ? AND user_id = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "UPDATE users_achievements SET progress = ? WHERE achievement_name = ? AND user_id = ? LIMIT 1")) {
             statement.setInt(3, habbo.getHabboInfo().getId());
-            for (Map.Entry<Achievement, Integer> map : habbo.getHabboStats().getAchievementProgress().entrySet()) {
+            for (Map.Entry<Achievement, Integer> map :
+                    habbo.getHabboStats().getAchievementProgress().entrySet()) {
                 statement.setInt(1, map.getValue());
                 statement.setString(2, map.getKey().name);
                 statement.addBatch();
@@ -231,7 +257,9 @@ public class AchievementManager {
             return 0;
         }
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT progress FROM users_achievements WHERE user_id = ? AND achievement_name = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT progress FROM users_achievements WHERE user_id = ? AND achievement_name = ? LIMIT 1")) {
             statement.setInt(1, userId);
             statement.setString(2, achievement.name);
             try (ResultSet set = statement.executeQuery()) {
@@ -254,7 +282,8 @@ public class AchievementManager {
             }
 
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
-                try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM achievements")) {
+                try (Statement statement = connection.createStatement();
+                        ResultSet set = statement.executeQuery("SELECT * FROM achievements")) {
                     while (set.next()) {
                         if (!this.achievements.containsKey(set.getString("name"))) {
                             this.achievements.put(set.getString("name"), new Achievement(set));
@@ -268,11 +297,12 @@ public class AchievementManager {
                     LOGGER.error("Caught exception", e);
                 }
 
-
                 synchronized (this.talentTrackLevels) {
                     this.talentTrackLevels.clear();
 
-                    try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM achievements_talents ORDER BY level ASC")) {
+                    try (Statement statement = connection.createStatement();
+                            ResultSet set =
+                                    statement.executeQuery("SELECT * FROM achievements_talents ORDER BY level ASC")) {
                         while (set.next()) {
                             TalentTrackLevel level = new TalentTrackLevel(set);
 
@@ -321,10 +351,13 @@ public class AchievementManager {
     public TalentTrackLevel calculateTalenTrackLevel(Habbo habbo, TalentTrackType type) {
         TalentTrackLevel level = null;
 
-        for (Map.Entry<Integer, TalentTrackLevel> entry : this.talentTrackLevels.get(type).entrySet()) {
+        for (Map.Entry<Integer, TalentTrackLevel> entry :
+                this.talentTrackLevels.get(type).entrySet()) {
             final boolean[] allCompleted = {true};
-            for (Map.Entry<Achievement, Integer> achievementEntry : entry.getValue().achievements.entrySet()) {
-                if (habbo.getHabboStats().getAchievementProgress(achievementEntry.getKey()) < achievementEntry.getValue()) {
+            for (Map.Entry<Achievement, Integer> achievementEntry :
+                    entry.getValue().achievements.entrySet()) {
+                if (habbo.getHabboStats().getAchievementProgress(achievementEntry.getKey())
+                        < achievementEntry.getValue()) {
                     allCompleted[0] = false;
                     break;
                 }
@@ -353,7 +386,9 @@ public class AchievementManager {
                     if (level != null) {
                         if (level.items != null && !level.items.isEmpty()) {
                             for (Item item : level.items) {
-                                HabboItem rewardItem = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getHabboInfo().getId(), item, 0, 0, "");
+                                HabboItem rewardItem = Emulator.getGameEnvironment()
+                                        .getItemManager()
+                                        .createItem(habbo.getHabboInfo().getId(), item, 0, 0, "");
                                 habbo.getInventory().getItemsComponent().addItem(rewardItem);
                                 habbo.getClient().sendResponse(new AddHabboItemComposer(rewardItem));
                                 habbo.getClient().sendResponse(new InventoryRefreshComposer());
@@ -363,10 +398,14 @@ public class AchievementManager {
                         if (level.badges != null && level.badges.length > 0) {
                             for (String badge : level.badges) {
                                 if (!badge.isEmpty()) {
-                                    if (!habbo.getInventory().getBadgesComponent().hasBadge(badge)) {
+                                    if (!habbo.getInventory()
+                                            .getBadgesComponent()
+                                            .hasBadge(badge)) {
                                         HabboBadge b = new HabboBadge(0, badge, 0, habbo);
                                         Emulator.getThreading().run(b);
-                                        habbo.getInventory().getBadgesComponent().addBadge(b);
+                                        habbo.getInventory()
+                                                .getBadgesComponent()
+                                                .addBadge(b);
                                         habbo.getClient().sendResponse(new AddUserBadgeComposer(b));
                                     }
                                 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/Bot.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/Bot.java
@@ -1,33 +1,41 @@
 package com.eu.habbo.habbohotel.bots;
 
 import com.eu.habbo.Emulator;
-import com.eu.habbo.habbohotel.rooms.*;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomChatMessage;
+import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
+import com.eu.habbo.habbohotel.rooms.RoomTile;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.rooms.RoomUserAction;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboGender;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
-import com.eu.habbo.messages.outgoing.rooms.users.*;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserActionComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserShoutComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserTalkComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserWhisperComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUsersComposer;
 import com.eu.habbo.plugin.events.bots.BotChatEvent;
 import com.eu.habbo.plugin.events.bots.BotShoutEvent;
 import com.eu.habbo.plugin.events.bots.BotTalkEvent;
 import com.eu.habbo.plugin.events.bots.BotWhisperEvent;
 import com.eu.habbo.threading.runnables.BotFollowHabbo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Bot implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(Bot.class);
 
     public static final String NO_CHAT_SET = "${bot.skill.chatter.configuration.text.placeholder}";
-    public static String[] PLACEMENT_MESSAGES = "Yo!;Hello I'm a real party animal!;Hello!".split(";");
-    public static boolean BOT_LIMIT_WALKING_DISTANCE = true;
-    public static int BOT_WALKING_DISTANCE_RADIUS = 5;
+    public static volatile String[] PLACEMENT_MESSAGES = "Yo!;Hello I'm a real party animal!;Hello!".split(";");
+    public static volatile boolean BOT_LIMIT_WALKING_DISTANCE = true;
+    public static volatile int BOT_WALKING_DISTANCE_RADIUS = 5;
 
     private final ArrayList<String> chatLines;
     private transient int id;
@@ -47,17 +55,13 @@ public class Bot implements Runnable {
     private int lastChatIndex;
     private int bubble;
 
-
     private final String type;
-
 
     private int effect;
 
     private transient boolean canWalk = true;
 
-
     private boolean needsUpdate;
-
 
     private transient int followingHabboId;
 
@@ -89,7 +93,8 @@ public class Bot implements Runnable {
         this.chatAuto = set.getString("chat_auto").equals("1");
         this.chatRandom = set.getString("chat_random").equals("1");
         this.chatDelay = set.getShort("chat_delay");
-        this.chatLines = new ArrayList<>(Arrays.asList(set.getString("chat_lines").split("\r")));
+        this.chatLines =
+                new ArrayList<>(Arrays.asList(set.getString("chat_lines").split("\r")));
         this.type = set.getString("type");
         this.effect = set.getInt("effect");
         this.canWalk = set.getString("freeroam").equals("1");
@@ -119,13 +124,9 @@ public class Bot implements Runnable {
         this.needsUpdate = false;
     }
 
-    public static void initialise() {
+    public static void initialise() {}
 
-    }
-
-    public static void dispose() {
-
-    }
+    public static void dispose() {}
 
     public void needsUpdate(boolean needsUpdate) {
         this.needsUpdate = needsUpdate;
@@ -140,7 +141,9 @@ public class Bot implements Runnable {
         if (this.needsUpdate) {
             Room localRoom = this.room;
             RoomUnit localRoomUnit = this.roomUnit;
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE bots SET name = ?, motto = ?, figure = ?, gender = ?, user_id = ?, room_id = ?, x = ?, y = ?, z = ?, rot = ?, dance = ?, freeroam = ?, chat_lines = ?, chat_auto = ?, chat_random = ?, chat_delay = ?, effect = ?, bubble_id = ? WHERE id = ?")) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    PreparedStatement statement = connection.prepareStatement(
+                            "UPDATE bots SET name = ?, motto = ?, figure = ?, gender = ?, user_id = ?, room_id = ?, x = ?, y = ?, z = ?, rot = ?, dance = ?, freeroam = ?, chat_lines = ?, chat_auto = ?, chat_random = ?, chat_delay = ?, effect = ?, bubble_id = ? WHERE id = ?")) {
                 statement.setString(1, this.name);
                 statement.setString(2, this.motto);
                 statement.setString(3, this.figure);
@@ -150,8 +153,14 @@ public class Bot implements Runnable {
                 statement.setInt(7, localRoomUnit == null ? 0 : localRoomUnit.getX());
                 statement.setInt(8, localRoomUnit == null ? 0 : localRoomUnit.getY());
                 statement.setDouble(9, localRoomUnit == null ? 0 : localRoomUnit.getZ());
-                statement.setInt(10, localRoomUnit == null ? 0 : localRoomUnit.getBodyRotation().getValue());
-                statement.setInt(11, localRoomUnit == null ? 0 : localRoomUnit.getDanceType().getType());
+                statement.setInt(
+                        10,
+                        localRoomUnit == null
+                                ? 0
+                                : localRoomUnit.getBodyRotation().getValue());
+                statement.setInt(
+                        11,
+                        localRoomUnit == null ? 0 : localRoomUnit.getDanceType().getType());
                 statement.setString(12, this.canWalk ? "1" : "0");
                 StringBuilder text = new StringBuilder();
                 for (String s : this.chatLines) {
@@ -180,11 +189,14 @@ public class Bot implements Runnable {
                         this.roomUnit.setGoalLocation(
                                 Bot.BOT_LIMIT_WALKING_DISTANCE
                                         ? this.room.getRandomWalkableTilesAround(
-                                        this.getRoomUnit(),
-                                        this.room.getLayout().getTile(this.roomUnit.getBotStartLocation().x, this.roomUnit.getBotStartLocation().y),
-                                        Bot.BOT_WALKING_DISTANCE_RADIUS)
-                                        : this.room.getRandomWalkableTile()
-                        );
+                                                this.getRoomUnit(),
+                                                this.room
+                                                        .getLayout()
+                                                        .getTile(
+                                                                this.roomUnit.getBotStartLocation().x,
+                                                                this.roomUnit.getBotStartLocation().y),
+                                                Bot.BOT_WALKING_DISTANCE_RADIUS)
+                                        : this.room.getRandomWalkableTile());
 
                         int timeOut = Emulator.getRandom().nextInt(20) * 2;
                         this.roomUnit.setWalkTimeOut((timeOut < 10 ? 5 : timeOut) + Emulator.getIntUnixTimestamp());
@@ -198,14 +210,23 @@ public class Bot implements Runnable {
                         this.lastChatIndex = 0;
                     }
 
-                    String message = this.chatLines.get(this.lastChatIndex)
-                            .replace(Emulator.getTexts().getValue("wired.variable.owner", "%owner%"), this.room.getOwnerName())
-                            .replace(Emulator.getTexts().getValue("wired.variable.item_count", "%item_count%"), this.room.itemCount() + "")
+                    String message = this.chatLines
+                            .get(this.lastChatIndex)
+                            .replace(
+                                    Emulator.getTexts().getValue("wired.variable.owner", "%owner%"),
+                                    this.room.getOwnerName())
+                            .replace(
+                                    Emulator.getTexts().getValue("wired.variable.item_count", "%item_count%"),
+                                    this.room.itemCount() + "")
                             .replace(Emulator.getTexts().getValue("wired.variable.name", "%name%"), this.name)
-                            .replace(Emulator.getTexts().getValue("wired.variable.roomname", "%roomname%"), this.room.getName())
-                            .replace(Emulator.getTexts().getValue("wired.variable.user_count", "%user_count%"), this.room.getUserCount() + "");
+                            .replace(
+                                    Emulator.getTexts().getValue("wired.variable.roomname", "%roomname%"),
+                                    this.room.getName())
+                            .replace(
+                                    Emulator.getTexts().getValue("wired.variable.user_count", "%user_count%"),
+                                    this.room.getUserCount() + "");
 
-                    if(!WiredManager.triggerUserSays(room, this.getRoomUnit(), message)) {
+                    if (!WiredManager.triggerUserSays(room, this.getRoomUnit(), message)) {
                         this.talk(message);
                     }
 
@@ -221,18 +242,18 @@ public class Bot implements Runnable {
                     this.chatTimeOut = Emulator.getIntUnixTimestamp() + this.chatDelay;
                 }
             }
-
         }
     }
 
     public void talk(String message) {
         if (this.room != null) {
             BotChatEvent event = new BotTalkEvent(this, message);
-            if (Emulator.getPluginManager().fireEvent(event).isCancelled())
-                return;
+            if (Emulator.getPluginManager().fireEvent(event).isCancelled()) return;
 
             this.chatTimestamp = Emulator.getIntUnixTimestamp();
-            this.room.botChat(new RoomUserTalkComposer(new RoomChatMessage(event.message, this.roomUnit, RoomChatMessageBubbles.getBubble(this.getBubbleId()))).compose());
+            this.room.botChat(new RoomUserTalkComposer(new RoomChatMessage(
+                            event.message, this.roomUnit, RoomChatMessageBubbles.getBubble(this.getBubbleId())))
+                    .compose());
 
             if (message.equals("o/") || message.equals("_o/")) {
                 this.room.sendComposer(new RoomUserActionComposer(this.roomUnit, RoomUserAction.WAVE).compose());
@@ -243,11 +264,12 @@ public class Bot implements Runnable {
     public void shout(String message) {
         if (this.room != null) {
             BotChatEvent event = new BotShoutEvent(this, message);
-            if (Emulator.getPluginManager().fireEvent(event).isCancelled())
-                return;
+            if (Emulator.getPluginManager().fireEvent(event).isCancelled()) return;
 
             this.chatTimestamp = Emulator.getIntUnixTimestamp();
-            this.room.botChat(new RoomUserShoutComposer(new RoomChatMessage(event.message, this.roomUnit, RoomChatMessageBubbles.getBubble(this.getBubbleId()))).compose());
+            this.room.botChat(new RoomUserShoutComposer(new RoomChatMessage(
+                            event.message, this.roomUnit, RoomChatMessageBubbles.getBubble(this.getBubbleId())))
+                    .compose());
 
             if (message.equals("o/") || message.equals("_o/")) {
                 this.room.sendComposer(new RoomUserActionComposer(this.roomUnit, RoomUserAction.WAVE).compose());
@@ -258,11 +280,13 @@ public class Bot implements Runnable {
     public void whisper(String message, Habbo habbo) {
         if (this.room != null && habbo != null) {
             BotWhisperEvent event = new BotWhisperEvent(this, message, habbo);
-            if (Emulator.getPluginManager().fireEvent(event).isCancelled())
-                return;
+            if (Emulator.getPluginManager().fireEvent(event).isCancelled()) return;
 
             this.chatTimestamp = Emulator.getIntUnixTimestamp();
-            event.target.getClient().sendResponse(new RoomUserWhisperComposer(new RoomChatMessage(event.message, this.roomUnit, RoomChatMessageBubbles.getBubble(this.getBubbleId()))));
+            event.target
+                    .getClient()
+                    .sendResponse(new RoomUserWhisperComposer(new RoomChatMessage(
+                            event.message, this.roomUnit, RoomChatMessageBubbles.getBubble(this.getBubbleId()))));
         }
     }
 
@@ -271,7 +295,7 @@ public class Bot implements Runnable {
             room.giveEffect(this.roomUnit, this.effect, -1);
         }
 
-        if(PLACEMENT_MESSAGES.length > 0) {
+        if (PLACEMENT_MESSAGES.length > 0) {
             String message = PLACEMENT_MESSAGES[Emulator.getRandom().nextInt(PLACEMENT_MESSAGES.length)];
             if (!WiredManager.triggerUserSays(room, this.getRoomUnit(), message)) {
                 this.talk(message);
@@ -283,9 +307,7 @@ public class Bot implements Runnable {
         this.stopFollowingHabbo();
     }
 
-    public void onUserSay(final RoomChatMessage message) {
-
-    }
+    public void onUserSay(final RoomChatMessage message) {}
 
     public int getId() {
         return this.id;
@@ -325,8 +347,7 @@ public class Bot implements Runnable {
         this.figure = figure;
         this.needsUpdate = true;
 
-        if (this.room != null)
-            this.room.sendComposer(new RoomUsersComposer(this).compose());
+        if (this.room != null) this.room.sendComposer(new RoomUsersComposer(this).compose());
     }
 
     public HabboGender getGender() {
@@ -337,8 +358,7 @@ public class Bot implements Runnable {
         this.gender = gender;
         this.needsUpdate = true;
 
-        if (this.room != null)
-            this.room.sendComposer(new RoomUsersComposer(this).compose());
+        if (this.room != null) this.room.sendComposer(new RoomUsersComposer(this).compose());
     }
 
     public int getOwnerId() {
@@ -349,8 +369,7 @@ public class Bot implements Runnable {
         this.ownerId = ownerId;
         this.needsUpdate = true;
 
-        if (this.room != null)
-            this.room.sendComposer(new RoomUsersComposer(this).compose());
+        if (this.room != null) this.room.sendComposer(new RoomUsersComposer(this).compose());
     }
 
     public String getOwnerName() {
@@ -361,8 +380,7 @@ public class Bot implements Runnable {
         this.ownerName = ownerName;
         this.needsUpdate = true;
 
-        if (this.room != null)
-            this.room.sendComposer(new RoomUsersComposer(this).compose());
+        if (this.room != null) this.room.sendComposer(new RoomUsersComposer(this).compose());
     }
 
     public Room getRoom() {
@@ -408,7 +426,8 @@ public class Bot implements Runnable {
     }
 
     public void setChatDelay(short chatDelay) {
-        this.chatDelay = (short) Math.min(Math.max(chatDelay, BotManager.MINIMUM_CHAT_SPEED), BotManager.MAXIMUM_CHAT_SPEED);
+        this.chatDelay =
+                (short) Math.min(Math.max(chatDelay, BotManager.MINIMUM_CHAT_SPEED), BotManager.MAXIMUM_CHAT_SPEED);
         this.needsUpdate = true;
         this.chatTimeOut = Emulator.getIntUnixTimestamp() + this.chatDelay;
     }
@@ -473,7 +492,8 @@ public class Bot implements Runnable {
     public void startFollowingHabbo(Habbo habbo) {
         this.followingHabboId = habbo.getHabboInfo().getId();
 
-        Emulator.getThreading().run(new BotFollowHabbo(this, habbo, habbo.getHabboInfo().getCurrentRoom()));
+        Emulator.getThreading()
+                .run(new BotFollowHabbo(this, habbo, habbo.getHabboInfo().getCurrentRoom()));
     }
 
     public void stopFollowingHabbo() {
@@ -502,7 +522,9 @@ public class Bot implements Runnable {
     }
 
     public void onPlaceUpdate() {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE bots SET name = ?, motto = ?, figure = ?, gender = ?, user_id = ?, room_id = ?, x = ?, y = ?, z = ?, rot = ?, dance = ?, freeroam = ?, chat_lines = ?, chat_auto = ?, chat_random = ?, chat_delay = ?, effect = ?, bubble_id = ? WHERE id = ?")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "UPDATE bots SET name = ?, motto = ?, figure = ?, gender = ?, user_id = ?, room_id = ?, x = ?, y = ?, z = ?, rot = ?, dance = ?, freeroam = ?, chat_lines = ?, chat_auto = ?, chat_random = ?, chat_delay = ?, effect = ?, bubble_id = ? WHERE id = ?")) {
             statement.setString(1, this.name);
             statement.setString(2, this.motto);
             statement.setString(3, this.figure);
@@ -512,8 +534,11 @@ public class Bot implements Runnable {
             statement.setInt(7, this.roomUnit == null ? 0 : this.roomUnit.getX());
             statement.setInt(8, this.roomUnit == null ? 0 : this.roomUnit.getY());
             statement.setDouble(9, this.roomUnit == null ? 0 : this.roomUnit.getZ());
-            statement.setInt(10, this.roomUnit == null ? 0 : this.roomUnit.getBodyRotation().getValue());
-            statement.setInt(11, this.roomUnit == null ? 0 : this.roomUnit.getDanceType().getType());
+            statement.setInt(
+                    10,
+                    this.roomUnit == null ? 0 : this.roomUnit.getBodyRotation().getValue());
+            statement.setInt(
+                    11, this.roomUnit == null ? 0 : this.roomUnit.getDanceType().getType());
             statement.setString(12, this.canWalk ? "1" : "0");
             StringBuilder text = new StringBuilder();
             for (String s : this.chatLines) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/BotManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/BotManager.java
@@ -2,7 +2,13 @@ package com.eu.habbo.habbohotel.bots;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.permissions.Permission;
-import com.eu.habbo.habbohotel.rooms.*;
+import com.eu.habbo.habbohotel.rooms.FurnitureMovementError;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomTile;
+import com.eu.habbo.habbohotel.rooms.RoomTileState;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.rooms.RoomUnitType;
+import com.eu.habbo.habbohotel.rooms.RoomUserRotation;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboInfo;
 import com.eu.habbo.habbohotel.users.HabboItem;
@@ -15,25 +21,26 @@ import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUsersComposer;
 import com.eu.habbo.plugin.events.bots.BotPickUpEvent;
 import com.eu.habbo.plugin.events.bots.BotPlacedEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.reflect.Method;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
-
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BotManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(BotManager.class);
 
-    final private static Map<String, Class<? extends Bot>> botDefenitions = new HashMap<>();
-    public static int MINIMUM_CHAT_SPEED = 7;
-    public static int MAXIMUM_CHAT_SPEED = 604800;
-    public static int MAXIMUM_CHAT_LENGTH = 120;
-    public static int MAXIMUM_NAME_LENGTH = 15;
-    public static int MAXIMUM_BOT_INVENTORY_SIZE = 25;
+    private static final Map<String, Class<? extends Bot>> botDefenitions = new HashMap<>();
+    public static volatile int MINIMUM_CHAT_SPEED = 7;
+    public static volatile int MAXIMUM_CHAT_SPEED = 604800;
+    public static volatile int MAXIMUM_CHAT_LENGTH = 120;
+    public static volatile int MAXIMUM_NAME_LENGTH = 15;
+    public static volatile int MAXIMUM_BOT_INVENTORY_SIZE = 25;
 
     public BotManager() throws Exception {
         long millis = System.currentTimeMillis();
@@ -60,10 +67,15 @@ public class BotManager {
                 m.setAccessible(true);
                 m.invoke(null);
             } catch (NoSuchMethodException e) {
-                LOGGER.info("Bot Manager -> Failed to execute initialise method upon bot type '{}'. No Such Method!", set.getKey());
+                LOGGER.info(
+                        "Bot Manager -> Failed to execute initialise method upon bot type '{}'. No Such Method!",
+                        set.getKey());
                 return false;
             } catch (Exception e) {
-                LOGGER.info("Bot Manager -> Failed to execute initialise method upon bot type '{}'. Error: {}", set.getKey(), e.getMessage());
+                LOGGER.info(
+                        "Bot Manager -> Failed to execute initialise method upon bot type '{}'. Error: {}",
+                        set.getKey(),
+                        e.getMessage());
                 return false;
             }
         }
@@ -89,11 +101,14 @@ public class BotManager {
         }
     }
 
-    public Bot createBot(Connection connection, Map<String, String> data, String type, int ownerId) throws SQLException {
+    public Bot createBot(Connection connection, Map<String, String> data, String type, int ownerId)
+            throws SQLException {
         if (ownerId <= 0) return null;
 
         Bot bot = null;
-        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO bots (user_id, room_id, name, motto, figure, gender, type) VALUES (?, 0, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO bots (user_id, room_id, name, motto, figure, gender, type) VALUES (?, 0, ?, ?, ?, ?, ?)",
+                Statement.RETURN_GENERATED_KEYS)) {
             statement.setInt(1, ownerId);
             statement.setString(2, data.get("name"));
             statement.setString(3, data.get("motto"));
@@ -103,7 +118,8 @@ public class BotManager {
             statement.execute();
             try (ResultSet set = statement.getGeneratedKeys()) {
                 if (set.next()) {
-                    try (PreparedStatement stmt = connection.prepareStatement("SELECT users.username AS owner_name, bots.* FROM bots LEFT JOIN users ON bots.user_id = users.id WHERE bots.id = ? LIMIT 1")) {
+                    try (PreparedStatement stmt = connection.prepareStatement(
+                            "SELECT users.username AS owner_name, bots.* FROM bots LEFT JOIN users ON bots.user_id = users.id WHERE bots.id = ? LIMIT 1")) {
                         stmt.setInt(1, set.getInt(1));
                         try (ResultSet resultSet = stmt.executeQuery()) {
                             if (resultSet.next()) {
@@ -122,21 +138,27 @@ public class BotManager {
         BotPlacedEvent event = new BotPlacedEvent(bot, location, habbo);
         Emulator.getPluginManager().fireEvent(event);
 
-        if (event.isCancelled())
-            return;
+        if (event.isCancelled()) return;
 
         if (room != null && bot != null && habbo != null) {
-            if (room.getOwnerId() == habbo.getHabboInfo().getId() || habbo.hasPermission(Permission.ACC_ANYROOMOWNER) || habbo.hasPermission(Permission.ACC_PLACEFURNI)) {
-                if (room.getCurrentBots().size() >= Room.MAXIMUM_BOTS && !habbo.hasPermission(Permission.ACC_UNLIMITED_BOTS)) {
+            if (room.getOwnerId() == habbo.getHabboInfo().getId()
+                    || habbo.hasPermission(Permission.ACC_ANYROOMOWNER)
+                    || habbo.hasPermission(Permission.ACC_PLACEFURNI)) {
+                if (room.getCurrentBots().size() >= Room.MAXIMUM_BOTS
+                        && !habbo.hasPermission(Permission.ACC_UNLIMITED_BOTS)) {
                     habbo.getClient().sendResponse(new BotErrorComposer(BotErrorComposer.ROOM_ERROR_MAX_BOTS));
                     return;
                 }
 
-                if (room.hasHabbosAt(location.x, location.y) || (!location.isWalkable() && location.state != RoomTileState.SIT && location.state != RoomTileState.LAY))
-                    return;
+                if (room.hasHabbosAt(location.x, location.y)
+                        || (!location.isWalkable()
+                                && location.state != RoomTileState.SIT
+                                && location.state != RoomTileState.LAY)) return;
 
                 if (room.hasBotsAt(location.x, location.y)) {
-                    habbo.getClient().sendResponse(new BotErrorComposer(BotErrorComposer.ROOM_ERROR_BOTS_SELECTED_TILE_NOT_FREE));
+                    habbo.getClient()
+                            .sendResponse(
+                                    new BotErrorComposer(BotErrorComposer.ROOM_ERROR_BOTS_SELECTED_TILE_NOT_FREE));
                     return;
                 }
 
@@ -174,7 +196,10 @@ public class BotManager {
 
                 bot.cycle(false);
             } else {
-                habbo.getClient().sendResponse(new BubbleAlertComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, FurnitureMovementError.NO_RIGHTS.errorCode));
+                habbo.getClient()
+                        .sendResponse(new BubbleAlertComposer(
+                                BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key,
+                                FurnitureMovementError.NO_RIGHTS.errorCode));
             }
         }
     }
@@ -196,16 +221,22 @@ public class BotManager {
             BotPickUpEvent pickedUpEvent = new BotPickUpEvent(bot, habbo);
             Emulator.getPluginManager().fireEvent(pickedUpEvent);
 
-            if (pickedUpEvent.isCancelled())
-                return;
+            if (pickedUpEvent.isCancelled()) return;
 
             Room currentRoom = habbo != null ? habbo.getHabboInfo().getCurrentRoom() : null;
             if (habbo == null
                     || bot.getOwnerId() == habbo.getHabboInfo().getId()
                     || habbo.hasPermission(Permission.ACC_ANYROOMOWNER)
-                    || (currentRoom != null && (currentRoom.getOwnerId() == habbo.getHabboInfo().getId() || habbo.hasPermission(Permission.ACC_PLACEFURNI)))) {
-                if (habbo != null && !habbo.hasPermission(Permission.ACC_UNLIMITED_BOTS) && habbo.getInventory().getBotsComponent().getBots().size() >= BotManager.MAXIMUM_BOT_INVENTORY_SIZE) {
-                    habbo.alert(Emulator.getTexts().getValue("error.bots.max.inventory").replace("%amount%", BotManager.MAXIMUM_BOT_INVENTORY_SIZE + ""));
+                    || (currentRoom != null
+                            && (currentRoom.getOwnerId() == habbo.getHabboInfo().getId()
+                                    || habbo.hasPermission(Permission.ACC_PLACEFURNI)))) {
+                if (habbo != null
+                        && !habbo.hasPermission(Permission.ACC_UNLIMITED_BOTS)
+                        && habbo.getInventory().getBotsComponent().getBots().size()
+                                >= BotManager.MAXIMUM_BOT_INVENTORY_SIZE) {
+                    habbo.alert(Emulator.getTexts()
+                            .getValue("error.bots.max.inventory")
+                            .replace("%amount%", BotManager.MAXIMUM_BOT_INVENTORY_SIZE + ""));
                     return;
                 }
 
@@ -217,7 +248,9 @@ public class BotManager {
                 bot.needsUpdate(true);
                 Emulator.getThreading().run(bot);
 
-                Habbo receiver = habbo == null ? Emulator.getGameEnvironment().getHabboManager().getHabbo(receiverInfo.getId()) : habbo;
+                Habbo receiver = habbo == null
+                        ? Emulator.getGameEnvironment().getHabboManager().getHabbo(receiverInfo.getId())
+                        : habbo;
                 if (receiver != null) {
                     receiver.getInventory().getBotsComponent().addBot(bot);
                     receiver.getClient().sendResponse(new AddBotComposer(bot));
@@ -241,8 +274,7 @@ public class BotManager {
 
             if (botClazz != null)
                 return botClazz.getDeclaredConstructor(ResultSet.class).newInstance(set);
-            else
-                LOGGER.error("Unknown Bot Type: {}", type);
+            else LOGGER.error("Unknown Bot Type: {}", type);
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
         } catch (Exception e) {
@@ -253,7 +285,8 @@ public class BotManager {
     }
 
     public boolean deleteBot(Bot bot) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("DELETE FROM bots WHERE id = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("DELETE FROM bots WHERE id = ? LIMIT 1")) {
             statement.setInt(1, bot.getId());
             return statement.execute();
         } catch (SQLException e) {
@@ -270,9 +303,14 @@ public class BotManager {
                 m.setAccessible(true);
                 m.invoke(null);
             } catch (NoSuchMethodException e) {
-                LOGGER.info("Bot Manager -> Failed to execute dispose method upon bot type '{}'. No Such Method!", set.getKey());
+                LOGGER.info(
+                        "Bot Manager -> Failed to execute dispose method upon bot type '{}'. No Such Method!",
+                        set.getKey());
             } catch (Exception e) {
-                LOGGER.info("Bot Manager -> Failed to execute dispose method upon bot type '{}'. Error: {}", set.getKey(), e.getMessage());
+                LOGGER.info(
+                        "Bot Manager -> Failed to execute dispose method upon bot type '{}'. Error: {}",
+                        set.getKey(),
+                        e.getMessage());
             }
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -3,14 +3,61 @@ package com.eu.habbo.habbohotel.catalog;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.achievements.AchievementManager;
 import com.eu.habbo.habbohotel.bots.Bot;
-import com.eu.habbo.habbohotel.catalog.layouts.*;
+import com.eu.habbo.habbohotel.catalog.layouts.BadgeDisplayLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.BotsLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.BuildersClubAddonsLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.BuildersClubFrontPageLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.BuildersClubLoyaltyLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.CatalogRootLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.ClubBuyLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.ClubGiftsLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.ColorGroupingLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.CustomPrefixLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.Default_3x3Layout;
+import com.eu.habbo.habbohotel.catalog.layouts.FrontPageFeaturedLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.FrontpageLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.GuildForumLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.GuildFrontpageLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.GuildFurnitureLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.InfoDucketsLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.InfoLoyaltyLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.InfoMonkeyLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.InfoNikoLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.InfoPetsLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.InfoRentablesLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.LoyaltyVipBuyLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.MadMoneyLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.MarketplaceLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.MarketplaceOwnItems;
+import com.eu.habbo.habbohotel.catalog.layouts.PetCustomizationLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.Pets2Layout;
+import com.eu.habbo.habbohotel.catalog.layouts.Pets3Layout;
+import com.eu.habbo.habbohotel.catalog.layouts.PetsLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.RecentPurchasesLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.RecyclerInfoLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.RecyclerLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.RecyclerPrizesLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.RoomAdsLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.RoomBundleLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.SingleBundle;
+import com.eu.habbo.habbohotel.catalog.layouts.SoldLTDItemsLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.SpacesLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.TraxLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.TrophiesLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.VipBuyLayout;
 import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.guilds.Guild;
 import com.eu.habbo.habbohotel.items.FurnitureType;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.SoundTrack;
-import com.eu.habbo.habbohotel.items.interactions.*;
+import com.eu.habbo.habbohotel.items.interactions.InteractionBadgeDisplay;
+import com.eu.habbo.habbohotel.items.interactions.InteractionGuildFurni;
+import com.eu.habbo.habbohotel.items.interactions.InteractionGuildGate;
+import com.eu.habbo.habbohotel.items.interactions.InteractionHopper;
+import com.eu.habbo.habbohotel.items.interactions.InteractionMusicDisc;
+import com.eu.habbo.habbohotel.items.interactions.InteractionTeleport;
+import com.eu.habbo.habbohotel.items.interactions.InteractionTrophy;
 import com.eu.habbo.habbohotel.modtool.ScripterManager;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.pets.Pet;
@@ -19,7 +66,14 @@ import com.eu.habbo.habbohotel.users.HabboBadge;
 import com.eu.habbo.habbohotel.users.HabboGender;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.users.inventory.EffectsComponent;
-import com.eu.habbo.messages.outgoing.catalog.*;
+import com.eu.habbo.messages.outgoing.catalog.AlertLimitedSoldOutComposer;
+import com.eu.habbo.messages.outgoing.catalog.AlertPurchaseFailedComposer;
+import com.eu.habbo.messages.outgoing.catalog.AlertPurchaseUnavailableComposer;
+import com.eu.habbo.messages.outgoing.catalog.DiscountComposer;
+import com.eu.habbo.messages.outgoing.catalog.PetBoughtNotificationComposer;
+import com.eu.habbo.messages.outgoing.catalog.PurchaseOKComposer;
+import com.eu.habbo.messages.outgoing.catalog.RedeemVoucherErrorComposer;
+import com.eu.habbo.messages.outgoing.catalog.RedeemVoucherOKComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.inventory.AddBotComposer;
@@ -40,156 +94,169 @@ import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.sql.*;
-import java.util.*;
-import java.util.stream.Collectors;
 
 public class CatalogManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogManager.class);
 
-    public static final Map<String, Class<? extends CatalogPage>> pageDefinitions = new HashMap<String, Class<? extends CatalogPage>>(CatalogPageLayouts.values().length) {
-        {
-            for (CatalogPageLayouts layout : CatalogPageLayouts.values()) {
-                switch (layout) {
-                    case frontpage:
-                        this.put(layout.name().toLowerCase(), FrontpageLayout.class);
-                        break;
-                    case badge_display:
-                        this.put(layout.name().toLowerCase(), BadgeDisplayLayout.class);
-                        break;
-                    case spaces_new:
-                        this.put(layout.name().toLowerCase(), SpacesLayout.class);
-                        break;
-                    case trophies:
-                        this.put(layout.name().toLowerCase(), TrophiesLayout.class);
-                        break;
-                    case bots:
-                        this.put(layout.name().toLowerCase(), BotsLayout.class);
-                        break;
-                    case club_buy:
-                        this.put(layout.name().toLowerCase(), ClubBuyLayout.class);
-                        break;
-                    case club_gift:
-                        this.put(layout.name().toLowerCase(), ClubGiftsLayout.class);
-                        break;
-                    case sold_ltd_items:
-                        this.put(layout.name().toLowerCase(), SoldLTDItemsLayout.class);
-                        break;
-                    case single_bundle:
-                        this.put(layout.name().toLowerCase(), SingleBundle.class);
-                        break;
-                    case roomads:
-                        this.put(layout.name().toLowerCase(), RoomAdsLayout.class);
-                        break;
-                    case recycler:
-                        if (Emulator.getConfig().getBoolean("hotel.ecotron.enabled"))
-                            this.put(layout.name().toLowerCase(), RecyclerLayout.class);
-                        break;
-                    case recycler_info:
-                        if (Emulator.getConfig().getBoolean("hotel.ecotron.enabled"))
-                            this.put(layout.name().toLowerCase(), RecyclerInfoLayout.class);
-                    case recycler_prizes:
-                        if (Emulator.getConfig().getBoolean("hotel.ecotron.enabled"))
-                            this.put(layout.name().toLowerCase(), RecyclerPrizesLayout.class);
-                        break;
-                    case marketplace:
-                        if (Emulator.getConfig().getBoolean("hotel.marketplace.enabled"))
-                            this.put(layout.name().toLowerCase(), MarketplaceLayout.class);
-                        break;
-                    case marketplace_own_items:
-                        if (Emulator.getConfig().getBoolean("hotel.marketplace.enabled"))
-                            this.put(layout.name().toLowerCase(), MarketplaceOwnItems.class);
-                        break;
-                    case info_duckets:
-                        this.put(layout.name().toLowerCase(), InfoDucketsLayout.class);
-                        break;
-                    case info_pets:
-                        this.put(layout.name().toLowerCase(), InfoPetsLayout.class);
-                        break;
-                    case info_rentables:
-                        this.put(layout.name().toLowerCase(), InfoRentablesLayout.class);
-                        break;
-                    case info_loyalty:
-                        this.put(layout.name().toLowerCase(), InfoLoyaltyLayout.class);
-                        break;
-                    case loyalty_vip_buy:
-                        this.put(layout.name().toLowerCase(), LoyaltyVipBuyLayout.class);
-                        break;
-                    case guilds:
-                        this.put(layout.name().toLowerCase(), GuildFrontpageLayout.class);
-                        break;
-                    case guild_furni:
-                        this.put(layout.name().toLowerCase(), GuildFurnitureLayout.class);
-                        break;
-                    case guild_forum:
-                        this.put(layout.name().toLowerCase(), GuildForumLayout.class);
-                        break;
-                    case pets:
-                        this.put(layout.name().toLowerCase(), PetsLayout.class);
-                        break;
-                    case pets2:
-                        this.put(layout.name().toLowerCase(), Pets2Layout.class);
-                        break;
-                    case pets3:
-                        this.put(layout.name().toLowerCase(), Pets3Layout.class);
-                        break;
-                    case soundmachine:
-                        this.put(layout.name().toLowerCase(), TraxLayout.class);
-                        break;
-                    case default_3x3_color_grouping:
-                        this.put(layout.name().toLowerCase(), ColorGroupingLayout.class);
-                        break;
-                    case recent_purchases:
-                        this.put(layout.name().toLowerCase(), RecentPurchasesLayout.class);
-                        break;
-                    case room_bundle:
-                        this.put(layout.name().toLowerCase(), RoomBundleLayout.class);
-                        break;
-                    case petcustomization:
-                        this.put(layout.name().toLowerCase(), PetCustomizationLayout.class);
-                        break;
-                    case vip_buy:
-                        this.put(layout.name().toLowerCase(), VipBuyLayout.class);
-                        break;
-                    case frontpage_featured:
-                        this.put(layout.name().toLowerCase(), FrontPageFeaturedLayout.class);
-                        break;
-                    case builders_club_addons:
-                        this.put(layout.name().toLowerCase(), BuildersClubAddonsLayout.class);
-                        break;
-                    case builders_club_frontpage:
-                        this.put(layout.name().toLowerCase(), BuildersClubFrontPageLayout.class);
-                        break;
-                    case builders_club_loyalty:
-                        this.put(layout.name().toLowerCase(), BuildersClubLoyaltyLayout.class);
-                        break;
-                    case monkey:
-                        this.put(layout.name().toLowerCase(), InfoMonkeyLayout.class);
-                        break;
-                    case niko:
-                        this.put(layout.name().toLowerCase(), InfoNikoLayout.class);
-                        break;
-                    case mad_money:
-                        this.put(layout.name().toLowerCase(), MadMoneyLayout.class);
-                        break;
-                    case custom_prefix:
-                        this.put(layout.name().toLowerCase(), CustomPrefixLayout.class);
-                        break;
-                    case default_3x3:
-                    default:
-                        this.put("default_3x3", Default_3x3Layout.class);
-                        break;
+    public static final Map<String, Class<? extends CatalogPage>> pageDefinitions =
+            new HashMap<String, Class<? extends CatalogPage>>(CatalogPageLayouts.values().length) {
+                {
+                    for (CatalogPageLayouts layout : CatalogPageLayouts.values()) {
+                        switch (layout) {
+                            case frontpage:
+                                this.put(layout.name().toLowerCase(), FrontpageLayout.class);
+                                break;
+                            case badge_display:
+                                this.put(layout.name().toLowerCase(), BadgeDisplayLayout.class);
+                                break;
+                            case spaces_new:
+                                this.put(layout.name().toLowerCase(), SpacesLayout.class);
+                                break;
+                            case trophies:
+                                this.put(layout.name().toLowerCase(), TrophiesLayout.class);
+                                break;
+                            case bots:
+                                this.put(layout.name().toLowerCase(), BotsLayout.class);
+                                break;
+                            case club_buy:
+                                this.put(layout.name().toLowerCase(), ClubBuyLayout.class);
+                                break;
+                            case club_gift:
+                                this.put(layout.name().toLowerCase(), ClubGiftsLayout.class);
+                                break;
+                            case sold_ltd_items:
+                                this.put(layout.name().toLowerCase(), SoldLTDItemsLayout.class);
+                                break;
+                            case single_bundle:
+                                this.put(layout.name().toLowerCase(), SingleBundle.class);
+                                break;
+                            case roomads:
+                                this.put(layout.name().toLowerCase(), RoomAdsLayout.class);
+                                break;
+                            case recycler:
+                                if (Emulator.getConfig().getBoolean("hotel.ecotron.enabled"))
+                                    this.put(layout.name().toLowerCase(), RecyclerLayout.class);
+                                break;
+                            case recycler_info:
+                                if (Emulator.getConfig().getBoolean("hotel.ecotron.enabled"))
+                                    this.put(layout.name().toLowerCase(), RecyclerInfoLayout.class);
+                            case recycler_prizes:
+                                if (Emulator.getConfig().getBoolean("hotel.ecotron.enabled"))
+                                    this.put(layout.name().toLowerCase(), RecyclerPrizesLayout.class);
+                                break;
+                            case marketplace:
+                                if (Emulator.getConfig().getBoolean("hotel.marketplace.enabled"))
+                                    this.put(layout.name().toLowerCase(), MarketplaceLayout.class);
+                                break;
+                            case marketplace_own_items:
+                                if (Emulator.getConfig().getBoolean("hotel.marketplace.enabled"))
+                                    this.put(layout.name().toLowerCase(), MarketplaceOwnItems.class);
+                                break;
+                            case info_duckets:
+                                this.put(layout.name().toLowerCase(), InfoDucketsLayout.class);
+                                break;
+                            case info_pets:
+                                this.put(layout.name().toLowerCase(), InfoPetsLayout.class);
+                                break;
+                            case info_rentables:
+                                this.put(layout.name().toLowerCase(), InfoRentablesLayout.class);
+                                break;
+                            case info_loyalty:
+                                this.put(layout.name().toLowerCase(), InfoLoyaltyLayout.class);
+                                break;
+                            case loyalty_vip_buy:
+                                this.put(layout.name().toLowerCase(), LoyaltyVipBuyLayout.class);
+                                break;
+                            case guilds:
+                                this.put(layout.name().toLowerCase(), GuildFrontpageLayout.class);
+                                break;
+                            case guild_furni:
+                                this.put(layout.name().toLowerCase(), GuildFurnitureLayout.class);
+                                break;
+                            case guild_forum:
+                                this.put(layout.name().toLowerCase(), GuildForumLayout.class);
+                                break;
+                            case pets:
+                                this.put(layout.name().toLowerCase(), PetsLayout.class);
+                                break;
+                            case pets2:
+                                this.put(layout.name().toLowerCase(), Pets2Layout.class);
+                                break;
+                            case pets3:
+                                this.put(layout.name().toLowerCase(), Pets3Layout.class);
+                                break;
+                            case soundmachine:
+                                this.put(layout.name().toLowerCase(), TraxLayout.class);
+                                break;
+                            case default_3x3_color_grouping:
+                                this.put(layout.name().toLowerCase(), ColorGroupingLayout.class);
+                                break;
+                            case recent_purchases:
+                                this.put(layout.name().toLowerCase(), RecentPurchasesLayout.class);
+                                break;
+                            case room_bundle:
+                                this.put(layout.name().toLowerCase(), RoomBundleLayout.class);
+                                break;
+                            case petcustomization:
+                                this.put(layout.name().toLowerCase(), PetCustomizationLayout.class);
+                                break;
+                            case vip_buy:
+                                this.put(layout.name().toLowerCase(), VipBuyLayout.class);
+                                break;
+                            case frontpage_featured:
+                                this.put(layout.name().toLowerCase(), FrontPageFeaturedLayout.class);
+                                break;
+                            case builders_club_addons:
+                                this.put(layout.name().toLowerCase(), BuildersClubAddonsLayout.class);
+                                break;
+                            case builders_club_frontpage:
+                                this.put(layout.name().toLowerCase(), BuildersClubFrontPageLayout.class);
+                                break;
+                            case builders_club_loyalty:
+                                this.put(layout.name().toLowerCase(), BuildersClubLoyaltyLayout.class);
+                                break;
+                            case monkey:
+                                this.put(layout.name().toLowerCase(), InfoMonkeyLayout.class);
+                                break;
+                            case niko:
+                                this.put(layout.name().toLowerCase(), InfoNikoLayout.class);
+                                break;
+                            case mad_money:
+                                this.put(layout.name().toLowerCase(), MadMoneyLayout.class);
+                                break;
+                            case custom_prefix:
+                                this.put(layout.name().toLowerCase(), CustomPrefixLayout.class);
+                                break;
+                            case default_3x3:
+                            default:
+                                this.put("default_3x3", Default_3x3Layout.class);
+                                break;
+                        }
+                    }
                 }
-            }
-        }
-    };
+            };
     public static int catalogItemAmount;
-    public static int PURCHASE_COOLDOWN = 1;
-    public static boolean SORT_USING_ORDERNUM = false;
+    public static volatile int PURCHASE_COOLDOWN = 1;
+    public static volatile boolean SORT_USING_ORDERNUM = false;
     public final Int2ObjectMap<CatalogPage> catalogPages;
     public final Int2ObjectMap<CatalogPage> buildersClubCatalogPages;
     public final Int2ObjectMap<CatalogFeaturedPage> catalogFeaturedPages;
@@ -233,7 +300,6 @@ public class CatalogManager {
         LOGGER.info("Catalog Manager -> Loaded! ({} MS)", System.currentTimeMillis() - millis);
     }
 
-
     public synchronized void initialize() {
         Emulator.getPluginManager().fireEvent(new EmulatorLoadCatalogManagerEvent());
 
@@ -258,31 +324,27 @@ public class CatalogManager {
 
         for (CatalogPage page : this.catalogPages.values()) {
             for (CatalogItem catalogItem : page.getCatalogItems().values()) {
-                if (catalogItem.getAmount() != 1)
-                    continue;
+                if (catalogItem.getAmount() != 1) continue;
 
                 int credits = catalogItem.getCredits();
                 int points = catalogItem.getPoints();
                 int pointsType = catalogItem.getPointsType();
 
-                if (points <= 0 || pointsType != diamondType)
-                    continue;
+                if (points <= 0 || pointsType != diamondType) continue;
 
                 Set<Item> baseItems = catalogItem.getBaseItems();
 
-                if (baseItems.size() != 1)
-                    continue;
+                if (baseItems.size() != 1) continue;
 
                 for (Item item : baseItems) {
                     FurnitureType type = item.getType();
 
-                    if (type != FurnitureType.FLOOR && type != FurnitureType.WALL)
-                        continue;
+                    if (type != FurnitureType.FLOOR && type != FurnitureType.WALL) continue;
 
                     int spriteId = item.getSpriteId();
 
                     if (spriteId > 0 && !this.furnitureValues.containsKey(spriteId)) {
-                        this.furnitureValues.put(spriteId, new int[]{credits, points, pointsType});
+                        this.furnitureValues.put(spriteId, new int[] {credits, points, pointsType});
                     }
                 }
             }
@@ -294,15 +356,16 @@ public class CatalogManager {
     }
 
     private void rebuildRareValuesPayloadCache() {
-        try (java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream(this.furnitureValues.size() * 16 + 8);
-             java.io.DataOutputStream out = new java.io.DataOutputStream(baos)) {
+        try (java.io.ByteArrayOutputStream baos =
+                        new java.io.ByteArrayOutputStream(this.furnitureValues.size() * 16 + 8);
+                java.io.DataOutputStream out = new java.io.DataOutputStream(baos)) {
             out.writeInt(this.furnitureValues.size());
             for (Int2ObjectMap.Entry<int[]> entry : this.furnitureValues.int2ObjectEntrySet()) {
                 int[] value = entry.getValue();
                 out.writeInt(entry.getIntKey()); // spriteId
-                out.writeInt(value[0]);        // credits
-                out.writeInt(value[1]);        // points
-                out.writeInt(value[2]);        // pointsType
+                out.writeInt(value[0]); // credits
+                out.writeInt(value[1]); // points
+                out.writeInt(value[2]); // pointsType
             }
             this.rareValuesPayloadCache = baos.toByteArray();
         } catch (java.io.IOException e) {
@@ -324,7 +387,8 @@ public class CatalogManager {
 
         Map<Integer, LinkedList<Integer>> limiteds = new HashMap<>();
         Int2IntMap totals = new Int2IntOpenHashMap();
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM catalog_items_limited")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT * FROM catalog_items_limited")) {
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
                     if (!limiteds.containsKey(set.getInt("catalog_item_id"))) {
@@ -344,17 +408,20 @@ public class CatalogManager {
         }
 
         for (Map.Entry<Integer, LinkedList<Integer>> set : limiteds.entrySet()) {
-            this.limitedNumbers.put(set.getKey(), new CatalogLimitedConfiguration(set.getKey(), set.getValue(), totals.get(set.getKey())));
+            this.limitedNumbers.put(
+                    set.getKey(),
+                    new CatalogLimitedConfiguration(set.getKey(), set.getValue(), totals.get(set.getKey())));
         }
     }
-
 
     private synchronized void loadCatalogPages() {
         this.catalogPages.clear();
 
         final Map<Integer, CatalogPage> pages = new HashMap<>();
         pages.put(-1, new CatalogRootLayout());
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM catalog_pages ORDER BY parent_id, id")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("SELECT * FROM catalog_pages ORDER BY parent_id, id")) {
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
                     Class<? extends CatalogPage> pageClazz = pageDefinitions.get(set.getString("page_layout"));
@@ -365,7 +432,8 @@ public class CatalogManager {
                     }
 
                     try {
-                        CatalogPage page = pageClazz.getConstructor(ResultSet.class).newInstance(set);
+                        CatalogPage page =
+                                pageClazz.getConstructor(ResultSet.class).newInstance(set);
                         pages.put(page.getId(), page);
                     } catch (Exception e) {
                         LOGGER.error("Failed to load layout: {}", set.getString("page_layout"));
@@ -385,7 +453,11 @@ public class CatalogManager {
                 }
             } else {
                 if (object.parentId != -2) {
-                    LOGGER.info("Parent Page not found for {} (ID: {}, parent_id: {})", object.getPageName(), object.id, object.parentId);
+                    LOGGER.info(
+                            "Parent Page not found for {} (ID: {}, parent_id: {})",
+                            object.getPageName(),
+                            object.id,
+                            object.parentId);
                 }
             }
         }
@@ -401,10 +473,11 @@ public class CatalogManager {
         final Map<Integer, CatalogPage> pages = new HashMap<>();
         pages.put(-1, new CatalogRootLayout());
 
-        String query = "SELECT id, parent_id, caption, caption AS caption_save, page_layout, icon_color, icon_image, 1 AS min_rank, order_num, visible, enabled, '0' AS club_only, 'BUILDERS_CLUB' AS catalog_mode, page_headline, page_teaser, page_special, page_text1, page_text2, page_text_details, page_text_teaser, '' AS includes FROM catalog_pages_bc ORDER BY parent_id, id";
+        String query =
+                "SELECT id, parent_id, caption, caption AS caption_save, page_layout, icon_color, icon_image, 1 AS min_rank, order_num, visible, enabled, '0' AS club_only, 'BUILDERS_CLUB' AS catalog_mode, page_headline, page_teaser, page_special, page_text1, page_text2, page_text_details, page_text_teaser, '' AS includes FROM catalog_pages_bc ORDER BY parent_id, id";
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement(query)) {
+                PreparedStatement statement = connection.prepareStatement(query)) {
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
                     Class<? extends CatalogPage> pageClazz = pageDefinitions.get(set.getString("page_layout"));
@@ -415,7 +488,8 @@ public class CatalogManager {
                     }
 
                     try {
-                        CatalogPage page = pageClazz.getConstructor(ResultSet.class).newInstance(set);
+                        CatalogPage page =
+                                pageClazz.getConstructor(ResultSet.class).newInstance(set);
                         pages.put(page.getId(), page);
                     } catch (Exception e) {
                         LOGGER.error("Failed to load Builders Club layout: {}", set.getString("page_layout"));
@@ -435,7 +509,11 @@ public class CatalogManager {
                 }
             } else {
                 if (object.parentId != -2) {
-                    LOGGER.info("Builders Club parent page not found for {} (ID: {}, parent_id: {})", object.getPageName(), object.id, object.parentId);
+                    LOGGER.info(
+                            "Builders Club parent page not found for {} (ID: {}, parent_id: {})",
+                            object.getPageName(),
+                            object.id,
+                            object.parentId);
                 }
             }
         }
@@ -445,22 +523,25 @@ public class CatalogManager {
         LOGGER.info("Loaded {} Builders Club Catalog Pages!", this.buildersClubCatalogPages.size());
     }
 
-
     private synchronized void loadCatalogFeaturedPages() {
         this.catalogFeaturedPages.clear();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM catalog_featured_pages ORDER BY slot_id ASC")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM catalog_featured_pages ORDER BY slot_id ASC")) {
             while (set.next()) {
-                this.catalogFeaturedPages.put(set.getInt("slot_id"), new CatalogFeaturedPage(
+                this.catalogFeaturedPages.put(
                         set.getInt("slot_id"),
-                        set.getString("caption"),
-                        set.getString("image"),
-                        CatalogFeaturedPage.Type.valueOf(set.getString("type").toUpperCase()),
-                        set.getInt("expire_timestamp"),
-                        set.getString("page_name"),
-                        set.getInt("page_id"),
-                        set.getString("product_name")
-                ));
+                        new CatalogFeaturedPage(
+                                set.getInt("slot_id"),
+                                set.getString("caption"),
+                                set.getString("image"),
+                                CatalogFeaturedPage.Type.valueOf(
+                                        set.getString("type").toUpperCase()),
+                                set.getInt("expire_timestamp"),
+                                set.getString("page_name"),
+                                set.getInt("page_id"),
+                                set.getString("product_name")));
             }
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
@@ -472,7 +553,9 @@ public class CatalogManager {
         this.clubItems.clear();
         catalogItemAmount = 0;
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM catalog_items")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM catalog_items")) {
             CatalogItem item;
             while (set.next()) {
                 List<String> valueErrors = CatalogValueValidator.validate(CatalogValueValidator.Values.from(set));
@@ -480,8 +563,7 @@ public class CatalogManager {
                     valueErrors.forEach(error -> LOGGER.error("Catalog value validation: {}", error));
                     continue;
                 }
-                if (set.getString("item_ids").equals("0"))
-                    continue;
+                if (set.getString("item_ids").equals("0")) continue;
 
                 if (set.getString("catalog_name").contains("HABBO_CLUB_")) {
                     this.clubItems.add(new CatalogItem(set));
@@ -490,8 +572,7 @@ public class CatalogManager {
 
                 CatalogPage page = this.catalogPages.get(set.getInt("page_id"));
 
-                if (page == null)
-                    continue;
+                if (page == null) continue;
 
                 item = page.getCatalogItem(set.getInt("id"));
 
@@ -506,8 +587,7 @@ public class CatalogManager {
 
                         this.offerDefs.put(searchOfferId, item.getId());
                     }
-                } else
-                    item.update(set);
+                } else item.update(set);
 
                 if (item.isLimited()) {
                     this.createOrUpdateLimitedConfig(item);
@@ -531,11 +611,12 @@ public class CatalogManager {
     private synchronized void loadBuildersClubCatalogItems() {
         this.buildersClubOfferDefs.clear();
 
-        String query = "SELECT id, item_ids, page_id, catalog_name, 0 AS cost_credits, 0 AS cost_points, 0 AS points_type, 1 AS amount, 0 AS limited_stack, 0 AS limited_sells, extradata, '0' AS club_only, '1' AS have_offer, id AS offer_id, order_number FROM catalog_items_bc";
+        String query =
+                "SELECT id, item_ids, page_id, catalog_name, 0 AS cost_credits, 0 AS cost_points, 0 AS points_type, 1 AS amount, 0 AS limited_stack, 0 AS limited_sells, extradata, '0' AS club_only, '1' AS have_offer, id AS offer_id, order_number FROM catalog_items_bc";
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             Statement statement = connection.createStatement();
-             ResultSet set = statement.executeQuery(query)) {
+                Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery(query)) {
             CatalogItem item;
 
             while (set.next()) {
@@ -578,7 +659,9 @@ public class CatalogManager {
     private void loadClubOffers() {
         this.clubOffers.clear();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM catalog_club_offers WHERE enabled = ?")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("SELECT * FROM catalog_club_offers WHERE enabled = ?")) {
             statement.setString(1, "1");
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
@@ -594,7 +677,9 @@ public class CatalogManager {
         synchronized (this.targetOffers) {
             this.targetOffers.clear();
 
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM catalog_target_offers WHERE end_timestamp > ?")) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    PreparedStatement statement = connection.prepareStatement(
+                            "SELECT * FROM catalog_target_offers WHERE end_timestamp > ?")) {
                 statement.setInt(1, Emulator.getIntUnixTimestamp());
                 try (ResultSet set = statement.executeQuery()) {
                     while (set.next()) {
@@ -607,12 +692,13 @@ public class CatalogManager {
         }
     }
 
-
     private void loadVouchers() {
         synchronized (this.vouchers) {
             this.vouchers.clear();
 
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM vouchers")) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    Statement statement = connection.createStatement();
+                    ResultSet set = statement.executeQuery("SELECT * FROM vouchers")) {
                 while (set.next()) {
                     this.vouchers.add(new Voucher(set));
                 }
@@ -622,11 +708,12 @@ public class CatalogManager {
         }
     }
 
-
     public void loadRecycler() {
         synchronized (this.prizes) {
             this.prizes.clear();
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM recycler_prizes")) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    Statement statement = connection.createStatement();
+                    ResultSet set = statement.executeQuery("SELECT * FROM recycler_prizes")) {
                 while (set.next()) {
                     Item item = Emulator.getGameEnvironment().getItemManager().getItem(set.getInt("item_id"));
 
@@ -646,14 +733,16 @@ public class CatalogManager {
         }
     }
 
-
     public void loadGiftWrappers() {
         synchronized (this.giftWrappers) {
             synchronized (this.giftFurnis) {
                 this.giftWrappers.clear();
                 this.giftFurnis.clear();
 
-                try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM gift_wrappers ORDER BY sprite_id DESC")) {
+                try (Connection connection =
+                                Emulator.getDatabase().getDataSource().getConnection();
+                        Statement statement = connection.createStatement();
+                        ResultSet set = statement.executeQuery("SELECT * FROM gift_wrappers ORDER BY sprite_id DESC")) {
                     while (set.next()) {
                         switch (set.getString("type")) {
                             case "wrapper":
@@ -676,7 +765,9 @@ public class CatalogManager {
         synchronized (this.clothing) {
             this.clothing.clear();
 
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM catalog_clothing")) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    Statement statement = connection.createStatement();
+                    ResultSet set = statement.executeQuery("SELECT * FROM catalog_clothing")) {
                 while (set.next()) {
                     this.clothing.put(set.getInt("id"), new ClothItem(set));
                 }
@@ -709,8 +800,7 @@ public class CatalogManager {
 
     public void redeemVoucher(GameClient client, String voucherCode) {
         Habbo habbo = client.getHabbo();
-        if (habbo == null)
-            return;
+        if (habbo == null) return;
 
         Voucher voucher = Emulator.getGameEnvironment().getCatalogManager().getVoucher(voucherCode);
         if (voucher == null) {
@@ -718,15 +808,20 @@ public class CatalogManager {
             return;
         }
 
-        Voucher.ClaimResult claimResult = voucher.claimForUser(habbo.getHabboInfo().getId());
+        Voucher.ClaimResult claimResult =
+                voucher.claimForUser(habbo.getHabboInfo().getId());
         switch (claimResult) {
             case CLAIMED:
                 break;
             case EXHAUSTED:
-                client.sendResponse(new RedeemVoucherErrorComposer(Emulator.getGameEnvironment().getCatalogManager().deleteVoucher(voucher) ? RedeemVoucherErrorComposer.INVALID_CODE : RedeemVoucherErrorComposer.TECHNICAL_ERROR));
+                client.sendResponse(new RedeemVoucherErrorComposer(
+                        Emulator.getGameEnvironment().getCatalogManager().deleteVoucher(voucher)
+                                ? RedeemVoucherErrorComposer.INVALID_CODE
+                                : RedeemVoucherErrorComposer.TECHNICAL_ERROR));
                 return;
             case USER_LIMIT:
-                client.sendResponse(new ModToolIssueHandledComposer("You have exceeded the limit for redeeming this voucher."));
+                client.sendResponse(
+                        new ModToolIssueHandledComposer("You have exceeded the limit for redeeming this voucher."));
                 return;
             case FAILED:
             default:
@@ -753,7 +848,8 @@ public class CatalogManager {
     }
 
     public boolean deleteVoucher(Voucher voucher) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("DELETE FROM vouchers WHERE code = ?")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("DELETE FROM vouchers WHERE code = ?")) {
             statement.setString(1, voucher.code);
 
             synchronized (this.vouchers) {
@@ -768,7 +864,6 @@ public class CatalogManager {
         return false;
     }
 
-
     public CatalogPage getCatalogPage(int pageId) {
         return this.catalogPages.get(pageId);
     }
@@ -779,19 +874,22 @@ public class CatalogManager {
 
     public CatalogPage getCatalogPage(String captionSafe) {
         return this.catalogPages.values().stream()
-                .filter(p -> p != null && p.getPageName() != null && p.getPageName().equalsIgnoreCase(captionSafe))
-                .findAny().orElse(null);
+                .filter(p ->
+                        p != null && p.getPageName() != null && p.getPageName().equalsIgnoreCase(captionSafe))
+                .findAny()
+                .orElse(null);
     }
 
     public CatalogPage getCatalogPageByLayout(String layoutName) {
         return this.catalogPages.values().stream()
-                .filter(p -> p != null &&
-                        p.isVisible() &&
-                        p.isEnabled() &&
-                        p.getRank() < 2 &&
-                        p.getLayout() != null && p.getLayout().equalsIgnoreCase(layoutName)
-                )
-                .findAny().orElse(null);
+                .filter(p -> p != null
+                        && p.isVisible()
+                        && p.isEnabled()
+                        && p.getRank() < 2
+                        && p.getLayout() != null
+                        && p.getLayout().equalsIgnoreCase(layoutName))
+                .findAny()
+                .orElse(null);
     }
 
     public CatalogItem getCatalogItem(int id) {
@@ -814,7 +912,6 @@ public class CatalogManager {
         return item[0];
     }
 
-
     public List<CatalogPage> getCatalogPages(int parentId, final Habbo habbo) {
         return this.getCatalogPages(parentId, habbo, CatalogPageType.NORMAL);
     }
@@ -830,9 +927,12 @@ public class CatalogManager {
 
         for (CatalogPage object : parentPage.childPages.values()) {
             boolean isVisiblePage = object.visible;
-            boolean hasRightRank = object.getRank() <= habbo.getHabboInfo().getRank().getId();
-            boolean clubRightsOkay = !object.isClubOnly() || habbo.getHabboInfo().getHabboStats().hasActiveClub();
-            boolean pageTypeMatches = (pageType == CatalogPageType.BUILDER) || object.getCatalogPageType().matches(pageType);
+            boolean hasRightRank =
+                    object.getRank() <= habbo.getHabboInfo().getRank().getId();
+            boolean clubRightsOkay =
+                    !object.isClubOnly() || habbo.getHabboInfo().getHabboStats().hasActiveClub();
+            boolean pageTypeMatches = (pageType == CatalogPageType.BUILDER)
+                    || object.getCatalogPageType().matches(pageType);
 
             if (isVisiblePage && hasRightRank && clubRightsOkay && pageTypeMatches) {
                 pages.add(object);
@@ -847,31 +947,26 @@ public class CatalogManager {
         return this.catalogFeaturedPages;
     }
 
-
     public CatalogItem getClubItem(int itemId) {
         synchronized (this.clubItems) {
             for (CatalogItem item : this.clubItems) {
-                if (item.getId() == itemId)
-                    return item;
+                if (item.getId() == itemId) return item;
             }
         }
 
         return null;
     }
 
-
     public boolean moveCatalogItem(CatalogItem item, int pageId) {
         CatalogPage page = this.getCatalogPage(item.getPageId());
 
-        if (page == null)
-            return false;
+        if (page == null) return false;
 
         page.getCatalogItems().remove(item.getId());
 
         page = this.getCatalogPage(pageId);
 
-        if (page == null)
-            return false;
+        if (page == null) return false;
 
         page.getCatalogItems().put(item.getId(), item);
 
@@ -882,22 +977,27 @@ public class CatalogManager {
         return true;
     }
 
-
     public Item getRandomRecyclerPrize() {
         int level = 1;
 
-        if (Emulator.getRandom().nextInt(Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.5")) + 1 == Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.5")) {
+        if (Emulator.getRandom().nextInt(Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.5")) + 1
+                == Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.5")) {
             level = 5;
-        } else if (Emulator.getRandom().nextInt(Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.4")) + 1 == Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.4")) {
+        } else if (Emulator.getRandom().nextInt(Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.4")) + 1
+                == Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.4")) {
             level = 4;
-        } else if (Emulator.getRandom().nextInt(Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.3")) + 1 == Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.3")) {
+        } else if (Emulator.getRandom().nextInt(Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.3")) + 1
+                == Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.3")) {
             level = 3;
-        } else if (Emulator.getRandom().nextInt(Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.2")) + 1 == Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.2")) {
+        } else if (Emulator.getRandom().nextInt(Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.2")) + 1
+                == Emulator.getConfig().getInt("hotel.ecotron.rarity.chance.2")) {
             level = 2;
         }
 
         if (this.prizes.containsKey(level) && !this.prizes.get(level).isEmpty()) {
-            return (Item) this.prizes.get(level).toArray()[Emulator.getRandom().nextInt(this.prizes.get(level).size())];
+            return (Item) this.prizes.get(level)
+                    .toArray()[
+                    Emulator.getRandom().nextInt(this.prizes.get(level).size())];
         } else {
             LOGGER.error("No rewards specified for rarity level {}", level);
         }
@@ -905,12 +1005,33 @@ public class CatalogManager {
         return null;
     }
 
-
-    public CatalogPage createCatalogPage(String caption, String captionSave, int roomId, int icon, CatalogPageLayouts layout, int minRank, int parentId, CatalogPageType pageType, CatalogPageType catalogMode) {
-        return createCatalogPage(caption, captionSave, roomId, icon, layout, minRank, parentId, pageType, catalogMode, true, true, 1);
+    public CatalogPage createCatalogPage(
+            String caption,
+            String captionSave,
+            int roomId,
+            int icon,
+            CatalogPageLayouts layout,
+            int minRank,
+            int parentId,
+            CatalogPageType pageType,
+            CatalogPageType catalogMode) {
+        return createCatalogPage(
+                caption, captionSave, roomId, icon, layout, minRank, parentId, pageType, catalogMode, true, true, 1);
     }
 
-    public CatalogPage createCatalogPage(String caption, String captionSave, int roomId, int icon, CatalogPageLayouts layout, int minRank, int parentId, CatalogPageType pageType, CatalogPageType catalogMode, boolean visible, boolean enabled, int orderNum) {
+    public CatalogPage createCatalogPage(
+            String caption,
+            String captionSave,
+            int roomId,
+            int icon,
+            CatalogPageLayouts layout,
+            int minRank,
+            int parentId,
+            CatalogPageType pageType,
+            CatalogPageType catalogMode,
+            boolean visible,
+            boolean enabled,
+            int orderNum) {
         CatalogPage catalogPage = null;
         boolean buildersClubPage = (pageType == CatalogPageType.BUILDER);
         String insertQuery = buildersClubPage
@@ -921,7 +1042,8 @@ public class CatalogManager {
                 : "SELECT * FROM catalog_pages WHERE id = ?";
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement(insertQuery, Statement.RETURN_GENERATED_KEYS)) {
+                PreparedStatement statement =
+                        connection.prepareStatement(insertQuery, Statement.RETURN_GENERATED_KEYS)) {
             statement.setInt(1, parentId);
             statement.setString(2, caption);
 
@@ -950,11 +1072,14 @@ public class CatalogManager {
                         stmt.setInt(1, set.getInt(1));
                         try (ResultSet page = stmt.executeQuery()) {
                             if (page.next()) {
-                                Class<? extends CatalogPage> pageClazz = pageDefinitions.get(page.getString("page_layout"));
+                                Class<? extends CatalogPage> pageClazz =
+                                        pageDefinitions.get(page.getString("page_layout"));
 
                                 if (pageClazz != null) {
                                     try {
-                                        catalogPage = pageClazz.getConstructor(ResultSet.class).newInstance(page);
+                                        catalogPage = pageClazz
+                                                .getConstructor(ResultSet.class)
+                                                .newInstance(page);
                                     } catch (Exception e) {
                                         LOGGER.error("Caught exception", e);
                                     }
@@ -978,13 +1103,11 @@ public class CatalogManager {
         return catalogPage;
     }
 
-
     public CatalogLimitedConfiguration getLimitedConfig(CatalogItem item) {
         synchronized (this.limitedNumbers) {
             return this.limitedNumbers.get(item.getId());
         }
     }
-
 
     public CatalogLimitedConfiguration createOrUpdateLimitedConfig(CatalogItem item) {
         if (item.isLimited()) {
@@ -999,7 +1122,8 @@ public class CatalogManager {
                     if (limitedConfiguration.getTotalSet() == 0) {
                         limitedConfiguration.setTotalSet(item.limitedStack);
                     } else if (item.limitedStack > limitedConfiguration.getTotalSet()) {
-                        limitedConfiguration.generateNumbers(item.limitedStack + 1, item.limitedStack - limitedConfiguration.getTotalSet());
+                        limitedConfiguration.generateNumbers(
+                                item.limitedStack + 1, item.limitedStack - limitedConfiguration.getTotalSet());
                     } else {
                         item.limitedStack = limitedConfiguration.getTotalSet();
                     }
@@ -1011,7 +1135,6 @@ public class CatalogManager {
 
         return null;
     }
-
 
     public void dispose() {
         for (CatalogPage page : this.catalogPages.values()) {
@@ -1026,16 +1149,19 @@ public class CatalogManager {
         LOGGER.info("Catalog Manager -> Disposed!");
     }
 
-
-    public void purchaseItem(CatalogPage page, CatalogItem item, Habbo habbo, int amount, String extradata, boolean free) {
+    public void purchaseItem(
+            CatalogPage page, CatalogItem item, Habbo habbo, int amount, String extradata, boolean free) {
         if (item == null) {
-            habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+            habbo.getClient()
+                    .sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
             return;
         }
 
         synchronized (habbo.getHabboStats()) {
             if (habbo.getHabboStats().isPurchasingFurniture) {
-                habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                habbo.getClient()
+                        .sendResponse(
+                                new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                 return;
             }
             habbo.getHabboStats().isPurchasingFurniture = true;
@@ -1055,13 +1181,17 @@ public class CatalogManager {
         int limitedNumber = 0;
 
         try {
-            if (item.isClubOnly() && !habbo.getClient().getHabbo().getHabboStats().hasActiveClub()) {
-                habbo.getClient().sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.REQUIRES_CLUB));
+            if (item.isClubOnly()
+                    && !habbo.getClient().getHabbo().getHabboStats().hasActiveClub()) {
+                habbo.getClient()
+                        .sendResponse(
+                                new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.REQUIRES_CLUB));
                 return;
             }
 
             if (amount <= 0) {
-                habbo.getClient().sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                habbo.getClient()
+                        .sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                 return;
             }
 
@@ -1077,13 +1207,29 @@ public class CatalogManager {
                     if (Emulator.getConfig().getBoolean("hotel.catalog.ltd.limit.enabled")) {
                         int ltdLimit = Emulator.getConfig().getInt("hotel.purchase.ltd.limit.daily.total");
                         if (habbo.getHabboStats().totalLtds() >= ltdLimit) {
-                            habbo.alert(Emulator.getTexts().getValue("error.catalog.buy.limited.daily.total").replace("%itemname%", item.getBaseItems().iterator().next().getDisplayName()).replace("%limit%", ltdLimit + ""));
+                            habbo.alert(Emulator.getTexts()
+                                    .getValue("error.catalog.buy.limited.daily.total")
+                                    .replace(
+                                            "%itemname%",
+                                            item.getBaseItems()
+                                                    .iterator()
+                                                    .next()
+                                                    .getDisplayName())
+                                    .replace("%limit%", ltdLimit + ""));
                             return;
                         }
 
                         ltdLimit = Emulator.getConfig().getInt("hotel.purchase.ltd.limit.daily.item");
                         if (habbo.getHabboStats().totalLtds(item.id) >= ltdLimit) {
-                            habbo.alert(Emulator.getTexts().getValue("error.catalog.buy.limited.daily.item").replace("%itemname%", item.getBaseItems().iterator().next().getDisplayName()).replace("%limit%", ltdLimit + ""));
+                            habbo.alert(Emulator.getTexts()
+                                    .getValue("error.catalog.buy.limited.daily.item")
+                                    .replace(
+                                            "%itemname%",
+                                            item.getBaseItems()
+                                                    .iterator()
+                                                    .next()
+                                                    .getDisplayName())
+                                    .replace("%limit%", ltdLimit + ""));
                             return;
                         }
                     }
@@ -1095,8 +1241,11 @@ public class CatalogManager {
                     } else {
                         long requestedItems = (long) amount * item.getAmount();
                         if (requestedItems > 100) {
-                            habbo.alert("Whoops! You tried to buy this " + requestedItems + " times. This must've been a mistake.");
-                            habbo.getClient().sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                            habbo.alert("Whoops! You tried to buy this " + requestedItems
+                                    + " times. This must've been a mistake.");
+                            habbo.getClient()
+                                    .sendResponse(new AlertPurchaseUnavailableComposer(
+                                            AlertPurchaseUnavailableComposer.ILLEGAL));
                             return;
                         }
                     }
@@ -1104,12 +1253,17 @@ public class CatalogManager {
 
                 Set<HabboItem> itemsList = new HashSet<>();
 
-
                 if (amount > 1 && !CatalogItem.haveOffer(item)) {
-                    String message = Emulator.getTexts().getValue("scripter.warning.catalog.amount").replace("%username%", habbo.getHabboInfo().getUsername()).replace("%itemname%", item.getName()).replace("%pagename%", page.getCaption());
+                    String message = Emulator.getTexts()
+                            .getValue("scripter.warning.catalog.amount")
+                            .replace("%username%", habbo.getHabboInfo().getUsername())
+                            .replace("%itemname%", item.getName())
+                            .replace("%pagename%", page.getCaption());
                     ScripterManager.scripterDetected(habbo.getClient(), message);
                     LOGGER.info(message);
-                    habbo.getClient().sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                    habbo.getClient()
+                            .sendResponse(
+                                    new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                     return;
                 }
 
@@ -1127,8 +1281,7 @@ public class CatalogManager {
                 int totalPoints = free ? 0 : this.calculateDiscountedPrice(item.getPoints(), amount, item);
 
                 if (totalCredits > habbo.getHabboInfo().getCredits()) return;
-                if (totalPoints > habbo.getHabboInfo().getCurrencyAmount(item.getPointsType()))
-                    return;
+                if (totalPoints > habbo.getHabboInfo().getCurrencyAmount(item.getPointsType())) return;
 
                 if (limitedConfiguration != null) limitedNumber = limitedConfiguration.getNumber();
 
@@ -1143,8 +1296,17 @@ public class CatalogManager {
                 }
 
                 if (this.isAtomicFurniturePurchase(item)) {
-                    this.purchaseFurnitureAtomically(item, habbo, amount, extradata, free, limitedConfiguration,
-                            limitedStack, limitedNumber, totalCredits, totalPoints);
+                    this.purchaseFurnitureAtomically(
+                            item,
+                            habbo,
+                            amount,
+                            extradata,
+                            free,
+                            limitedConfiguration,
+                            limitedStack,
+                            limitedNumber,
+                            totalCredits,
+                            totalPoints);
                     return;
                 }
 
@@ -1155,16 +1317,23 @@ public class CatalogManager {
                 for (int i = 0; i < amount; i++) {
                     for (Item baseItem : item.getBaseItems()) {
                         for (int k = 0; k < item.getItemAmount(baseItem.getId()); k++) {
-                            if (baseItem.getName().startsWith("rentable_bot_") || baseItem.getName().startsWith("bot_")) {
+                            if (baseItem.getName().startsWith("rentable_bot_")
+                                    || baseItem.getName().startsWith("bot_")) {
                                 String baseName = baseItem.getName();
                                 String type = item.getName().replace("rentable_bot_", "");
                                 type = type.replace("bot_", "");
                                 type = type.replace("visitor_logger", "visitor_log");
 
                                 if (("bot_" + com.eu.habbo.habbohotel.bots.FrankBot.BOT_TYPE).equals(baseName)
-                                        || ("rentable_bot_" + com.eu.habbo.habbohotel.bots.FrankBot.BOT_TYPE).equals(baseName)) {
-                                    if (!habbo.getClient().getHabbo().hasPermission(com.eu.habbo.habbohotel.bots.FrankBot.PERMISSION_USE)) {
-                                        habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                                        || ("rentable_bot_" + com.eu.habbo.habbohotel.bots.FrankBot.BOT_TYPE)
+                                                .equals(baseName)) {
+                                    if (!habbo.getClient()
+                                            .getHabbo()
+                                            .hasPermission(com.eu.habbo.habbohotel.bots.FrankBot.PERMISSION_USE)) {
+                                        habbo.getClient()
+                                                .sendResponse(new AlertPurchaseFailedComposer(
+                                                                AlertPurchaseFailedComposer.SERVER_ERROR)
+                                                        .compose());
                                         return;
                                     }
                                 }
@@ -1177,22 +1346,38 @@ public class CatalogManager {
                                     }
                                 }
 
-                                Bot bot = Emulator.getGameEnvironment().getBotManager().createBot(data, type, habbo.getHabboInfo().getId());
+                                Bot bot = Emulator.getGameEnvironment()
+                                        .getBotManager()
+                                        .createBot(
+                                                data, type, habbo.getHabboInfo().getId());
 
                                 if (bot != null) {
                                     createdBots.add(bot);
-                                    bot.setOwnerId(habbo.getClient().getHabbo().getHabboInfo().getId());
-                                    bot.setOwnerName(habbo.getClient().getHabbo().getHabboInfo().getUsername());
+                                    bot.setOwnerId(habbo.getClient()
+                                            .getHabbo()
+                                            .getHabboInfo()
+                                            .getId());
+                                    bot.setOwnerName(habbo.getClient()
+                                            .getHabbo()
+                                            .getHabboInfo()
+                                            .getUsername());
                                     bot.needsUpdate(true);
                                     Emulator.getThreading().run(bot);
-                                    habbo.getClient().getHabbo().getInventory().getBotsComponent().addBot(bot);
+                                    habbo.getClient()
+                                            .getHabbo()
+                                            .getInventory()
+                                            .getBotsComponent()
+                                            .addBot(bot);
                                     habbo.getClient().sendResponse(new AddBotComposer(bot));
 
                                     if (!unseenItems.containsKey(AddHabboItemComposer.AddHabboItemCategory.BOT)) {
-                                        unseenItems.put(AddHabboItemComposer.AddHabboItemCategory.BOT, new ArrayList<>());
+                                        unseenItems.put(
+                                                AddHabboItemComposer.AddHabboItemCategory.BOT, new ArrayList<>());
                                     }
 
-                                    unseenItems.get(AddHabboItemComposer.AddHabboItemCategory.BOT).add(bot.getId());
+                                    unseenItems
+                                            .get(AddHabboItemComposer.AddHabboItemCategory.BOT)
+                                            .add(bot.getId());
                                 } else {
                                     throw new Exception("Failed to create bot of type: " + type);
                                 }
@@ -1210,35 +1395,53 @@ public class CatalogManager {
                                 String[] data = extradata.split("\n");
 
                                 if (data.length < 3) {
-                                    habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                                    habbo.getClient()
+                                            .sendResponse(new AlertPurchaseFailedComposer(
+                                                    AlertPurchaseFailedComposer.SERVER_ERROR));
                                     return;
                                 }
 
                                 Pet pet = null;
                                 try {
-                                    pet = Emulator.getGameEnvironment().getPetManager().createPet(baseItem, data[0], data[1], data[2], habbo.getClient());
+                                    pet = Emulator.getGameEnvironment()
+                                            .getPetManager()
+                                            .createPet(baseItem, data[0], data[1], data[2], habbo.getClient());
                                 } catch (Exception e) {
                                     LOGGER.error("Caught exception", e);
-                                    habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                                    habbo.getClient()
+                                            .sendResponse(new AlertPurchaseFailedComposer(
+                                                    AlertPurchaseFailedComposer.SERVER_ERROR));
                                 }
 
                                 if (pet == null) {
-                                    habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                                    habbo.getClient()
+                                            .sendResponse(new AlertPurchaseFailedComposer(
+                                                    AlertPurchaseFailedComposer.SERVER_ERROR));
                                     return;
                                 }
 
                                 createdPets.add(pet);
-                                habbo.getClient().getHabbo().getInventory().getPetsComponent().addPet(pet);
+                                habbo.getClient()
+                                        .getHabbo()
+                                        .getInventory()
+                                        .getPetsComponent()
+                                        .addPet(pet);
                                 habbo.getClient().sendResponse(new AddPetComposer(pet));
                                 habbo.getClient().sendResponse(new PetBoughtNotificationComposer(pet, false));
 
-                                AchievementManager.progressAchievement(habbo.getClient().getHabbo(), Emulator.getGameEnvironment().getAchievementManager().getAchievement("PetLover"));
+                                AchievementManager.progressAchievement(
+                                        habbo.getClient().getHabbo(),
+                                        Emulator.getGameEnvironment()
+                                                .getAchievementManager()
+                                                .getAchievement("PetLover"));
 
                                 if (!unseenItems.containsKey(AddHabboItemComposer.AddHabboItemCategory.PET)) {
                                     unseenItems.put(AddHabboItemComposer.AddHabboItemCategory.PET, new ArrayList<>());
                                 }
 
-                                unseenItems.get(AddHabboItemComposer.AddHabboItemCategory.PET).add(pet.getId());
+                                unseenItems
+                                        .get(AddHabboItemComposer.AddHabboItemCategory.PET)
+                                        .add(pet.getId());
                             } else if (baseItem.getType() == FurnitureType.BADGE) {
                                 if (!habbo.getInventory().getBadgesComponent().hasBadge(baseItem.getName())) {
                                     if (!badges.contains(baseItem.getName())) {
@@ -1248,22 +1451,70 @@ public class CatalogManager {
                                     badgeFound = true;
                                 }
                             } else {
-                                if (baseItem.getInteractionType().getType() == InteractionTrophy.class || baseItem.getInteractionType().getType() == InteractionBadgeDisplay.class) {
-                                    if (baseItem.getInteractionType().getType() == InteractionBadgeDisplay.class && !habbo.getClient().getHabbo().getInventory().getBadgesComponent().hasBadge(extradata)) {
-                                        ScripterManager.scripterDetected(habbo.getClient(), Emulator.getTexts().getValue("scripter.warning.catalog.badge_display").replace("%username%", habbo.getClient().getHabbo().getHabboInfo().getUsername()).replace("%badge%", extradata));
+                                if (baseItem.getInteractionType().getType() == InteractionTrophy.class
+                                        || baseItem.getInteractionType().getType() == InteractionBadgeDisplay.class) {
+                                    if (baseItem.getInteractionType().getType() == InteractionBadgeDisplay.class
+                                            && !habbo.getClient()
+                                                    .getHabbo()
+                                                    .getInventory()
+                                                    .getBadgesComponent()
+                                                    .hasBadge(extradata)) {
+                                        ScripterManager.scripterDetected(
+                                                habbo.getClient(),
+                                                Emulator.getTexts()
+                                                        .getValue("scripter.warning.catalog.badge_display")
+                                                        .replace(
+                                                                "%username%",
+                                                                habbo.getClient()
+                                                                        .getHabbo()
+                                                                        .getHabboInfo()
+                                                                        .getUsername())
+                                                        .replace("%badge%", extradata));
                                         extradata = "UMAD";
                                     }
 
-                                    if (extradata.length() > Emulator.getConfig().getInt("hotel.trophies.length.max", 300)) {
-                                        extradata = extradata.substring(0, Emulator.getConfig().getInt("hotel.trophies.length.max", 300));
+                                    if (extradata.length()
+                                            > Emulator.getConfig().getInt("hotel.trophies.length.max", 300)) {
+                                        extradata = extradata.substring(
+                                                0, Emulator.getConfig().getInt("hotel.trophies.length.max", 300));
                                     }
 
-                                    extradata = habbo.getClient().getHabbo().getHabboInfo().getUsername() + (char) 9 + Calendar.getInstance().get(Calendar.DAY_OF_MONTH) + "-" + (Calendar.getInstance().get(Calendar.MONTH) + 1) + "-" + Calendar.getInstance().get(Calendar.YEAR) + (char) 9 + Emulator.getGameEnvironment().getWordFilter().filter(extradata.replace(((char) 9) + "", ""), habbo);
+                                    extradata = habbo.getClient()
+                                                    .getHabbo()
+                                                    .getHabboInfo()
+                                                    .getUsername() + (char) 9
+                                            + Calendar.getInstance().get(Calendar.DAY_OF_MONTH) + "-"
+                                            + (Calendar.getInstance().get(Calendar.MONTH) + 1) + "-"
+                                            + Calendar.getInstance().get(Calendar.YEAR) + (char) 9
+                                            + Emulator.getGameEnvironment()
+                                                    .getWordFilter()
+                                                    .filter(extradata.replace(((char) 9) + "", ""), habbo);
                                 }
 
-                                if (InteractionTeleport.class.isAssignableFrom(baseItem.getInteractionType().getType())) {
-                                    HabboItem teleportOne = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getClient().getHabbo().getHabboInfo().getId(), baseItem, limitedStack, limitedNumber, extradata);
-                                    HabboItem teleportTwo = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getClient().getHabbo().getHabboInfo().getId(), baseItem, limitedStack, limitedNumber, extradata);
+                                if (InteractionTeleport.class.isAssignableFrom(
+                                        baseItem.getInteractionType().getType())) {
+                                    HabboItem teleportOne = Emulator.getGameEnvironment()
+                                            .getItemManager()
+                                            .createItem(
+                                                    habbo.getClient()
+                                                            .getHabbo()
+                                                            .getHabboInfo()
+                                                            .getId(),
+                                                    baseItem,
+                                                    limitedStack,
+                                                    limitedNumber,
+                                                    extradata);
+                                    HabboItem teleportTwo = Emulator.getGameEnvironment()
+                                            .getItemManager()
+                                            .createItem(
+                                                    habbo.getClient()
+                                                            .getHabbo()
+                                                            .getHabboInfo()
+                                                            .getId(),
+                                                    baseItem,
+                                                    limitedStack,
+                                                    limitedNumber,
+                                                    extradata);
                                     if (teleportOne == null || teleportTwo == null) {
                                         if (teleportOne != null) createdItems.add(teleportOne);
                                         if (teleportTwo != null) createdItems.add(teleportTwo);
@@ -1271,37 +1522,75 @@ public class CatalogManager {
                                     }
                                     createdItems.add(teleportOne);
                                     createdItems.add(teleportTwo);
-                                    Emulator.getGameEnvironment().getItemManager().insertTeleportPair(teleportOne.getId(), teleportTwo.getId());
+                                    Emulator.getGameEnvironment()
+                                            .getItemManager()
+                                            .insertTeleportPair(teleportOne.getId(), teleportTwo.getId());
                                     itemsList.add(teleportOne);
                                     itemsList.add(teleportTwo);
                                 } else if (baseItem.getInteractionType().getType() == InteractionHopper.class) {
-                                    HabboItem hopper = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getClient().getHabbo().getHabboInfo().getId(), baseItem, limitedStack, limitedNumber, extradata);
+                                    HabboItem hopper = Emulator.getGameEnvironment()
+                                            .getItemManager()
+                                            .createItem(
+                                                    habbo.getClient()
+                                                            .getHabbo()
+                                                            .getHabboInfo()
+                                                            .getId(),
+                                                    baseItem,
+                                                    limitedStack,
+                                                    limitedNumber,
+                                                    extradata);
 
-                                    if (hopper == null) throw new IllegalStateException("failed to create catalog hopper");
+                                    if (hopper == null)
+                                        throw new IllegalStateException("failed to create catalog hopper");
                                     createdItems.add(hopper);
 
-                                    Emulator.getGameEnvironment().getItemManager().insertHopper(hopper);
+                                    Emulator.getGameEnvironment()
+                                            .getItemManager()
+                                            .insertHopper(hopper);
 
                                     itemsList.add(hopper);
-                                } else if (baseItem.getInteractionType().getType() == InteractionGuildFurni.class || baseItem.getInteractionType().getType() == InteractionGuildGate.class) {
+                                } else if (baseItem.getInteractionType().getType() == InteractionGuildFurni.class
+                                        || baseItem.getInteractionType().getType() == InteractionGuildGate.class) {
                                     int guildId;
                                     try {
                                         guildId = Integer.parseInt(extradata);
                                     } catch (Exception e) {
                                         LOGGER.error("Caught exception", e);
-                                        habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                                        habbo.getClient()
+                                                .sendResponse(new AlertPurchaseFailedComposer(
+                                                        AlertPurchaseFailedComposer.SERVER_ERROR));
                                         return;
                                     }
 
-                                    Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
+                                    Guild guild = Emulator.getGameEnvironment()
+                                            .getGuildManager()
+                                            .getGuild(guildId);
 
-                                    if (guild != null && Emulator.getGameEnvironment().getGuildManager().getGuildMember(guild, habbo) != null) {
-                                        if (baseItem.getName().equals("guild_forum") && guild.getOwnerId() != habbo.getHabboInfo().getId()) {
-                                            habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                                    if (guild != null
+                                            && Emulator.getGameEnvironment()
+                                                            .getGuildManager()
+                                                            .getGuildMember(guild, habbo)
+                                                    != null) {
+                                        if (baseItem.getName().equals("guild_forum")
+                                                && guild.getOwnerId()
+                                                        != habbo.getHabboInfo().getId()) {
+                                            habbo.getClient()
+                                                    .sendResponse(new AlertPurchaseFailedComposer(
+                                                            AlertPurchaseFailedComposer.SERVER_ERROR));
                                             return;
                                         }
 
-                                        HabboItem createdItem = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getClient().getHabbo().getHabboInfo().getId(), baseItem, limitedStack, limitedNumber, extradata);
+                                        HabboItem createdItem = Emulator.getGameEnvironment()
+                                                .getItemManager()
+                                                .createItem(
+                                                        habbo.getClient()
+                                                                .getHabbo()
+                                                                .getHabboInfo()
+                                                                .getId(),
+                                                        baseItem,
+                                                        limitedStack,
+                                                        limitedNumber,
+                                                        extradata);
                                         if (!(createdItem instanceof InteractionGuildFurni)) {
                                             if (createdItem != null) createdItems.add(createdItem);
                                             throw new IllegalStateException("failed to create catalog guild item");
@@ -1312,7 +1601,9 @@ public class CatalogManager {
                                         habboItem.needsUpdate(true);
 
                                         Emulator.getThreading().run(habboItem);
-                                        Emulator.getGameEnvironment().getGuildManager().setGuild(habboItem, guildId);
+                                        Emulator.getGameEnvironment()
+                                                .getGuildManager()
+                                                .setGuild(habboItem, guildId);
                                         itemsList.add(habboItem);
 
                                         if (baseItem.getName().equals("guild_forum")) {
@@ -1320,14 +1611,39 @@ public class CatalogManager {
                                         }
                                     }
                                 } else if (baseItem.getInteractionType().getType() == InteractionMusicDisc.class) {
-                                    SoundTrack track = Emulator.getGameEnvironment().getItemManager().getSoundTrack(item.getExtradata());
+                                    SoundTrack track = Emulator.getGameEnvironment()
+                                            .getItemManager()
+                                            .getSoundTrack(item.getExtradata());
 
                                     if (track == null) {
-                                        habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                                        habbo.getClient()
+                                                .sendResponse(new AlertPurchaseFailedComposer(
+                                                        AlertPurchaseFailedComposer.SERVER_ERROR));
                                         return;
                                     }
 
-                                    HabboItem createdItem = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getClient().getHabbo().getHabboInfo().getId(), baseItem, limitedStack, limitedNumber, habbo.getClient().getHabbo().getHabboInfo().getUsername() + "\n" + Calendar.getInstance().get(Calendar.DAY_OF_MONTH) + "\n" + (Calendar.getInstance().get(Calendar.MONTH) + 1) + "\n" + Calendar.getInstance().get(Calendar.YEAR) + "\n" + track.getLength() + "\n" + track.getName() + "\n" + track.getId());
+                                    HabboItem createdItem = Emulator.getGameEnvironment()
+                                            .getItemManager()
+                                            .createItem(
+                                                    habbo.getClient()
+                                                            .getHabbo()
+                                                            .getHabboInfo()
+                                                            .getId(),
+                                                    baseItem,
+                                                    limitedStack,
+                                                    limitedNumber,
+                                                    habbo.getClient()
+                                                                    .getHabbo()
+                                                                    .getHabboInfo()
+                                                                    .getUsername() + "\n"
+                                                            + Calendar.getInstance()
+                                                                    .get(Calendar.DAY_OF_MONTH) + "\n"
+                                                            + (Calendar.getInstance()
+                                                                            .get(Calendar.MONTH)
+                                                                    + 1) + "\n"
+                                                            + Calendar.getInstance()
+                                                                    .get(Calendar.YEAR) + "\n" + track.getLength()
+                                                            + "\n" + track.getName() + "\n" + track.getId());
                                     if (!(createdItem instanceof InteractionMusicDisc)) {
                                         if (createdItem != null) createdItems.add(createdItem);
                                         throw new IllegalStateException("failed to create catalog music disc");
@@ -1339,10 +1655,25 @@ public class CatalogManager {
                                     Emulator.getThreading().run(habboItem);
                                     itemsList.add(habboItem);
 
-                                    AchievementManager.progressAchievement(habbo, Emulator.getGameEnvironment().getAchievementManager().getAchievement("MusicCollector"));
+                                    AchievementManager.progressAchievement(
+                                            habbo,
+                                            Emulator.getGameEnvironment()
+                                                    .getAchievementManager()
+                                                    .getAchievement("MusicCollector"));
                                 } else {
-                                    HabboItem habboItem = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getClient().getHabbo().getHabboInfo().getId(), baseItem, limitedStack, limitedNumber, extradata);
-                                    if (habboItem == null) throw new IllegalStateException("failed to create catalog item");
+                                    HabboItem habboItem = Emulator.getGameEnvironment()
+                                            .getItemManager()
+                                            .createItem(
+                                                    habbo.getClient()
+                                                            .getHabbo()
+                                                            .getHabboInfo()
+                                                            .getId(),
+                                                    baseItem,
+                                                    limitedStack,
+                                                    limitedNumber,
+                                                    extradata);
+                                    if (habboItem == null)
+                                        throw new IllegalStateException("failed to create catalog item");
                                     createdItems.add(habboItem);
                                     itemsList.add(habboItem);
                                 }
@@ -1352,11 +1683,14 @@ public class CatalogManager {
                 }
 
                 if (badgeFound && item.getBaseItems().size() == 1) {
-                    habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.ALREADY_HAVE_BADGE));
+                    habbo.getClient()
+                            .sendResponse(
+                                    new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.ALREADY_HAVE_BADGE));
                     return;
                 }
 
-                UserCatalogItemPurchasedEvent purchasedEvent = new UserCatalogItemPurchasedEvent(habbo, item, itemsList, totalCredits, totalPoints, badges);
+                UserCatalogItemPurchasedEvent purchasedEvent =
+                        new UserCatalogItemPurchasedEvent(habbo, item, itemsList, totalCredits, totalPoints, badges);
                 Emulator.getPluginManager().fireEvent(purchasedEvent);
 
                 CatalogPurchaseMath.requireNonNegative(purchasedEvent.totalCredits, "plugin-adjusted credit price");
@@ -1364,18 +1698,24 @@ public class CatalogManager {
 
                 if (purchasedEvent.totalCredits > habbo.getHabboInfo().getCredits()
                         || purchasedEvent.totalPoints > habbo.getHabboInfo().getCurrencyAmount(item.getPointsType())) {
-                    habbo.getClient().sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                    habbo.getClient()
+                            .sendResponse(
+                                    new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                     return;
                 }
 
                 paidCredits = (!free && !habbo.hasPermission(Permission.ACC_INFINITE_CREDITS))
-                        ? purchasedEvent.totalCredits : 0;
+                        ? purchasedEvent.totalCredits
+                        : 0;
                 paidPoints = (!free && !habbo.hasPermission(Permission.ACC_INFINITE_POINTS))
-                        ? purchasedEvent.totalPoints : 0;
+                        ? purchasedEvent.totalPoints
+                        : 0;
                 paidPointsType = item.getPointsType();
 
                 if (!CatalogPaymentService.tryTake(habbo, paidCredits, paidPointsType, paidPoints)) {
-                    habbo.getClient().sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                    habbo.getClient()
+                            .sendResponse(
+                                    new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                     return;
                 }
                 paymentTaken = true;
@@ -1390,10 +1730,19 @@ public class CatalogManager {
                 }
 
                 if (purchasedEvent.itemsList != null && !purchasedEvent.itemsList.isEmpty()) {
-                    habbo.getClient().getHabbo().getInventory().getItemsComponent().addItems(purchasedEvent.itemsList);
-                    unseenItems.put(AddHabboItemComposer.AddHabboItemCategory.OWNED_FURNI, purchasedEvent.itemsList.stream().map(HabboItem::getId).collect(Collectors.toList()));
+                    habbo.getClient()
+                            .getHabbo()
+                            .getInventory()
+                            .getItemsComponent()
+                            .addItems(purchasedEvent.itemsList);
+                    unseenItems.put(
+                            AddHabboItemComposer.AddHabboItemCategory.OWNED_FURNI,
+                            purchasedEvent.itemsList.stream()
+                                    .map(HabboItem::getId)
+                                    .collect(Collectors.toList()));
 
-                    Emulator.getPluginManager().fireEvent(new UserCatalogFurnitureBoughtEvent(habbo, item, purchasedEvent.itemsList));
+                    Emulator.getPluginManager()
+                            .fireEvent(new UserCatalogFurnitureBoughtEvent(habbo, item, purchasedEvent.itemsList));
 
                     if (limitedConfiguration != null) {
                         for (HabboItem itm : purchasedEvent.itemsList) {
@@ -1402,7 +1751,8 @@ public class CatalogManager {
                     }
                 }
 
-                if (!purchasedEvent.badges.isEmpty() && !unseenItems.containsKey(AddHabboItemComposer.AddHabboItemCategory.BADGE)) {
+                if (!purchasedEvent.badges.isEmpty()
+                        && !unseenItems.containsKey(AddHabboItemComposer.AddHabboItemCategory.BADGE)) {
                     unseenItems.put(AddHabboItemComposer.AddHabboItemCategory.BADGE, new ArrayList<>());
                 }
 
@@ -1416,7 +1766,9 @@ public class CatalogManager {
                     keys.put("image", "${image.library.url}album1584/" + badge.getCode() + ".gif");
                     keys.put("message", Emulator.getTexts().getValue("commands.generic.cmd_badge.received"));
                     habbo.getClient().sendResponse(new BubbleAlertComposer(BubbleAlertKeys.RECEIVED_BADGE.key, keys));
-                    unseenItems.get(AddHabboItemComposer.AddHabboItemCategory.BADGE).add(badge.getId());
+                    unseenItems
+                            .get(AddHabboItemComposer.AddHabboItemCategory.BADGE)
+                            .add(badge.getId());
                 }
 
                 // Durable items and wallet debit now agree. Nonessential response,
@@ -1443,33 +1795,35 @@ public class CatalogManager {
 
                 Set<String> itemIds = new HashSet<>();
 
-                for(HabboItem ix : purchasedEvent.itemsList) {
+                for (HabboItem ix : purchasedEvent.itemsList) {
                     itemIds.add(ix.getId() + "");
                 }
 
-                if(!free) {
-                    Emulator.getThreading().run(new CatalogPurchaseLogEntry(
-                            Emulator.getIntUnixTimestamp(),
-                            purchasedEvent.habbo.getHabboInfo().getId(),
-                            purchasedEvent.catalogItem != null ? purchasedEvent.catalogItem.getId() : 0,
-                            String.join(";", itemIds),
-                            purchasedEvent.catalogItem != null ? purchasedEvent.catalogItem.getName() : "",
-                            purchasedEvent.totalCredits,
-                            purchasedEvent.totalPoints,
-                            item != null ? item.getPointsType() : 0,
-                            amount
-                    ));
+                if (!free) {
+                    Emulator.getThreading()
+                            .run(new CatalogPurchaseLogEntry(
+                                    Emulator.getIntUnixTimestamp(),
+                                    purchasedEvent.habbo.getHabboInfo().getId(),
+                                    purchasedEvent.catalogItem != null ? purchasedEvent.catalogItem.getId() : 0,
+                                    String.join(";", itemIds),
+                                    purchasedEvent.catalogItem != null ? purchasedEvent.catalogItem.getName() : "",
+                                    purchasedEvent.totalCredits,
+                                    purchasedEvent.totalPoints,
+                                    item != null ? item.getPointsType() : 0,
+                                    amount));
                 }
 
             } catch (Exception e) {
                 LOGGER.error("Exception caught", e);
-                habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                habbo.getClient()
+                        .sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
             }
         } finally {
             try {
                 if (!purchaseDelivered) {
                     for (HabboItem createdItem : createdItems) {
-                        if (createdItem != null) Emulator.getGameEnvironment().getItemManager().deleteItem(createdItem);
+                        if (createdItem != null)
+                            Emulator.getGameEnvironment().getItemManager().deleteItem(createdItem);
                     }
                     for (Bot bot : createdBots) {
                         habbo.getInventory().getBotsComponent().removeBot(bot);
@@ -1500,8 +1854,11 @@ public class CatalogManager {
     private boolean isAtomicFurniturePurchase(CatalogItem item) {
         if (item == null || item.getBaseItems().isEmpty()) return false;
         for (Item baseItem : item.getBaseItems()) {
-            if (baseItem == null || Item.isBot(baseItem) || Item.isPet(baseItem)
-                    || baseItem.getType() == FurnitureType.BADGE || baseItem.getType() == FurnitureType.EFFECT) {
+            if (baseItem == null
+                    || Item.isBot(baseItem)
+                    || Item.isPet(baseItem)
+                    || baseItem.getType() == FurnitureType.BADGE
+                    || baseItem.getType() == FurnitureType.EFFECT) {
                 return false;
             }
         }
@@ -1511,8 +1868,9 @@ public class CatalogManager {
     private boolean isAtomicEntitlementPurchase(CatalogItem item) {
         if (item == null || item.getBaseItems().isEmpty()) return false;
         for (Item baseItem : item.getBaseItems()) {
-            if (baseItem == null || (baseItem.getType() != FurnitureType.BADGE
-                    && baseItem.getType() != FurnitureType.EFFECT)) return false;
+            if (baseItem == null
+                    || (baseItem.getType() != FurnitureType.BADGE && baseItem.getType() != FurnitureType.EFFECT))
+                return false;
         }
         return true;
     }
@@ -1533,75 +1891,97 @@ public class CatalogManager {
         return true;
     }
 
-    private void purchaseBotsAndPetsAtomically(CatalogItem item, Habbo habbo, int amount, String extraData,
-                                               boolean free, int totalCredits, int totalPoints) throws SQLException {
+    private void purchaseBotsAndPetsAtomically(
+            CatalogItem item,
+            Habbo habbo,
+            int amount,
+            String extraData,
+            boolean free,
+            int totalCredits,
+            int totalPoints)
+            throws SQLException {
         String[] petData = extraData.split("\n");
-        String operationId = EconomyOperationId.create(
-                "catalog:" + habbo.getHabboInfo().getId() + ":" + item.getId());
-        SpecialCompanionPurchase purchase = CatalogPurchaseTransaction.execute(
-                habbo, operationId, connection -> {
-                    List<Bot> bots = new ArrayList<>();
-                    List<Pet> pets = new ArrayList<>();
-                    for (int index = 0; index < amount; index++) {
-                        for (Item baseItem : item.getBaseItems()) {
-                            for (int count = 0; count < item.getItemAmount(baseItem.getId()); count++) {
-                                if (Item.isBot(baseItem)) {
-                                    String baseName = baseItem.getName();
-                                    String type = item.getName().replace("rentable_bot_", "").replace("bot_", "")
-                                            .replace("visitor_logger", "visitor_log");
-                                    if (("bot_" + com.eu.habbo.habbohotel.bots.FrankBot.BOT_TYPE).equals(baseName)
-                                            || ("rentable_bot_" + com.eu.habbo.habbohotel.bots.FrankBot.BOT_TYPE)
+        String operationId =
+                EconomyOperationId.create("catalog:" + habbo.getHabboInfo().getId() + ":" + item.getId());
+        SpecialCompanionPurchase purchase = CatalogPurchaseTransaction.execute(habbo, operationId, connection -> {
+            List<Bot> bots = new ArrayList<>();
+            List<Pet> pets = new ArrayList<>();
+            for (int index = 0; index < amount; index++) {
+                for (Item baseItem : item.getBaseItems()) {
+                    for (int count = 0; count < item.getItemAmount(baseItem.getId()); count++) {
+                        if (Item.isBot(baseItem)) {
+                            String baseName = baseItem.getName();
+                            String type = item.getName()
+                                    .replace("rentable_bot_", "")
+                                    .replace("bot_", "")
+                                    .replace("visitor_logger", "visitor_log");
+                            if (("bot_" + com.eu.habbo.habbohotel.bots.FrankBot.BOT_TYPE).equals(baseName)
+                                    || ("rentable_bot_" + com.eu.habbo.habbohotel.bots.FrankBot.BOT_TYPE)
                                             .equals(baseName)) {
-                                        if (!habbo.hasPermission(com.eu.habbo.habbohotel.bots.FrankBot.PERMISSION_USE)) {
-                                            throw new SQLException("Missing permission for Frank bot");
-                                        }
-                                    }
-                                    Map<String, String> data = new HashMap<>();
-                                    for (String value : item.getExtradata().split(";")) {
-                                        String[] pair = value.split(":", 2);
-                                        if (pair.length == 2) data.put(pair[0], pair[1]);
-                                    }
-                                    Bot bot = Emulator.getGameEnvironment().getBotManager().createBot(connection,
-                                            data, type, habbo.getHabboInfo().getId());
-                                    if (bot == null) throw new SQLException("Unable to create catalog bot");
-                                    bots.add(bot);
-                                } else {
-                                    if (petData.length < 3) throw new SQLException("Invalid catalog pet data");
-                                    Pet pet = Emulator.getGameEnvironment().getPetManager().createPet(connection,
-                                            baseItem, petData[0], petData[1], petData[2], habbo.getClient());
-                                    if (pet == null) throw new SQLException("Unable to create catalog pet");
-                                    pets.add(pet);
+                                if (!habbo.hasPermission(com.eu.habbo.habbohotel.bots.FrankBot.PERMISSION_USE)) {
+                                    throw new SQLException("Missing permission for Frank bot");
                                 }
                             }
+                            Map<String, String> data = new HashMap<>();
+                            for (String value : item.getExtradata().split(";")) {
+                                String[] pair = value.split(":", 2);
+                                if (pair.length == 2) data.put(pair[0], pair[1]);
+                            }
+                            Bot bot = Emulator.getGameEnvironment()
+                                    .getBotManager()
+                                    .createBot(
+                                            connection,
+                                            data,
+                                            type,
+                                            habbo.getHabboInfo().getId());
+                            if (bot == null) throw new SQLException("Unable to create catalog bot");
+                            bots.add(bot);
+                        } else {
+                            if (petData.length < 3) throw new SQLException("Invalid catalog pet data");
+                            Pet pet = Emulator.getGameEnvironment()
+                                    .getPetManager()
+                                    .createPet(
+                                            connection,
+                                            baseItem,
+                                            petData[0],
+                                            petData[1],
+                                            petData[2],
+                                            habbo.getClient());
+                            if (pet == null) throw new SQLException("Unable to create catalog pet");
+                            pets.add(pet);
                         }
                     }
+                }
+            }
 
-                    UserCatalogItemPurchasedEvent event = new UserCatalogItemPurchasedEvent(
-                            habbo, item, new HashSet<>(), totalCredits, totalPoints, new ArrayList<>());
-                    Emulator.getPluginManager().fireEvent(event);
-                    ResolvedCatalogCharges charges = this.resolveCatalogCharges(habbo, item, free, event);
-                    if (!free) this.writePurchaseLog(connection, event, charges, amount);
-                    SpecialCompanionPurchase result = new SpecialCompanionPurchase(
-                            event, bots, pets, charges.credits(), charges.points(), charges.pointsType());
-                    return new CatalogPurchaseTransaction.PreparedPurchase<>(
-                            result, charges.credits(), charges.points(), charges.pointsType());
-                });
+            UserCatalogItemPurchasedEvent event = new UserCatalogItemPurchasedEvent(
+                    habbo, item, new HashSet<>(), totalCredits, totalPoints, new ArrayList<>());
+            Emulator.getPluginManager().fireEvent(event);
+            ResolvedCatalogCharges charges = this.resolveCatalogCharges(habbo, item, free, event);
+            if (!free) this.writePurchaseLog(connection, event, charges, amount);
+            SpecialCompanionPurchase result = new SpecialCompanionPurchase(
+                    event, bots, pets, charges.credits(), charges.points(), charges.pointsType());
+            return new CatalogPurchaseTransaction.PreparedPurchase<>(
+                    result, charges.credits(), charges.points(), charges.pointsType());
+        });
 
         this.publishCommittedCharges(habbo, purchase.credits(), purchase.points(), purchase.pointsType());
         Map<AddHabboItemComposer.AddHabboItemCategory, List<Integer>> unseenItems = new HashMap<>();
         for (Bot bot : purchase.bots()) {
             habbo.getInventory().getBotsComponent().addBot(bot);
             habbo.getClient().sendResponse(new AddBotComposer(bot));
-            unseenItems.computeIfAbsent(AddHabboItemComposer.AddHabboItemCategory.BOT, ignored -> new ArrayList<>())
+            unseenItems
+                    .computeIfAbsent(AddHabboItemComposer.AddHabboItemCategory.BOT, ignored -> new ArrayList<>())
                     .add(bot.getId());
         }
         for (Pet pet : purchase.pets()) {
             habbo.getInventory().getPetsComponent().addPet(pet);
             habbo.getClient().sendResponse(new AddPetComposer(pet));
             habbo.getClient().sendResponse(new PetBoughtNotificationComposer(pet, false));
-            AchievementManager.progressAchievement(habbo,
-                    Emulator.getGameEnvironment().getAchievementManager().getAchievement("PetLover"));
-            unseenItems.computeIfAbsent(AddHabboItemComposer.AddHabboItemCategory.PET, ignored -> new ArrayList<>())
+            AchievementManager.progressAchievement(
+                    habbo, Emulator.getGameEnvironment().getAchievementManager().getAchievement("PetLover"));
+            unseenItems
+                    .computeIfAbsent(AddHabboItemComposer.AddHabboItemCategory.PET, ignored -> new ArrayList<>())
                     .add(pet.getId());
         }
         habbo.getHabboStats().addPurchase(purchase.event().catalogItem);
@@ -1610,8 +1990,9 @@ public class CatalogManager {
         habbo.getClient().sendResponse(new InventoryRefreshComposer());
     }
 
-    private void purchaseEntitlementsAtomically(CatalogItem item, Habbo habbo, int amount, boolean free,
-                                                int totalCredits, int totalPoints) throws SQLException {
+    private void purchaseEntitlementsAtomically(
+            CatalogItem item, Habbo habbo, int amount, boolean free, int totalCredits, int totalPoints)
+            throws SQLException {
         List<String> requestedBadges = new ArrayList<>();
         Map<Integer, Integer> requestedEffects = new HashMap<>();
         for (int index = 0; index < amount; index++) {
@@ -1620,8 +2001,9 @@ public class CatalogManager {
                 if (baseItem.getType() == FurnitureType.BADGE) {
                     if (habbo.getInventory().getBadgesComponent().hasBadge(baseItem.getName())) {
                         if (item.getBaseItems().size() == 1) {
-                            habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(
-                                    AlertPurchaseFailedComposer.ALREADY_HAVE_BADGE));
+                            habbo.getClient()
+                                    .sendResponse(new AlertPurchaseFailedComposer(
+                                            AlertPurchaseFailedComposer.ALREADY_HAVE_BADGE));
                             return;
                         }
                     } else if (!requestedBadges.contains(baseItem.getName())) {
@@ -1629,16 +2011,16 @@ public class CatalogManager {
                     }
                 } else {
                     int effectId = habbo.getHabboInfo().getGender() == HabboGender.F
-                            ? baseItem.getEffectF() : baseItem.getEffectM();
+                            ? baseItem.getEffectF()
+                            : baseItem.getEffectM();
                     if (effectId > 0) requestedEffects.merge(effectId, count, Integer::sum);
                 }
             }
         }
 
-        String operationId = EconomyOperationId.create(
-                "catalog:" + habbo.getHabboInfo().getId() + ":" + item.getId());
-        EntitlementPurchase purchase = CatalogPurchaseTransaction.execute(
-                habbo, operationId, connection -> {
+        String operationId =
+                EconomyOperationId.create("catalog:" + habbo.getHabboInfo().getId() + ":" + item.getId());
+        EntitlementPurchase purchase = CatalogPurchaseTransaction.execute(habbo, operationId, connection -> {
             UserCatalogItemPurchasedEvent event = new UserCatalogItemPurchasedEvent(
                     habbo, item, new HashSet<>(), totalCredits, totalPoints, new ArrayList<>(requestedBadges));
             Emulator.getPluginManager().fireEvent(event);
@@ -1655,8 +2037,8 @@ public class CatalogManager {
             Map<Integer, EffectsComponent.HabboEffect> effects = new HashMap<>();
             for (Map.Entry<Integer, Integer> requested : requestedEffects.entrySet()) {
                 for (int count = 0; count < requested.getValue(); count++) {
-                    EffectsComponent.HabboEffect effect = EffectsComponent.persistEffect(connection,
-                            habbo.getHabboInfo().getId(), requested.getKey(), 86400);
+                    EffectsComponent.HabboEffect effect = EffectsComponent.persistEffect(
+                            connection, habbo.getHabboInfo().getId(), requested.getKey(), 86400);
                     effects.put(requested.getKey(), effect);
                 }
             }
@@ -1692,15 +2074,22 @@ public class CatalogManager {
         habbo.getClient().sendResponse(new InventoryRefreshComposer());
     }
 
-    private void purchaseFurnitureAtomically(CatalogItem item, Habbo habbo, int amount, String extraData,
-                                             boolean free, CatalogLimitedConfiguration limitedConfiguration,
-                                             int limitedStack, int limitedNumber, int totalCredits, int totalPoints)
+    private void purchaseFurnitureAtomically(
+            CatalogItem item,
+            Habbo habbo,
+            int amount,
+            String extraData,
+            boolean free,
+            CatalogLimitedConfiguration limitedConfiguration,
+            int limitedStack,
+            int limitedNumber,
+            int totalCredits,
+            int totalPoints)
             throws SQLException {
         int userId = habbo.getHabboInfo().getId();
         try {
             String operationId = EconomyOperationId.create("catalog:" + userId + ":" + item.getId());
-            AtomicFurniturePurchase purchase = CatalogPurchaseTransaction.execute(
-                    habbo, operationId, connection -> {
+            AtomicFurniturePurchase purchase = CatalogPurchaseTransaction.execute(habbo, operationId, connection -> {
                 Set<HabboItem> createdItems = new HashSet<>();
                 Map<InteractionGuildFurni, Guild> guildFurniture = new HashMap<>();
                 boolean includesMusicDisc = false;
@@ -1716,50 +2105,91 @@ public class CatalogManager {
                                 } catch (NumberFormatException exception) {
                                     throw new SQLException("Invalid guild furniture id", exception);
                                 }
-                                Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
-                                if (guild == null || Emulator.getGameEnvironment().getGuildManager()
-                                        .getGuildMember(guild, habbo) == null) {
+                                Guild guild = Emulator.getGameEnvironment()
+                                        .getGuildManager()
+                                        .getGuild(guildId);
+                                if (guild == null
+                                        || Emulator.getGameEnvironment()
+                                                        .getGuildManager()
+                                                        .getGuildMember(guild, habbo)
+                                                == null) {
                                     throw new SQLException("User cannot purchase furniture for guild " + guildId);
                                 }
                                 if (baseItem.getName().equals("guild_forum")
-                                        && guild.getOwnerId() != habbo.getHabboInfo().getId()) {
+                                        && guild.getOwnerId()
+                                                != habbo.getHabboInfo().getId()) {
                                     throw new SQLException("Only the guild owner can purchase its forum");
                                 }
                                 InteractionGuildFurni created = (InteractionGuildFurni) Emulator.getGameEnvironment()
-                                        .getItemManager().createItem(connection, userId, baseItem,
-                                                limitedStack, limitedNumber, "");
+                                        .getItemManager()
+                                        .createItem(connection, userId, baseItem, limitedStack, limitedNumber, "");
                                 if (created == null) throw new SQLException("Unable to create guild furniture");
-                                Emulator.getGameEnvironment().getGuildManager().persistGuild(connection,
-                                        created.getId(), guildId);
+                                Emulator.getGameEnvironment()
+                                        .getGuildManager()
+                                        .persistGuild(connection, created.getId(), guildId);
                                 created.setGuildId(guildId);
                                 guildFurniture.put(created, guild);
                                 createdItems.add(created);
                             } else if (baseItem.getInteractionType().getType() == InteractionMusicDisc.class) {
-                                SoundTrack track = Emulator.getGameEnvironment().getItemManager()
+                                SoundTrack track = Emulator.getGameEnvironment()
+                                        .getItemManager()
                                         .getSoundTrack(item.getExtradata());
                                 if (track == null) throw new SQLException("Unknown catalog music track");
                                 itemExtraData = this.createMusicDiscExtraData(habbo, track);
-                                HabboItem created = Emulator.getGameEnvironment().getItemManager().createItem(
-                                        connection, userId, baseItem, limitedStack, limitedNumber, itemExtraData);
+                                HabboItem created = Emulator.getGameEnvironment()
+                                        .getItemManager()
+                                        .createItem(
+                                                connection,
+                                                userId,
+                                                baseItem,
+                                                limitedStack,
+                                                limitedNumber,
+                                                itemExtraData);
                                 if (created == null) throw new SQLException("Unable to create music disc");
                                 createdItems.add(created);
                                 includesMusicDisc = true;
-                            } else if (InteractionTeleport.class.isAssignableFrom(baseItem.getInteractionType().getType())) {
-                                HabboItem first = Emulator.getGameEnvironment().getItemManager().createItem(
-                                        connection, userId, baseItem, limitedStack, limitedNumber, itemExtraData);
-                                HabboItem second = Emulator.getGameEnvironment().getItemManager().createItem(
-                                        connection, userId, baseItem, limitedStack, limitedNumber, itemExtraData);
-                                if (first == null || second == null) throw new SQLException("Unable to create teleport pair");
-                                Emulator.getGameEnvironment().getItemManager().insertTeleportPair(
-                                        connection, first.getId(), second.getId());
+                            } else if (InteractionTeleport.class.isAssignableFrom(
+                                    baseItem.getInteractionType().getType())) {
+                                HabboItem first = Emulator.getGameEnvironment()
+                                        .getItemManager()
+                                        .createItem(
+                                                connection,
+                                                userId,
+                                                baseItem,
+                                                limitedStack,
+                                                limitedNumber,
+                                                itemExtraData);
+                                HabboItem second = Emulator.getGameEnvironment()
+                                        .getItemManager()
+                                        .createItem(
+                                                connection,
+                                                userId,
+                                                baseItem,
+                                                limitedStack,
+                                                limitedNumber,
+                                                itemExtraData);
+                                if (first == null || second == null)
+                                    throw new SQLException("Unable to create teleport pair");
+                                Emulator.getGameEnvironment()
+                                        .getItemManager()
+                                        .insertTeleportPair(connection, first.getId(), second.getId());
                                 createdItems.add(first);
                                 createdItems.add(second);
                             } else {
-                                HabboItem created = Emulator.getGameEnvironment().getItemManager().createItem(
-                                        connection, userId, baseItem, limitedStack, limitedNumber, itemExtraData);
+                                HabboItem created = Emulator.getGameEnvironment()
+                                        .getItemManager()
+                                        .createItem(
+                                                connection,
+                                                userId,
+                                                baseItem,
+                                                limitedStack,
+                                                limitedNumber,
+                                                itemExtraData);
                                 if (created == null) throw new SQLException("Unable to create catalog furniture");
                                 if (baseItem.getInteractionType().getType() == InteractionHopper.class) {
-                                    Emulator.getGameEnvironment().getItemManager().insertHopper(connection, created);
+                                    Emulator.getGameEnvironment()
+                                            .getItemManager()
+                                            .insertHopper(connection, created);
                                 }
                                 createdItems.add(created);
                             }
@@ -1767,18 +2197,21 @@ public class CatalogManager {
                     }
                 }
 
-                Set<Integer> createdIds = createdItems.stream().map(HabboItem::getId).collect(Collectors.toSet());
+                Set<Integer> createdIds =
+                        createdItems.stream().map(HabboItem::getId).collect(Collectors.toSet());
                 UserCatalogItemPurchasedEvent purchasedEvent = new UserCatalogItemPurchasedEvent(
                         habbo, item, createdItems, totalCredits, totalPoints, new ArrayList<>());
                 Emulator.getPluginManager().fireEvent(purchasedEvent);
-                Set<Integer> eventIds = purchasedEvent.itemsList.stream().map(HabboItem::getId).collect(Collectors.toSet());
+                Set<Integer> eventIds =
+                        purchasedEvent.itemsList.stream().map(HabboItem::getId).collect(Collectors.toSet());
                 if (!createdIds.equals(eventIds)) {
                     throw new SQLException("Catalog plugin changed the atomic furniture set");
                 }
 
                 ResolvedCatalogCharges charges = this.resolveCatalogCharges(habbo, item, free, purchasedEvent);
                 if (limitedConfiguration != null) {
-                    HabboItem limitedItem = createdItems.stream().findFirst()
+                    HabboItem limitedItem = createdItems.stream()
+                            .findFirst()
                             .orElseThrow(() -> new SQLException("Limited purchase created no furniture"));
                     limitedConfiguration.limitedSold(connection, item.getId(), habbo, limitedItem);
                 }
@@ -1786,8 +2219,12 @@ public class CatalogManager {
                     this.writePurchaseLog(connection, purchasedEvent, charges, amount);
                 }
                 AtomicFurniturePurchase result = new AtomicFurniturePurchase(
-                        purchasedEvent, guildFurniture, includesMusicDisc,
-                        charges.credits(), charges.points(), charges.pointsType());
+                        purchasedEvent,
+                        guildFurniture,
+                        includesMusicDisc,
+                        charges.credits(),
+                        charges.points(),
+                        charges.pointsType());
                 return new CatalogPurchaseTransaction.PreparedPurchase<>(
                         result, charges.credits(), charges.points(), charges.pointsType());
             });
@@ -1810,8 +2247,10 @@ public class CatalogManager {
         String value = extraData;
         if (baseItem.getInteractionType().getType() == InteractionBadgeDisplay.class
                 && !habbo.getInventory().getBadgesComponent().hasBadge(value)) {
-            ScripterManager.scripterDetected(habbo.getClient(),
-                    Emulator.getTexts().getValue("scripter.warning.catalog.badge_display")
+            ScripterManager.scripterDetected(
+                    habbo.getClient(),
+                    Emulator.getTexts()
+                            .getValue("scripter.warning.catalog.badge_display")
                             .replace("%username%", habbo.getHabboInfo().getUsername())
                             .replace("%badge%", value));
             value = "UMAD";
@@ -1834,8 +2273,8 @@ public class CatalogManager {
                 + track.getLength() + "\n" + track.getName() + "\n" + track.getId();
     }
 
-    private ResolvedCatalogCharges resolveCatalogCharges(Habbo habbo, CatalogItem item, boolean free,
-                                                         UserCatalogItemPurchasedEvent purchasedEvent) {
+    private ResolvedCatalogCharges resolveCatalogCharges(
+            Habbo habbo, CatalogItem item, boolean free, UserCatalogItemPurchasedEvent purchasedEvent) {
         int credits = 0;
         int points = 0;
         int pointsType = item.getPointsType();
@@ -1853,13 +2292,22 @@ public class CatalogManager {
         return new ResolvedCatalogCharges(credits, points, pointsType);
     }
 
-    private void writePurchaseLog(Connection connection, UserCatalogItemPurchasedEvent event,
-                                  ResolvedCatalogCharges charges, int amount) throws SQLException {
-        Set<String> itemIds = event.itemsList.stream().map(item -> Integer.toString(item.getId())).collect(Collectors.toSet());
+    private void writePurchaseLog(
+            Connection connection, UserCatalogItemPurchasedEvent event, ResolvedCatalogCharges charges, int amount)
+            throws SQLException {
+        Set<String> itemIds = event.itemsList.stream()
+                .map(item -> Integer.toString(item.getId()))
+                .collect(Collectors.toSet());
         CatalogPurchaseLogEntry entry = new CatalogPurchaseLogEntry(
-                Emulator.getIntUnixTimestamp(), event.habbo.getHabboInfo().getId(), event.catalogItem.getId(),
-                String.join(";", itemIds), event.catalogItem.getName(), charges.credits(), charges.points(),
-                charges.pointsType(), amount);
+                Emulator.getIntUnixTimestamp(),
+                event.habbo.getHabboInfo().getId(),
+                event.catalogItem.getId(),
+                String.join(";", itemIds),
+                event.catalogItem.getName(),
+                charges.credits(),
+                charges.points(),
+                charges.pointsType(),
+                amount);
         try (PreparedStatement statement = connection.prepareStatement(entry.getQuery())) {
             entry.log(statement);
             statement.executeBatch();
@@ -1872,11 +2320,13 @@ public class CatalogManager {
         Set<HabboItem> items = purchase.event().itemsList;
         habbo.getInventory().getItemsComponent().addItems(items);
         Map<AddHabboItemComposer.AddHabboItemCategory, List<Integer>> unseenItems = new HashMap<>();
-        unseenItems.put(AddHabboItemComposer.AddHabboItemCategory.OWNED_FURNI,
+        unseenItems.put(
+                AddHabboItemComposer.AddHabboItemCategory.OWNED_FURNI,
                 items.stream().map(HabboItem::getId).collect(Collectors.toList()));
-        Emulator.getPluginManager().fireEvent(new UserCatalogFurnitureBoughtEvent(
-                habbo, purchase.event().catalogItem, items));
-        for (Map.Entry<InteractionGuildFurni, Guild> guildEntry : purchase.guildFurniture().entrySet()) {
+        Emulator.getPluginManager()
+                .fireEvent(new UserCatalogFurnitureBoughtEvent(habbo, purchase.event().catalogItem, items));
+        for (Map.Entry<InteractionGuildFurni, Guild> guildEntry :
+                purchase.guildFurniture().entrySet()) {
             if (guildEntry.getKey().getBaseItem().getName().equals("guild_forum")) {
                 guildEntry.getValue().setForum(true);
                 guildEntry.getValue().needsUpdate = true;
@@ -1884,8 +2334,8 @@ public class CatalogManager {
             }
         }
         if (purchase.includesMusicDisc()) {
-            AchievementManager.progressAchievement(habbo,
-                    Emulator.getGameEnvironment().getAchievementManager().getAchievement("MusicCollector"));
+            AchievementManager.progressAchievement(
+                    habbo, Emulator.getGameEnvironment().getAchievementManager().getAchievement("MusicCollector"));
         }
         habbo.getHabboStats().addPurchase(purchase.event().catalogItem);
         habbo.getClient().sendResponse(new AddHabboItemComposer(unseenItems));
@@ -1898,27 +2348,37 @@ public class CatalogManager {
             habbo.getClient().sendResponse(new UserCreditsComposer(habbo));
         }
         if (points > 0) {
-            habbo.getClient().sendResponse(new UserPointsComposer(
-                    habbo.getHabboInfo().getCurrencyAmount(pointsType), -points, pointsType));
+            habbo.getClient()
+                    .sendResponse(new UserPointsComposer(
+                            habbo.getHabboInfo().getCurrencyAmount(pointsType), -points, pointsType));
         }
     }
 
-    private record ResolvedCatalogCharges(int credits, int points, int pointsType) {
-    }
+    private record ResolvedCatalogCharges(int credits, int points, int pointsType) {}
 
-    private record AtomicFurniturePurchase(UserCatalogItemPurchasedEvent event,
-                                           Map<InteractionGuildFurni, Guild> guildFurniture,
-                                           boolean includesMusicDisc, int credits, int points, int pointsType) {
-    }
+    private record AtomicFurniturePurchase(
+            UserCatalogItemPurchasedEvent event,
+            Map<InteractionGuildFurni, Guild> guildFurniture,
+            boolean includesMusicDisc,
+            int credits,
+            int points,
+            int pointsType) {}
 
-    private record EntitlementPurchase(UserCatalogItemPurchasedEvent event, List<HabboBadge> badges,
-                                       Map<Integer, EffectsComponent.HabboEffect> effects, int credits, int points,
-                                       int pointsType) {
-    }
+    private record EntitlementPurchase(
+            UserCatalogItemPurchasedEvent event,
+            List<HabboBadge> badges,
+            Map<Integer, EffectsComponent.HabboEffect> effects,
+            int credits,
+            int points,
+            int pointsType) {}
 
-    private record SpecialCompanionPurchase(UserCatalogItemPurchasedEvent event, List<Bot> bots, List<Pet> pets,
-                                            int credits, int points, int pointsType) {
-    }
+    private record SpecialCompanionPurchase(
+            UserCatalogItemPurchasedEvent event,
+            List<Bot> bots,
+            List<Pet> pets,
+            int credits,
+            int points,
+            int pointsType) {}
 
     public List<ClubOffer> getClubOffers() {
         return this.getClubOffers(ClubOffer.WINDOW_HABBO_CLUB);
@@ -1964,7 +2424,8 @@ public class CatalogManager {
             if (amount >= threshold) additionalDiscounts++;
         }
 
-        int totalDiscountedItems = (basicDiscount * DiscountComposer.DISCOUNT_AMOUNT_PER_BATCH) + bonusDiscount + additionalDiscounts;
+        int totalDiscountedItems =
+                (basicDiscount * DiscountComposer.DISCOUNT_AMOUNT_PER_BATCH) + bonusDiscount + additionalDiscounts;
 
         int payableItems = Math.max(0, amount - totalDiscountedItems);
         return CatalogPurchaseMath.checkedPrice(originalPrice, payableItems);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/TargetOffer.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/TargetOffer.java
@@ -1,15 +1,13 @@
 package com.eu.habbo.habbohotel.catalog;
 
-
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.users.cache.HabboOfferPurchase;
 import com.eu.habbo.messages.ServerMessage;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 public class TargetOffer {
-    public static int ACTIVE_TARGET_OFFER_ID = 0;
+    public static volatile int ACTIVE_TARGET_OFFER_ID = 0;
 
     private final int id;
     private final int catalogItem;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlace.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlace.java
@@ -21,9 +21,6 @@ import com.eu.habbo.plugin.events.marketplace.MarketPlaceItemOfferedEvent;
 import com.eu.habbo.plugin.events.marketplace.MarketPlaceItemSoldEvent;
 import com.eu.habbo.plugin.events.users.UserCreditsEvent;
 import com.eu.habbo.plugin.events.users.UserPointsEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -32,7 +29,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MarketPlace {
     private static final Logger LOGGER = LoggerFactory.getLogger(MarketPlace.class);
@@ -50,16 +48,17 @@ public class MarketPlace {
     public static final int MINIMUM_LISTING_PRICE = 1;
     public static final int MAXIMUM_LISTING_PRICE = 1_000_000_000;
 
-    //Configuration. Loaded from database & updated accordingly.
-    public static boolean MARKETPLACE_ENABLED = true;
+    // Configuration. Loaded from database & updated accordingly.
+    public static volatile boolean MARKETPLACE_ENABLED = true;
 
-    //Currency to use.
-    public static int MARKETPLACE_CURRENCY = 0;
-
+    // Currency to use.
+    public static volatile int MARKETPLACE_CURRENCY = 0;
 
     public static Set<MarketPlaceOffer> getOwnOffers(Habbo habbo) {
         Set<MarketPlaceOffer> offers = new HashSet<>();
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT items_base.type AS type, items.item_id AS base_item_id, items.limited_data AS ltd_data, marketplace_items.* FROM marketplace_items INNER JOIN items ON marketplace_items.item_id = items.id INNER JOIN items_base ON items.item_id = items_base.id WHERE marketplace_items.user_id = ?")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT items_base.type AS type, items.item_id AS base_item_id, items.limited_data AS ltd_data, marketplace_items.* FROM marketplace_items INNER JOIN items ON marketplace_items.item_id = items.id INNER JOIN items_base ON items.item_id = items_base.id WHERE marketplace_items.user_id = ?")) {
             statement.setInt(1, habbo.getHabboInfo().getId());
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
@@ -73,7 +72,6 @@ public class MarketPlace {
         return offers;
     }
 
-
     public static void takeBackItem(Habbo habbo, int offerId) {
         MarketPlaceOffer offer = habbo.getInventory().getOffer(offerId);
 
@@ -81,17 +79,21 @@ public class MarketPlace {
             return;
         }
 
-        if (!Emulator.getPluginManager().fireEvent(new MarketPlaceItemCancelledEvent(offer)).isCancelled()) {
+        if (!Emulator.getPluginManager()
+                .fireEvent(new MarketPlaceItemCancelledEvent(offer))
+                .isCancelled()) {
             takeBackItem(habbo, offer);
         }
     }
-
 
     private static void takeBackItem(Habbo habbo, MarketPlaceOffer offer) {
         if (offer != null && habbo.getInventory().getMarketplaceItems().contains(offer)) {
             RequestOffersEvent.cachedResults.clear();
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
-                try (PreparedStatement ownerCheck = connection.prepareStatement("SELECT user_id FROM marketplace_items WHERE id = ?", ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY)) {
+                try (PreparedStatement ownerCheck = connection.prepareStatement(
+                        "SELECT user_id FROM marketplace_items WHERE id = ?",
+                        ResultSet.TYPE_SCROLL_INSENSITIVE,
+                        ResultSet.CONCUR_READ_ONLY)) {
                     ownerCheck.setInt(1, offer.getOfferId());
                     try (ResultSet ownerSet = ownerCheck.executeQuery()) {
                         ownerSet.last();
@@ -102,28 +104,40 @@ public class MarketPlace {
 
                         ownerSet.first();
                         if (ownerSet.getInt("user_id") != habbo.getHabboInfo().getId()) {
-                            LOGGER.warn("User {} attempted to take back marketplace offer {} owned by user {}", habbo.getHabboInfo().getId(), offer.getOfferId(), ownerSet.getInt("user_id"));
+                            LOGGER.warn(
+                                    "User {} attempted to take back marketplace offer {} owned by user {}",
+                                    habbo.getHabboInfo().getId(),
+                                    offer.getOfferId(),
+                                    ownerSet.getInt("user_id"));
                             return;
                         }
 
-                        try (PreparedStatement statement = connection.prepareStatement("DELETE FROM marketplace_items WHERE id = ? AND state != 2")) {
+                        try (PreparedStatement statement = connection.prepareStatement(
+                                "DELETE FROM marketplace_items WHERE id = ? AND state != 2")) {
                             statement.setInt(1, offer.getOfferId());
                             int count = statement.executeUpdate();
 
                             if (count != 0) {
                                 habbo.getInventory().removeMarketplaceOffer(offer);
-                                try (PreparedStatement updateItems = connection.prepareStatement("UPDATE items SET user_id = ? WHERE id = ? LIMIT 1")) {
+                                try (PreparedStatement updateItems = connection.prepareStatement(
+                                        "UPDATE items SET user_id = ? WHERE id = ? LIMIT 1")) {
                                     updateItems.setInt(1, habbo.getHabboInfo().getId());
                                     updateItems.setInt(2, offer.getSoldItemId());
                                     updateItems.execute();
 
-                                    try (PreparedStatement selectItem = connection.prepareStatement("SELECT * FROM items WHERE id = ? LIMIT 1")) {
+                                    try (PreparedStatement selectItem =
+                                            connection.prepareStatement("SELECT * FROM items WHERE id = ? LIMIT 1")) {
                                         selectItem.setInt(1, offer.getSoldItemId());
                                         try (ResultSet set = selectItem.executeQuery()) {
                                             while (set.next()) {
-                                                HabboItem item = Emulator.getGameEnvironment().getItemManager().loadHabboItem(set);
-                                                habbo.getInventory().getItemsComponent().addItem(item);
-                                                habbo.getClient().sendResponse(new MarketplaceCancelSaleComposer(offer, true));
+                                                HabboItem item = Emulator.getGameEnvironment()
+                                                        .getItemManager()
+                                                        .loadHabboItem(set);
+                                                habbo.getInventory()
+                                                        .getItemsComponent()
+                                                        .addItem(item);
+                                                habbo.getClient()
+                                                        .sendResponse(new MarketplaceCancelSaleComposer(offer, true));
                                                 habbo.getClient().sendResponse(new AddHabboItemComposer(item));
                                                 habbo.getClient().sendResponse(new InventoryRefreshComposer());
                                             }
@@ -141,10 +155,10 @@ public class MarketPlace {
         }
     }
 
-
     public static List<MarketPlaceOffer> getOffers(int minPrice, int maxPrice, String search, int sort) {
         List<MarketPlaceOffer> offers = new ArrayList<>(10);
-        String query = "SELECT B.* FROM marketplace_items a INNER JOIN (SELECT b.item_id AS base_item_id, b.limited_data AS ltd_data, marketplace_items.*, AVG(price) as avg, MIN(marketplace_items.price) as minPrice, MAX(marketplace_items.price) as maxPrice, COUNT(*) as number, (SELECT COUNT(*) FROM marketplace_items c INNER JOIN items as items_b ON c.item_id = items_b.id WHERE state = 2 AND items_b.item_id = base_item_id AND DATE(from_unixtime(sold_timestamp)) = CURDATE()) as sold_count_today FROM marketplace_items INNER JOIN items b ON marketplace_items.item_id = b.id INNER JOIN items_base bi ON b.item_id = bi.id INNER JOIN catalog_items ci ON bi.id = ci.item_ids WHERE price = (SELECT MIN(e.price) FROM marketplace_items e, items d WHERE e.item_id = d.id AND d.item_id = b.item_id AND e.state = 1 AND e.timestamp > ? AND e.price BETWEEN ? AND ? GROUP BY d.item_id) AND state = 1 AND timestamp > ? AND marketplace_items.price BETWEEN ? AND ?";
+        String query =
+                "SELECT B.* FROM marketplace_items a INNER JOIN (SELECT b.item_id AS base_item_id, b.limited_data AS ltd_data, marketplace_items.*, AVG(price) as avg, MIN(marketplace_items.price) as minPrice, MAX(marketplace_items.price) as maxPrice, COUNT(*) as number, (SELECT COUNT(*) FROM marketplace_items c INNER JOIN items as items_b ON c.item_id = items_b.id WHERE state = 2 AND items_b.item_id = base_item_id AND DATE(from_unixtime(sold_timestamp)) = CURDATE()) as sold_count_today FROM marketplace_items INNER JOIN items b ON marketplace_items.item_id = b.id INNER JOIN items_base bi ON b.item_id = bi.id INNER JOIN catalog_items ci ON bi.id = ci.item_ids WHERE price = (SELECT MIN(e.price) FROM marketplace_items e, items d WHERE e.item_id = d.id AND d.item_id = b.item_id AND e.state = 1 AND e.timestamp > ? AND e.price BETWEEN ? AND ? GROUP BY d.item_id) AND state = 1 AND timestamp > ? AND marketplace_items.price BETWEEN ? AND ?";
         if (minPrice > 0) {
             query += " AND CEIL(price + (price / 100)) >= ?";
         }
@@ -185,7 +199,8 @@ public class MarketPlace {
 
         query += " LIMIT 250";
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement(query)) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(query)) {
             int paramIndex = 1;
             statement.setInt(paramIndex++, Emulator.getIntUnixTimestamp() - 172800);
             statement.setInt(paramIndex++, MINIMUM_LISTING_PRICE);
@@ -217,9 +232,12 @@ public class MarketPlace {
         return offers;
     }
 
-
     public static void serializeItemInfo(int itemId, ServerMessage message) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT avg(marketplace_items.price) as price, COUNT(*) as sold, (datediff(NOW(), DATE(from_unixtime(marketplace_items.timestamp)))) as day FROM marketplace_items INNER JOIN items ON items.id = marketplace_items.item_id INNER JOIN items_base ON items.item_id = items_base.id WHERE items.limited_data = '0:0' AND marketplace_items.state = 2 AND items_base.sprite_id = ? AND DATE(from_unixtime(marketplace_items.timestamp)) >= NOW() - INTERVAL 30 DAY GROUP BY DATE(from_unixtime(marketplace_items.timestamp))", ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY)) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT avg(marketplace_items.price) as price, COUNT(*) as sold, (datediff(NOW(), DATE(from_unixtime(marketplace_items.timestamp)))) as day FROM marketplace_items INNER JOIN items ON items.id = marketplace_items.item_id INNER JOIN items_base ON items.item_id = items_base.id WHERE items.limited_data = '0:0' AND marketplace_items.state = 2 AND items_base.sprite_id = ? AND DATE(from_unixtime(marketplace_items.timestamp)) >= NOW() - INTERVAL 30 DAY GROUP BY DATE(from_unixtime(marketplace_items.timestamp))",
+                        ResultSet.TYPE_SCROLL_INSENSITIVE,
+                        ResultSet.CONCUR_READ_ONLY)) {
             statement.setInt(1, itemId);
 
             message.appendInt(avarageLastXDays(itemId, 7));
@@ -245,10 +263,13 @@ public class MarketPlace {
         }
     }
 
-
     public static int itemsOnSale(int baseItemId) {
         int number = 0;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT COUNT(*) as number, AVG(price) as avg FROM marketplace_items INNER JOIN items ON marketplace_items.item_id = items.id INNER JOIN items_base ON items.item_id = items_base.id WHERE state = 1 AND timestamp >= ? AND items_base.sprite_id = ?", ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY)) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT COUNT(*) as number, AVG(price) as avg FROM marketplace_items INNER JOIN items ON marketplace_items.item_id = items.id INNER JOIN items_base ON items.item_id = items_base.id WHERE state = 1 AND timestamp >= ? AND items_base.sprite_id = ?",
+                        ResultSet.TYPE_SCROLL_INSENSITIVE,
+                        ResultSet.CONCUR_READ_ONLY)) {
             statement.setInt(1, Emulator.getIntUnixTimestamp() - 172800);
             statement.setInt(2, baseItemId);
             try (ResultSet set = statement.executeQuery()) {
@@ -262,10 +283,13 @@ public class MarketPlace {
         return number;
     }
 
-
     private static int avarageLastXDays(int baseItemId, int days) {
         int avg = 0;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT AVG(price) as avg FROM marketplace_items INNER JOIN items ON marketplace_items.item_id = items.id INNER JOIN items_base ON items.item_id = items_base.id WHERE state = 2 AND DATE(from_unixtime(timestamp)) >= NOW() - INTERVAL ? DAY AND items_base.sprite_id = ?", ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY)) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT AVG(price) as avg FROM marketplace_items INNER JOIN items ON marketplace_items.item_id = items.id INNER JOIN items_base ON items.item_id = items_base.id WHERE state = 2 AND DATE(from_unixtime(timestamp)) >= NOW() - INTERVAL ? DAY AND items_base.sprite_id = ?",
+                        ResultSet.TYPE_SCROLL_INSENSITIVE,
+                        ResultSet.CONCUR_READ_ONLY)) {
             statement.setInt(1, days);
             statement.setInt(2, baseItemId);
 
@@ -280,7 +304,6 @@ public class MarketPlace {
         return calculateCommision(avg);
     }
 
-
     public static void buyItem(int offerId, GameClient client) {
         RequestOffersEvent.cachedResults.clear();
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
@@ -288,7 +311,8 @@ public class MarketPlace {
                 statement.setInt(1, offerId);
                 try (ResultSet set = statement.executeQuery()) {
                     if (set.next()) {
-                        try (PreparedStatement itemStatement = connection.prepareStatement(PURCHASE_ITEM_SQL, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY)) {
+                        try (PreparedStatement itemStatement = connection.prepareStatement(
+                                PURCHASE_ITEM_SQL, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY)) {
                             itemStatement.setInt(1, set.getInt("item_id"));
                             try (ResultSet itemSet = itemStatement.executeQuery()) {
                                 itemSet.first();
@@ -303,14 +327,31 @@ public class MarketPlace {
                                     int price = MarketPlace.calculateCommision(rawPrice);
                                     if (set.getInt("state") != 1) {
                                         sendErrorMessage(client, set.getInt("item_id"), offerId);
-                                    } else if ((MARKETPLACE_CURRENCY == 0 && price > client.getHabbo().getHabboInfo().getCredits()) || (MARKETPLACE_CURRENCY > 0 && price > client.getHabbo().getHabboInfo().getCurrencyAmount(MARKETPLACE_CURRENCY))) {
-                                        client.sendResponse(new MarketplaceBuyErrorComposer(MarketplaceBuyErrorComposer.NOT_ENOUGH_CREDITS, 0, offerId, price));
+                                    } else if ((MARKETPLACE_CURRENCY == 0
+                                                    && price
+                                                            > client.getHabbo()
+                                                                    .getHabboInfo()
+                                                                    .getCredits())
+                                            || (MARKETPLACE_CURRENCY > 0
+                                                    && price
+                                                            > client.getHabbo()
+                                                                    .getHabboInfo()
+                                                                    .getCurrencyAmount(MARKETPLACE_CURRENCY))) {
+                                        client.sendResponse(new MarketplaceBuyErrorComposer(
+                                                MarketplaceBuyErrorComposer.NOT_ENOUGH_CREDITS, 0, offerId, price));
                                     } else {
-                                        Habbo habbo = Emulator.getGameServer().getGameClientManager().getHabbo(set.getInt("user_id"));
-                                        HabboItem item = Emulator.getGameEnvironment().getItemManager().loadHabboItem(itemSet);
+                                        Habbo habbo = Emulator.getGameServer()
+                                                .getGameClientManager()
+                                                .getHabbo(set.getInt("user_id"));
+                                        HabboItem item = Emulator.getGameEnvironment()
+                                                .getItemManager()
+                                                .loadHabboItem(itemSet);
 
-                                        MarketPlaceItemSoldEvent event = new MarketPlaceItemSoldEvent(habbo, client.getHabbo(), item, set.getInt("price"));
-                                        if (Emulator.getPluginManager().fireEvent(event).isCancelled()
+                                        MarketPlaceItemSoldEvent event = new MarketPlaceItemSoldEvent(
+                                                habbo, client.getHabbo(), item, set.getInt("price"));
+                                        if (Emulator.getPluginManager()
+                                                        .fireEvent(event)
+                                                        .isCancelled()
                                                 || !isValidListingPrice(event.price)) {
                                             return;
                                         }
@@ -318,48 +359,56 @@ public class MarketPlace {
                                         int soldTimestamp = Emulator.getIntUnixTimestamp();
                                         event.price = calculateCommision(event.price);
 
-                                        PreparedCharge charge = prepareMarketplaceCharge(client.getHabbo(), event.price);
+                                        PreparedCharge charge =
+                                                prepareMarketplaceCharge(client.getHabbo(), event.price);
                                         if (charge == null) return;
 
                                         EconomyMutationResult walletMutation =
-                                                LedgerWalletMutation.coordinated(
-                                                        client.getHabbo(),
-                                                        () -> {
-                                                            EconomyMutationResult mutation =
-                                                                    MarketPlacePurchaseTransaction.commit(
-                                                                            offerId,
-                                                                            item.getId(),
-                                                                            client.getHabbo().getHabboInfo().getId(),
-                                                                            charge.currencyType(),
-                                                                            -charge.delta(),
-                                                                            soldTimestamp);
-                                                            if (mutation != null) {
-                                                                LedgerWalletMutation.applyCommitted(
-                                                                        client.getHabbo(),
-                                                                        charge.currencyType(),
-                                                                        mutation.balanceAfter());
-                                                            }
-                                                            return mutation;
-                                                        });
+                                                LedgerWalletMutation.coordinated(client.getHabbo(), () -> {
+                                                    EconomyMutationResult mutation =
+                                                            MarketPlacePurchaseTransaction.commit(
+                                                                    offerId,
+                                                                    item.getId(),
+                                                                    client.getHabbo()
+                                                                            .getHabboInfo()
+                                                                            .getId(),
+                                                                    charge.currencyType(),
+                                                                    -charge.delta(),
+                                                                    soldTimestamp);
+                                                    if (mutation != null) {
+                                                        LedgerWalletMutation.applyCommitted(
+                                                                client.getHabbo(),
+                                                                charge.currencyType(),
+                                                                mutation.balanceAfter());
+                                                    }
+                                                    return mutation;
+                                                });
                                         if (walletMutation == null) {
-                                            sendErrorMessage(client, item.getBaseItem().getId(), offerId);
+                                            sendErrorMessage(
+                                                    client, item.getBaseItem().getId(), offerId);
                                             return;
                                         }
 
-                                        item.setUserId(client.getHabbo().getHabboInfo().getId());
+                                        item.setUserId(
+                                                client.getHabbo().getHabboInfo().getId());
                                         item.needsUpdate(true);
                                         Emulator.getThreading().run(item);
 
-                                        client.getHabbo().getInventory().getItemsComponent().addItem(item);
+                                        client.getHabbo()
+                                                .getInventory()
+                                                .getItemsComponent()
+                                                .addItem(item);
 
                                         publishMarketplaceCharge(client, charge);
 
                                         client.sendResponse(new AddHabboItemComposer(item));
                                         client.sendResponse(new InventoryRefreshComposer());
-                                        client.sendResponse(new MarketplaceBuyErrorComposer(MarketplaceBuyErrorComposer.REFRESH, 0, offerId, price));
+                                        client.sendResponse(new MarketplaceBuyErrorComposer(
+                                                MarketplaceBuyErrorComposer.REFRESH, 0, offerId, price));
 
                                         if (habbo != null) {
-                                            MarketPlaceOffer offer = habbo.getInventory().getOffer(offerId);
+                                            MarketPlaceOffer offer =
+                                                    habbo.getInventory().getOffer(offerId);
                                             if (offer != null) {
                                                 offer.setState(MarketPlaceState.SOLD);
                                                 offer.setSoldTimestamp(soldTimestamp);
@@ -377,26 +426,33 @@ public class MarketPlace {
         }
     }
 
-
     public static void sendErrorMessage(GameClient client, int baseItemId, int offerId) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT marketplace_items.*, COUNT( * ) AS count\n" +
-                "FROM marketplace_items\n" +
-                "INNER JOIN items ON marketplace_items.item_id = items.id\n" +
-                "INNER JOIN items_base ON items.item_id = items_base.id\n" +
-                "WHERE items_base.sprite_id = ( \n" +
-                "SELECT items_base.sprite_id\n" +
-                "FROM items_base\n" +
-                "WHERE items_base.id = ? LIMIT 1)\n" +
-                "ORDER BY price ASC\n" +
-                "LIMIT 1", ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY)) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT marketplace_items.*, COUNT( * ) AS count\n" + "FROM marketplace_items\n"
+                                + "INNER JOIN items ON marketplace_items.item_id = items.id\n"
+                                + "INNER JOIN items_base ON items.item_id = items_base.id\n"
+                                + "WHERE items_base.sprite_id = ( \n"
+                                + "SELECT items_base.sprite_id\n"
+                                + "FROM items_base\n"
+                                + "WHERE items_base.id = ? LIMIT 1)\n"
+                                + "ORDER BY price ASC\n"
+                                + "LIMIT 1",
+                        ResultSet.TYPE_SCROLL_INSENSITIVE,
+                        ResultSet.CONCUR_READ_ONLY)) {
             statement.setInt(1, baseItemId);
             try (ResultSet countSet = statement.executeQuery()) {
                 countSet.last();
                 if (countSet.getRow() == 0)
-                    client.sendResponse(new MarketplaceBuyErrorComposer(MarketplaceBuyErrorComposer.SOLD_OUT, 0, offerId, 0));
+                    client.sendResponse(
+                            new MarketplaceBuyErrorComposer(MarketplaceBuyErrorComposer.SOLD_OUT, 0, offerId, 0));
                 else {
                     countSet.first();
-                    client.sendResponse(new MarketplaceBuyErrorComposer(MarketplaceBuyErrorComposer.UPDATES, countSet.getInt("count"), countSet.getInt("id"), MarketPlace.calculateCommision(countSet.getInt("price"))));
+                    client.sendResponse(new MarketplaceBuyErrorComposer(
+                            MarketplaceBuyErrorComposer.UPDATES,
+                            countSet.getInt("count"),
+                            countSet.getInt("id"),
+                            MarketPlace.calculateCommision(countSet.getInt("price"))));
                 }
             }
         } catch (SQLException e) {
@@ -404,13 +460,10 @@ public class MarketPlace {
         }
     }
 
-
     public static boolean sellItem(GameClient client, HabboItem item, int price) {
-        if (item == null || client == null)
-            return false;
+        if (item == null || client == null) return false;
 
-        if (!item.getBaseItem().allowMarketplace() || !isValidListingPrice(price))
-            return false;
+        if (!item.getBaseItem().allowMarketplace() || !isValidListingPrice(price)) return false;
 
         MarketPlaceItemOfferedEvent event = new MarketPlaceItemOfferedEvent(client.getHabbo(), item, price);
         if (Emulator.getPluginManager().fireEvent(event).isCancelled()) {
@@ -426,7 +479,10 @@ public class MarketPlace {
 
         MarketPlaceOffer offer = new MarketPlaceOffer(event.item, event.price, client.getHabbo());
         if (!offer.isPersisted()) {
-            LOGGER.warn("Marketplace offer insert failed for user {} item {}", client.getHabbo().getHabboInfo().getId(), event.item.getId());
+            LOGGER.warn(
+                    "Marketplace offer insert failed for user {} item {}",
+                    client.getHabbo().getHabboInfo().getId(),
+                    event.item.getId());
             return false;
         }
 
@@ -438,7 +494,6 @@ public class MarketPlace {
 
         return true;
     }
-
 
     public static void getCredits(GameClient client) {
         Set<MarketPlaceOffer> offers = new HashSet<>();
@@ -459,15 +514,20 @@ public class MarketPlace {
                 ? client.getHabbo().getHabboInfo().getCredits()
                 : client.getHabbo().getHabboInfo().getCurrencyAmount(MARKETPLACE_CURRENCY);
         if (claimable > Integer.MAX_VALUE) {
-            LOGGER.warn("Marketplace payout for user {} exceeds wallet range: {}",
-                    client.getHabbo().getHabboInfo().getId(), claimable);
+            LOGGER.warn(
+                    "Marketplace payout for user {} exceeds wallet range: {}",
+                    client.getHabbo().getHabboInfo().getId(),
+                    claimable);
             return;
         }
         try {
             WalletBalanceMath.checkedBalance(currentBalance, (int) claimable);
         } catch (IllegalArgumentException e) {
-            LOGGER.warn("Marketplace payout for user {} would overflow wallet: current={}, payout={}",
-                    client.getHabbo().getHabboInfo().getId(), currentBalance, claimable);
+            LOGGER.warn(
+                    "Marketplace payout for user {} would overflow wallet: current={}, payout={}",
+                    client.getHabbo().getHabboInfo().getId(),
+                    currentBalance,
+                    claimable);
             return;
         }
 
@@ -496,7 +556,9 @@ public class MarketPlace {
     }
 
     private static boolean removeUser(MarketPlaceOffer offer) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE marketplace_items SET user_id = ? WHERE id = ?")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("UPDATE marketplace_items SET user_id = ? WHERE id = ?")) {
             statement.setInt(1, -1);
             statement.setInt(2, offer.getOfferId());
             return statement.executeUpdate() > 0;
@@ -506,7 +568,6 @@ public class MarketPlace {
         }
     }
 
-
     public static int calculateCommision(int price) {
         long commission = price + (long) Math.ceil(price / 100.0);
         return commission > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) commission;
@@ -515,20 +576,18 @@ public class MarketPlace {
     private static PreparedCharge prepareMarketplaceCharge(Habbo buyer, int price) {
         if (MARKETPLACE_CURRENCY == 0) {
             UserCreditsEvent event = new UserCreditsEvent(buyer, -price);
-            if (Emulator.getPluginManager().fireEvent(event).isCancelled()
-                    || event.credits != -price) return null;
+            if (Emulator.getPluginManager().fireEvent(event).isCancelled() || event.credits != -price) return null;
             return new PreparedCharge(-1, event.credits);
         }
 
         UserPointsEvent event = new UserPointsEvent(buyer, -price, MARKETPLACE_CURRENCY);
         if (Emulator.getPluginManager().fireEvent(event).isCancelled()
-                || event.type != MARKETPLACE_CURRENCY || event.points != -price) return null;
+                || event.type != MARKETPLACE_CURRENCY
+                || event.points != -price) return null;
         return new PreparedCharge(event.type, event.points);
     }
 
-    private static void publishMarketplaceCharge(
-            GameClient client,
-            PreparedCharge charge) {
+    private static void publishMarketplaceCharge(GameClient client, PreparedCharge charge) {
         if (charge.currencyType() < 0) {
             client.sendResponse(new UserCreditsComposer(client.getHabbo()));
             return;
@@ -540,8 +599,7 @@ public class MarketPlace {
                 charge.currencyType()));
     }
 
-    private record PreparedCharge(int currencyType, int delta) {
-    }
+    private record PreparedCharge(int currencyType, int delta) {}
 
     public static boolean isValidListingPrice(int price) {
         return price >= MINIMUM_LISTING_PRICE && price <= MAXIMUM_LISTING_PRICE;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -1,7 +1,91 @@
 package com.eu.habbo.habbohotel.items;
 
 import com.eu.habbo.Emulator;
-import com.eu.habbo.habbohotel.items.interactions.*;
+import com.eu.habbo.habbohotel.items.interactions.InteractionAreaHideControl;
+import com.eu.habbo.habbohotel.items.interactions.InteractionBackgroundToner;
+import com.eu.habbo.habbohotel.items.interactions.InteractionBadgeDisplay;
+import com.eu.habbo.habbohotel.items.interactions.InteractionBlackHole;
+import com.eu.habbo.habbohotel.items.interactions.InteractionBuildArea;
+import com.eu.habbo.habbohotel.items.interactions.InteractionCannon;
+import com.eu.habbo.habbohotel.items.interactions.InteractionClothing;
+import com.eu.habbo.habbohotel.items.interactions.InteractionColorPlate;
+import com.eu.habbo.habbohotel.items.interactions.InteractionColorWheel;
+import com.eu.habbo.habbohotel.items.interactions.InteractionConfInvisControl;
+import com.eu.habbo.habbohotel.items.interactions.InteractionCostumeHopper;
+import com.eu.habbo.habbohotel.items.interactions.InteractionCrackable;
+import com.eu.habbo.habbohotel.items.interactions.InteractionCrackableMaster;
+import com.eu.habbo.habbohotel.items.interactions.InteractionDefault;
+import com.eu.habbo.habbohotel.items.interactions.InteractionDice;
+import com.eu.habbo.habbohotel.items.interactions.InteractionDiceDisableControl;
+import com.eu.habbo.habbohotel.items.interactions.InteractionDoorkickDisableControl;
+import com.eu.habbo.habbohotel.items.interactions.InteractionEffectGate;
+import com.eu.habbo.habbohotel.items.interactions.InteractionEffectGiver;
+import com.eu.habbo.habbohotel.items.interactions.InteractionEffectTile;
+import com.eu.habbo.habbohotel.items.interactions.InteractionEffectToggle;
+import com.eu.habbo.habbohotel.items.interactions.InteractionEffectVendingMachine;
+import com.eu.habbo.habbohotel.items.interactions.InteractionEffectVendingMachineNoSides;
+import com.eu.habbo.habbohotel.items.interactions.InteractionExternalImage;
+import com.eu.habbo.habbohotel.items.interactions.InteractionFXBox;
+import com.eu.habbo.habbohotel.items.interactions.InteractionFireworks;
+import com.eu.habbo.habbohotel.items.interactions.InteractionGate;
+import com.eu.habbo.habbohotel.items.interactions.InteractionGift;
+import com.eu.habbo.habbohotel.items.interactions.InteractionGroupPressurePlate;
+import com.eu.habbo.habbohotel.items.interactions.InteractionGuildFurni;
+import com.eu.habbo.habbohotel.items.interactions.InteractionGuildGate;
+import com.eu.habbo.habbohotel.items.interactions.InteractionGymEquipment;
+import com.eu.habbo.habbohotel.items.interactions.InteractionHabboClubGate;
+import com.eu.habbo.habbohotel.items.interactions.InteractionHabboClubHopper;
+import com.eu.habbo.habbohotel.items.interactions.InteractionHabboClubTeleportTile;
+import com.eu.habbo.habbohotel.items.interactions.InteractionHanditem;
+import com.eu.habbo.habbohotel.items.interactions.InteractionHanditemBlockControl;
+import com.eu.habbo.habbohotel.items.interactions.InteractionHanditemTile;
+import com.eu.habbo.habbohotel.items.interactions.InteractionHideWiredControl;
+import com.eu.habbo.habbohotel.items.interactions.InteractionHopper;
+import com.eu.habbo.habbohotel.items.interactions.InteractionInformationTerminal;
+import com.eu.habbo.habbohotel.items.interactions.InteractionJukeBox;
+import com.eu.habbo.habbohotel.items.interactions.InteractionLoveLock;
+import com.eu.habbo.habbohotel.items.interactions.InteractionMannequin;
+import com.eu.habbo.habbohotel.items.interactions.InteractionMonsterCrackable;
+import com.eu.habbo.habbohotel.items.interactions.InteractionMoodLight;
+import com.eu.habbo.habbohotel.items.interactions.InteractionMultiHeight;
+import com.eu.habbo.habbohotel.items.interactions.InteractionMusicDisc;
+import com.eu.habbo.habbohotel.items.interactions.InteractionMuteArea;
+import com.eu.habbo.habbohotel.items.interactions.InteractionNoSidesVendingMachine;
+import com.eu.habbo.habbohotel.items.interactions.InteractionObstacle;
+import com.eu.habbo.habbohotel.items.interactions.InteractionOneWayGate;
+import com.eu.habbo.habbohotel.items.interactions.InteractionPostIt;
+import com.eu.habbo.habbohotel.items.interactions.InteractionPressurePlate;
+import com.eu.habbo.habbohotel.items.interactions.InteractionPuzzleBox;
+import com.eu.habbo.habbohotel.items.interactions.InteractionPyramid;
+import com.eu.habbo.habbohotel.items.interactions.InteractionQueueSpeedControl;
+import com.eu.habbo.habbohotel.items.interactions.InteractionRandomState;
+import com.eu.habbo.habbohotel.items.interactions.InteractionRedeemableSubscriptionBox;
+import com.eu.habbo.habbohotel.items.interactions.InteractionRentableSpace;
+import com.eu.habbo.habbohotel.items.interactions.InteractionRoller;
+import com.eu.habbo.habbohotel.items.interactions.InteractionRoomAds;
+import com.eu.habbo.habbohotel.items.interactions.InteractionRoomOMatic;
+import com.eu.habbo.habbohotel.items.interactions.InteractionSnowboardSlope;
+import com.eu.habbo.habbohotel.items.interactions.InteractionStackHelper;
+import com.eu.habbo.habbohotel.items.interactions.InteractionStackWalkHelper;
+import com.eu.habbo.habbohotel.items.interactions.InteractionStickyPole;
+import com.eu.habbo.habbohotel.items.interactions.InteractionSwitch;
+import com.eu.habbo.habbohotel.items.interactions.InteractionSwitchRemoteControl;
+import com.eu.habbo.habbohotel.items.interactions.InteractionTalkingFurniture;
+import com.eu.habbo.habbohotel.items.interactions.InteractionTeleport;
+import com.eu.habbo.habbohotel.items.interactions.InteractionTeleportTile;
+import com.eu.habbo.habbohotel.items.interactions.InteractionTent;
+import com.eu.habbo.habbohotel.items.interactions.InteractionTileEffectProvider;
+import com.eu.habbo.habbohotel.items.interactions.InteractionTileWalkMagic;
+import com.eu.habbo.habbohotel.items.interactions.InteractionTrap;
+import com.eu.habbo.habbohotel.items.interactions.InteractionTrophy;
+import com.eu.habbo.habbohotel.items.interactions.InteractionVendingMachine;
+import com.eu.habbo.habbohotel.items.interactions.InteractionVikingCotie;
+import com.eu.habbo.habbohotel.items.interactions.InteractionVoteCounter;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWater;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWaterItem;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredDisableControl;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredHighscore;
+import com.eu.habbo.habbohotel.items.interactions.InteractionYoutubeTV;
 import com.eu.habbo.habbohotel.items.interactions.games.InteractionGameTimer;
 import com.eu.habbo.habbohotel.items.interactions.games.InteractionGameUpCounter;
 import com.eu.habbo.habbohotel.items.interactions.games.battlebanzai.InteractionBattleBanzaiPuck;
@@ -43,51 +127,253 @@ import com.eu.habbo.habbohotel.items.interactions.games.tag.bunnyrun.Interaction
 import com.eu.habbo.habbohotel.items.interactions.games.tag.icetag.InteractionIceTagField;
 import com.eu.habbo.habbohotel.items.interactions.games.tag.icetag.InteractionIceTagPole;
 import com.eu.habbo.habbohotel.items.interactions.games.tag.rollerskate.InteractionRollerskateField;
-import com.eu.habbo.habbohotel.items.interactions.pets.*;
+import com.eu.habbo.habbohotel.items.interactions.pets.InteractionMonsterPlantSeed;
+import com.eu.habbo.habbohotel.items.interactions.pets.InteractionNest;
+import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetBreedingNest;
+import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetDrink;
+import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetFood;
+import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetToy;
+import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetTrampoline;
+import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetTree;
 import com.eu.habbo.habbohotel.items.interactions.totems.InteractionTotemHead;
 import com.eu.habbo.habbohotel.items.interactions.totems.InteractionTotemLegs;
 import com.eu.habbo.habbohotel.items.interactions.totems.InteractionTotemPlanet;
-import com.eu.habbo.habbohotel.items.interactions.wired.conditions.*;
-import com.eu.habbo.habbohotel.items.interactions.wired.effects.*;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChestCurrency;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChestFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredContract;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionActorDir;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionChestHasItemType;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionChestHasItems;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionCounterTimeMatches;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionDateRangeActive;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionFrozen;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionFurniHaveFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionFurniHaveHabbo;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionFurniInRange;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionFurniNotInRange;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionFurniTypeMatch;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionGroupMember;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboCount;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboHasEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboHasHandItem;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboHasMinItems;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboHasRights;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboIsFemale;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboIsMale;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboLacksCredits;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboLacksDiamonds;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboLacksDuckets;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboNotHasRights;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboNotOwnsFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboOwnsBadge;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboOwnsFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHabboWearsBadge;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHasAltitude;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHasTag;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionHasVariable;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionLessTimeElapsed;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionMatchDate;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionMatchStatePosition;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionMatchTime;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionMoreTimeElapsed;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionMottoContains;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionMovementValidation;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotFrozen;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotFurniHaveFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotFurniHaveHabbo;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotFurniTypeMatch;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotHabboCount;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotHabboHasEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotHabboHasHandItem;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotHabboOwnsBadge;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotHabboWearsBadge;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotHasTag;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotHasVariable;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotInGroup;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotInTeam;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotMatchStatePosition;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotSameHeight;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotTriggerOnFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotTriggererMatch;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionNotUserPerformsAction;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionSameHeight;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionSelectionQuantity;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionTeamHasRank;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionTeamHasScore;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionTeamMember;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionTriggerOnFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionTriggererMatch;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionUserInRange;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionUserNotInRange;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionUserPerformsAction;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionVariableAgeMatch;
+import com.eu.habbo.habbohotel.items.interactions.wired.conditions.WiredConditionVariableValueMatch;
+import com.eu.habbo.habbohotel.items.interactions.wired.contract.InteractionWiredContractPayment;
+import com.eu.habbo.habbohotel.items.interactions.wired.contract.InteractionWiredContractReward;
+import com.eu.habbo.habbohotel.items.interactions.wired.contract.InteractionWiredContractTrade;
+import com.eu.habbo.habbohotel.items.interactions.wired.contract.InteractionWiredCustomContract;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectAddTag;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectAdjustClock;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectAlert;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectAllUsersLeaveTeam;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectBotClothes;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectBotFollowHabbo;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectBotGiveHandItem;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectBotTalk;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectBotTalkToHabbo;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectBotTeleport;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectBotWalkToFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectCancelTransaction;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectChangeFurniDirection;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectChangeVariableValue;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectControlClock;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectForwardUserToRoom;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectFreeze;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectFurniToFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectFurniToUser;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveBadge;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveCredits;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveCurrencyFromChest;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveDiamonds;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveDuckets;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveExperience;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveFurniFromChest;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveHandItem;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveLook;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveRespect;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveReward;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveScore;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveScoreToTeam;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveVariable;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectInitTransaction;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectJoinTeam;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectKickHabbo;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectLay;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectLeaveTeam;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectLog;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectMakeFastWalk;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectMakeUserSay;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectMatchFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectMoveFurniAsGroup;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectMoveFurniAway;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectMoveFurniTo;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectMoveFurniTowards;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectMoveRotateFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectMoveRotateUser;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectMoveUserTiles;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectMuteHabbo;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectNegativeLog;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectNegativeSendSignal;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectNegativeShowMessage;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectNegativeTriggerStacks;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectOpenHabboPages;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectPlaceFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectRelativeMove;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectRemoveBadge;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectRemoveFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectRemoveTag;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectRemoveVariable;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectResetHighscores;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectResetTimers;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectSayCommand;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectSendSignal;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectSetAltitude;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectSit;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectTeleport;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectToggleFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectToggleMoodlight;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectToggleRandom;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectTriggerStacks;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectUnfreeze;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectUserToFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectWalkToFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectWhisper;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredBlob;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraAnimationTime;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraContextVariable;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraExecuteInOrder;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraExecutionLimit;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraFilterFurni;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraFilterFurniByVariable;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraFilterUser;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraFilterUsersByVariable;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraFurniVariable;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMoveCarryUsers;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraExecuteInOrder;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraExecutionLimit;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovePhysics;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMoveNoAnimation;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovePhysics;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraTimeUtilities;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraOrEval;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraRandom;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraRoomVariable;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraTextOutputFurniName;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraTextInputVariable;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraTextOutputUsername;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraTextOutputVariable;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraContextVariable;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraUserVariable;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableEcho;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraUnseen;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableReference;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableTextConnector;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraQuest;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraQuestChain;
-import com.eu.habbo.habbohotel.items.interactions.wired.contract.InteractionWiredContractPayment;
-import com.eu.habbo.habbohotel.items.interactions.wired.contract.InteractionWiredContractReward;
-import com.eu.habbo.habbohotel.items.interactions.wired.contract.InteractionWiredContractTrade;
-import com.eu.habbo.habbohotel.items.interactions.wired.contract.InteractionWiredCustomContract;
-import com.eu.habbo.habbohotel.items.interactions.wired.selector.*;
-import com.eu.habbo.habbohotel.items.interactions.wired.triggers.*;
-import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChestCurrency;
-import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChestFurni;
-import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredContract;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraRandom;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraRoomVariable;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraTextInputVariable;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraTextOutputFurniName;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraTextOutputUsername;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraTextOutputVariable;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraTimeUtilities;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraUnseen;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraUserVariable;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableEcho;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableReference;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableTextConnector;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectFurniAltitude;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectFurniArea;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectFurniByType;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectFurniNeighborhood;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectFurniOnFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectFurniPicks;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectFurniSignal;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectFurniWithVariable;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectRemoteSelector;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectScanChestFurniByType;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectUsersArea;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectUsersByAction;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectUsersByName;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectUsersByType;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectUsersGroup;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectUsersHandItem;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectUsersNeighborhood;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectUsersOnFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectUsersSignal;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectUsersTeam;
+import com.eu.habbo.habbohotel.items.interactions.wired.selector.WiredEffectUsersWithVariable;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerAtSetTime;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerAtTimeLong;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerBotReachedFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerBotReachedHabbo;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerClockCounter;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerCollision;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerFurniStateToggled;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerGameEnds;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerGameStarts;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboClicksFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboClicksTile;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboClicksUser;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboEntersRoom;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboIdles;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboLeavesRoom;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboPerformsAction;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboSaysKeyword;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboStartsDancing;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboStopsDancing;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboUnidles;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboWalkOffFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboWalkOnFurni;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerReceiveSignal;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerRepeater;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerRepeaterLong;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerRepeaterShort;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerScoreAchieved;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerTeamLoses;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerTeamWins;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerTransactionComplete;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerTransactionFail;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerUsernameAsTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerVariableChanged;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.highscores.WiredHighscoreManager;
@@ -97,12 +383,23 @@ import com.eu.habbo.threading.runnables.QueryDeleteHabboItem;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.lang.reflect.Constructor;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.lang.reflect.Constructor;
-import java.sql.*;
-import java.util.*;
 
 public class ItemManager {
 
@@ -119,8 +416,8 @@ public class ItemManager {
             ORDER BY id DESC
             """;
 
-    //Configuration. Loaded from database & updated accordingly.
-    public static boolean RECYCLER_ENABLED = true;
+    // Configuration. Loaded from database & updated accordingly.
+    public static volatile boolean RECYCLER_ENABLED = true;
 
     private final Int2ObjectMap<Item> items;
     private final Int2ObjectMap<CrackableReward> crackableRewards;
@@ -229,8 +526,10 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_conf_hidewired", InteractionHideWiredControl.class));
         this.interactionsList.add(new ItemInteraction("conf_dice_disable", InteractionDiceDisableControl.class));
         this.interactionsList.add(new ItemInteraction("wf_conf_dice_disable", InteractionDiceDisableControl.class));
-        this.interactionsList.add(new ItemInteraction("conf_doorkick_disable", InteractionDoorkickDisableControl.class));
-        this.interactionsList.add(new ItemInteraction("wf_conf_doorkick_disable", InteractionDoorkickDisableControl.class));
+        this.interactionsList.add(
+                new ItemInteraction("conf_doorkick_disable", InteractionDoorkickDisableControl.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_conf_doorkick_disable", InteractionDoorkickDisableControl.class));
         this.interactionsList.add(new ItemInteraction("switch_remote_control", InteractionSwitchRemoteControl.class));
         this.interactionsList.add(new ItemInteraction("fx_box", InteractionFXBox.class));
         this.interactionsList.add(new ItemInteraction("blackhole", InteractionBlackHole.class));
@@ -245,14 +544,17 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("handitem_tile", InteractionHanditemTile.class));
         this.interactionsList.add(new ItemInteraction("effect_giver", InteractionEffectGiver.class));
         this.interactionsList.add(new ItemInteraction("effect_vendingmachine", InteractionEffectVendingMachine.class));
-        this.interactionsList.add(new ItemInteraction("effect_vendingmachine_no_sides", InteractionEffectVendingMachineNoSides.class));
+        this.interactionsList.add(
+                new ItemInteraction("effect_vendingmachine_no_sides", InteractionEffectVendingMachineNoSides.class));
         this.interactionsList.add(new ItemInteraction("crackable_monster", InteractionMonsterCrackable.class));
         this.interactionsList.add(new ItemInteraction("snowboard_slope", InteractionSnowboardSlope.class));
         this.interactionsList.add(new ItemInteraction("pressureplate_group", InteractionGroupPressurePlate.class));
         this.interactionsList.add(new ItemInteraction("effect_tile_group", InteractionEffectTile.class));
-        this.interactionsList.add(new ItemInteraction("crackable_subscription_box", InteractionRedeemableSubscriptionBox.class));
+        this.interactionsList.add(
+                new ItemInteraction("crackable_subscription_box", InteractionRedeemableSubscriptionBox.class));
         this.interactionsList.add(new ItemInteraction("random_state", InteractionRandomState.class));
-        this.interactionsList.add(new ItemInteraction("vendingmachine_no_sides", InteractionNoSidesVendingMachine.class));
+        this.interactionsList.add(
+                new ItemInteraction("vendingmachine_no_sides", InteractionNoSidesVendingMachine.class));
         this.interactionsList.add(new ItemInteraction("tile_walkmagic", InteractionTileWalkMagic.class));
         this.interactionsList.add(new ItemInteraction("antenna", InteractionDefault.class));
         this.interactionsList.add(new ItemInteraction("room_invisible_click_tile", InteractionDefault.class));
@@ -265,7 +567,8 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_trg_click_furni", WiredTriggerHabboClicksFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_click_tile", WiredTriggerHabboClicksTile.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_click_user", WiredTriggerHabboClicksUser.class));
-        this.interactionsList.add(new ItemInteraction("wf_trg_user_performs_action", WiredTriggerHabboPerformsAction.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_trg_user_performs_action", WiredTriggerHabboPerformsAction.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_enter_room", WiredTriggerHabboEntersRoom.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_leave_room", WiredTriggerHabboLeavesRoom.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_says_something", WiredTriggerHabboSaysKeyword.class));
@@ -313,20 +616,26 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_act_toggle_moodlight", WiredEffectToggleMoodlight.class));
         this.interactionsList.add(new ItemInteraction("wf_act_reset_highscores", WiredEffectResetHighscores.class));
         this.interactionsList.add(new ItemInteraction("wf_act_move_user_tiles", WiredEffectMoveUserTiles.class));
-        this.interactionsList.add(new ItemInteraction("wf_act_all_users_leave_team", WiredEffectAllUsersLeaveTeam.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_act_all_users_leave_team", WiredEffectAllUsersLeaveTeam.class));
         // Phase-C conditions (currency / freeze / furni-range / same-height)
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_habbo_has_credits", WiredConditionHabboLacksCredits.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_habbo_has_diamonds", WiredConditionHabboLacksDiamonds.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_habbo_has_duckets", WiredConditionHabboLacksDuckets.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_habbo_has_credits", WiredConditionHabboLacksCredits.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_habbo_has_diamonds", WiredConditionHabboLacksDiamonds.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_habbo_has_duckets", WiredConditionHabboLacksDuckets.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_freeze", WiredConditionFrozen.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_not_freeze", WiredConditionNotFrozen.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_furni_in_range", WiredConditionFurniInRange.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_furni_not_in_range", WiredConditionFurniNotInRange.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_furni_not_in_range", WiredConditionFurniNotInRange.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_has_same_height", WiredConditionSameHeight.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_not_has_same_height", WiredConditionNotSameHeight.class));
         // owns_furni: check the triggerer's inventory for the picked furni type(s) (reuse HAS_ALTITUDE picker).
         this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_owns_furni", WiredConditionHabboOwnsFurni.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_not_owns_furni", WiredConditionHabboNotOwnsFurni.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_habbo_not_owns_furni", WiredConditionHabboNotOwnsFurni.class));
         // Negative-branch effects (run when the stack's conditions FAIL); reuse the SHOW_MESSAGE dialog.
         this.interactionsList.add(new ItemInteraction("wf_act_neg_show_message", WiredEffectNegativeShowMessage.class));
         this.interactionsList.add(new ItemInteraction("wf_act_neg_log", WiredEffectNegativeLog.class));
@@ -340,12 +649,13 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_cnd_not_has_tag", WiredConditionNotHasTag.class));
         // Identity conditions reusing a meaningful existing dialog field (text = motto / int = item count).
         this.interactionsList.add(new ItemInteraction("wf_cnd_motto_contains", WiredConditionMottoContains.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_has_at_least_x_items", WiredConditionHabboHasMinItems.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_habbo_has_at_least_x_items", WiredConditionHabboHasMinItems.class));
         // OWNED-badge check (Phase A skipped these because only a worn-badge class existed): reuses the
         // wears-badge dialog but checks inventory ownership via BadgesComponent.hasBadge.
         this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_owns_badge", WiredConditionHabboOwnsBadge.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_habbo_owns_badge", WiredConditionNotHabboOwnsBadge.class));
-
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_habbo_owns_badge", WiredConditionNotHabboOwnsBadge.class));
 
         this.interactionsList.add(new ItemInteraction("wf_act_toggle_state", WiredEffectToggleFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_reset_timers", WiredEffectResetTimers.class));
@@ -365,7 +675,8 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_act_give_reward", WiredEffectGiveReward.class));
         this.interactionsList.add(new ItemInteraction("wf_act_call_stacks", WiredEffectTriggerStacks.class));
         this.interactionsList.add(new ItemInteraction("wf_act_neg_call_stack", WiredEffectNegativeTriggerStacks.class));
-        this.interactionsList.add(new ItemInteraction("wf_act_neg_call_stacks", WiredEffectNegativeTriggerStacks.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_act_neg_call_stacks", WiredEffectNegativeTriggerStacks.class));
         this.interactionsList.add(new ItemInteraction("wf_act_kick_user", WiredEffectKickHabbo.class));
         this.interactionsList.add(new ItemInteraction("wf_act_mute_triggerer", WiredEffectMuteHabbo.class));
         this.interactionsList.add(new ItemInteraction("wf_act_bot_teleport", WiredEffectBotTeleport.class));
@@ -432,24 +743,30 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_cnd_not_wearing_b", WiredConditionNotHabboWearsBadge.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_not_in_group", WiredConditionNotInGroup.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_not_in_team", WiredConditionNotInTeam.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_match_snap", WiredConditionNotMatchStatePosition.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_match_snap", WiredConditionNotMatchStatePosition.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_not_trggrer_on", WiredConditionNotTriggerOnFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_actor_in_team", WiredConditionTeamMember.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_trggrer_on_frn", WiredConditionTriggerOnFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_has_handitem", WiredConditionHabboHasHandItem.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_has_handitem", WiredConditionNotHabboHasHandItem.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_has_handitem", WiredConditionNotHabboHasHandItem.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_date_rng_active", WiredConditionDateRangeActive.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_valid_moves", WiredConditionMovementValidation.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_counter_time_matches", WiredConditionCounterTimeMatches.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_counter_time_matches", WiredConditionCounterTimeMatches.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_match_time", WiredConditionMatchTime.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_match_date", WiredConditionMatchDate.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_actor_dir", WiredConditionActorDir.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_slc_quantity", WiredConditionSelectionQuantity.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_user_performs_action", WiredConditionUserPerformsAction.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_user_performs_action", WiredConditionNotUserPerformsAction.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_user_performs_action", WiredConditionUserPerformsAction.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_user_performs_action", WiredConditionNotUserPerformsAction.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_has_altitude", WiredConditionHasAltitude.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_triggerer_match", WiredConditionTriggererMatch.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_triggerer_match", WiredConditionNotTriggererMatch.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_triggerer_match", WiredConditionNotTriggererMatch.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_team_has_score", WiredConditionTeamHasScore.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_team_has_rank", WiredConditionTeamHasRank.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_has_var", WiredConditionHasVariable.class));
@@ -469,23 +786,29 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_act_init_transaction", WiredEffectInitTransaction.class));
         this.interactionsList.add(new ItemInteraction("wf_act_cancel_transaction", WiredEffectCancelTransaction.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_chest_has_items", WiredConditionChestHasItems.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_chest_has_item_type", WiredConditionChestHasItemType.class));
-        this.interactionsList.add(new ItemInteraction("wf_trg_transaction_complete", WiredTriggerTransactionComplete.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_chest_has_item_type", WiredConditionChestHasItemType.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_trg_transaction_complete", WiredTriggerTransactionComplete.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_transaction_fail", WiredTriggerTransactionFail.class));
         this.interactionsList.add(new ItemInteraction("wf_contract_payment", InteractionWiredContract.Payment.class));
         this.interactionsList.add(new ItemInteraction("wf_contract_reward", InteractionWiredContract.Reward.class));
         this.interactionsList.add(new ItemInteraction("wf_contract_trade", InteractionWiredContract.Trade.class));
-        this.interactionsList.add(new ItemInteraction("wf_xtra_custom_contract", InteractionWiredContract.Custom.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_xtra_custom_contract", InteractionWiredContract.Custom.class));
         // Phase-2 chest-full wired: give-from-chest, has-item conditions, scanner, transactions,
         // place/remove-furni, contracts, quests (chest storage furni above are from the #291 base).
         this.interactionsList.add(new ItemInteraction("wf_act_give_currency", WiredEffectGiveCurrencyFromChest.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_chest_has_items", WiredConditionChestHasItems.class));
         this.interactionsList.add(new ItemInteraction("wf_act_give_furni", WiredEffectGiveFurniFromChest.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_chest_has_item_type", WiredConditionChestHasItemType.class));
-        this.interactionsList.add(new ItemInteraction("wf_xtra_scan_chest_furni_by_type", WiredEffectScanChestFurniByType.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_chest_has_item_type", WiredConditionChestHasItemType.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_xtra_scan_chest_furni_by_type", WiredEffectScanChestFurniByType.class));
         this.interactionsList.add(new ItemInteraction("wf_act_init_transaction", WiredEffectInitTransaction.class));
         this.interactionsList.add(new ItemInteraction("wf_act_cancel_transaction", WiredEffectCancelTransaction.class));
-        this.interactionsList.add(new ItemInteraction("wf_trg_transaction_complete", WiredTriggerTransactionComplete.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_trg_transaction_complete", WiredTriggerTransactionComplete.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_transaction_fail", WiredTriggerTransactionFail.class));
         this.interactionsList.add(new ItemInteraction("wf_act_place_furni", WiredEffectPlaceFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_remove_furni", WiredEffectRemoveFurni.class));
@@ -496,7 +819,6 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_var_quest", WiredExtraQuest.class));
         this.interactionsList.add(new ItemInteraction("wf_var_quest_chain", WiredExtraQuestChain.class));
 
-
         this.interactionsList.add(new ItemInteraction("wf_xtra_random", WiredExtraRandom.class));
         this.interactionsList.add(new ItemInteraction("wf_xtra_unseen", WiredExtraUnseen.class));
         this.interactionsList.add(new ItemInteraction("wf_blob", WiredBlob.class));
@@ -504,20 +826,28 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_xtra_filter_furni", WiredExtraFilterFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_xtra_filter_user", WiredExtraFilterUser.class));
         this.interactionsList.add(new ItemInteraction("wf_xtra_filter_users", WiredExtraFilterUser.class));
-        this.interactionsList.add(new ItemInteraction("wf_xtra_filter_furni_by_var", WiredExtraFilterFurniByVariable.class));
-        this.interactionsList.add(new ItemInteraction("wf_xtra_filter_users_by_var", WiredExtraFilterUsersByVariable.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_xtra_filter_furni_by_var", WiredExtraFilterFurniByVariable.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_xtra_filter_users_by_var", WiredExtraFilterUsersByVariable.class));
         this.interactionsList.add(new ItemInteraction("wf_xtra_mov_carry_users", WiredExtraMoveCarryUsers.class));
         this.interactionsList.add(new ItemInteraction("wf_xtra_mov_no_animation", WiredExtraMoveNoAnimation.class));
         this.interactionsList.add(new ItemInteraction("wf_xtra_anim_time", WiredExtraAnimationTime.class));
         this.interactionsList.add(new ItemInteraction("wf_xtra_mov_physics", WiredExtraMovePhysics.class));
         this.interactionsList.add(new ItemInteraction("wf_xtra_exec_in_order", WiredExtraExecuteInOrder.class));
         this.interactionsList.add(new ItemInteraction("wf_xtra_execution_limit", WiredExtraExecutionLimit.class));
-        this.interactionsList.add(new ItemInteraction("wf_xtra_text_output_username", WiredExtraTextOutputUsername.class));
-        this.interactionsList.add(new ItemInteraction("wf_xtra_text_output_furni_name", WiredExtraTextOutputFurniName.class));
-        this.interactionsList.add(new ItemInteraction("wf_xtra_text_output_variable", WiredExtraTextOutputVariable.class));
-        this.interactionsList.add(new ItemInteraction("wf_xtra_text_input_variable", WiredExtraTextInputVariable.class));
-        this.interactionsList.add(new ItemInteraction("wf_xtra_var_text_connector", WiredExtraVariableTextConnector.class));
-        this.interactionsList.add(new ItemInteraction("wf_xtra_var_lvlup_system", WiredExtraVariableLevelUpSystem.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_xtra_text_output_username", WiredExtraTextOutputUsername.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_xtra_text_output_furni_name", WiredExtraTextOutputFurniName.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_xtra_text_output_variable", WiredExtraTextOutputVariable.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_xtra_text_input_variable", WiredExtraTextInputVariable.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_xtra_var_text_connector", WiredExtraVariableTextConnector.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_xtra_var_lvlup_system", WiredExtraVariableLevelUpSystem.class));
         this.interactionsList.add(new ItemInteraction("wf_var_user", WiredExtraUserVariable.class));
         this.interactionsList.add(new ItemInteraction("wf_var_furni", WiredExtraFurniVariable.class));
         this.interactionsList.add(new ItemInteraction("wf_var_room", WiredExtraRoomVariable.class));
@@ -530,7 +860,8 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_act_dont_chase_top", WiredEffectMoveFurniAway.class));
         this.interactionsList.add(new ItemInteraction("wf_act_give_score_room", WiredEffectGiveScore.class));
         this.interactionsList.add(new ItemInteraction("wf_act_give_score_pp", WiredEffectGiveScore.class));
-        this.interactionsList.add(new ItemInteraction("wf_act_bot_give_handitem_or_effect", WiredEffectBotGiveHandItem.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_act_bot_give_handitem_or_effect", WiredEffectBotGiveHandItem.class));
         this.interactionsList.add(new ItemInteraction("wf_act_teleport_all", WiredEffectTeleport.class));
         this.interactionsList.add(new ItemInteraction("wf_act_teleport_red", WiredEffectTeleport.class));
         this.interactionsList.add(new ItemInteraction("wf_act_teleport_green", WiredEffectTeleport.class));
@@ -539,20 +870,24 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_is_male", WiredConditionHabboIsMale.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_is_female", WiredConditionHabboIsFemale.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_has_rights", WiredConditionHabboHasRights.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_habbo_has_rights", WiredConditionHabboNotHasRights.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_habbo_has_rights", WiredConditionHabboNotHasRights.class));
         this.interactionsList.add(new ItemInteraction("wf_act_set_state", WiredEffectMatchFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_set_trg_state", WiredEffectMatchFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_open_gates", WiredEffectMatchFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_close_dice", WiredEffectToggleFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_close_gates", WiredEffectToggleFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_color_furni", WiredEffectToggleFurni.class));
-        this.interactionsList.add(new ItemInteraction("wf_act_move_furni_from_stack", WiredEffectMoveRotateFurni.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_act_move_furni_from_stack", WiredEffectMoveRotateFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_move_rotate_no_under", WiredEffectMoveRotateFurni.class));
-        this.interactionsList.add(new ItemInteraction("wf_act_allign_furni_stack", WiredEffectChangeFurniDirection.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_act_allign_furni_stack", WiredEffectChangeFurniDirection.class));
         this.interactionsList.add(new ItemInteraction("wf_act_execute_for_users", WiredEffectTriggerStacks.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_trg_by_user", WiredConditionTriggererMatch.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_not_trg_by_user", WiredConditionNotTriggererMatch.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_bot_is_dancing", WiredConditionNotUserPerformsAction.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_bot_is_dancing", WiredConditionNotUserPerformsAction.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_click_bot", WiredTriggerHabboClicksUser.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_double_click_furni", WiredTriggerHabboClicksFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_anti_afk", WiredTriggerHabboUnidles.class));
@@ -560,16 +895,20 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_act_send_bubble", WiredEffectMakeUserSay.class));
         this.interactionsList.add(new ItemInteraction("wf_act_double_click", WiredEffectToggleFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_give_enable", WiredEffectGiveEffect.class));
-        this.interactionsList.add(new ItemInteraction("wf_act_forward_user_to_room", WiredEffectForwardUserToRoom.class));
-        // Official teleport-to-room wired furni (exist in furnidata) -> same effect (reuses the SHOW_MESSAGE dialog; text field = target room id).
+        this.interactionsList.add(
+                new ItemInteraction("wf_act_forward_user_to_room", WiredEffectForwardUserToRoom.class));
+        // Official teleport-to-room wired furni (exist in furnidata) -> same effect (reuses the SHOW_MESSAGE dialog;
+        // text field = target room id).
         this.interactionsList.add(new ItemInteraction("wf_act_teleport_to_room", WiredEffectForwardUserToRoom.class));
         this.interactionsList.add(new ItemInteraction("wf_act_tele_room", WiredEffectForwardUserToRoom.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_user_in_range", WiredConditionUserInRange.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_user_not_in_range", WiredConditionUserNotInRange.class));
-        this.interactionsList.add(new ItemInteraction("wf_trg_username_as_trigger", WiredTriggerUsernameAsTrigger.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_trg_username_as_trigger", WiredTriggerUsernameAsTrigger.class));
         this.interactionsList.add(new ItemInteraction("wf_act_alert_habbo", WiredEffectAlert.class));
         this.interactionsList.add(new ItemInteraction("wf_act_bot_talk_custom", WiredEffectBotTalk.class));
-        this.interactionsList.add(new ItemInteraction("wf_act_bot_talk_to_avatar_custom", WiredEffectBotTalkToHabbo.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_act_bot_talk_to_avatar_custom", WiredEffectBotTalkToHabbo.class));
         this.interactionsList.add(new ItemInteraction("wf_act_call_stacks_custom", WiredEffectTriggerStacks.class));
         this.interactionsList.add(new ItemInteraction("wf_act_execute_stack_custom", WiredEffectTriggerStacks.class));
         this.interactionsList.add(new ItemInteraction("wf_act_cnd_move_furni", WiredEffectMoveFurniTo.class));
@@ -583,14 +922,19 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_act_tp_furni_to_habbo", WiredEffectFurniToUser.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_in_group", WiredConditionGroupMember.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_not_habbo_in_group", WiredConditionNotInGroup.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_match_snapshot_new", WiredConditionMatchStatePosition.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_match_snap_new", WiredConditionNotMatchStatePosition.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_match_snapshot_new", WiredConditionMatchStatePosition.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_match_snap_new", WiredConditionNotMatchStatePosition.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_tgr_furni_hv_avtrs", WiredConditionFurniHaveHabbo.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_tgr_furni_hv_avtrs", WiredConditionNotFurniHaveHabbo.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_tgr_furni_hv_avtrs", WiredConditionNotFurniHaveHabbo.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_wears_effect", WiredConditionHabboHasEffect.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_wears_effect", WiredConditionNotHabboHasEffect.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_wears_effect", WiredConditionNotHabboHasEffect.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_wears_handitem", WiredConditionHabboHasHandItem.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_wears_handitem", WiredConditionNotHabboHasHandItem.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_wears_handitem", WiredConditionNotHabboHasHandItem.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_trgr_stuff_matches", WiredConditionFurniTypeMatch.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_cnd_collision", WiredTriggerCollision.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_user_exits_room", WiredTriggerHabboLeavesRoom.class));
@@ -598,7 +942,8 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_act_lower_furni", WiredEffectSetAltitude.class));
         this.interactionsList.add(new ItemInteraction("wf_act_raise_furni", WiredEffectSetAltitude.class));
         this.interactionsList.add(new ItemInteraction("wf_act_match_to_sshot_height", WiredEffectMatchFurni.class));
-        this.interactionsList.add(new ItemInteraction("wf_act_match_to_sshot_height_instant", WiredEffectMatchFurni.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_act_match_to_sshot_height_instant", WiredEffectMatchFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_plus_match_furni_state", WiredEffectMatchFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_move_rotate_collide", WiredEffectMoveRotateFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_move_rotate_diagonal", WiredEffectMoveRotateFurni.class));
@@ -606,14 +951,19 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_act_show_message_room", WiredEffectWhisper.class));
         this.interactionsList.add(new ItemInteraction("wf_act_toggle_state_down", WiredEffectToggleFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_toggle_state_trg", WiredEffectToggleFurni.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_atleast_one_user_in_team", WiredConditionTeamMember.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_atleast_one_user_in_team", WiredConditionTeamMember.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_bot_is_dancing", WiredConditionUserPerformsAction.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_is_dancing", WiredConditionUserPerformsAction.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_not_habbo_is_dancing", WiredConditionNotUserPerformsAction.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_furni_state_pattern", WiredConditionMatchStatePosition.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_habbo_is_dancing", WiredConditionUserPerformsAction.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_not_habbo_is_dancing", WiredConditionNotUserPerformsAction.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_furni_state_pattern", WiredConditionMatchStatePosition.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_is_state", WiredConditionMatchStatePosition.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_trg_state_is", WiredConditionMatchStatePosition.class));
-        this.interactionsList.add(new ItemInteraction("wf_cnd_furnis_hv_avtrs_custom", WiredConditionFurniHaveHabbo.class));
+        this.interactionsList.add(
+                new ItemInteraction("wf_cnd_furnis_hv_avtrs_custom", WiredConditionFurniHaveHabbo.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_x_habbos_on_furni", WiredConditionFurniHaveHabbo.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_exact_keyword", WiredTriggerHabboSaysKeyword.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_says_command", WiredTriggerHabboSaysKeyword.class));
@@ -628,63 +978,63 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_xtra_var_time_util", WiredExtraTimeUtilities.class));
         // ---- end inert-furni group ----
 
-
         this.interactionsList.add(new ItemInteraction("wf_highscore", InteractionWiredHighscore.class));
 
-
         this.interactionsList.add(new ItemInteraction("battlebanzai_tile", InteractionBattleBanzaiTile.class));
-        this.interactionsList.add(new ItemInteraction("battlebanzai_random_teleport", InteractionBattleBanzaiTeleporter.class));
+        this.interactionsList.add(
+                new ItemInteraction("battlebanzai_random_teleport", InteractionBattleBanzaiTeleporter.class));
         this.interactionsList.add(new ItemInteraction("battlebanzai_sphere", InteractionBattleBanzaiSphere.class));
         this.interactionsList.add(new ItemInteraction("battlebanzai_puck", InteractionBattleBanzaiPuck.class));
 
-
         this.interactionsList.add(new ItemInteraction("battlebanzai_gate_blue", InteractionBattleBanzaiGateBlue.class));
-        this.interactionsList.add(new ItemInteraction("battlebanzai_gate_green", InteractionBattleBanzaiGateGreen.class));
+        this.interactionsList.add(
+                new ItemInteraction("battlebanzai_gate_green", InteractionBattleBanzaiGateGreen.class));
         this.interactionsList.add(new ItemInteraction("battlebanzai_gate_red", InteractionBattleBanzaiGateRed.class));
-        this.interactionsList.add(new ItemInteraction("battlebanzai_gate_yellow", InteractionBattleBanzaiGateYellow.class));
+        this.interactionsList.add(
+                new ItemInteraction("battlebanzai_gate_yellow", InteractionBattleBanzaiGateYellow.class));
 
-
-        this.interactionsList.add(new ItemInteraction("battlebanzai_counter_blue", InteractionBattleBanzaiScoreboardBlue.class));
-        this.interactionsList.add(new ItemInteraction("battlebanzai_counter_green", InteractionBattleBanzaiScoreboardGreen.class));
-        this.interactionsList.add(new ItemInteraction("battlebanzai_counter_red", InteractionBattleBanzaiScoreboardRed.class));
-        this.interactionsList.add(new ItemInteraction("battlebanzai_counter_yellow", InteractionBattleBanzaiScoreboardYellow.class));
-
+        this.interactionsList.add(
+                new ItemInteraction("battlebanzai_counter_blue", InteractionBattleBanzaiScoreboardBlue.class));
+        this.interactionsList.add(
+                new ItemInteraction("battlebanzai_counter_green", InteractionBattleBanzaiScoreboardGreen.class));
+        this.interactionsList.add(
+                new ItemInteraction("battlebanzai_counter_red", InteractionBattleBanzaiScoreboardRed.class));
+        this.interactionsList.add(
+                new ItemInteraction("battlebanzai_counter_yellow", InteractionBattleBanzaiScoreboardYellow.class));
 
         this.interactionsList.add(new ItemInteraction("freeze_block", InteractionFreezeBlock.class));
         this.interactionsList.add(new ItemInteraction("freeze_tile", InteractionFreezeTile.class));
         this.interactionsList.add(new ItemInteraction("freeze_exit", InteractionFreezeExitTile.class));
-
 
         this.interactionsList.add(new ItemInteraction("freeze_gate_blue", InteractionFreezeGateBlue.class));
         this.interactionsList.add(new ItemInteraction("freeze_gate_green", InteractionFreezeGateGreen.class));
         this.interactionsList.add(new ItemInteraction("freeze_gate_red", InteractionFreezeGateRed.class));
         this.interactionsList.add(new ItemInteraction("freeze_gate_yellow", InteractionFreezeGateYellow.class));
 
-
         this.interactionsList.add(new ItemInteraction("freeze_counter_blue", InteractionFreezeScoreboardBlue.class));
         this.interactionsList.add(new ItemInteraction("freeze_counter_green", InteractionFreezeScoreboardGreen.class));
         this.interactionsList.add(new ItemInteraction("freeze_counter_red", InteractionFreezeScoreboardRed.class));
-        this.interactionsList.add(new ItemInteraction("freeze_counter_yellow", InteractionFreezeScoreboardYellow.class));
-
+        this.interactionsList.add(
+                new ItemInteraction("freeze_counter_yellow", InteractionFreezeScoreboardYellow.class));
 
         this.interactionsList.add(new ItemInteraction("icetag_pole", InteractionIceTagPole.class));
         this.interactionsList.add(new ItemInteraction("icetag_field", InteractionIceTagField.class));
 
-
         this.interactionsList.add(new ItemInteraction("bunnyrun_pole", InteractionBunnyrunPole.class));
         this.interactionsList.add(new ItemInteraction("bunnyrun_field", InteractionBunnyrunField.class));
 
-
         this.interactionsList.add(new ItemInteraction("rollerskate_field", InteractionRollerskateField.class));
-
 
         this.interactionsList.add(new ItemInteraction("football", InteractionFootball.class));
         this.interactionsList.add(new ItemInteraction("rebug_football", InteractionRebugFootball.class));
         this.interactionsList.add(new ItemInteraction("football_gate", InteractionFootballGate.class));
-        this.interactionsList.add(new ItemInteraction("football_counter_blue", InteractionFootballScoreboardBlue.class));
-        this.interactionsList.add(new ItemInteraction("football_counter_green", InteractionFootballScoreboardGreen.class));
+        this.interactionsList.add(
+                new ItemInteraction("football_counter_blue", InteractionFootballScoreboardBlue.class));
+        this.interactionsList.add(
+                new ItemInteraction("football_counter_green", InteractionFootballScoreboardGreen.class));
         this.interactionsList.add(new ItemInteraction("football_counter_red", InteractionFootballScoreboardRed.class));
-        this.interactionsList.add(new ItemInteraction("football_counter_yellow", InteractionFootballScoreboardYellow.class));
+        this.interactionsList.add(
+                new ItemInteraction("football_counter_yellow", InteractionFootballScoreboardYellow.class));
         this.interactionsList.add(new ItemInteraction("football_goal_blue", InteractionFootballGoalBlue.class));
         this.interactionsList.add(new ItemInteraction("football_goal_green", InteractionFootballGoalGreen.class));
         this.interactionsList.add(new ItemInteraction("football_goal_red", InteractionFootballGoalRed.class));
@@ -701,54 +1051,45 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("totem_planet", InteractionTotemPlanet.class));
     }
 
-
     public void addItemInteraction(ItemInteraction itemInteraction) {
         for (ItemInteraction interaction : this.interactionsList) {
-            if (interaction.getType() == itemInteraction.getType() ||
-                    interaction.getName().equalsIgnoreCase(itemInteraction.getName()))
-
-                throw new RuntimeException("Interaction Types must be unique. An class with type: " + interaction.getClass().getName() + " was already added OR the key: " + interaction.getName() + " is already in use.");
+            if (interaction.getType() == itemInteraction.getType()
+                    || interaction.getName().equalsIgnoreCase(itemInteraction.getName()))
+                throw new RuntimeException("Interaction Types must be unique. An class with type: "
+                        + interaction.getClass().getName() + " was already added OR the key: " + interaction.getName()
+                        + " is already in use.");
         }
 
         this.interactionsList.add(itemInteraction);
     }
 
-
     public ItemInteraction getItemInteraction(Class<? extends HabboItem> type) {
         for (ItemInteraction interaction : this.interactionsList) {
-            if (interaction.getType() == type)
-                return interaction;
+            if (interaction.getType() == type) return interaction;
         }
 
         LOGGER.debug("Can't find interaction class: {}", type.getName());
         return this.getItemInteraction(InteractionDefault.class);
     }
 
-
     public ItemInteraction getItemInteraction(String type) {
         for (ItemInteraction interaction : this.interactionsList) {
-            if (interaction.getName().equalsIgnoreCase(type))
-                return interaction;
+            if (interaction.getName().equalsIgnoreCase(type)) return interaction;
         }
 
         return this.getItemInteraction(InteractionDefault.class);
     }
 
-
     public void loadItems() {
-        try (
-                Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
                 Statement statement = connection.createStatement();
-                ResultSet set = statement.executeQuery(BASE_ITEMS_SQL)
-        ) {
+                ResultSet set = statement.executeQuery(BASE_ITEMS_SQL)) {
             while (set.next()) {
                 try {
-                    //Item proxyItem =
+                    // Item proxyItem =
                     int id = set.getInt("id");
-                    if (!this.items.containsKey(id))
-                        this.items.put(id, new Item(set));
-                    else
-                        this.items.get(id).update(set);
+                    if (!this.items.containsKey(id)) this.items.put(id, new Item(set));
+                    else this.items.get(id).update(set);
                 } catch (Exception e) {
                     LOGGER.error("Failed to load Item ({})", set.getInt("id"));
                     LOGGER.error("Caught exception", e);
@@ -759,10 +1100,11 @@ public class ItemManager {
         }
     }
 
-
     public void loadCrackable() {
         this.crackableRewards.clear();
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM items_crackable"); ResultSet set = statement.executeQuery()) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT * FROM items_crackable");
+                ResultSet set = statement.executeQuery()) {
             while (set.next()) {
                 CrackableReward reward;
                 try {
@@ -781,14 +1123,10 @@ public class ItemManager {
         }
     }
 
-
     public int getCrackableCount(int itemId) {
-        if (this.crackableRewards.containsKey(itemId))
-            return this.crackableRewards.get(itemId).count;
-        else
-            return 0;
+        if (this.crackableRewards.containsKey(itemId)) return this.crackableRewards.get(itemId).count;
+        else return 0;
     }
-
 
     public int calculateCrackState(int count, int max, Item baseItem) {
         if (count <= 0 || max <= 0 || baseItem == null || baseItem.getStateCount() <= 0) {
@@ -807,11 +1145,12 @@ public class ItemManager {
         return reward == null ? null : this.getItem(reward.getRandomReward());
     }
 
-
     public void loadSoundTracks() {
         this.soundTracks.clear();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM soundtracks"); ResultSet set = statement.executeQuery()) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT * FROM soundtracks");
+                ResultSet set = statement.executeQuery()) {
             while (set.next()) {
                 this.soundTracks.put(set.getString("code"), new SoundTrack(set));
             }
@@ -826,8 +1165,7 @@ public class ItemManager {
 
     public SoundTrack getSoundTrack(int id) {
         for (Map.Entry<String, SoundTrack> entry : this.soundTracks.entrySet()) {
-            if (entry.getValue().getId() == id)
-                return entry.getValue();
+            if (entry.getValue().getId() == id) return entry.getValue();
         }
 
         return null;
@@ -864,14 +1202,18 @@ public class ItemManager {
         return null;
     }
 
-    public HabboItem createItem(Connection connection, int habboId, Item item, int limitedStack, int limitedSells, String extraData) throws SQLException {
+    public HabboItem createItem(
+            Connection connection, int habboId, Item item, int limitedStack, int limitedSells, String extraData)
+            throws SQLException {
         if (habboId <= 0 || item == null) {
             return null;
         }
 
         extraData = ItemDataGuard.normalizeExtraData(extraData);
 
-        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO items (user_id, item_id, extra_data, limited_data) VALUES (?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO items (user_id, item_id, extra_data, limited_data) VALUES (?, ?, ?, ?)",
+                Statement.RETURN_GENERATED_KEYS)) {
             statement.setInt(1, habboId);
             statement.setInt(2, item.getId());
             statement.setString(3, extraData);
@@ -880,14 +1222,19 @@ public class ItemManager {
 
             try (ResultSet set = statement.getGeneratedKeys()) {
                 if (set.next()) {
-                    Class<? extends HabboItem> itemClass = item.getInteractionType().getType();
+                    Class<? extends HabboItem> itemClass =
+                            item.getInteractionType().getType();
 
                     if (itemClass != null) {
                         try {
-                            return itemClass.getDeclaredConstructor(int.class, int.class, Item.class, String.class, int.class, int.class).newInstance(set.getInt(1), habboId, item, extraData, limitedStack, limitedSells);
+                            return itemClass
+                                    .getDeclaredConstructor(
+                                            int.class, int.class, Item.class, String.class, int.class, int.class)
+                                    .newInstance(set.getInt(1), habboId, item, extraData, limitedStack, limitedSells);
                         } catch (Exception e) {
                             LOGGER.error("Caught exception", e);
-                            return new InteractionDefault(set.getInt(1), habboId, item, extraData, limitedStack, limitedSells);
+                            return new InteractionDefault(
+                                    set.getInt(1), habboId, item, extraData, limitedStack, limitedSells);
                         }
                     }
                 }
@@ -899,7 +1246,8 @@ public class ItemManager {
     public void loadNewUserGifts() {
         this.newuserGifts.clear();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM nux_gifts")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT * FROM nux_gifts")) {
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
                     this.newuserGifts.put(set.getInt("id"), new NewUserGift(set));
@@ -928,12 +1276,14 @@ public class ItemManager {
 
     public void deleteItem(HabboItem item) {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
-            try (PreparedStatement statement = connection.prepareStatement("DELETE FROM items_teleports WHERE teleport_one_id = ? OR teleport_two_id = ?")) {
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "DELETE FROM items_teleports WHERE teleport_one_id = ? OR teleport_two_id = ?")) {
                 statement.setInt(1, item.getId());
                 statement.setInt(2, item.getId());
                 statement.executeUpdate();
             }
-            try (PreparedStatement statement = connection.prepareStatement("DELETE FROM items_hoppers WHERE item_id = ?")) {
+            try (PreparedStatement statement =
+                    connection.prepareStatement("DELETE FROM items_hoppers WHERE item_id = ?")) {
                 statement.setInt(1, item.getId());
                 statement.executeUpdate();
             }
@@ -948,27 +1298,46 @@ public class ItemManager {
 
     public HabboItem handleRecycle(Habbo habbo, String itemId) {
         int rewardItemId = ItemDataGuard.parsePositiveInt(itemId);
-        if (habbo == null || habbo.getHabboInfo() == null || rewardItemId <= 0
+        if (habbo == null
+                || habbo.getHabboInfo() == null
+                || rewardItemId <= 0
                 || Emulator.getGameEnvironment().getCatalogManager().ecotronItem == null) {
             return null;
         }
 
-        String extradata = Calendar.getInstance().get(Calendar.DAY_OF_MONTH) + "-" + (Calendar.getInstance().get(Calendar.MONTH) + 1) + "-" + Calendar.getInstance().get(Calendar.YEAR);
+        String extradata = Calendar.getInstance().get(Calendar.DAY_OF_MONTH) + "-"
+                + (Calendar.getInstance().get(Calendar.MONTH) + 1) + "-"
+                + Calendar.getInstance().get(Calendar.YEAR);
 
         HabboItem item = null;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO items (user_id, item_id, extra_data) VALUES (?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO items (user_id, item_id, extra_data) VALUES (?, ?, ?)",
+                        Statement.RETURN_GENERATED_KEYS)) {
             statement.setInt(1, habbo.getHabboInfo().getId());
-            statement.setInt(2, Emulator.getGameEnvironment().getCatalogManager().ecotronItem.getId());
+            statement.setInt(
+                    2,
+                    Emulator.getGameEnvironment()
+                            .getCatalogManager()
+                            .ecotronItem
+                            .getId());
             statement.setString(3, extradata);
             statement.execute();
 
             try (ResultSet set = statement.getGeneratedKeys()) {
-                try (PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO items_presents (item_id, base_item_reward) VALUES (?, ?)")) {
+                try (PreparedStatement preparedStatement = connection.prepareStatement(
+                        "INSERT INTO items_presents (item_id, base_item_reward) VALUES (?, ?)")) {
                     while (set.next() && item == null) {
                         preparedStatement.setInt(1, set.getInt(1));
                         preparedStatement.setInt(2, rewardItemId);
                         preparedStatement.addBatch();
-                        item = new InteractionDefault(set.getInt(1), habbo.getHabboInfo().getId(), Emulator.getGameEnvironment().getCatalogManager().ecotronItem, extradata, 0, 0);
+                        item = new InteractionDefault(
+                                set.getInt(1),
+                                habbo.getHabboInfo().getId(),
+                                Emulator.getGameEnvironment().getCatalogManager().ecotronItem,
+                                extradata,
+                                0,
+                                0);
                     }
 
                     preparedStatement.executeBatch();
@@ -984,23 +1353,28 @@ public class ItemManager {
     public HabboItem handleOpenRecycleBox(Habbo habbo, HabboItem box) {
         Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(box.getId()));
         HabboItem item = null;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM items_presents WHERE item_id = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("SELECT * FROM items_presents WHERE item_id = ? LIMIT 1")) {
             statement.setInt(1, box.getId());
             try (ResultSet rewardSet = statement.executeQuery()) {
                 if (rewardSet.next()) {
-                    try (PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO items (user_id, item_id) VALUES(?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+                    try (PreparedStatement preparedStatement = connection.prepareStatement(
+                            "INSERT INTO items (user_id, item_id) VALUES(?, ?)", Statement.RETURN_GENERATED_KEYS)) {
                         preparedStatement.setInt(1, habbo.getHabboInfo().getId());
                         preparedStatement.setInt(2, rewardSet.getInt("base_item_reward"));
                         preparedStatement.execute();
 
                         try (ResultSet set = preparedStatement.getGeneratedKeys()) {
                             if (set.next()) {
-                                try (PreparedStatement request = connection.prepareStatement("SELECT * FROM items WHERE id = ? LIMIT 1")) {
+                                try (PreparedStatement request =
+                                        connection.prepareStatement("SELECT * FROM items WHERE id = ? LIMIT 1")) {
                                     request.setInt(1, set.getInt(1));
 
                                     try (ResultSet resultSet = request.executeQuery()) {
                                         if (resultSet.next()) {
-                                            try (PreparedStatement deleteStatement = connection.prepareStatement("DELETE FROM items_presents WHERE item_id = ? LIMIT 1")) {
+                                            try (PreparedStatement deleteStatement = connection.prepareStatement(
+                                                    "DELETE FROM items_presents WHERE item_id = ? LIMIT 1")) {
                                                 deleteStatement.setInt(1, box.getId());
                                                 deleteStatement.execute();
 
@@ -1032,7 +1406,8 @@ public class ItemManager {
     }
 
     public void insertTeleportPair(Connection connection, int itemOneId, int itemTwoId) throws SQLException {
-        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO items_teleports (teleport_one_id, teleport_two_id) VALUES (?, ?)")) {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO items_teleports (teleport_one_id, teleport_two_id) VALUES (?, ?)")) {
             statement.setInt(1, itemOneId);
             statement.setInt(2, itemTwoId);
             statement.execute();
@@ -1056,9 +1431,11 @@ public class ItemManager {
     }
 
     public int[] getTargetTeleportRoomId(HabboItem item) {
-        int[] target = new int[]{};
+        int[] target = new int[] {};
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT items_teleports.*, A.room_id as a_room_id, A.id as a_id, B.room_id as b_room_id, B.id as b_id FROM items_teleports INNER JOIN items AS A ON items_teleports.teleport_one_id = A.id INNER JOIN items AS B ON items_teleports.teleport_two_id = B.id WHERE (teleport_one_id = ? OR teleport_two_id = ?) LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT items_teleports.*, A.room_id as a_room_id, A.id as a_id, B.room_id as b_room_id, B.id as b_id FROM items_teleports INNER JOIN items AS A ON items_teleports.teleport_one_id = A.id INNER JOIN items AS B ON items_teleports.teleport_two_id = B.id WHERE (teleport_one_id = ? OR teleport_two_id = ?) LIMIT 1")) {
             statement.setInt(1, item.getId());
             statement.setInt(2, item.getId());
 
@@ -1069,7 +1446,7 @@ public class ItemManager {
                     final int targetItemId = useA ? set.getInt("a_id") : set.getInt("b_id");
 
                     if (targetRoomId > 0 && targetItemId > 0) {
-                        target = new int[]{targetRoomId, targetItemId};
+                        target = new int[] {targetRoomId, targetItemId};
                     }
                 }
             }
@@ -1082,7 +1459,8 @@ public class ItemManager {
 
     public HabboItem loadHabboItem(int itemId) {
         HabboItem item = null;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM items WHERE id = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement("SELECT * FROM items WHERE id = ? LIMIT 1")) {
             statement.setInt(1, itemId);
             try (ResultSet set = statement.executeQuery()) {
                 if (set.next()) {
@@ -1101,8 +1479,7 @@ public class ItemManager {
     public HabboItem loadHabboItem(ResultSet set) throws SQLException {
         Item baseItem = this.getItem(set.getInt("item_id"));
 
-        if (baseItem == null)
-            return null;
+        if (baseItem == null) return null;
 
         Class<? extends HabboItem> itemClass = baseItem.getInteractionType().getType();
 
@@ -1131,9 +1508,10 @@ public class ItemManager {
 
         if (habbo != null) {
             userId = habbo.getHabboInfo().getId();
-        }
-        else {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT id FROM users WHERE username = ?")) {
+        } else {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    PreparedStatement statement =
+                            connection.prepareStatement("SELECT id FROM users WHERE username = ?")) {
                 statement.setString(1, username);
                 try (ResultSet set = statement.executeQuery()) {
                     if (set.next()) {
@@ -1145,7 +1523,7 @@ public class ItemManager {
             }
         }
 
-        if(userId > 0) {
+        if (userId > 0) {
             return createGift(userId, item, extraData, limitedStack, limitedSells);
         }
 
@@ -1153,8 +1531,7 @@ public class ItemManager {
     }
 
     public HabboItem createGift(int userId, Item item, String extraData, int limitedStack, int limitedSells) {
-        if (userId <= 0 || item == null)
-            return null;
+        if (userId <= 0 || item == null) return null;
 
         if (extraData != null && extraData.length() > ItemDataGuard.MAX_EXTRA_DATA_LENGTH) {
             LOGGER.error("Extradata exceeds maximum length of 1000 characters: {}", extraData);
@@ -1175,8 +1552,7 @@ public class ItemManager {
     }
 
     public Item getItem(int itemId) {
-        if (itemId <= 0)
-            return null;
+        if (itemId <= 0) return null;
 
         return this.items.get(itemId);
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionPostIt.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionPostIt.java
@@ -5,12 +5,11 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 public class InteractionPostIt extends HabboItem {
-    public static String STICKYPOLE_PREFIX_TEXT = "";
+    public static volatile String STICKYPOLE_PREFIX_TEXT = "";
 
     public InteractionPostIt(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
@@ -31,9 +30,7 @@ public class InteractionPostIt extends HabboItem {
     }
 
     @Override
-    public void onWalk(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {
-
-    }
+    public void onWalk(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {}
 
     @Override
     public void serializeExtradata(ServerMessage serverMessage) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionRoller.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionRoller.java
@@ -7,15 +7,14 @@ import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
-import org.apache.commons.math3.util.Pair;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Set;
+import org.apache.commons.math3.util.Pair;
 
 public class InteractionRoller extends HabboItem {
-    public static boolean NO_RULES = false;
+    public static volatile boolean NO_RULES = false;
     public static int DELAY = 400;
 
     public InteractionRoller(ResultSet set, Item baseItem) throws SQLException {
@@ -52,9 +51,7 @@ public class InteractionRoller extends HabboItem {
     }
 
     @Override
-    public void onWalk(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {
-
-    }
+    public void onWalk(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {}
 
     @Override
     public void onWalkOn(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {
@@ -65,7 +62,6 @@ public class InteractionRoller extends HabboItem {
     public void onWalkOff(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {
         super.onWalkOff(roomUnit, room, objects);
     }
-
 
     @Override
     public boolean canStackAt(Room room, List<Pair<RoomTile, Set<HabboItem>>> itemsAtLocation) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSendSignal.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSendSignal.java
@@ -7,33 +7,41 @@ import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
-import com.eu.habbo.habbohotel.rooms.RoomSpecialTypes;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.WiredEffectType;
-import com.eu.habbo.habbohotel.wired.core.*;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredEvent;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WiredEffectSendSignal extends InteractionWiredEffect {
     private static final Logger LOGGER = LoggerFactory.getLogger(WiredEffectSendSignal.class);
 
     public static final WiredEffectType type = WiredEffectType.SEND_SIGNAL;
 
-    public static int MAX_SIGNAL_DEPTH = 100;
+    public static volatile int MAX_SIGNAL_DEPTH = 100;
 
-    private static final int ANTENNA_PICKED  = 0;
+    private static final int ANTENNA_PICKED = 0;
     private static final int ANTENNA_TRIGGER = 1;
     private static final String ANTENNA_INTERACTION = "antenna";
     private static final String FORWARD_ITEM_SPLIT_REGEX = "[;,\\t]";
@@ -42,12 +50,12 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
 
     private Set<HabboItem> items;
     private Set<HabboItem> forwardItems;
-    private int     antennaSource   = ANTENNA_PICKED;
-    private int     furniForward    = WiredSourceUtil.SOURCE_TRIGGER;
-    private int     userForward     = WiredSourceUtil.SOURCE_TRIGGER;
-    private boolean signalPerFurni  = false;
-    private boolean signalPerUser   = false;
-    private int     channel         = 0;
+    private int antennaSource = ANTENNA_PICKED;
+    private int furniForward = WiredSourceUtil.SOURCE_TRIGGER;
+    private int userForward = WiredSourceUtil.SOURCE_TRIGGER;
+    private boolean signalPerFurni = false;
+    private boolean signalPerUser = false;
+    private int channel = 0;
 
     public WiredEffectSendSignal(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
@@ -66,7 +74,11 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
         Room room = ctx.room();
         if (room == null) return;
 
-        LOGGER.debug("[SendSignal] execute() called, itemId={}, antennaSource={}, pickedItems={}", this.getId(), antennaSource, this.items.size());
+        LOGGER.debug(
+                "[SendSignal] execute() called, itemId={}, antennaSource={}, pickedItems={}",
+                this.getId(),
+                antennaSource,
+                this.items.size());
 
         int currentDepth = ctx.event().getCallStackDepth();
         if (currentDepth >= MAX_SIGNAL_DEPTH) {
@@ -76,9 +88,7 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
 
         Collection<HabboItem> antennas;
         if (antennaSource == ANTENNA_TRIGGER) {
-            antennas = ctx.sourceItem()
-                    .map(Collections::<HabboItem>singleton)
-                    .orElse(Collections.emptySet());
+            antennas = ctx.sourceItem().map(Collections::<HabboItem>singleton).orElse(Collections.emptySet());
         } else {
             Collection<HabboItem> baseAntennas = new ArrayList<>(this.items);
 
@@ -96,12 +106,16 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
                 .collect(Collectors.toList());
 
         if (resolvedAntennas.isEmpty()) {
-            LOGGER.debug("[SendSignal] No antennas resolved, aborting. antennaSource={}, selectorModified={}", antennaSource, ctx.targets().isItemsModifiedBySelector());
+            LOGGER.debug(
+                    "[SendSignal] No antennas resolved, aborting. antennaSource={}, selectorModified={}",
+                    antennaSource,
+                    ctx.targets().isItemsModifiedBySelector());
             return;
         }
         LOGGER.debug("[SendSignal] Resolved {} antenna(s), firing signals", resolvedAntennas.size());
 
-        RoomUnit triggeringUser = ctx.event().getOriginActor().orElseGet(() -> ctx.actor().orElse(null));
+        RoomUnit triggeringUser =
+                ctx.event().getOriginActor().orElseGet(() -> ctx.actor().orElse(null));
         List<RoomUnit> forwardedUsers = WiredSourceUtil.resolveUsersRaw(ctx, this.userForward);
         List<HabboItem> forwardedFurni = WiredSourceUtil.resolveItemsRaw(ctx, this.furniForward, this.forwardItems);
 
@@ -121,16 +135,14 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
                 mergedUsers.put(forwardedUser.getId(), forwardedUser);
             }
 
-            usersToSend = mergedUsers.isEmpty()
-                    ? Collections.singletonList(null)
-                    : new ArrayList<>(mergedUsers.values());
+            usersToSend =
+                    mergedUsers.isEmpty() ? Collections.singletonList(null) : new ArrayList<>(mergedUsers.values());
         } else {
             usersToSend = Collections.singletonList(triggeringUser);
         }
 
-        Collection<HabboItem> furniToSend = !forwardedFurni.isEmpty()
-                ? forwardedFurni
-                : Collections.singletonList(null);
+        Collection<HabboItem> furniToSend =
+                !forwardedFurni.isEmpty() ? forwardedFurni : Collections.singletonList(null);
 
         int nextDepth = currentDepth + 1;
         int signalUserCount = signalPerUser
@@ -140,13 +152,22 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
         for (RoomUnit user : usersToSend) {
             for (HabboItem sourceItem : furniToSend) {
                 for (HabboItem antenna : resolvedAntennas) {
-                    fireSignalAtAntenna(ctx, room, antenna, user, triggeringUser, sourceItem, signalUserCount, nextDepth);
+                    fireSignalAtAntenna(
+                            ctx, room, antenna, user, triggeringUser, sourceItem, signalUserCount, nextDepth);
                 }
             }
         }
     }
 
-    private void fireSignalAtAntenna(WiredContext ctx, Room room, HabboItem antenna, RoomUnit actor, RoomUnit originActor, HabboItem sourceItem, int signalUserCount, int depth) {
+    private void fireSignalAtAntenna(
+            WiredContext ctx,
+            Room room,
+            HabboItem antenna,
+            RoomUnit actor,
+            RoomUnit originActor,
+            HabboItem sourceItem,
+            int signalUserCount,
+            int depth) {
         if (antenna == null) return;
         RoomTile tile = room.getLayout().getTile(antenna.getX(), antenna.getY());
         if (tile == null) return;
@@ -155,8 +176,15 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
 
         int signalChannel = antenna.getId();
 
-        LOGGER.debug("[SendSignal] fireSignalAtAntenna: antennaId={} tile={},{} depth={} channel={} actor={} sourceItem={}",
-                signalChannel, tile.x, tile.y, depth, signalChannel, actor != null ? actor.getId() : "null", sourceItem != null ? sourceItem.getId() : "null");
+        LOGGER.debug(
+                "[SendSignal] fireSignalAtAntenna: antennaId={} tile={},{} depth={} channel={} actor={} sourceItem={}",
+                signalChannel,
+                tile.x,
+                tile.y,
+                depth,
+                signalChannel,
+                actor != null ? actor.getId() : "null",
+                sourceItem != null ? sourceItem.getId() : "null");
 
         WiredEvent.Builder builder = WiredEvent.builder(WiredEvent.Type.SIGNAL_RECEIVED, room)
                 .tile(tile)
@@ -190,29 +218,31 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
         antenna.setExtradata("1");
         room.updateItemState(antenna);
 
-        Emulator.getThreading().run(() -> {
-            if (!room.isLoaded()) return;
+        Emulator.getThreading()
+                .run(
+                        () -> {
+                            if (!room.isLoaded()) return;
 
-            Long currentToken = ANTENNA_PULSE_TOKENS.get(antenna.getId());
-            if (currentToken == null || currentToken.longValue() != token) return;
+                            Long currentToken = ANTENNA_PULSE_TOKENS.get(antenna.getId());
+                            if (currentToken == null || currentToken.longValue() != token) return;
 
-            antenna.setExtradata("0");
-            room.updateItemState(antenna);
-            ANTENNA_PULSE_TOKENS.remove(antenna.getId(), token);
-        }, ANTENNA_PULSE_MS);
+                            antenna.setExtradata("0");
+                            room.updateItemState(antenna);
+                            ANTENNA_PULSE_TOKENS.remove(antenna.getId(), token);
+                        },
+                        ANTENNA_PULSE_MS);
     }
 
     @Override
     public void serializeWiredData(ServerMessage message, Room room) {
         List<HabboItem> itemsSnapshot = new ArrayList<>(this.items);
 
-        itemsSnapshot.removeIf(item ->
-                item.getRoomId() != this.getRoomId() || room.getHabboItem(item.getId()) == null);
+        itemsSnapshot.removeIf(item -> item.getRoomId() != this.getRoomId() || room.getHabboItem(item.getId()) == null);
         this.items.retainAll(itemsSnapshot);
 
         List<HabboItem> forwardSnapshot = new ArrayList<>(this.forwardItems);
-        forwardSnapshot.removeIf(item ->
-                item.getRoomId() != this.getRoomId() || room.getHabboItem(item.getId()) == null);
+        forwardSnapshot.removeIf(
+                item -> item.getRoomId() != this.getRoomId() || room.getHabboItem(item.getId()) == null);
         this.forwardItems.retainAll(forwardSnapshot);
 
         String forwardString = forwardSnapshot.stream()
@@ -287,10 +317,10 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
 
         int[] params = settings.getIntParams();
         int requestedAntennaSource = params.length > 0 ? params[0] : ANTENNA_PICKED;
-        this.furniForward   = normalizeSource(params.length > 1 ? params[1] : WiredSourceUtil.SOURCE_TRIGGER);
-        this.userForward    = normalizeSource(params.length > 2 ? params[2] : WiredSourceUtil.SOURCE_TRIGGER);
+        this.furniForward = normalizeSource(params.length > 1 ? params[1] : WiredSourceUtil.SOURCE_TRIGGER);
+        this.userForward = normalizeSource(params.length > 2 ? params[2] : WiredSourceUtil.SOURCE_TRIGGER);
         this.signalPerFurni = params.length > 3 && params[3] == 1;
-        this.signalPerUser  = params.length > 4 && params[4] == 1;
+        this.signalPerUser = params.length > 4 && params[4] == 1;
         this.channel = params.length > 5 ? params[5] : 0;
         this.antennaSource = requestedAntennaSource;
         if (!newItems.isEmpty()) {
@@ -314,8 +344,16 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
         }
         this.setDelay(delay);
 
-        LOGGER.debug("[SendSignal] saveData: antennaSource={}, furniForward={}, userForward={}, signalPerFurni={}, signalPerUser={}, channel={}, items={}, forwardItems={}",
-                antennaSource, furniForward, userForward, signalPerFurni, signalPerUser, channel, items.size(), forwardItems.size());
+        LOGGER.debug(
+                "[SendSignal] saveData: antennaSource={}, furniForward={}, userForward={}, signalPerFurni={}, signalPerUser={}, channel={}, items={}, forwardItems={}",
+                antennaSource,
+                furniForward,
+                userForward,
+                signalPerFurni,
+                signalPerUser,
+                channel,
+                items.size(),
+                forwardItems.size());
 
         return true;
     }
@@ -330,12 +368,17 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
     public String getWiredData() {
         List<HabboItem> itemsSnapshot = new ArrayList<>(this.items);
         List<HabboItem> forwardSnapshot = new ArrayList<>(this.forwardItems);
-        return WiredManager.getGson().toJson(new JsonData(
-                this.getDelay(),
-                itemsSnapshot.stream().map(HabboItem::getId).collect(Collectors.toList()),
-                forwardSnapshot.stream().map(HabboItem::getId).collect(Collectors.toList()),
-                antennaSource, furniForward, userForward, signalPerFurni, signalPerUser, channel
-        ));
+        return WiredManager.getGson()
+                .toJson(new JsonData(
+                        this.getDelay(),
+                        itemsSnapshot.stream().map(HabboItem::getId).collect(Collectors.toList()),
+                        forwardSnapshot.stream().map(HabboItem::getId).collect(Collectors.toList()),
+                        antennaSource,
+                        furniForward,
+                        userForward,
+                        signalPerFurni,
+                        signalPerUser,
+                        channel));
     }
 
     @Override
@@ -347,12 +390,12 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
         JsonData data = WiredUtilityPayloadGuard.fromJson(wiredData, JsonData.class);
         if (data != null) {
             this.setDelay(WiredUtilityPayloadGuard.delay(data.delay));
-            this.antennaSource  = data.antennaSource;
-            this.furniForward   = normalizeSource(data.furniForward);
-            this.userForward    = normalizeSource(data.userForward);
+            this.antennaSource = data.antennaSource;
+            this.furniForward = normalizeSource(data.furniForward);
+            this.userForward = normalizeSource(data.userForward);
             this.signalPerFurni = data.signalPerFurni;
-            this.signalPerUser  = data.signalPerUser;
-            this.channel        = data.channel;
+            this.signalPerUser = data.signalPerUser;
+            this.channel = data.channel;
             if (data.itemIds != null) {
                 for (Integer id : data.itemIds) {
                     HabboItem item = room.getHabboItem(id);
@@ -377,12 +420,12 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
     public void onPickUp() {
         this.items.clear();
         this.forwardItems.clear();
-        this.antennaSource  = ANTENNA_PICKED;
-        this.furniForward   = WiredSourceUtil.SOURCE_TRIGGER;
-        this.userForward    = WiredSourceUtil.SOURCE_TRIGGER;
+        this.antennaSource = ANTENNA_PICKED;
+        this.furniForward = WiredSourceUtil.SOURCE_TRIGGER;
+        this.userForward = WiredSourceUtil.SOURCE_TRIGGER;
         this.signalPerFurni = false;
-        this.signalPerUser  = false;
-        this.channel        = 0;
+        this.signalPerUser = false;
+        this.channel = 0;
         this.setDelay(0);
     }
 
@@ -513,17 +556,25 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
         boolean signalPerUser;
         int channel;
 
-        public JsonData(int delay, List<Integer> itemIds, List<Integer> forwardItemIds, int antennaSource, int furniForward,
-                        int userForward, boolean signalPerFurni, boolean signalPerUser, int channel) {
-            this.delay          = delay;
-            this.itemIds        = itemIds;
+        public JsonData(
+                int delay,
+                List<Integer> itemIds,
+                List<Integer> forwardItemIds,
+                int antennaSource,
+                int furniForward,
+                int userForward,
+                boolean signalPerFurni,
+                boolean signalPerUser,
+                int channel) {
+            this.delay = delay;
+            this.itemIds = itemIds;
             this.forwardItemIds = forwardItemIds;
-            this.antennaSource  = antennaSource;
-            this.furniForward   = furniForward;
-            this.userForward    = userForward;
+            this.antennaSource = antennaSource;
+            this.furniForward = furniForward;
+            this.userForward = userForward;
             this.signalPerFurni = signalPerFurni;
-            this.signalPerUser  = signalPerUser;
-            this.channel        = channel;
+            this.signalPerUser = signalPerUser;
+            this.channel = channel;
         }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/Messenger.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/Messenger.java
@@ -8,10 +8,6 @@ import com.eu.habbo.habbohotel.users.HabboInfo;
 import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.messages.outgoing.friends.UpdateFriendComposer;
 import com.eu.habbo.plugin.events.users.friends.UserAcceptFriendRequestEvent;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -21,15 +17,18 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Messenger {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Messenger.class);
 
-    //Configuration. Loaded from database & updated accordingly.
-    public static boolean SAVE_PRIVATE_CHATS = false;
-    public static int MAXIMUM_FRIENDS = 200;
-    public static int MAXIMUM_FRIENDS_HC = 500;
+    // Configuration. Loaded from database & updated accordingly.
+    public static volatile boolean SAVE_PRIVATE_CHATS = false;
+    public static volatile int MAXIMUM_FRIENDS = 200;
+    public static volatile int MAXIMUM_FRIENDS_HC = 500;
 
     private final ConcurrentHashMap<Integer, MessengerBuddy> friends;
     private final Set<FriendRequest> friendRequests;
@@ -40,7 +39,9 @@ public class Messenger {
     }
 
     public static void unfriend(int userOne, int userTwo) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("DELETE FROM messenger_friendships WHERE (user_one_id = ? AND user_two_id = ?) OR (user_one_id = ? AND user_two_id = ?)")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "DELETE FROM messenger_friendships WHERE (user_one_id = ? AND user_two_id = ?) OR (user_one_id = ? AND user_two_id = ?)")) {
             statement.setInt(1, userOne);
             statement.setInt(2, userTwo);
             statement.setInt(3, userTwo);
@@ -53,7 +54,10 @@ public class Messenger {
 
     public static Set<MessengerBuddy> searchUsers(String username) {
         Set<MessengerBuddy> users = new HashSet<>();
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM users WHERE username LIKE ? ORDER BY username ASC LIMIT " + Emulator.getConfig().getInt("hotel.messenger.search.maxresults"))) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT * FROM users WHERE username LIKE ? ORDER BY username ASC LIMIT "
+                                + Emulator.getConfig().getInt("hotel.messenger.search.maxresults"))) {
             statement.setString(1, com.eu.habbo.util.SqlLikeEscaper.escape(username) + "%");
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
@@ -85,7 +89,9 @@ public class Messenger {
             return false;
         }
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM messenger_friendrequests WHERE (user_to_id = ? AND user_from_id = ?) OR (user_to_id = ? AND user_from_id = ?) LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT * FROM messenger_friendrequests WHERE (user_to_id = ? AND user_from_id = ?) OR (user_to_id = ? AND user_from_id = ?) LIMIT 1")) {
             statement.setInt(1, habbo.getHabboInfo().getId());
             statement.setInt(2, habboInfo.getId());
             statement.setInt(3, habboInfo.getId());
@@ -103,7 +109,9 @@ public class Messenger {
     }
 
     public static boolean friendRequested(int userFrom, int userTo) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM messenger_friendrequests WHERE user_to_id = ? AND user_from_id = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT * FROM messenger_friendrequests WHERE user_to_id = ? AND user_from_id = ? LIMIT 1")) {
             statement.setInt(1, userFrom);
             statement.setInt(2, userTo);
 
@@ -120,7 +128,9 @@ public class Messenger {
     }
 
     public static void makeFriendRequest(int userFrom, int userTo) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO messenger_friendrequests (user_to_id, user_from_id) VALUES (?, ?)")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO messenger_friendrequests (user_to_id, user_from_id) VALUES (?, ?)")) {
             statement.setInt(1, userTo);
             statement.setInt(2, userFrom);
             statement.executeUpdate();
@@ -132,16 +142,16 @@ public class Messenger {
     public static int getFriendCount(int userId) {
         Habbo habbo = Emulator.getGameServer().getGameClientManager().getHabbo(userId);
 
-        if (habbo != null)
-            return habbo.getMessenger().getFriends().size();
+        if (habbo != null) return habbo.getMessenger().getFriends().size();
 
         int count = 0;
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT count(id) as count FROM messenger_friendships WHERE user_one_id = ?")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT count(id) as count FROM messenger_friendships WHERE user_one_id = ?")) {
             statement.setInt(1, userId);
             try (ResultSet set = statement.executeQuery()) {
-                if (set.next())
-                    count = set.getInt("count");
+                if (set.next()) count = set.getInt("count");
             }
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
@@ -156,14 +166,20 @@ public class Messenger {
         map.put(2, new HashSet<>());
         map.put(3, new HashSet<>());
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT users.id, users.look, users.username, messenger_friendships.relation FROM messenger_friendships INNER JOIN users ON users.id = messenger_friendships.user_two_id WHERE user_one_id = ? ORDER BY RAND() LIMIT 50")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT users.id, users.look, users.username, messenger_friendships.relation FROM messenger_friendships INNER JOIN users ON users.id = messenger_friendships.user_two_id WHERE user_one_id = ? ORDER BY RAND() LIMIT 50")) {
             statement.setInt(1, userId);
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
-                    if (set.getInt("relation") == 0)
-                        continue;
+                    if (set.getInt("relation") == 0) continue;
 
-                    MessengerBuddy buddy = new MessengerBuddy(set.getInt("id"), set.getString("username"), set.getString("look"), (short) set.getInt("relation"), userId);
+                    MessengerBuddy buddy = new MessengerBuddy(
+                            set.getInt("id"),
+                            set.getString("username"),
+                            set.getString("look"),
+                            (short) set.getInt("relation"),
+                            userId);
                     map.get((int) buddy.getRelation()).add(buddy);
                 }
             }
@@ -174,14 +190,16 @@ public class Messenger {
     }
 
     public static void checkFriendSizeProgress(Habbo habbo) {
-        int progress = habbo.getHabboStats().getAchievementProgress(Emulator.getGameEnvironment().getAchievementManager().getAchievement("FriendListSize"));
+        int progress = habbo.getHabboStats()
+                .getAchievementProgress(
+                        Emulator.getGameEnvironment().getAchievementManager().getAchievement("FriendListSize"));
 
         int toProgress = 1;
 
-        Achievement achievement = Emulator.getGameEnvironment().getAchievementManager().getAchievement("FriendListSize");
+        Achievement achievement =
+                Emulator.getGameEnvironment().getAchievementManager().getAchievement("FriendListSize");
 
-        if (achievement == null)
-            return;
+        if (achievement == null) return;
 
         if (progress > 0) {
             toProgress = habbo.getMessenger().getFriends().size() - progress;
@@ -196,14 +214,14 @@ public class Messenger {
 
     public void loadFriends(Habbo habbo) {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT " +
-                     "users.id, " +
-                     "users.username, " +
-                     "users.gender, " +
-                     "users.online, " +
-                     "users.look, " +
-                     "users.motto, " +
-                     "messenger_friendships.* FROM messenger_friendships INNER JOIN users ON messenger_friendships.user_two_id = users.id WHERE user_one_id = ?")) {
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT " + "users.id, "
+                                + "users.username, "
+                                + "users.gender, "
+                                + "users.online, "
+                                + "users.look, "
+                                + "users.motto, "
+                                + "messenger_friendships.* FROM messenger_friendships INNER JOIN users ON messenger_friendships.user_two_id = users.id WHERE user_one_id = ?")) {
             statement.setInt(1, habbo.getHabboInfo().getId());
 
             try (ResultSet set = statement.executeQuery()) {
@@ -222,20 +240,23 @@ public class Messenger {
         }
 
         if (habbo.hasPermission(StaffChatBuddy.PERMISSION_KEY)) {
-            this.friends.putIfAbsent(StaffChatBuddy.BUDDY_ID, new StaffChatBuddy(habbo.getHabboInfo().getId()));
+            this.friends.putIfAbsent(
+                    StaffChatBuddy.BUDDY_ID,
+                    new StaffChatBuddy(habbo.getHabboInfo().getId()));
         }
     }
 
     public MessengerBuddy loadFriend(Habbo habbo, int userId) {
         MessengerBuddy buddy = null;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT " +
-                "users.id, " +
-                "users.username, " +
-                "users.gender, " +
-                "users.online, " +
-                "users.look, " +
-                "users.motto, " +
-                "messenger_friendships.* FROM messenger_friendships INNER JOIN users ON messenger_friendships.user_two_id = users.id WHERE user_one_id = ? AND user_two_id = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT " + "users.id, "
+                                + "users.username, "
+                                + "users.gender, "
+                                + "users.online, "
+                                + "users.look, "
+                                + "users.motto, "
+                                + "messenger_friendships.* FROM messenger_friendships INNER JOIN users ON messenger_friendships.user_two_id = users.id WHERE user_one_id = ? AND user_two_id = ? LIMIT 1")) {
             statement.setInt(1, habbo.getHabboInfo().getId());
             statement.setInt(2, userId);
 
@@ -253,7 +274,9 @@ public class Messenger {
     }
 
     public void loadFriendRequests(Habbo habbo) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT users.id, users.username, users.look FROM messenger_friendrequests INNER JOIN users ON user_from_id = users.id WHERE user_to_id = ?")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT users.id, users.username, users.look FROM messenger_friendrequests INNER JOIN users ON user_from_id = users.id WHERE user_to_id = ?")) {
             statement.setInt(1, habbo.getHabboInfo().getId());
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
@@ -292,14 +315,14 @@ public class Messenger {
     public void connectionChanged(Habbo owner, boolean online, boolean inRoom) {
         if (owner != null) {
             for (Map.Entry<Integer, MessengerBuddy> map : this.getFriends().entrySet()) {
-                if (map.getValue().getOnline() == 0)
-                    continue;
+                if (map.getValue().getOnline() == 0) continue;
 
                 Habbo habbo = Emulator.getGameServer().getGameClientManager().getHabbo(map.getKey());
 
                 if (habbo != null) {
                     if (habbo.getMessenger() != null) {
-                        MessengerBuddy buddy = habbo.getMessenger().getFriend(owner.getHabboInfo().getId());
+                        MessengerBuddy buddy = habbo.getMessenger()
+                                .getFriend(owner.getHabboInfo().getId());
 
                         if (buddy != null) {
                             buddy.setOnline(online);
@@ -316,7 +339,9 @@ public class Messenger {
     }
 
     public void deleteAllFriendRequests(int userTo) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("DELETE FROM messenger_friendrequests WHERE user_to_id = ?")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("DELETE FROM messenger_friendrequests WHERE user_to_id = ?")) {
             statement.setInt(1, userTo);
             statement.executeUpdate();
         } catch (SQLException e) {
@@ -325,7 +350,9 @@ public class Messenger {
     }
 
     public int deleteFriendRequests(int userFrom, int userTo) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("DELETE FROM messenger_friendrequests WHERE (user_to_id = ? AND user_from_id = ?) OR (user_to_id = ? AND user_from_id = ?)")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "DELETE FROM messenger_friendrequests WHERE (user_to_id = ? AND user_from_id = ?) OR (user_to_id = ? AND user_from_id = ?)")) {
             statement.setInt(1, userTo);
             statement.setInt(2, userFrom);
             statement.setInt(4, userTo);
@@ -338,12 +365,14 @@ public class Messenger {
         return 0;
     }
 
-    //TODO Needs redesign. userFrom is redundant.
+    // TODO Needs redesign. userFrom is redundant.
     public void acceptFriendRequest(int userFrom, int userTo) {
         int count = this.deleteFriendRequests(userFrom, userTo);
 
         if (count > 0) {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO messenger_friendships (user_one_id, user_two_id, friends_since) VALUES (?, ?, ?)")) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    PreparedStatement statement = connection.prepareStatement(
+                            "INSERT INTO messenger_friendships (user_one_id, user_two_id, friends_since) VALUES (?, ?, ?)")) {
                 statement.setInt(1, userFrom);
                 statement.setInt(2, userTo);
                 statement.setInt(3, Emulator.getIntUnixTimestamp());
@@ -361,14 +390,22 @@ public class Messenger {
             Habbo habboFrom = Emulator.getGameServer().getGameClientManager().getHabbo(userFrom);
 
             if (habboTo != null && habboFrom != null) {
-                MessengerBuddy to = new MessengerBuddy(habboFrom, habboTo.getHabboInfo().getId());
-                MessengerBuddy from = new MessengerBuddy(habboTo, habboFrom.getHabboInfo().getId());
+                MessengerBuddy to =
+                        new MessengerBuddy(habboFrom, habboTo.getHabboInfo().getId());
+                MessengerBuddy from =
+                        new MessengerBuddy(habboTo, habboFrom.getHabboInfo().getId());
 
+                habboTo.getMessenger()
+                        .friends
+                        .putIfAbsent(habboFrom.getHabboInfo().getId(), to);
+                habboFrom
+                        .getMessenger()
+                        .friends
+                        .putIfAbsent(habboTo.getHabboInfo().getId(), from);
 
-                habboTo.getMessenger().friends.putIfAbsent(habboFrom.getHabboInfo().getId(), to);
-                habboFrom.getMessenger().friends.putIfAbsent(habboTo.getHabboInfo().getId(), from);
-
-                if (Emulator.getPluginManager().fireEvent(new UserAcceptFriendRequestEvent(habboTo, from)).isCancelled()) {
+                if (Emulator.getPluginManager()
+                        .fireEvent(new UserAcceptFriendRequestEvent(habboTo, from))
+                        .isCancelled()) {
                     this.removeBuddy(userTo);
                     return;
                 }
@@ -376,9 +413,12 @@ public class Messenger {
                 habboTo.getClient().sendResponse(new UpdateFriendComposer(habboTo, to, 1));
                 habboFrom.getClient().sendResponse(new UpdateFriendComposer(habboFrom, from, 1));
             } else if (habboTo != null) {
-                habboTo.getClient().sendResponse(new UpdateFriendComposer(habboTo, this.loadFriend(habboTo, userFrom), 1));
+                habboTo.getClient()
+                        .sendResponse(new UpdateFriendComposer(habboTo, this.loadFriend(habboTo, userFrom), 1));
             } else if (habboFrom != null) {
-                habboFrom.getClient().sendResponse(new UpdateFriendComposer(habboFrom, this.loadFriend(habboFrom, userTo), 1));
+                habboFrom
+                        .getClient()
+                        .sendResponse(new UpdateFriendComposer(habboFrom, this.loadFriend(habboFrom, userTo), 1));
             }
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/WordFilter.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/WordFilter.java
@@ -6,10 +6,6 @@ import com.eu.habbo.habbohotel.rooms.RoomChatMessage;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.friends.FriendChatMessageComposer;
 import com.eu.habbo.plugin.events.users.UserTriggerWordFilterEvent;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -18,13 +14,17 @@ import java.text.Normalizer;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WordFilter {
     private static final Logger LOGGER = LoggerFactory.getLogger(WordFilter.class);
 
-    private static final Pattern DIACRITICS_AND_FRIENDS = Pattern.compile("[\\p{InCombiningDiacriticalMarks}\\p{IsLm}\\p{IsSk}]+");
-    public static boolean ENABLED_FRIENDCHAT = true;
-    public static String DEFAULT_REPLACEMENT = "bobba";
+    private static final Pattern DIACRITICS_AND_FRIENDS =
+            Pattern.compile("[\\p{InCombiningDiacriticalMarks}\\p{IsLm}\\p{IsSk}]+");
+    public static volatile boolean ENABLED_FRIENDCHAT = true;
+    public static volatile String DEFAULT_REPLACEMENT = "bobba";
     protected Set<WordFilterWord> autoReportWords = new HashSet<>();
     protected Set<WordFilterWord> hideMessageWords = new HashSet<>();
     protected Set<WordFilterWord> words = new HashSet<>();
@@ -43,14 +43,14 @@ public class WordFilter {
     }
 
     public synchronized void reload() {
-        if (!Emulator.getConfig().getBoolean("hotel.wordfilter.enabled"))
-            return;
+        if (!Emulator.getConfig().getBoolean("hotel.wordfilter.enabled")) return;
 
         this.autoReportWords.clear();
         this.hideMessageWords.clear();
         this.words.clear();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement()) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                Statement statement = connection.createStatement()) {
             try (ResultSet set = statement.executeQuery("SELECT * FROM wordfilter")) {
                 while (set.next()) {
                     WordFilterWord word;
@@ -63,10 +63,8 @@ public class WordFilter {
                     }
 
                     if (!word.prefixOnly) {
-                        if (word.autoReport)
-                            this.autoReportWords.add(word);
-                        else if (word.hideMessage)
-                            this.hideMessageWords.add(word);
+                        if (word.autoReport) this.autoReportWords.add(word);
+                        else if (word.hideMessage) this.hideMessageWords.add(word);
                     }
 
                     this.words.add(word);
@@ -78,15 +76,25 @@ public class WordFilter {
     }
 
     public String normalise(String message) {
-        return DIACRITICS_AND_FRIENDS.matcher(Normalizer.normalize(StringUtils.stripAccents(message), Normalizer.Form.NFKD)
-                .replaceAll("[,.;:'\"]", " ").replace("I", "l")
-                .replaceAll("[^\\p{ASCII}*$]", "").replaceAll("\\p{M}", " ")
-                .replaceAll("^\\p{M}*$]", "").replaceAll("[1|]", "i")
-                .replace("2", "z").replace("3", "e")
-                .replace("4", "a").replace("5", "s")
-                .replace("8", "b").replace("0", "o")
-                .replace(" ", " ").replace("$", "s")
-                .replace("ß", "b").trim()).replaceAll(" ");
+        return DIACRITICS_AND_FRIENDS
+                .matcher(Normalizer.normalize(StringUtils.stripAccents(message), Normalizer.Form.NFKD)
+                        .replaceAll("[,.;:'\"]", " ")
+                        .replace("I", "l")
+                        .replaceAll("[^\\p{ASCII}*$]", "")
+                        .replaceAll("\\p{M}", " ")
+                        .replaceAll("^\\p{M}*$]", "")
+                        .replaceAll("[1|]", "i")
+                        .replace("2", "z")
+                        .replace("3", "e")
+                        .replace("4", "a")
+                        .replace("5", "s")
+                        .replace("8", "b")
+                        .replace("0", "o")
+                        .replace(" ", " ")
+                        .replace("$", "s")
+                        .replace("ß", "b")
+                        .trim())
+                .replaceAll(" ");
     }
 
     public boolean autoReportCheck(RoomChatMessage roomChatMessage) {
@@ -94,10 +102,31 @@ public class WordFilter {
 
         for (WordFilterWord word : this.autoReportWords) {
             if (message.contains(word.key)) {
-                Emulator.getGameEnvironment().getModToolManager().quickTicket(roomChatMessage.getHabbo(), "Automatic WordFilter", roomChatMessage.getMessage());
+                Emulator.getGameEnvironment()
+                        .getModToolManager()
+                        .quickTicket(roomChatMessage.getHabbo(), "Automatic WordFilter", roomChatMessage.getMessage());
 
                 if (Emulator.getConfig().getBoolean("notify.staff.chat.auto.report")) {
-                    Emulator.getGameEnvironment().getHabboManager().sendPacketToHabbosWithPermission(new FriendChatMessageComposer(new Message(roomChatMessage.getHabbo().getHabboInfo().getId(), 0, Emulator.getTexts().getValue("warning.auto.report").replace("%user%", roomChatMessage.getHabbo().getHabboInfo().getUsername()).replace("%word%", word.key))).compose(), "acc_staff_chat");
+                    Emulator.getGameEnvironment()
+                            .getHabboManager()
+                            .sendPacketToHabbosWithPermission(
+                                    new FriendChatMessageComposer(new Message(
+                                                    roomChatMessage
+                                                            .getHabbo()
+                                                            .getHabboInfo()
+                                                            .getId(),
+                                                    0,
+                                                    Emulator.getTexts()
+                                                            .getValue("warning.auto.report")
+                                                            .replace(
+                                                                    "%user%",
+                                                                    roomChatMessage
+                                                                            .getHabbo()
+                                                                            .getHabboInfo()
+                                                                            .getUsername())
+                                                            .replace("%word%", word.key)))
+                                            .compose(),
+                                    "acc_staff_chat");
                 }
                 return true;
             }
@@ -139,8 +168,9 @@ public class WordFilter {
 
             if (StringUtils.containsIgnoreCase(filteredMessage, word.key)) {
                 if (habbo != null) {
-                    if (Emulator.getPluginManager().fireEvent(new UserTriggerWordFilterEvent(habbo, word)).isCancelled())
-                        continue;
+                    if (Emulator.getPluginManager()
+                            .fireEvent(new UserTriggerWordFilterEvent(habbo, word))
+                            .isCancelled()) continue;
                 }
                 filteredMessage = filteredMessage.replace("(?i)" + word.key, word.replacement);
                 foundShit = true;
@@ -170,8 +200,9 @@ public class WordFilter {
 
             if (StringUtils.containsIgnoreCase(message, word.key)) {
                 if (habbo != null) {
-                    if (Emulator.getPluginManager().fireEvent(new UserTriggerWordFilterEvent(habbo, word)).isCancelled())
-                        continue;
+                    if (Emulator.getPluginManager()
+                            .fireEvent(new UserTriggerWordFilterEvent(habbo, word))
+                            .isCancelled()) continue;
                 }
 
                 message = message.replace(word.key, word.replacement);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/navigation/NavigatorManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/navigation/NavigatorManager.java
@@ -3,9 +3,6 @@ package com.eu.habbo.habbohotel.navigation;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.Habbo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -17,13 +14,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NavigatorManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NavigatorManager.class);
 
-    public static int MAXIMUM_RESULTS_PER_PAGE = 10;
-    public static boolean CATEGORY_SORT_USING_ORDER_NUM = false;
+    public static volatile int MAXIMUM_RESULTS_PER_PAGE = 10;
+    public static volatile boolean CATEGORY_SORT_USING_ORDER_NUM = false;
 
     public final Map<Integer, NavigatorPublicCategory> publicCategories = new HashMap<>();
     public final ConcurrentHashMap<String, NavigatorFilterField> filterSettings = new ConcurrentHashMap<>();
@@ -46,7 +45,9 @@ public class NavigatorManager {
             synchronized (this.publicCategories) {
                 this.publicCategories.clear();
 
-                try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM navigator_publiccats WHERE visible = '1' ORDER BY order_num DESC")) {
+                try (Statement statement = connection.createStatement();
+                        ResultSet set = statement.executeQuery(
+                                "SELECT * FROM navigator_publiccats WHERE visible = '1' ORDER BY order_num DESC")) {
                     while (set.next()) {
                         this.publicCategories.put(set.getInt("id"), new NavigatorPublicCategory(set));
                     }
@@ -54,17 +55,22 @@ public class NavigatorManager {
                     LOGGER.error("Caught SQL exception", e);
                 }
 
-                try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM navigator_publics WHERE visible = '1'")) {
+                try (Statement statement = connection.createStatement();
+                        ResultSet set = statement.executeQuery("SELECT * FROM navigator_publics WHERE visible = '1'")) {
                     while (set.next()) {
                         NavigatorPublicCategory category = this.publicCategories.get(set.getInt("public_cat_id"));
 
                         if (category != null) {
-                            Room room = Emulator.getGameEnvironment().getRoomManager().loadRoom(set.getInt("room_id"));
+                            Room room = Emulator.getGameEnvironment()
+                                    .getRoomManager()
+                                    .loadRoom(set.getInt("room_id"));
 
                             if (room != null) {
                                 category.addRoom(room);
                             } else {
-                                LOGGER.error("Public room (ID: {} defined in navigator_publics does not exist!", set.getInt("room_id"));
+                                LOGGER.error(
+                                        "Public room (ID: {} defined in navigator_publics does not exist!",
+                                        set.getInt("room_id"));
                             }
                         }
                     }
@@ -74,7 +80,8 @@ public class NavigatorManager {
             }
 
             synchronized (this.filterSettings) {
-                try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM navigator_filter")) {
+                try (Statement statement = connection.createStatement();
+                        ResultSet set = statement.executeQuery("SELECT * FROM navigator_filter")) {
                     while (set.next()) {
                         Method field = null;
                         Class<?> clazz = Room.class;
@@ -99,7 +106,14 @@ public class NavigatorManager {
                         }
 
                         if (field != null) {
-                            this.filterSettings.put(set.getString("key"), new NavigatorFilterField(set.getString("key"), field, set.getString("database_query"), NavigatorFilterComparator.valueOf(set.getString("compare").toUpperCase())));
+                            this.filterSettings.put(
+                                    set.getString("key"),
+                                    new NavigatorFilterField(
+                                            set.getString("key"),
+                                            field,
+                                            set.getString("database_query"),
+                                            NavigatorFilterComparator.valueOf(
+                                                    set.getString("compare").toUpperCase())));
                         }
                     }
                 } catch (SQLException e) {
@@ -110,10 +124,13 @@ public class NavigatorManager {
             LOGGER.error("Caught SQL exception", e);
         }
 
-        List<Room> staffPromotedRooms = Emulator.getGameEnvironment().getRoomManager().getRoomsStaffPromoted();
+        List<Room> staffPromotedRooms =
+                Emulator.getGameEnvironment().getRoomManager().getRoomsStaffPromoted();
 
         for (Room room : staffPromotedRooms) {
-            this.publicCategories.get(Emulator.getConfig().getInt("hotel.navigator.staffpicks.categoryid")).addRoom(room);
+            this.publicCategories
+                    .get(Emulator.getConfig().getInt("hotel.navigator.staffpicks.categoryid"))
+                    .addRoom(room);
         }
     }
 
@@ -150,7 +167,9 @@ public class NavigatorManager {
                 rooms = Emulator.getGameEnvironment().getRoomManager().getPublicRooms();
                 break;
             case "popular":
-                rooms = Emulator.getGameEnvironment().getRoomManager().getPopularRooms(Emulator.getConfig().getInt("hotel.navigator.popular.amount"));
+                rooms = Emulator.getGameEnvironment()
+                        .getRoomManager()
+                        .getPopularRooms(Emulator.getConfig().getInt("hotel.navigator.popular.amount"));
                 break;
             case "categories":
                 rooms = Emulator.getGameEnvironment().getRoomManager().getRoomsPromoted();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/PetManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/PetManager.java
@@ -3,8 +3,57 @@ package com.eu.habbo.habbohotel.pets;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.items.Item;
-import com.eu.habbo.habbohotel.items.interactions.pets.*;
-import com.eu.habbo.habbohotel.pets.actions.*;
+import com.eu.habbo.habbohotel.items.interactions.pets.InteractionNest;
+import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetDrink;
+import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetFood;
+import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetToy;
+import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetTrampoline;
+import com.eu.habbo.habbohotel.pets.actions.ActionBeg;
+import com.eu.habbo.habbohotel.pets.actions.ActionBounce;
+import com.eu.habbo.habbohotel.pets.actions.ActionBreatheFire;
+import com.eu.habbo.habbohotel.pets.actions.ActionBreed;
+import com.eu.habbo.habbohotel.pets.actions.ActionChickenDance;
+import com.eu.habbo.habbohotel.pets.actions.ActionCount;
+import com.eu.habbo.habbohotel.pets.actions.ActionCroak;
+import com.eu.habbo.habbohotel.pets.actions.ActionDance;
+import com.eu.habbo.habbohotel.pets.actions.ActionDip;
+import com.eu.habbo.habbohotel.pets.actions.ActionDown;
+import com.eu.habbo.habbohotel.pets.actions.ActionDrink;
+import com.eu.habbo.habbohotel.pets.actions.ActionEat;
+import com.eu.habbo.habbohotel.pets.actions.ActionFlatten;
+import com.eu.habbo.habbohotel.pets.actions.ActionFollow;
+import com.eu.habbo.habbohotel.pets.actions.ActionFollowLeft;
+import com.eu.habbo.habbohotel.pets.actions.ActionFollowRight;
+import com.eu.habbo.habbohotel.pets.actions.ActionFree;
+import com.eu.habbo.habbohotel.pets.actions.ActionHang;
+import com.eu.habbo.habbohotel.pets.actions.ActionHere;
+import com.eu.habbo.habbohotel.pets.actions.ActionHighJump;
+import com.eu.habbo.habbohotel.pets.actions.ActionJump;
+import com.eu.habbo.habbohotel.pets.actions.ActionMambo;
+import com.eu.habbo.habbohotel.pets.actions.ActionMoveForward;
+import com.eu.habbo.habbohotel.pets.actions.ActionNest;
+import com.eu.habbo.habbohotel.pets.actions.ActionPlay;
+import com.eu.habbo.habbohotel.pets.actions.ActionPlayDead;
+import com.eu.habbo.habbohotel.pets.actions.ActionPlayFootball;
+import com.eu.habbo.habbohotel.pets.actions.ActionRelax;
+import com.eu.habbo.habbohotel.pets.actions.ActionRingOfFire;
+import com.eu.habbo.habbohotel.pets.actions.ActionRoll;
+import com.eu.habbo.habbohotel.pets.actions.ActionSilent;
+import com.eu.habbo.habbohotel.pets.actions.ActionSit;
+import com.eu.habbo.habbohotel.pets.actions.ActionSpeak;
+import com.eu.habbo.habbohotel.pets.actions.ActionSpin;
+import com.eu.habbo.habbohotel.pets.actions.ActionStand;
+import com.eu.habbo.habbohotel.pets.actions.ActionStay;
+import com.eu.habbo.habbohotel.pets.actions.ActionSwing;
+import com.eu.habbo.habbohotel.pets.actions.ActionSwitch;
+import com.eu.habbo.habbohotel.pets.actions.ActionTeleport;
+import com.eu.habbo.habbohotel.pets.actions.ActionTorch;
+import com.eu.habbo.habbohotel.pets.actions.ActionTripleJump;
+import com.eu.habbo.habbohotel.pets.actions.ActionTurnLeft;
+import com.eu.habbo.habbohotel.pets.actions.ActionTurnRight;
+import com.eu.habbo.habbohotel.pets.actions.ActionWagTail;
+import com.eu.habbo.habbohotel.pets.actions.ActionWave;
+import com.eu.habbo.habbohotel.pets.actions.ActionWings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
@@ -13,23 +62,29 @@ import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import org.apache.commons.math3.distribution.NormalDistribution;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.math3.distribution.NormalDistribution;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PetManager {
-    public static int MAXIMUM_PET_INVENTORY_SIZE = 25;
+    public static volatile int MAXIMUM_PET_INVENTORY_SIZE = 25;
     private static final Logger LOGGER = LoggerFactory.getLogger(PetManager.class);
-    public static final int[] experiences = new int[]{100, 200, 400, 600, 900, 1300, 1800, 2400, 3200, 4300, 5700, 7600, 10100, 13300, 17500, 23000, 30200, 39600, 51900};
-    static int[] skins = new int[]{0, 1, 6, 7};
+    public static final int[] experiences = new int[] {
+        100, 200, 400, 600, 900, 1300, 1800, 2400, 3200, 4300, 5700, 7600, 10100, 13300, 17500, 23000, 30200, 39600,
+        51900
+    };
+    static int[] skins = new int[] {0, 1, 6, 7};
     public final Map<Integer, PetAction> petActions = new HashMap<Integer, PetAction>() {
         {
             this.put(0, new ActionFree());
@@ -78,14 +133,12 @@ public class PetManager {
             this.put(44, new ActionWagTail());
             this.put(45, new ActionCount());
             this.put(46, new ActionBreed());
-
         }
     };
     private final Map<Integer, Set<PetRace>> petRaces;
     private final Map<Integer, PetData> petData;
     private final Int2IntMap breedingPetType;
     private final Map<Integer, Int2ObjectMap<ArrayList<PetBreedingReward>>> breedingReward;
-
 
     public PetManager() {
         long millis = System.currentTimeMillis();
@@ -110,7 +163,9 @@ public class PetManager {
             }
         }
 
-        if(index == -1) { index = experiences.length; }
+        if (index == -1) {
+            index = experiences.length;
+        }
         return index + 1;
     }
 
@@ -120,10 +175,13 @@ public class PetManager {
 
     public static int randomBody(int minimumRarity, boolean isRare) {
         int maxIndex = MonsterplantPet.bodyRarity.size();
-        int randomIndex = isRare 
-            ? random(Math.max(minimumRarity - 1, 0), Math.min(maxIndex, (maxIndex - minimumRarity) + minimumRarity), 2.0) 
-            : random(Math.max(minimumRarity - 1, 0), maxIndex, 2.0);
-        
+        int randomIndex = isRare
+                ? random(
+                        Math.max(minimumRarity - 1, 0),
+                        Math.min(maxIndex, (maxIndex - minimumRarity) + minimumRarity),
+                        2.0)
+                : random(Math.max(minimumRarity - 1, 0), maxIndex, 2.0);
+
         // Clamp to valid range to prevent ArrayIndexOutOfBoundsException
         randomIndex = Math.max(0, Math.min(randomIndex, maxIndex - 1));
 
@@ -133,10 +191,13 @@ public class PetManager {
 
     public static int randomColor(int minimumRarity, boolean isRare) {
         int maxIndex = MonsterplantPet.colorRarity.size();
-        int randomIndex = isRare 
-            ? random(Math.max(minimumRarity - 1, 0), Math.min(maxIndex, (maxIndex - minimumRarity) + minimumRarity), 2.0) 
-            : random(Math.max(minimumRarity - 1, 0), maxIndex, 2.0);
-        
+        int randomIndex = isRare
+                ? random(
+                        Math.max(minimumRarity - 1, 0),
+                        Math.min(maxIndex, (maxIndex - minimumRarity) + minimumRarity),
+                        2.0)
+                : random(Math.max(minimumRarity - 1, 0), maxIndex, 2.0);
+
         // Clamp to valid range to prevent ArrayIndexOutOfBoundsException
         randomIndex = Math.max(0, Math.min(randomIndex, maxIndex - 1));
 
@@ -151,14 +212,10 @@ public class PetManager {
     }
 
     public static Pet loadPet(ResultSet set) throws SQLException {
-        if (set.getInt("type") == 15)
-            return new HorsePet(set);
-        else if (set.getInt("type") == 16)
-            return new MonsterplantPet(set);
-        else if (set.getInt("type") == 26 || set.getInt("type") == 27)
-            return new GnomePet(set);
-        else
-            return new Pet(set);
+        if (set.getInt("type") == 15) return new HorsePet(set);
+        else if (set.getInt("type") == 16) return new MonsterplantPet(set);
+        else if (set.getInt("type") == 26 || set.getInt("type") == 27) return new GnomePet(set);
+        else return new Pet(set);
     }
 
     public static NormalDistribution getNormalDistributionForBreeding(int levelOne, int levelTwo) {
@@ -189,7 +246,9 @@ public class PetManager {
     private void loadRaces(Connection connection) {
         this.petRaces.clear();
 
-        try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM pet_breeds ORDER BY race, color_one, color_two ASC")) {
+        try (Statement statement = connection.createStatement();
+                ResultSet set =
+                        statement.executeQuery("SELECT * FROM pet_breeds ORDER BY race, color_one, color_two ASC")) {
             while (set.next()) {
                 if (this.petRaces.get(set.getInt("race")) == null)
                     this.petRaces.put(set.getInt("race"), new HashSet<>());
@@ -202,7 +261,8 @@ public class PetManager {
     }
 
     private void loadPetData(Connection connection) {
-        try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM pet_actions ORDER BY pet_type ASC")) {
+        try (Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM pet_actions ORDER BY pet_type ASC")) {
             while (set.next()) {
                 this.petData.put(set.getInt("pet_type"), new PetData(set));
             }
@@ -216,7 +276,8 @@ public class PetManager {
     }
 
     private void loadPetItems(Connection connection) {
-        try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM pet_items")) {
+        try (Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM pet_items")) {
             while (set.next()) {
                 Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(set.getInt("item_id"));
 
@@ -228,7 +289,8 @@ public class PetManager {
                             PetData.generalFoodItems.add(baseItem);
                         else if (baseItem.getInteractionType().getType() == InteractionPetDrink.class)
                             PetData.generalDrinkItems.add(baseItem);
-                        else if (baseItem.getInteractionType().getType() == InteractionPetToy.class || baseItem.getInteractionType().getType() == InteractionPetTrampoline.class)
+                        else if (baseItem.getInteractionType().getType() == InteractionPetToy.class
+                                || baseItem.getInteractionType().getType() == InteractionPetTrampoline.class)
                             PetData.generalToyItems.add(baseItem);
                     } else {
                         PetData data = this.getPetData(set.getInt("pet_id"));
@@ -240,7 +302,8 @@ public class PetManager {
                                 data.addFoodItem(baseItem);
                             else if (baseItem.getInteractionType().getType() == InteractionPetDrink.class)
                                 data.addDrinkItem(baseItem);
-                            else if (baseItem.getInteractionType().getType() == InteractionPetToy.class || baseItem.getInteractionType().getType() == InteractionPetTrampoline.class)
+                            else if (baseItem.getInteractionType().getType() == InteractionPetToy.class
+                                    || baseItem.getInteractionType().getType() == InteractionPetTrampoline.class)
                                 data.addToyItem(baseItem);
                         }
                     }
@@ -252,14 +315,20 @@ public class PetManager {
     }
 
     private void loadPetVocals(Connection connection) {
-        try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM pet_vocals")) {
+        try (Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM pet_vocals")) {
             while (set.next()) {
                 if (set.getInt("pet_id") >= 0) {
                     if (this.petData.containsKey(set.getInt("pet_id"))) {
-                        PetVocalsType petVocalsType = PetVocalsType.valueOf(set.getString("type").toUpperCase());
+                        PetVocalsType petVocalsType =
+                                PetVocalsType.valueOf(set.getString("type").toUpperCase());
 
                         if (petVocalsType != null) {
-                            this.petData.get(set.getInt("pet_id")).petVocals.get(petVocalsType).add(new PetVocal(set.getString("message")));
+                            this.petData
+                                    .get(set.getInt("pet_id"))
+                                    .petVocals
+                                    .get(petVocalsType)
+                                    .add(new PetVocal(set.getString("message")));
                         } else {
                             LOGGER.error("Unknown pet vocal type {}", set.getString("type"));
                         }
@@ -267,10 +336,14 @@ public class PetManager {
                         LOGGER.error("Missing pet_actions table entry for pet id {}", set.getInt("pet_id"));
                     }
                 } else {
-                    if (!PetData.generalPetVocals.containsKey(PetVocalsType.valueOf(set.getString("type").toUpperCase())))
-                        PetData.generalPetVocals.put(PetVocalsType.valueOf(set.getString("type").toUpperCase()), new HashSet<>());
+                    if (!PetData.generalPetVocals.containsKey(
+                            PetVocalsType.valueOf(set.getString("type").toUpperCase())))
+                        PetData.generalPetVocals.put(
+                                PetVocalsType.valueOf(set.getString("type").toUpperCase()), new HashSet<>());
 
-                    PetData.generalPetVocals.get(PetVocalsType.valueOf(set.getString("type").toUpperCase())).add(new PetVocal(set.getString("message")));
+                    PetData.generalPetVocals
+                            .get(PetVocalsType.valueOf(set.getString("type").toUpperCase()))
+                            .add(new PetVocal(set.getString("message")));
                 }
             }
         } catch (SQLException e) {
@@ -280,15 +353,18 @@ public class PetManager {
 
     private void loadPetCommands(Connection connection) {
         Map<Integer, PetCommand> commandsList = new HashMap<>();
-        try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM pet_commands_data")) {
+        try (Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM pet_commands_data")) {
             while (set.next()) {
-                commandsList.put(set.getInt("command_id"), new PetCommand(set, this.petActions.get(set.getInt("command_id"))));
+                commandsList.put(
+                        set.getInt("command_id"), new PetCommand(set, this.petActions.get(set.getInt("command_id"))));
             }
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
         }
 
-        try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM pet_commands ORDER BY pet_id ASC")) {
+        try (Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM pet_commands ORDER BY pet_id ASC")) {
             while (set.next()) {
                 PetData data = this.petData.get(set.getInt("pet_id"));
 
@@ -302,7 +378,8 @@ public class PetManager {
     }
 
     private void loadPetBreeding(Connection connection) {
-        try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM pet_breeding")) {
+        try (Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM pet_breeding")) {
             while (set.next()) {
                 this.breedingPetType.put(set.getInt("pet_id"), set.getInt("offspring_id"));
             }
@@ -310,7 +387,8 @@ public class PetManager {
             LOGGER.error("Caught SQL exception", e);
         }
 
-        try (Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM pet_breeding_races")) {
+        try (Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM pet_breeding_races")) {
             while (set.next()) {
                 PetBreedingReward reward = new PetBreedingReward(set);
                 if (!this.breedingReward.containsKey(reward.petType)) {
@@ -345,7 +423,8 @@ public class PetManager {
     public int getRarityForOffspring(Pet pet) {
         final int[] rarityLevel = {0};
 
-        Int2ObjectMap<ArrayList<PetBreedingReward>> offspringList = this.breedingReward.get(pet.getPetData().getType());
+        Int2ObjectMap<ArrayList<PetBreedingReward>> offspringList =
+                this.breedingReward.get(pet.getPetData().getType());
 
         for (Int2ObjectMap.Entry<ArrayList<PetBreedingReward>> entry : offspringList.int2ObjectEntrySet()) {
             for (PetBreedingReward reward : entry.getValue()) {
@@ -364,9 +443,11 @@ public class PetManager {
             if (this.petData.containsKey(type)) {
                 return this.petData.get(type);
             } else {
-                try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+                try (Connection connection =
+                        Emulator.getDatabase().getDataSource().getConnection()) {
                     LOGGER.error("Missing petdata for type {}. Adding this to the database...", type);
-                    try (PreparedStatement statement = connection.prepareStatement("INSERT INTO pet_actions (pet_type, pet_name, offspring_type, happy_actions, tired_actions, random_actions, can_swim) VALUES (?, ?, ?, ?, ?, ?, ?)")) {
+                    try (PreparedStatement statement = connection.prepareStatement(
+                            "INSERT INTO pet_actions (pet_type, pet_name, offspring_type, happy_actions, tired_actions, random_actions, can_swim) VALUES (?, ?, ?, ?, ?, ?, ?)")) {
                         statement.setInt(1, type);
                         statement.setString(2, getFallbackPetName(type));
                         statement.setInt(3, getFallbackOffspringType(type));
@@ -377,7 +458,8 @@ public class PetManager {
                         statement.execute();
                     }
 
-                    try (PreparedStatement statement = connection.prepareStatement("SELECT * FROM pet_actions WHERE pet_type = ? LIMIT 1")) {
+                    try (PreparedStatement statement =
+                            connection.prepareStatement("SELECT * FROM pet_actions WHERE pet_type = ? LIMIT 1")) {
                         statement.setInt(1, type);
                         try (ResultSet set = statement.executeQuery()) {
                             if (set.next()) {
@@ -455,16 +537,20 @@ public class PetManager {
         if (this.petData.containsKey(type)) {
             Pet pet;
             if (type == 15)
-                pet = new HorsePet(type, Integer.parseInt(race), color, name, client.getHabbo().getHabboInfo().getId());
-            else if (type == 16)
-                pet = this.createMonsterplant(null, client.getHabbo(), false, null, 0);
-            else
-                pet = new Pet(type,
+                pet = new HorsePet(
+                        type,
                         Integer.parseInt(race),
                         color,
                         name,
-                        client.getHabbo().getHabboInfo().getId()
-                );
+                        client.getHabbo().getHabboInfo().getId());
+            else if (type == 16) pet = this.createMonsterplant(null, client.getHabbo(), false, null, 0);
+            else
+                pet = new Pet(
+                        type,
+                        Integer.parseInt(race),
+                        color,
+                        name,
+                        client.getHabbo().getHabboInfo().getId());
 
             pet.needsUpdate = true;
             pet.run();
@@ -473,25 +559,38 @@ public class PetManager {
         return null;
     }
 
-    public Pet createPet(Connection connection, Item item, String name, String race, String color, GameClient client) throws SQLException {
+    public Pet createPet(Connection connection, Item item, String name, String race, String color, GameClient client)
+            throws SQLException {
         int type = Integer.parseInt(item.getName().toLowerCase().replace("a0 pet", ""));
         if (!this.petData.containsKey(type) || type == 16) return null;
 
         Pet pet = type == 15
-                ? new HorsePet(type, Integer.parseInt(race), color, name, client.getHabbo().getHabboInfo().getId())
-                : new Pet(type, Integer.parseInt(race), color, name, client.getHabbo().getHabboInfo().getId());
+                ? new HorsePet(
+                        type,
+                        Integer.parseInt(race),
+                        color,
+                        name,
+                        client.getHabbo().getHabboInfo().getId())
+                : new Pet(
+                        type,
+                        Integer.parseInt(race),
+                        color,
+                        name,
+                        client.getHabbo().getHabboInfo().getId());
         pet.needsUpdate = true;
         pet.save(connection);
         return pet;
     }
 
     public Pet createPet(int type, String name, GameClient client) {
-        return this.createPet(type, Emulator.getRandom().nextInt(this.petRaces.get(type).size() + 1), name, client);
+        return this.createPet(
+                type, Emulator.getRandom().nextInt(this.petRaces.get(type).size() + 1), name, client);
     }
 
     public Pet createPet(int type, int race, String name, GameClient client) {
         if (this.petData.containsKey(type)) {
-            Pet pet = new Pet(type, race, "FFFFFF", name, client.getHabbo().getHabboInfo().getId());
+            Pet pet = new Pet(
+                    type, race, "FFFFFF", name, client.getHabbo().getHabboInfo().getId());
             pet.needsUpdate = true;
             pet.run();
             return pet;
@@ -501,7 +600,7 @@ public class PetManager {
 
     public MonsterplantPet createMonsterplant(Room room, Habbo habbo, boolean rare, RoomTile t, int minimumRarity) {
         MonsterplantPet pet = new MonsterplantPet(
-                habbo.getHabboInfo().getId(),   //Owner ID
+                habbo.getHabboInfo().getId(), // Owner ID
                 randomBody(minimumRarity, rare),
                 randomColor(minimumRarity, rare),
                 Emulator.getRandom().nextInt(12) + 1,
@@ -509,8 +608,7 @@ public class PetManager {
                 Emulator.getRandom().nextInt(12) + 1,
                 Emulator.getRandom().nextInt(11),
                 Emulator.getRandom().nextInt(12) + 1,
-                Emulator.getRandom().nextInt(11)
-        );
+                Emulator.getRandom().nextInt(11));
 
         pet.setUserId(habbo.getHabboInfo().getId());
         pet.setRoom(room);
@@ -522,14 +620,18 @@ public class PetManager {
     }
 
     public Pet createGnome(String name, Room room, Habbo habbo) {
-        Pet pet = new GnomePet(26, 0, "FFFFFF", name, habbo.getHabboInfo().getId(),
-                "5 " +
-                        "0 -1 " + this.randomGnomeSkinColor() + " " +
-                        "1 10" + (1 + Emulator.getRandom().nextInt(2)) + " " + this.randomGnomeColor() + " " +
-                        "2 201 " + this.randomGnomeColor() + " " +
-                        "3 30" + (1 + Emulator.getRandom().nextInt(2)) + " " + this.randomGnomeColor() + " " +
-                        "4 40" + Emulator.getRandom().nextInt(2) + " " + this.randomGnomeColor()
-        );
+        Pet pet = new GnomePet(
+                26,
+                0,
+                "FFFFFF",
+                name,
+                habbo.getHabboInfo().getId(),
+                "5 " + "0 -1 "
+                        + this.randomGnomeSkinColor() + " " + "1 10"
+                        + (1 + Emulator.getRandom().nextInt(2)) + " " + this.randomGnomeColor() + " " + "2 201 "
+                        + this.randomGnomeColor() + " " + "3 30"
+                        + (1 + Emulator.getRandom().nextInt(2)) + " " + this.randomGnomeColor() + " " + "4 40"
+                        + Emulator.getRandom().nextInt(2) + " " + this.randomGnomeColor());
 
         pet.setUserId(habbo.getHabboInfo().getId());
         pet.setRoom(room);
@@ -542,14 +644,13 @@ public class PetManager {
     }
 
     public Pet createLeprechaun(String name, Room room, Habbo habbo) {
-        Pet pet = new GnomePet(27, 0, "FFFFFF", name, habbo.getHabboInfo().getId(),
-                "5 " +
-                        "0 -1 0 " +
-                        "1 102 19 " +
-                        "2 201 27 " +
-                        "3 302 23 " +
-                        "4 401 27"
-        );
+        Pet pet = new GnomePet(
+                27,
+                0,
+                "FFFFFF",
+                name,
+                habbo.getHabboInfo().getId(),
+                "5 " + "0 -1 0 " + "1 102 19 " + "2 201 27 " + "3 302 23 " + "4 401 27");
 
         pet.setUserId(habbo.getHabboInfo().getId());
         pet.setRoom(room);
@@ -581,7 +682,9 @@ public class PetManager {
     }
 
     public boolean deletePet(Pet pet) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("DELETE FROM users_pets WHERE id = ? LIMIT 1")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("DELETE FROM users_pets WHERE id = ? LIMIT 1")) {
             statement.setInt(1, pet.getId());
             return statement.execute();
         } catch (SQLException e) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -7,9 +7,11 @@ import com.eu.habbo.habbohotel.guilds.Guild;
 import com.eu.habbo.habbohotel.guilds.GuildMember;
 import com.eu.habbo.habbohotel.guilds.GuildMembershipStatus;
 import com.eu.habbo.habbohotel.guilds.GuildRank;
-import com.eu.habbo.habbohotel.items.FurnitureType;
 import com.eu.habbo.habbohotel.items.Item;
-import com.eu.habbo.habbohotel.items.interactions.*;
+import com.eu.habbo.habbohotel.items.interactions.InteractionBackgroundToner;
+import com.eu.habbo.habbohotel.items.interactions.InteractionFireworks;
+import com.eu.habbo.habbohotel.items.interactions.InteractionGuildFurni;
+import com.eu.habbo.habbohotel.items.interactions.InteractionJukeBox;
 import com.eu.habbo.habbohotel.items.interactions.games.InteractionGameTimer;
 import com.eu.habbo.habbohotel.items.interactions.games.InteractionGameUpCounter;
 import com.eu.habbo.habbohotel.permissions.Permission;
@@ -25,2846 +27,2887 @@ import com.eu.habbo.messages.ISerialize;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.guilds.GuildInfoComposer;
 import com.eu.habbo.messages.outgoing.hotelview.HotelViewComposer;
-import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
-import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.rooms.HideDoorbellComposer;
-import com.eu.habbo.messages.outgoing.rooms.UpdateStackHeightComposer;
-import com.eu.habbo.messages.outgoing.rooms.items.*;
+import com.eu.habbo.messages.outgoing.rooms.items.RemoveFloorItemComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.RoomFloorItemsComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserIgnoredComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
 import com.eu.habbo.messages.outgoing.wired.WiredRoomSettingsDataComposer;
-import com.eu.habbo.plugin.Event;
-import com.eu.habbo.plugin.events.furniture.FurniturePickedUpEvent;
 import com.eu.habbo.plugin.events.rooms.RoomLoadedEvent;
 import com.eu.habbo.plugin.events.rooms.RoomUnloadedEvent;
 import com.eu.habbo.plugin.events.rooms.RoomUnloadingEvent;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Rectangle;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Room implements Comparable<Room>, ISerialize, Runnable {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(Room.class);
-  private static final ThreadFactory LOAD_THREAD_FACTORY =
-          Thread.ofVirtual().name("room-load-", 0).factory();
-  private static final Executor LOAD_COORDINATOR =
-          task -> LOAD_THREAD_FACTORY.newThread(task).start();
-
-  // Manager instances for better separation of concerns
-  private RoomTileManager tileManager;
-  private RoomGameManager gameManager;
-  private RoomTradeManager tradeManager;
-  private RoomPromotionManager promotionManager;
-  private RoomWordQuizManager wordQuizManager;
-  private RoomRightsManager rightsManager;
-  private RoomUnitManager unitManager;
-  private RoomItemManager itemManager;
-  private RoomChatManager chatManager;
-  private RoomRollerManager rollerManager;
-  private RoomMessagingManager messagingManager;
-  private RoomCycleManager cycleManager;
-  private RoomUserVariableManager userVariableManager;
-  private RoomFurniVariableManager furniVariableManager;
-  private RoomVariableManager roomVariableManager;
-
-  public static final Comparator<Room> SORT_SCORE = (o1, o2) -> o2.getScore() - o1.getScore();
-  public static final Comparator<Room> SORT_ID = (o1, o2) -> o2.getId() - o1.getId();
-  private static final Int2ObjectMap<RoomMoodlightData> defaultMoodData = new Int2ObjectOpenHashMap<>();
-  //Configuration. Loaded from database & updated accordingly.
-  public static boolean HABBO_CHAT_DELAY = false;
-  public static int MAXIMUM_BOTS = 10;
-  public static int MAXIMUM_PETS = 10;
-  public static int MAXIMUM_FURNI = 2500;
-  public static int MAXIMUM_POSTITNOTES = 200;
-  public static int HAND_ITEM_TIME = 10;
-  public static int IDLE_CYCLES = 240;
-  public static int IDLE_CYCLES_KICK = 480;
-  public static String PREFIX_FORMAT = "[<font color=\"%color%\">%prefix%</font>] ";
-  public static int ROLLERS_MAXIMUM_ROLL_AVATARS = 1;
-  public static boolean MUTEAREA_CAN_WHISPER = false;
-  public static double MAXIMUM_FURNI_HEIGHT = 40d;
-  public static final int WIRED_ACCESS_EVERYONE = 1;
-  public static final int WIRED_ACCESS_USERS_WITH_RIGHTS = 2;
-  public static final int WIRED_ACCESS_GROUP_MEMBERS = 4;
-  public static final int WIRED_ACCESS_GROUP_ADMINS = 8;
-  public static final int WIRED_ACCESS_ALLOWED_INSPECT_MASK = WIRED_ACCESS_EVERYONE | WIRED_ACCESS_USERS_WITH_RIGHTS | WIRED_ACCESS_GROUP_MEMBERS | WIRED_ACCESS_GROUP_ADMINS;
-  public static final int WIRED_ACCESS_ALLOWED_MODIFY_MASK = WIRED_ACCESS_USERS_WITH_RIGHTS | WIRED_ACCESS_GROUP_MEMBERS | WIRED_ACCESS_GROUP_ADMINS;
-  public static final int WIRED_ACCESS_DEFAULT_INSPECT_MASK = 0;
-  public static final int WIRED_ACCESS_DEFAULT_MODIFY_MASK = 0;
-
-  static {
-    for (int i = 1; i <= 3; i++) {
-      RoomMoodlightData data = RoomMoodlightData.fromString("");
-      data.setId(i);
-      defaultMoodData.put(i, data);
-    }
-  }
-
-  public final Object roomUnitLock = new Object();
-  public final List<Integer> userVotes;
-  private final IntList rights;
-  private final Int2IntMap mutedHabbos;
-  private final Int2ObjectMap<RoomBan> bannedHabbos;
-  private final Set<Game> games;
-  private final Int2ObjectMap<RoomMoodlightData> moodlightData;
-  private final RoomDependencies dependencies;
-  private final RoomLifecycle lifecycle;
-  private final RoomLoader loader;
-  private final RoomItemPersistence itemPersistence;
-  private final RoomPersistence persistence;
-  private final RoomRepository repository;
-  private final RoomUserCountPersistence userCountPersistence;
-  public volatile double lastCycleCpuMs = 0.0;
-  public volatile String lastCycleThread = "N/A";
-
-  //Use appropriately. Could potentially cause memory leaks when used incorrectly.
-  public volatile boolean preventUnloading = false;
-  public volatile boolean preventUncaching = false;
-  public Set<ServerMessage> scheduledComposers = ConcurrentHashMap.newKeySet();
-  public final java.util.concurrent.ConcurrentLinkedQueue<Runnable> scheduledTasks = new java.util.concurrent.ConcurrentLinkedQueue<>();
-  public String wordQuiz = "";
-  public int noVotes = 0;
-  public int yesVotes = 0;
-  public int wordQuizEnd = 0;
-  public volatile ScheduledFuture<?> roomCycleTask;
-  private int id;
-  private int ownerId;
-  private volatile BiConsumer<Room, Integer> ownerChangeListener;
-  private String ownerName;
-  private String name;
-  private String description;
-  private RoomLayout layout;
-  private boolean overrideModel;
-  private String layoutName;
-  private String password;
-  private RoomState state;
-  private int usersMax;
-  private int score;
-  private int category;
-  private String floorPaint;
-  private String wallPaint;
-  private String backgroundPaint;
-  private int wallSize;
-  private int wallHeight;
-  private int floorSize;
-  private int guild;
-  private String tags;
-  private boolean publicRoom;
-  private boolean staffPromotedRoom;
-  private boolean allowPets;
-  private boolean allowPetsEat;
-  private boolean allowWalkthrough;
-  private boolean allowBotsWalk;
-  private boolean allowEffects;
-  private boolean hideWall;
-  private int chatMode;
-  private int chatWeight;
-  private int chatSpeed;
-  private int chatDistance;
-  private int chatProtection;
-  private int muteOption;
-  private int kickOption;
-  private int banOption;
-  private int pollId;
-  private boolean promoted;
-  private int tradeMode;
-  private boolean moveDiagonally;
-  private boolean allowUnderpass;
-  private boolean jukeboxActive;
-  private boolean hideWired;
-  private boolean buildersClubTrialLocked;
-  private RoomState buildersClubOriginalState;
-  private RoomPromotion promotion;
-  private volatile boolean needsUpdate;
-  private int rollerSpeed;
-  private int lastTimerReset = Emulator.getIntUnixTimestamp();
-  private volatile boolean muted;
-  private RoomSpecialTypes roomSpecialTypes;
-  private TraxManager traxManager;
-  private final Object wiredSettingsLock = new Object();
-  private volatile boolean wiredSettingsLoaded;
-  private int wiredInspectMask = WIRED_ACCESS_DEFAULT_INSPECT_MASK;
-  private int wiredModifyMask = WIRED_ACCESS_DEFAULT_MODIFY_MASK;
-  private boolean youtubeEnabled = false;
-  private boolean soundboardEnabled = false;
-  private String youtubeCurrentVideo = "";
-  private String youtubeSenderName = "";
-  private final java.util.List<String> youtubePlaylist = new java.util.concurrent.CopyOnWriteArrayList<>();
-  private final java.util.Set<Integer> youtubeWatchers = java.util.concurrent.ConcurrentHashMap.newKeySet();
-
-  public boolean isYoutubeEnabled() { return this.youtubeEnabled; }
-  public void setYoutubeEnabled(boolean enabled) { this.youtubeEnabled = enabled; }
-  public boolean isSoundboardEnabled() { return this.soundboardEnabled; }
-  public void setSoundboardEnabled(boolean enabled) { this.soundboardEnabled = enabled; }
-  public String getYoutubeCurrentVideo() { return this.youtubeCurrentVideo; }
-  public String getYoutubeSenderName() { return this.youtubeSenderName; }
-  public java.util.List<String> getYoutubePlaylist() { return this.youtubePlaylist; }
-  public java.util.Set<Integer> getYoutubeWatchers() { return this.youtubeWatchers; }
-
-  public void setYoutubeVideo(String videoId, String senderName, java.util.List<String> playlist) {
-    this.youtubeCurrentVideo = videoId;
-    this.youtubeSenderName = senderName;
-    this.youtubePlaylist.clear();
-    if (playlist != null) this.youtubePlaylist.addAll(playlist);
-  }
-
-  public void clearYoutubeVideo() {
-    this.youtubeCurrentVideo = "";
-    this.youtubeSenderName = "";
-    this.youtubePlaylist.clear();
-  }
-
-  public final Map<String, Object> cache;
-
-  Room(int id, int ownerId) {
-    this(id, ownerId, RoomDependencies.runtime());
-  }
-
-  Room(int id, int ownerId, RoomDependencies dependencies) {
-    this.cache = new HashMap<>();
-    this.dependencies = Objects.requireNonNull(dependencies, "dependencies");
-    this.lifecycle = new RoomLifecycle(new RoomCycleTaskSlot());
-    this.itemPersistence =
-        new RoomItemPersistence(this.dependencies.database());
-    this.persistence = new RoomPersistence(this.dependencies.database());
-    this.repository = new RoomRepository(this.dependencies.database());
-    this.id = id;
-    this.ownerId = ownerId;
-    this.userCountPersistence = this.createUserCountPersistence();
-    this.bannedHabbos = new Int2ObjectOpenHashMap<>();
-    this.moodlightData = new Int2ObjectOpenHashMap<>(defaultMoodData);
-    this.mutedHabbos = new Int2IntOpenHashMap();
-    this.games = ConcurrentHashMap.newKeySet();
-    this.rights = new IntArrayList();
-    this.userVotes = new ArrayList<>();
-    this.initializeManagers(
-        new RoomChatManager(this, RoomChatManager.DEFAULT_MUTE_TIME_SECONDS));
-    this.loader = this.createLoader();
-  }
-
-  public Room(ResultSet set) throws SQLException {
-    this(set, RoomDependencies.runtime());
-  }
-
-  Room(ResultSet set, RoomDependencies dependencies) throws SQLException {
-    this.cache = new HashMap<>(1000);
-    this.dependencies = Objects.requireNonNull(dependencies, "dependencies");
-    this.lifecycle = new RoomLifecycle(new RoomCycleTaskSlot());
-    this.itemPersistence =
-        new RoomItemPersistence(this.dependencies.database());
-    this.persistence = new RoomPersistence(this.dependencies.database());
-    this.repository = new RoomRepository(this.dependencies.database());
-    RoomSnapshot.Initial initial = RoomSnapshot.readInitial(set);
-    this.id = initial.id();
-    this.ownerId = initial.ownerId();
-    this.userCountPersistence = this.createUserCountPersistence();
-    this.ownerName = initial.ownerName();
-    this.name = initial.name();
-    this.description = initial.description();
-    this.password = initial.password();
-    this.state = initial.state();
-    this.usersMax = initial.usersMax();
-    this.score = initial.score();
-    this.category = initial.category();
-    this.floorPaint = initial.floorPaint();
-    this.wallPaint = initial.wallPaint();
-    this.backgroundPaint = initial.backgroundPaint();
-    this.wallSize = initial.wallSize();
-    this.wallHeight = initial.wallHeight();
-    this.floorSize = initial.floorSize();
-    this.tags = initial.tags();
-    this.publicRoom = initial.publicRoom();
-    this.staffPromotedRoom = initial.staffPromotedRoom();
-    this.allowPets = initial.allowPets();
-    this.allowPetsEat = initial.allowPetsEat();
-    this.allowWalkthrough = initial.allowWalkthrough();
-    this.hideWall = initial.hideWall();
-    this.youtubeEnabled = initial.youtubeEnabled();
-    this.soundboardEnabled = initial.soundboardEnabled();
-    this.chatMode = initial.chatMode();
-    this.chatWeight = initial.chatWeight();
-    this.chatSpeed = initial.chatSpeed();
-    this.chatDistance = initial.chatDistance();
-    this.chatProtection = initial.chatProtection();
-    this.muteOption = initial.muteOption();
-    this.kickOption = initial.kickOption();
-    this.banOption = initial.banOption();
-    this.pollId = initial.pollId();
-    this.guild = initial.guild();
-    this.rollerSpeed = initial.rollerSpeed();
-    this.overrideModel = initial.overrideModel();
-    this.layoutName = initial.layoutName();
-    this.promoted = initial.promoted();
-    this.jukeboxActive = initial.jukeboxActive();
-    this.hideWired = initial.hideWired();
-    this.buildersClubTrialLocked = initial.buildersClubTrialLocked();
-    this.buildersClubOriginalState = initial.buildersClubOriginalState();
-
-    this.bannedHabbos = new Int2ObjectOpenHashMap<>();
-
-    try (Connection connection = this.dependencies.database().openConnection()) {
-      // Load bans eagerly (needed for entry check before loadData)
-      this.loadBans(connection);
-    } catch (SQLException e) {
-      LOGGER.error("Caught SQL exception", e);
-    }
-
-    RoomSnapshot snapshot = RoomSnapshot.complete(initial, set);
-    this.tradeMode = snapshot.postBanLoad().tradeMode();
-    this.moveDiagonally = snapshot.postBanLoad().moveDiagonally();
-    this.allowUnderpass = snapshot.postBanLoad().allowUnderpass();
-
-    this.allowBotsWalk = true;
-    this.allowEffects = true;
-    this.moodlightData = new Int2ObjectOpenHashMap<>(defaultMoodData);
-
-    for (String s : snapshot.postBanLoad().moodlightData().split(";")) {
-      RoomMoodlightData data = RoomMoodlightData.fromString(s);
-      this.moodlightData.put(data.getId(), data);
-    }
-
-    this.mutedHabbos = new Int2IntOpenHashMap();
-    this.games = ConcurrentHashMap.newKeySet();
-
-    this.rights = new IntArrayList();
-    this.userVotes = new ArrayList<>();
-
-    // Initialize managers
-    this.initializeManagers();
-    this.loader = this.createLoader();
-  }
-
-  /**
-   * Initializes all manager instances for this room.
-   */
-  private void initializeManagers() {
-    this.initializeManagers(new RoomChatManager(this));
-  }
-
-  private void initializeManagers(RoomChatManager chatManager) {
-    this.tileManager = new RoomTileManager(this);
-    this.gameManager = new RoomGameManager(this);
-    this.tradeManager = new RoomTradeManager(this);
-    this.promotionManager = new RoomPromotionManager(this);
-    this.wordQuizManager = new RoomWordQuizManager(this);
-    this.rightsManager = new RoomRightsManager(this);
-    this.unitManager = new RoomUnitManager(this);
-    this.itemManager = new RoomItemManager(this);
-    this.chatManager = chatManager;
-    this.rollerManager = new RoomRollerManager(this);
-    this.messagingManager = new RoomMessagingManager(this);
-    this.cycleManager = new RoomCycleManager(this);
-    this.userVariableManager = new RoomUserVariableManager(this);
-    this.furniVariableManager = new RoomFurniVariableManager(this);
-    this.roomVariableManager = new RoomVariableManager(this);
-  }
-
-  // ==================== MANAGER GETTERS ====================
-
-  /**
-   * Gets the tile manager for this room.
-   */
-  public RoomTileManager getTileManager() {
-    return this.tileManager;
-  }
-
-  /**
-   * Gets the game manager for this room.
-   */
-  public RoomGameManager getGameManager() {
-    return this.gameManager;
-  }
-
-  /**
-   * Gets the trade manager for this room.
-   */
-  public RoomTradeManager getTradeManager() {
-    return this.tradeManager;
-  }
-
-  /**
-   * Gets the promotion manager for this room.
-   */
-  public RoomPromotionManager getPromotionManager() {
-    return this.promotionManager;
-  }
-
-  /**
-   * Gets the word quiz manager for this room.
-   */
-  public RoomWordQuizManager getWordQuizManager() {
-    return this.wordQuizManager;
-  }
-
-  /**
-   * Gets the rights manager for this room.
-   */
-  public RoomRightsManager getRightsManager() {
-    return this.rightsManager;
-  }
-
-  /**
-   * Gets the unit manager for this room.
-   */
-  public RoomUnitManager getUnitManager() {
-    return this.unitManager;
-  }
-
-  /**
-   * Gets the item manager for this room.
-   */
-  public RoomItemManager getItemManager() {
-    return this.itemManager;
-  }
-
-  /**
-   * Gets the chat manager for this room.
-   */
-  public RoomChatManager getChatManager() {
-    return this.chatManager;
-  }
-
-  /**
-   * Gets the messaging manager for this room.
-   */
-  public RoomMessagingManager getMessagingManager() {
-    return this.messagingManager;
-  }
-
-  /**
-   * Gets the cycle manager for this room.
-   */
-  public RoomCycleManager getCycleManager() {
-    return this.cycleManager;
-  }
-
-  public RoomUserVariableManager getUserVariableManager() {
-    return this.userVariableManager;
-  }
-
-  public RoomFurniVariableManager getFurniVariableManager() {
-    return this.furniVariableManager;
-  }
-
-  public RoomVariableManager getRoomVariableManager() {
-    return this.roomVariableManager;
-  }
-
-  /**
-   * Gets the roller manager for this room.
-   */
-  public RoomRollerManager getRollerManager() {
-    return this.rollerManager;
-  }
-
-  /**
-   * Checks if the room is currently loading data.
-   */
-  public boolean isLoadingInProgress() {
-    return this.lifecycle.isLoading();
-  }
-
-  /**
-   * Checks if the room data is loaded or is currently being loaded.
-   */
-  public boolean isLoadedOrLoading() {
-    return this.lifecycle.isLoadedOrLoading();
-  }
-
-  long beginLoadTransition() {
-    return this.lifecycle.beginLoad();
-  }
-
-  boolean publishLoadTransition(
-          long generation,
-          Supplier<ScheduledFuture<?>> cycleScheduler
-  ) {
-    return this.lifecycle.publishLoad(generation, cycleScheduler);
-  }
-
-  boolean beginUnloadTransition() {
-    return this.lifecycle.beginUnload();
-  }
-
-  void finishUnloadTransition() {
-    this.lifecycle.finishUnload();
-  }
-
-  void quiesceCycleTask() {
-    synchronized (this) {
-      this.lifecycle.quiesceCycle();
-    }
-  }
-
-  void resetIdleCycles() {
-    this.lifecycle.resetIdleCycles();
-  }
-
-  boolean advanceIdleUnload(boolean empty) {
-    return this.lifecycle.advanceIdleUnload(empty);
-  }
-
-  private void failLoadTransition(long generation) {
-    this.lifecycle.failLoad(generation);
-  }
-
-  /**
-   * Starts loading room data asynchronously in the background.
-   * This allows the room to start loading before the user fully enters,
-   * reducing perceived load time.
-   */
-  public void startBackgroundLoad() {
-    this.lifecycle.startBackgroundLoad(
-        LOAD_COORDINATOR,
-        this::loadDataInternal);
-  }
-
-  /**
-   * Waits for background loading to complete if it's in progress.
-   * If loading hasn't started yet, starts loading synchronously.
-   */
-  public void waitForLoad() {
-    if (this.lifecycle.isLoaded()) {
-      return;
-    }
-    CompletableFuture<Void> future = this.lifecycle.loadingFuture();
-
-    if (future != null) {
-      try {
-        future.join();
-      } catch (Exception e) {
-        LOGGER.error("Error waiting for room load", e);
-      }
-    } else {
-      this.loadData();
-    }
-  }
-
-  public void loadData() {
-    RoomLifecycle.LoadAttempt attempt =
-        this.lifecycle.beginOrJoinLoad();
-    CompletableFuture<Void> futureToWait = attempt.future();
-
-    // Wait for existing load outside the lock
-    if (futureToWait != null) {
-      try {
-        futureToWait.join();
-      } catch (Exception e) {
-        LOGGER.error("Error waiting for room load", e);
-      }
-      return;
-    }
-
-    // Load if needed
-    if (attempt.generation() >= 0L) {
-      this.loadDataInternal(attempt.generation());
-    }
-  }
-
-  /**
-   * Internal method that performs the actual room data loading.
-   * Uses parallel loading for independent operations to reduce total load time.
-   */
-  private void loadDataInternal(long generation) {
-    try {
-      this.performLoadData(generation);
-    } catch (Exception exception) {
-      LOGGER.error("Caught exception during room load", exception);
-    } finally {
-      this.failLoadTransition(generation);
-    }
-  }
-
-  private void performLoadData(long generation) {
-    this.loader.load(generation);
-  }
-
-  private RoomLoader createLoader() {
-    return new RoomLoader(
-            new RoomLoadOperations(),
-            () -> Emulator.getThreading().getService());
-  }
-
-  private final class RoomCycleTaskSlot
-      implements RoomLifecycle.CycleTaskSlot {
-
-    @Override
-    public ScheduledFuture<?> get() {
-      return Room.this.roomCycleTask;
-    }
-
-    @Override
-    public void set(ScheduledFuture<?> task) {
-      Room.this.roomCycleTask = task;
-    }
-  }
-
-  private final class RoomLoadOperations implements RoomLoader.Operations {
-
-    @Override
-    public int roomId() {
-      return Room.this.id;
-    }
-
-    @Override
-    public boolean prepare(long generation) {
-      return Room.this.lifecycle.prepareLoad(generation);
-    }
-
-    @Override
-    public void initialize() {
-      synchronized (Room.this.roomUnitLock) {
-        Room.this.unitManager.clear();
-      }
-      Room.this.roomSpecialTypes = new RoomSpecialTypes();
-    }
-
-    @Override
-    public void loadLayout() {
-      try {
-        Room.this.loadLayout();
-      } catch (Exception exception) {
-        LOGGER.error("Caught exception loading layout", exception);
-      }
-    }
-
-    @Override
-    public boolean shouldLoadPromotion() {
-      return Room.this.promoted;
-    }
-
-    @Override
-    public void loadPromotion() {
-      try (Connection connection =
-                   Room.this.dependencies.database().openConnection()) {
-        Room.this.promotionManager.loadPromotion(true, connection);
-        Room.this.promotion = Room.this.promotionManager.getPromotion();
-        Room.this.promoted =
-                Room.this.promotionManager.getPromotedFlag();
-      } catch (Exception exception) {
-        LOGGER.error("Caught exception loading promotion", exception);
-      }
-    }
-
-    @Override
-    public void loadItems() {
-      withConnection("Caught exception loading items", Room.this::loadItems);
-    }
-
-    @Override
-    public void loadRights() {
-      withConnection("Caught exception loading rights", Room.this::loadRights);
-    }
-
-    @Override
-    public void loadWordFilter() {
-      withConnection(
-              "Caught exception loading word filter",
-              Room.this::loadWordFilter);
-    }
-
-    @Override
-    public void loadBots() {
-      withConnection("Caught exception loading bots", Room.this::loadBots);
-    }
-
-    @Override
-    public void loadPets() {
-      withConnection("Caught exception loading pets", Room.this::loadPets);
-    }
-
-    @Override
-    public void loadHeightmap() {
-      try {
-        Room.this.loadHeightmap();
-      } catch (Exception exception) {
-        LOGGER.error("Caught exception loading heightmap", exception);
-      }
-    }
-
-    @Override
-    public void loadWiredData() {
-      withConnection(
-              "Caught exception loading wired data",
-              Room.this::loadWiredData);
-    }
-
-    @Override
-    public void resetIdleCycles() {
-      Room.this.cycleManager.resetIdleCycles();
-    }
-
-    @Override
-    public boolean finish(long generation) {
-      Room.this.traxManager = new TraxManager(
-              Room.this,
-              Room.this.dependencies.database());
-
-      if (Room.this.jukeboxActive) {
-        Room.this.traxManager.play(0);
-        for (HabboItem item : Room.this.roomSpecialTypes
-                .getItemsOfType(InteractionJukeBox.class)) {
-          item.setExtradata("1");
-          Room.this.updateItem(item);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Room.class);
+    private static final ThreadFactory LOAD_THREAD_FACTORY =
+            Thread.ofVirtual().name("room-load-", 0).factory();
+    private static final Executor LOAD_COORDINATOR =
+            task -> LOAD_THREAD_FACTORY.newThread(task).start();
+
+    // Manager instances for better separation of concerns
+    private RoomTileManager tileManager;
+    private RoomGameManager gameManager;
+    private RoomTradeManager tradeManager;
+    private RoomPromotionManager promotionManager;
+    private RoomWordQuizManager wordQuizManager;
+    private RoomRightsManager rightsManager;
+    private RoomUnitManager unitManager;
+    private RoomItemManager itemManager;
+    private RoomChatManager chatManager;
+    private RoomRollerManager rollerManager;
+    private RoomMessagingManager messagingManager;
+    private RoomCycleManager cycleManager;
+    private RoomUserVariableManager userVariableManager;
+    private RoomFurniVariableManager furniVariableManager;
+    private RoomVariableManager roomVariableManager;
+
+    public static final Comparator<Room> SORT_SCORE = (o1, o2) -> o2.getScore() - o1.getScore();
+    public static final Comparator<Room> SORT_ID = (o1, o2) -> o2.getId() - o1.getId();
+    private static final Int2ObjectMap<RoomMoodlightData> defaultMoodData = new Int2ObjectOpenHashMap<>();
+    // Configuration. Loaded from database & updated accordingly.
+    public static volatile boolean HABBO_CHAT_DELAY = false;
+    public static volatile int MAXIMUM_BOTS = 10;
+    public static volatile int MAXIMUM_PETS = 10;
+    public static volatile int MAXIMUM_FURNI = 2500;
+    public static volatile int MAXIMUM_POSTITNOTES = 200;
+    public static volatile int HAND_ITEM_TIME = 10;
+    public static volatile int IDLE_CYCLES = 240;
+    public static volatile int IDLE_CYCLES_KICK = 480;
+    public static volatile String PREFIX_FORMAT = "[<font color=\"%color%\">%prefix%</font>] ";
+    public static volatile int ROLLERS_MAXIMUM_ROLL_AVATARS = 1;
+    public static volatile boolean MUTEAREA_CAN_WHISPER = false;
+    public static double MAXIMUM_FURNI_HEIGHT = 40d;
+    public static final int WIRED_ACCESS_EVERYONE = 1;
+    public static final int WIRED_ACCESS_USERS_WITH_RIGHTS = 2;
+    public static final int WIRED_ACCESS_GROUP_MEMBERS = 4;
+    public static final int WIRED_ACCESS_GROUP_ADMINS = 8;
+    public static final int WIRED_ACCESS_ALLOWED_INSPECT_MASK = WIRED_ACCESS_EVERYONE
+            | WIRED_ACCESS_USERS_WITH_RIGHTS
+            | WIRED_ACCESS_GROUP_MEMBERS
+            | WIRED_ACCESS_GROUP_ADMINS;
+    public static final int WIRED_ACCESS_ALLOWED_MODIFY_MASK =
+            WIRED_ACCESS_USERS_WITH_RIGHTS | WIRED_ACCESS_GROUP_MEMBERS | WIRED_ACCESS_GROUP_ADMINS;
+    public static final int WIRED_ACCESS_DEFAULT_INSPECT_MASK = 0;
+    public static final int WIRED_ACCESS_DEFAULT_MODIFY_MASK = 0;
+
+    static {
+        for (int i = 1; i <= 3; i++) {
+            RoomMoodlightData data = RoomMoodlightData.fromString("");
+            data.setId(i);
+            defaultMoodData.put(i, data);
         }
-      }
-
-      for (HabboItem item : Room.this.roomSpecialTypes
-              .getItemsOfType(InteractionFireworks.class)) {
-        item.setExtradata("1");
-        Room.this.updateItem(item);
-      }
-
-      synchronized (Room.this) {
-        try {
-          if (Room.this.publishLoadTransition(
-                  generation,
-                  () -> Emulator.getThreading().getService()
-                          .scheduleAtFixedRate(
-                                  Room.this,
-                                  500,
-                                  500,
-                                  TimeUnit.MILLISECONDS))) {
-            Emulator.getPluginManager()
-                    .fireEvent(new RoomLoadedEvent(Room.this));
-            return true;
-          }
-        } catch (Exception exception) {
-          Room.this.failLoadTransition(generation);
-          LOGGER.error("Caught exception publishing room load", exception);
-        }
-      }
-      return false;
     }
 
-    @Override
-    public void reportFailure(String message, Exception exception) {
-      LOGGER.error(message, exception);
+    public final Object roomUnitLock = new Object();
+    public final List<Integer> userVotes;
+    private final IntList rights;
+    private final Int2IntMap mutedHabbos;
+    private final Int2ObjectMap<RoomBan> bannedHabbos;
+    private final Set<Game> games;
+    private final Int2ObjectMap<RoomMoodlightData> moodlightData;
+    private final RoomDependencies dependencies;
+    private final RoomLifecycle lifecycle;
+    private final RoomLoader loader;
+    private final RoomItemPersistence itemPersistence;
+    private final RoomPersistence persistence;
+    private final RoomRepository repository;
+    private final RoomUserCountPersistence userCountPersistence;
+    public volatile double lastCycleCpuMs = 0.0;
+    public volatile String lastCycleThread = "N/A";
+
+    // Use appropriately. Could potentially cause memory leaks when used incorrectly.
+    public volatile boolean preventUnloading = false;
+    public volatile boolean preventUncaching = false;
+    public Set<ServerMessage> scheduledComposers = ConcurrentHashMap.newKeySet();
+    public final java.util.concurrent.ConcurrentLinkedQueue<Runnable> scheduledTasks =
+            new java.util.concurrent.ConcurrentLinkedQueue<>();
+    public String wordQuiz = "";
+    public int noVotes = 0;
+    public int yesVotes = 0;
+    public int wordQuizEnd = 0;
+    public volatile ScheduledFuture<?> roomCycleTask;
+    private int id;
+    private int ownerId;
+    private volatile BiConsumer<Room, Integer> ownerChangeListener;
+    private String ownerName;
+    private String name;
+    private String description;
+    private RoomLayout layout;
+    private boolean overrideModel;
+    private String layoutName;
+    private String password;
+    private RoomState state;
+    private int usersMax;
+    private int score;
+    private int category;
+    private String floorPaint;
+    private String wallPaint;
+    private String backgroundPaint;
+    private int wallSize;
+    private int wallHeight;
+    private int floorSize;
+    private int guild;
+    private String tags;
+    private boolean publicRoom;
+    private boolean staffPromotedRoom;
+    private boolean allowPets;
+    private boolean allowPetsEat;
+    private boolean allowWalkthrough;
+    private boolean allowBotsWalk;
+    private boolean allowEffects;
+    private boolean hideWall;
+    private int chatMode;
+    private int chatWeight;
+    private int chatSpeed;
+    private int chatDistance;
+    private int chatProtection;
+    private int muteOption;
+    private int kickOption;
+    private int banOption;
+    private int pollId;
+    private boolean promoted;
+    private int tradeMode;
+    private boolean moveDiagonally;
+    private boolean allowUnderpass;
+    private boolean jukeboxActive;
+    private boolean hideWired;
+    private boolean buildersClubTrialLocked;
+    private RoomState buildersClubOriginalState;
+    private RoomPromotion promotion;
+    private volatile boolean needsUpdate;
+    private int rollerSpeed;
+    private int lastTimerReset = Emulator.getIntUnixTimestamp();
+    private volatile boolean muted;
+    private RoomSpecialTypes roomSpecialTypes;
+    private TraxManager traxManager;
+    private final Object wiredSettingsLock = new Object();
+    private volatile boolean wiredSettingsLoaded;
+    private int wiredInspectMask = WIRED_ACCESS_DEFAULT_INSPECT_MASK;
+    private int wiredModifyMask = WIRED_ACCESS_DEFAULT_MODIFY_MASK;
+    private boolean youtubeEnabled = false;
+    private boolean soundboardEnabled = false;
+    private String youtubeCurrentVideo = "";
+    private String youtubeSenderName = "";
+    private final java.util.List<String> youtubePlaylist = new java.util.concurrent.CopyOnWriteArrayList<>();
+    private final java.util.Set<Integer> youtubeWatchers = java.util.concurrent.ConcurrentHashMap.newKeySet();
+
+    public boolean isYoutubeEnabled() {
+        return this.youtubeEnabled;
     }
 
-    private void withConnection(
-            String failureMessage,
-            LoadWithConnection operation) {
-      try (Connection connection =
-                   Room.this.dependencies.database().openConnection()) {
-        operation.load(connection);
-      } catch (Exception exception) {
-        LOGGER.error(failureMessage, exception);
-      }
-    }
-  }
-
-  @FunctionalInterface
-  private interface LoadWithConnection {
-    void load(Connection connection);
-  }
-
-  private synchronized void loadLayout() {
-    if (this.layout == null) {
-      if (this.overrideModel) {
-        this.layout = Emulator.getGameEnvironment().getRoomManager().loadCustomLayout(this);
-      } else {
-        this.layout = Emulator.getGameEnvironment().getRoomManager()
-                .loadLayout(this.layoutName, this);
-      }
-    }
-  }
-
-  private synchronized void loadHeightmap() {
-    if (this.layout != null) {
-      for (short x = 0; x < this.layout.getMapSizeX(); x++) {
-        for (short y = 0; y < this.layout.getMapSizeY(); y++) {
-          RoomTile tile = this.layout.getTile(x, y);
-          if (tile != null) {
-            this.updateTile(tile);
-          }
-        }
-      }
-    } else {
-      LOGGER.error("Unknown Room Layout for Room (ID: {})", this.id);
-    }
-  }
-
-  private synchronized void loadItems(Connection connection) {
-    this.itemManager.loadItems(connection);
-  }
-
-  private synchronized void loadWiredData(Connection connection) {
-    this.itemManager.loadWiredData(connection);
-  }
-
-  private synchronized void loadBots(Connection connection) {
-    this.unitManager.clearBots();
-
-    try (PreparedStatement statement = connection.prepareStatement(
-            "SELECT users.username AS owner_name, bots.* FROM bots INNER JOIN users ON bots.user_id = users.id WHERE room_id = ?")) {
-      statement.setInt(1, this.id);
-      try (ResultSet set = statement.executeQuery()) {
-        while (set.next()) {
-          Bot b = Emulator.getGameEnvironment().getBotManager().loadBot(set);
-
-          if (b != null) {
-            b.setRoom(this);
-            b.setRoomUnit(new RoomUnit());
-            b.getRoomUnit().setPathFinderRoom(this);
-            b.getRoomUnit()
-                    .setLocation(this.layout.getTile((short) set.getInt("x"), (short) set.getInt("y")));
-            if (b.getRoomUnit().getCurrentLocation() == null) {
-              b.getRoomUnit().setLocation(this.getLayout().getDoorTile());
-              b.getRoomUnit()
-                      .setRotation(RoomUserRotation.fromValue(this.getLayout().getDoorDirection()));
-            } else {
-              b.getRoomUnit().setZ(set.getDouble("z"));
-              b.getRoomUnit().setPreviousLocationZ(set.getDouble("z"));
-              b.getRoomUnit().setRotation(RoomUserRotation.values()[set.getInt("rot")]);
-            }
-            b.getRoomUnit().setRoomUnitType(RoomUnitType.BOT);
-            b.getRoomUnit().setDanceType(DanceType.values()[set.getInt("dance")]);
-            //b.getRoomUnit().setCanWalk(set.getBoolean("freeroam"));
-            b.getRoomUnit().setInRoom(true);
-            this.giveEffect(b.getRoomUnit(), set.getInt("effect"), Integer.MAX_VALUE);
-            this.addBot(b);
-          }
-        }
-      }
-    } catch (SQLException e) {
-      LOGGER.error("Caught SQL exception", e);
-    }
-  }
-
-  private synchronized void loadPets(Connection connection) {
-    this.unitManager.clearPets();
-
-    try (PreparedStatement statement = connection.prepareStatement(
-            "SELECT users.username as pet_owner_name, users_pets.* FROM users_pets INNER JOIN users ON users_pets.user_id = users.id WHERE room_id = ?")) {
-      statement.setInt(1, this.id);
-      try (ResultSet set = statement.executeQuery()) {
-        while (set.next()) {
-          try {
-            Pet pet = PetManager.loadPet(set);
-            pet.setRoom(this);
-            pet.setRoomUnit(new RoomUnit());
-            pet.getRoomUnit().setPathFinderRoom(this);
-            pet.getRoomUnit()
-                    .setLocation(this.layout.getTile((short) set.getInt("x"), (short) set.getInt("y")));
-            if (pet.getRoomUnit().getCurrentLocation() == null) {
-              pet.getRoomUnit().setLocation(this.getLayout().getDoorTile());
-              pet.getRoomUnit()
-                      .setRotation(RoomUserRotation.fromValue(this.getLayout().getDoorDirection()));
-            } else {
-              pet.getRoomUnit().setZ(set.getDouble("z"));
-              pet.getRoomUnit().setRotation(RoomUserRotation.values()[set.getInt("rot")]);
-            }
-            pet.getRoomUnit().setRoomUnitType(RoomUnitType.PET);
-            pet.getRoomUnit().setCanWalk(true);
-            this.addPet(pet);
-
-            this.getFurniOwnerNames().put(pet.getUserId(), set.getString("pet_owner_name"));
-          } catch (SQLException e) {
-            LOGGER.error("Caught SQL exception", e);
-          }
-        }
-      }
-    } catch (SQLException e) {
-      LOGGER.error("Caught SQL exception", e);
-    }
-  }
-
-  private synchronized void loadWordFilter(Connection connection) {
-    this.chatManager.loadWordFilter(connection);
-  }
-
-  public void updateTile(RoomTile tile) {
-    this.tileManager.updateTile(tile);
-  }
-
-  public void updateTiles(Collection<RoomTile> tiles) {
-    this.tileManager.updateTiles(tiles);
-  }
-
-  public RoomTileState calculateTileState(RoomTile tile) {
-    return this.tileManager.calculateTileState(tile);
-  }
-
-  public RoomTileState calculateTileState(RoomTile tile, HabboItem exclude) {
-    return this.tileManager.calculateTileState(tile, exclude);
-  }
-
-  public boolean tileWalkable(RoomTile t) {
-    return this.tileManager.tileWalkable(t);
-  }
-
-  public boolean tileWalkable(short x, short y) {
-    return this.tileManager.tileWalkable(x, y);
-  }
-
-  public void pickUpItem(HabboItem item, Habbo picker) {
-    this.itemManager.pickUpItem(item, picker);
-  }
-
-  public void updateHabbosAt(Rectangle rectangle) {
-    for (short i = (short) rectangle.x; i < rectangle.x + rectangle.width; i++) {
-      for (short j = (short) rectangle.y; j < rectangle.y + rectangle.height; j++) {
-        this.updateHabbosAt(i, j);
-      }
-    }
-  }
-
-  public void updateHabbo(Habbo habbo) {
-    this.updateRoomUnit(habbo.getRoomUnit());
-  }
-
-  public void updateRoomUnit(RoomUnit roomUnit) {
-    HabboItem item = this.getTopItemAt(roomUnit.getX(), roomUnit.getY());
-
-    if ((item == null && !roomUnit.cmdSit) || (item != null && !item.getBaseItem().allowSit())) {
-      roomUnit.removeStatus(RoomUnitStatus.SIT);
+    public void setYoutubeEnabled(boolean enabled) {
+        this.youtubeEnabled = enabled;
     }
 
-    double oldZ = roomUnit.getZ();
-
-    if (item != null) {
-      if (item.getBaseItem().allowSit()) {
-        roomUnit.setZ(item.getZ());
-      } else {
-        roomUnit.setZ(item.getZ() + Item.getCurrentHeight(item));
-      }
-
-      if (oldZ != roomUnit.getZ()) {
-        this.scheduledTasks.add(() -> {
-          try {
-            item.onWalkOn(roomUnit, Room.this, null);
-          } catch (Exception e) {
-
-          }
-        });
-      }
+    public boolean isSoundboardEnabled() {
+        return this.soundboardEnabled;
     }
 
-    this.sendComposer(new RoomUserStatusComposer(roomUnit).compose());
-  }
-
-  public void updateHabbosAt(short x, short y) {
-    this.unitManager.updateHabbosAt(x, y);
-  }
-
-  public void updateHabbosAt(short x, short y, Collection<Habbo> habbos) {
-    this.unitManager.updateHabbosAt(x, y, habbos);
-  }
-
-  public void updateBotsAt(short x, short y) {
-    this.unitManager.updateBotsAt(x, y);
-  }
-
-  public void updatePetsAt(short x, short y) {
-    this.unitManager.updatePetsAt(x, y);
-  }
-
-  public void pickupPetsForHabbo(Habbo habbo) {
-    this.unitManager.pickupPetsForHabbo(habbo);
-  }
-
-  public void startTrade(Habbo userOne, Habbo userTwo) {
-    this.tradeManager.startTrade(userOne, userTwo);
-  }
-
-  public void stopTrade(RoomTrade trade) {
-    this.tradeManager.stopTrade(trade);
-  }
-
-  public RoomTrade getActiveTradeForHabbo(Habbo user) {
-    return this.tradeManager.getActiveTradeForHabbo(user);
-  }
-
-  public synchronized void dispose() {
-    this.lifecycle.dispose(
-        this.preventUnloading,
-        () -> Emulator.getPluginManager()
-            .fireEvent(new RoomUnloadingEvent(this))
-            .isCancelled(),
-        this::disposeState,
-        () -> Emulator.getPluginManager()
-            .fireEvent(new RoomUnloadedEvent(this)));
-  }
-
-  private void disposeState(boolean wasLoaded) {
-    if (wasLoaded) {
-      try {
-          if (this.traxManager != null && !this.traxManager.disposed()) {
-            this.traxManager.dispose();
-          }
-
-          this.scheduledTasks.clear();
-          this.scheduledComposers.clear();
-
-          synchronized (this.mutedHabbos) {
-            this.mutedHabbos.clear();
-          }
-
-          for (InteractionGameTimer timer : this.getRoomSpecialTypes().getGameTimers().values()) {
-            if (timer instanceof InteractionGameUpCounter) {
-              ((InteractionGameUpCounter) timer).resetOnRoomUnload(this);
-            } else {
-              timer.setRunning(false);
-            }
-          }
-
-          for (Game game : this.games) {
-            game.dispose();
-          }
-          this.games.clear();
-
-          removeAllPets(ownerId);
-
-          this.itemManager.saveAllPendingItems();
-
-          // Unregister all wired tickables for this room from the tick service
-          com.eu.habbo.habbohotel.wired.core.WiredManager.unregisterRoomTickables(this);
-
-          if (this.roomSpecialTypes != null) {
-            this.roomSpecialTypes.dispose();
-          }
-
-          // Clear wired engine caches for this room
-          if (com.eu.habbo.habbohotel.wired.core.WiredManager.getStackIndex() != null) {
-            com.eu.habbo.habbohotel.wired.core.WiredManager.getStackIndex().invalidateAll(this);
-          }
-          if (com.eu.habbo.habbohotel.wired.core.WiredManager.getEngine() != null) {
-            com.eu.habbo.habbohotel.wired.core.WiredManager.getEngine().clearRoomRecursionDepth(this.id);
-            com.eu.habbo.habbohotel.wired.core.WiredManager.getEngine().clearRoomRateLimiters(this.id);
-            com.eu.habbo.habbohotel.wired.core.WiredManager.getEngine().clearRoomBan(this.id);
-            com.eu.habbo.habbohotel.wired.core.WiredManager.getEngine().clearRoomDiagnostics(this.id);
-          }
-
-          this.itemManager.clear();
-
-          this.unitManager.clearQueue();
-
-          for (Habbo habbo : this.getCurrentHabbos().values()) {
-            Emulator.getGameEnvironment().getRoomManager().leaveRoom(habbo, this);
-          }
-
-          this.sendComposer(new HotelViewComposer().compose());
-
-          // Save bots BEFORE clearing - must happen before unitManager.clear()
-          for (Bot bot : this.getCurrentBots().values()) {
-            bot.needsUpdate(true);
-            bot.run();  // Run synchronously to ensure DB is updated before room reload
-          }
-
-          // Save ALL remaining pets (including owner's pets) BEFORE clearing
-          for (Pet pet : this.getCurrentPets().values()) {
-            pet.needsUpdate = true;
-            pet.run();  // Run synchronously to ensure DB is updated before room reload
-          }
-
-          this.unitManager.clear();
-          this.unitManager.clearBots();
-          this.unitManager.clearPets();
-      } catch (Exception e) {
-        LOGGER.error("Caught exception", e);
-      }
+    public void setSoundboardEnabled(boolean enabled) {
+        this.soundboardEnabled = enabled;
     }
 
-    try {
-      this.wordQuiz = "";
-      this.yesVotes = 0;
-      this.noVotes = 0;
-      this.updateDatabaseUserCount();
-      this.layout = null;
-    } catch (Exception e) {
-      LOGGER.error("Caught exception", e);
-    }
-  }
-
-  @Override
-  public int compareTo(Room o) {
-    if (o.getUserCount() != this.getUserCount()) {
-      return o.getCurrentHabbos().size() - this.getCurrentHabbos().size();
+    public String getYoutubeCurrentVideo() {
+        return this.youtubeCurrentVideo;
     }
 
-    return this.id - o.id;
-  }
-
-  @Override
-  public void serialize(ServerMessage message) {
-    message.appendInt(this.id);
-    message.appendString(this.name);
-    if (this.isPublicRoom()) {
-      message.appendInt(0);
-      message.appendString("");
-    } else {
-      message.appendInt(this.ownerId);
-      message.appendString(this.ownerName);
-    }
-    message.appendInt(this.state.getState());
-    message.appendInt(this.getUserCount());
-    message.appendInt(this.usersMax);
-    message.appendString(this.description);
-    message.appendInt(0);
-    message.appendInt(this.score);
-    message.appendInt(0);
-    message.appendInt(this.category);
-
-    String[] tags = Arrays.stream(this.tags.split(";")).filter(t -> !t.isEmpty())
-            .toArray(String[]::new);
-    message.appendInt(tags.length);
-    for (String s : tags) {
-      message.appendString(s);
+    public String getYoutubeSenderName() {
+        return this.youtubeSenderName;
     }
 
-    int base = 0;
-
-    if (this.getGuildId() > 0) {
-      base = base | 2;
+    public java.util.List<String> getYoutubePlaylist() {
+        return this.youtubePlaylist;
     }
 
-    if (this.isPromoted()) {
-      base = base | 4;
+    public java.util.Set<Integer> getYoutubeWatchers() {
+        return this.youtubeWatchers;
     }
 
-    if (!this.isPublicRoom()) {
-      base = base | 8;
+    public void setYoutubeVideo(String videoId, String senderName, java.util.List<String> playlist) {
+        this.youtubeCurrentVideo = videoId;
+        this.youtubeSenderName = senderName;
+        this.youtubePlaylist.clear();
+        if (playlist != null) this.youtubePlaylist.addAll(playlist);
     }
 
-    message.appendInt(base);
-
-    if (this.getGuildId() > 0) {
-      Guild g = Emulator.getGameEnvironment().getGuildManager().getGuild(this.getGuildId());
-      if (g != null) {
-        message.appendInt(g.getId());
-        message.appendString(g.getName());
-        message.appendString(g.getBadge());
-      } else {
-        message.appendInt(0);
-        message.appendString("");
-        message.appendString("");
-      }
+    public void clearYoutubeVideo() {
+        this.youtubeCurrentVideo = "";
+        this.youtubeSenderName = "";
+        this.youtubePlaylist.clear();
     }
 
-    if (this.promoted) {
-      message.appendString(this.promotion.getTitle());
-      message.appendString(this.promotion.getDescription());
-      message.appendInt((this.promotion.getEndTimestamp() - Emulator.getIntUnixTimestamp()) / 60);
+    public final Map<String, Object> cache;
+
+    Room(int id, int ownerId) {
+        this(id, ownerId, RoomDependencies.runtime());
     }
 
-  }
-
-  @Override
-  public void run() {
-    synchronized (this) {
-      boolean runCycle = this.lifecycle.isLoaded();
-
-      if (runCycle) {
-        try {
-          long startTime = System.nanoTime();
-          this.lastCycleThread = Thread.currentThread().getName();
-          // Run cycle directly instead of scheduling on thread pool
-          // This ensures all cycle tasks in the same tick execute synchronously
-          // preventing wired desync issues
-          this.cycle();
-          this.lastCycleCpuMs = (System.nanoTime() - startTime) / 1000000.0;
-        } catch (Exception e) {
-          LOGGER.error("Caught exception", e);
-        }
-      }
-
-      this.save();
-    }
-  }
-
-  public void save() {
-    if (this.needsUpdate) {
-      try {
-        this.persistence.save(this.persistenceState());
-        this.needsUpdate = false;
-      } catch (SQLException e) {
-        LOGGER.error("Caught SQL exception", e);
-      }
-    }
-  }
-
-  private RoomPersistence.State persistenceState() {
-    return new RoomPersistence.State(
-        this.id,
-        this.ownerId,
-        this.ownerName,
-        this.name,
-        this.description,
-        this.password,
-        this.state,
-        this.usersMax,
-        this.category,
-        this.score,
-        this.floorPaint,
-        this.wallPaint,
-        this.backgroundPaint,
-        this.wallSize,
-        this.wallHeight,
-        this.floorSize,
-        List.copyOf(this.moodlightData.values()),
-        this.tags,
-        this.allowPets,
-        this.allowPetsEat,
-        this.allowWalkthrough,
-        this.hideWall,
-        this.chatMode,
-        this.chatWeight,
-        this.chatSpeed,
-        this.chatDistance,
-        this.chatProtection,
-        this.muteOption,
-        this.kickOption,
-        this.banOption,
-        this.pollId,
-        this.guild,
-        this.rollerSpeed,
-        this.overrideModel,
-        this.staffPromotedRoom,
-        this.promoted,
-        this.tradeMode,
-        this.moveDiagonally,
-        this.jukeboxActive,
-        this.hideWired,
-        this.allowUnderpass,
-        this.youtubeEnabled,
-        this.buildersClubTrialLocked,
-        this.buildersClubOriginalState);
-  }
-
-  void savePendingItems(List<HabboItem> items) {
-    try {
-      this.itemPersistence.save(items);
-    } catch (SQLException exception) {
-      LOGGER.error("Caught SQL exception saving room items", exception);
-    }
-  }
-
-  /**
-   * Updates the user count in the database.
-   * Made public for access by RoomUnitManager.
-   */
-  public void updateDatabaseUserCount() {
-    try {
-      this.repository.updateUserCount(this.id, this.getUserCount());
-    } catch (SQLException e) {
-      LOGGER.error("Caught SQL exception", e);
-    }
-  }
-
-  void scheduleDatabaseUserCountUpdate() {
-    this.userCountPersistence.schedule();
-  }
-
-  private RoomUserCountPersistence createUserCountPersistence() {
-    return new RoomUserCountPersistence(
-        this::getUserCount,
-        userCount -> this.repository.updateUserCount(this.id, userCount),
-        this.dependencies.persistence()::execute);
-  }
-
-  private void cycle() {
-    this.cycleManager.cycle();
-  }
-
-  public int getId() {
-    return this.id;
-  }
-
-  public int getOwnerId() {
-    return this.ownerId;
-  }
-
-  public void setOwnerId(int ownerId) {
-    int previousOwnerId = this.ownerId;
-    this.ownerId = ownerId;
-
-    BiConsumer<Room, Integer> listener = this.ownerChangeListener;
-    if (listener != null && previousOwnerId != ownerId) {
-      listener.accept(this, previousOwnerId);
-    }
-  }
-
-  void setOwnerChangeListener(BiConsumer<Room, Integer> ownerChangeListener) {
-    this.ownerChangeListener = ownerChangeListener;
-  }
-
-  public String getOwnerName() {
-    return this.ownerName;
-  }
-
-  public void setOwnerName(String ownerName) {
-    this.ownerName = ownerName;
-  }
-
-  public String getName() {
-    return this.name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-
-    if (this.name.length() > 50) {
-      this.name = this.name.substring(0, 50);
+    Room(int id, int ownerId, RoomDependencies dependencies) {
+        this.cache = new HashMap<>();
+        this.dependencies = Objects.requireNonNull(dependencies, "dependencies");
+        this.lifecycle = new RoomLifecycle(new RoomCycleTaskSlot());
+        this.itemPersistence = new RoomItemPersistence(this.dependencies.database());
+        this.persistence = new RoomPersistence(this.dependencies.database());
+        this.repository = new RoomRepository(this.dependencies.database());
+        this.id = id;
+        this.ownerId = ownerId;
+        this.userCountPersistence = this.createUserCountPersistence();
+        this.bannedHabbos = new Int2ObjectOpenHashMap<>();
+        this.moodlightData = new Int2ObjectOpenHashMap<>(defaultMoodData);
+        this.mutedHabbos = new Int2IntOpenHashMap();
+        this.games = ConcurrentHashMap.newKeySet();
+        this.rights = new IntArrayList();
+        this.userVotes = new ArrayList<>();
+        this.initializeManagers(new RoomChatManager(this, RoomChatManager.DEFAULT_MUTE_TIME_SECONDS));
+        this.loader = this.createLoader();
     }
 
-    if (this.hasGuild()) {
-      Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(this.guild);
-
-      if (guild != null) {
-        guild.setRoomName(name);
-      }
-    }
-  }
-
-  public String getDescription() {
-    return this.description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-
-    if (this.description.length() > 250) {
-      this.description = this.description.substring(0, 250);
-    }
-  }
-
-  public RoomLayout getLayout() {
-    return this.layout;
-  }
-
-  RoomLayout currentLayout() {
-    return this.layout;
-  }
-
-  public void setLayout(RoomLayout layout) {
-    this.layout = layout;
-  }
-
-  public boolean hasCustomLayout() {
-    return this.overrideModel;
-  }
-
-  public void setHasCustomLayout(boolean overrideModel) {
-    this.overrideModel = overrideModel;
-  }
-
-  public String getPassword() {
-    return this.password;
-  }
-
-  public void setPassword(String password) {
-    this.password = password;
-
-    if (this.password.length() > 20) {
-      this.password = this.password.substring(0, 20);
-    }
-  }
-
-  public RoomState getState() {
-    return this.state;
-  }
-
-  public void setState(RoomState state) {
-    this.state = state;
-  }
-
-  public boolean isBuildersClubTrialLocked() {
-    return this.buildersClubTrialLocked;
-  }
-
-  public void setBuildersClubTrialLocked(boolean buildersClubTrialLocked) {
-    this.buildersClubTrialLocked = buildersClubTrialLocked;
-  }
-
-  public RoomState getBuildersClubOriginalState() {
-    return this.buildersClubOriginalState;
-  }
-
-  public void setBuildersClubOriginalState(RoomState buildersClubOriginalState) {
-    this.buildersClubOriginalState = buildersClubOriginalState;
-  }
-
-  public int getUsersMax() {
-    return this.usersMax;
-  }
-
-  public void setUsersMax(int usersMax) {
-    this.usersMax = usersMax;
-  }
-
-  public int getScore() {
-    return this.score;
-  }
-
-  public void setScore(int score) {
-    this.score = score;
-  }
-
-  public int getCategory() {
-    return this.category;
-  }
-
-  public void setCategory(int category) {
-    this.category = category;
-  }
-
-  public String getFloorPaint() {
-    return this.floorPaint;
-  }
-
-  public void setFloorPaint(String floorPaint) {
-    this.floorPaint = floorPaint;
-  }
-
-  public String getWallPaint() {
-    return this.wallPaint;
-  }
-
-  public void setWallPaint(String wallPaint) {
-    this.wallPaint = wallPaint;
-  }
-
-  public String getBackgroundPaint() {
-    return this.backgroundPaint;
-  }
-
-  public void setBackgroundPaint(String backgroundPaint) {
-    this.backgroundPaint = backgroundPaint;
-  }
-
-  public int getWallSize() {
-    return this.wallSize;
-  }
-
-  public void setWallSize(int wallSize) {
-    this.wallSize = wallSize;
-  }
-
-  public int getWallHeight() {
-    return this.wallHeight;
-  }
-
-  public void setWallHeight(int wallHeight) {
-    this.wallHeight = wallHeight;
-  }
-
-  public int getFloorSize() {
-    return this.floorSize;
-  }
-
-  public void setFloorSize(int floorSize) {
-    this.floorSize = floorSize;
-  }
-
-  public String getTags() {
-    return this.tags;
-  }
-
-  public void setTags(String tags) {
-    this.tags = tags;
-  }
-
-  public int getTradeMode() {
-    return this.tradeMode;
-  }
-
-  public void setTradeMode(int tradeMode) {
-    this.tradeMode = tradeMode;
-  }
-
-  public boolean moveDiagonally() {
-    return this.moveDiagonally;
-  }
-
-  public void moveDiagonally(boolean moveDiagonally) {
-    this.moveDiagonally = moveDiagonally;
-    this.layout.moveDiagonally(this.moveDiagonally);
-    this.needsUpdate = true;
-  }
-
-  public int getGuildId() {
-    return this.guild;
-  }
-
-  public boolean hasGuild() {
-    return this.getGuildId() != 0;
-  }
-
-  public boolean belongsToGuild() {
-    return this.guild > 0;
-  }
-
-  public void setGuild(int guild) {
-    this.guild = guild;
-  }
-
-  public String getGuildName() {
-    if (this.hasGuild()) {
-      Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(this.guild);
-
-      if (guild != null) {
-        return guild.getName();
-      }
+    public Room(ResultSet set) throws SQLException {
+        this(set, RoomDependencies.runtime());
     }
 
-    return "";
-  }
-
-  public boolean isPublicRoom() {
-    return this.publicRoom;
-  }
-
-  public void setPublicRoom(boolean publicRoom) {
-    this.publicRoom = publicRoom;
-  }
-
-  public boolean isStaffPromotedRoom() {
-    return this.staffPromotedRoom;
-  }
-
-  public void setStaffPromotedRoom(boolean staffPromotedRoom) {
-    this.staffPromotedRoom = staffPromotedRoom;
-  }
-
-  public boolean isAllowPets() {
-    return this.allowPets;
-  }
-
-  public void setAllowPets(boolean allowPets) {
-    this.allowPets = allowPets;
-    if (!allowPets) {
-      removeAllPets(ownerId);
-    }
-  }
-
-  public boolean isAllowPetsEat() {
-    return this.allowPetsEat;
-  }
-
-  public void setAllowPetsEat(boolean allowPetsEat) {
-    this.allowPetsEat = allowPetsEat;
-  }
-
-  public boolean isAllowWalkthrough() {
-    return this.allowWalkthrough;
-  }
-
-  public void setAllowWalkthrough(boolean allowWalkthrough) {
-    this.allowWalkthrough = allowWalkthrough;
-  }
-
-  public boolean isAllowUnderpass() {
-    return this.allowUnderpass;
-  }
-
-  public void setAllowUnderpass(boolean allowUnderpass) {
-    this.allowUnderpass = allowUnderpass;
-  }
-
-  public boolean isAllowBotsWalk() {
-    return this.allowBotsWalk;
-  }
-
-  public void setAllowBotsWalk(boolean allowBotsWalk) {
-    this.allowBotsWalk = allowBotsWalk;
-  }
-
-  public boolean isAllowEffects() {
-    return this.allowEffects;
-  }
-
-  public void setAllowEffects(boolean allowEffects) {
-    this.allowEffects = allowEffects;
-  }
-
-  public boolean isHideWall() {
-    return this.hideWall;
-  }
-
-  public void setHideWall(boolean hideWall) {
-    this.hideWall = hideWall;
-  }
-
-  public Color getBackgroundTonerColor() {
-    Color color = new Color(0, 0, 0);
-    Int2ObjectMap<HabboItem> items = this.itemManager.getRoomItems();
-
-    synchronized (items) {
-      for (HabboItem object : items.values()) {
-        if (object instanceof InteractionBackgroundToner) {
-          String[] extraData = object.getExtradata().split(":");
-
-          if (extraData.length == 4) {
-            if (extraData[0].equalsIgnoreCase("1")) {
-              return Color.getHSBColor(Integer.parseInt(extraData[1]),
-                      Integer.parseInt(extraData[2]), Integer.parseInt(extraData[3]));
-            }
-          }
-        }
-      }
-    }
-
-    return color;
-  }
-
-  public int getChatMode() {
-    return this.chatMode;
-  }
-
-  public void setChatMode(int chatMode) {
-    this.chatMode = chatMode;
-  }
-
-  public int getChatWeight() {
-    return this.chatWeight;
-  }
-
-  public void setChatWeight(int chatWeight) {
-    this.chatWeight = chatWeight;
-  }
-
-  public int getChatSpeed() {
-    return this.chatSpeed;
-  }
-
-  public void setChatSpeed(int chatSpeed) {
-    this.chatSpeed = chatSpeed;
-  }
-
-  public int getChatDistance() {
-    return this.chatDistance;
-  }
-
-  public void setChatDistance(int chatDistance) {
-    this.chatDistance = chatDistance;
-  }
-
-  public void removeAllPets() {
-    this.unitManager.removeAllPets();
-  }
-
-  /**
-   * Removes all pets from the room except if the owner id is excludeUserId
-   *
-   * @param excludeUserId Habbo id to keep pets
-   */
-  public void removeAllPets(int excludeUserId) {
-    this.unitManager.removeAllPets(excludeUserId);
-  }
-
-  public int getChatProtection() {
-    return this.chatProtection;
-  }
-
-  public void setChatProtection(int chatProtection) {
-    this.chatProtection = chatProtection;
-  }
-
-  public int getMuteOption() {
-    return this.muteOption;
-  }
-
-  public void setMuteOption(int muteOption) {
-    this.muteOption = muteOption;
-  }
-
-  public int getKickOption() {
-    return this.kickOption;
-  }
-
-  public void setKickOption(int kickOption) {
-    this.kickOption = kickOption;
-  }
-
-  public int getBanOption() {
-    return this.banOption;
-  }
-
-  public void setBanOption(int banOption) {
-    this.banOption = banOption;
-  }
-
-  public int getPollId() {
-    return this.pollId;
-  }
-
-  public void setPollId(int pollId) {
-    this.pollId = pollId;
-  }
-
-  public int getRollerSpeed() {
-    return this.rollerSpeed;
-  }
-
-  public void setRollerSpeed(int rollerSpeed) {
-    this.rollerSpeed = rollerSpeed;
-    this.needsUpdate = true;
-  }
-
-  public String[] filterAnything() {
-    return new String[]{this.getOwnerName(), this.getGuildName(), this.getDescription(),
-            this.getPromotionDesc()};
-  }
-
-  public long getCycleTimestamp() {
-    return this.cycleManager.getCycleTimestamp();
-  }
-
-  public boolean isPromoted() {
-    return this.promotionManager.isPromoted();
-  }
-
-  public RoomPromotion getPromotion() {
-    return this.promotion;
-  }
-
-  public String getPromotionDesc() {
-    if (this.promotion != null) {
-      return this.promotion.getDescription();
-    }
-
-    return "";
-  }
-
-  public void createPromotion(String title, String description, int category) {
-    this.promotionManager.createPromotion(title, description, category);
-  }
-
-  public boolean addGame(Game game) {
-    return this.gameManager.addGame(game);
-  }
-
-  public boolean deleteGame(Game game) {
-    return this.gameManager.deleteGame(game);
-  }
-
-  public Game getGame(Class<? extends Game> gameType) {
-    return this.gameManager.getGame(gameType);
-  }
-
-  public Game getGameOrCreate(Class<? extends Game> gameType) {
-    return this.gameManager.getGameOrCreate(gameType);
-  }
-
-  public Set<Game> getGames() {
-    return this.gameManager.getGames();
-  }
-
-  public int getUserCount() {
-    return this.unitManager.getHabboCount();
-  }
-
-  public ConcurrentHashMap<Integer, Habbo> getCurrentHabbos() {
-    return this.unitManager.getCurrentHabbos();
-  }
-
-  public Collection<Habbo> getHabbos() {
-    return this.unitManager.getHabbos();
-  }
-
-  public Int2ObjectMap<Habbo> getHabboQueue() {
-    return this.unitManager.getHabboQueue();
-  }
-
-  public Int2ObjectMap<String> getFurniOwnerNames() {
-    return this.itemManager.getFurniOwnerNames();
-  }
-
-  public String getFurniOwnerName(int userId) {
-    return this.itemManager.getFurniOwnerName(userId);
-  }
-
-  public Int2IntMap getFurniOwnerCount() {
-    return this.itemManager.getFurniOwnerCount();
-  }
-
-  public Int2ObjectMap<RoomMoodlightData> getMoodlightData() {
-    return this.moodlightData;
-  }
-
-  public int getLastTimerReset() {
-    return this.lastTimerReset;
-  }
-
-  public void setLastTimerReset(int lastTimerReset) {
-    this.lastTimerReset = lastTimerReset;
-  }
-
-  public void addToQueue(Habbo habbo) {
-    this.unitManager.addToQueue(habbo);
-  }
-
-  public boolean removeFromQueue(Habbo habbo) {
-    try {
-      this.sendComposer(new HideDoorbellComposer(habbo.getHabboInfo().getUsername()).compose());
-
-      return this.unitManager.removeFromQueue(habbo.getHabboInfo().getId()) != null;
-    } catch (Exception e) {
-      LOGGER.error("Caught exception", e);
-    }
-
-    return true;
-  }
-
-  public Int2ObjectMap<Bot> getCurrentBots() {
-    return this.unitManager.getCurrentBots();
-  }
-
-  public Int2ObjectMap<Pet> getCurrentPets() {
-    return this.unitManager.getCurrentPets();
-  }
-
-  public Set<String> getWordFilterWords() {
-    return this.chatManager.getWordFilterWords();
-  }
-
-  public RoomSpecialTypes getRoomSpecialTypes() {
-    return this.roomSpecialTypes;
-  }
-
-  /**
-   * Alias for getRoomSpecialTypes() for shorter access.
-   */
-  public RoomSpecialTypes getSpecialTypes() {
-    return this.roomSpecialTypes;
-  }
-
-  public boolean isPreLoaded() {
-    return this.lifecycle.isPreloaded();
-  }
-
-  public boolean isLoaded() {
-    return this.lifecycle.isLoaded();
-  }
-
-  public void setNeedsUpdate(boolean needsUpdate) {
-    this.needsUpdate = needsUpdate;
-  }
-
-  public IntList getRights() {
-    return this.rights;
-  }
-
-  public boolean isMuted() {
-    return this.muted;
-  }
-
-  public void setMuted(boolean muted) {
-    this.muted = muted;
-  }
-
-  public TraxManager getTraxManager() {
-    return this.traxManager;
-  }
-
-  public void addHabboItem(HabboItem item) {
-    this.itemManager.addHabboItem(item);
-  }
-
-  public HabboItem getHabboItem(int id) {
-    return this.itemManager.getHabboItem(id);
-  }
-
-  void removeHabboItem(int id) {
-    this.itemManager.removeHabboItem(id);
-  }
-
-
-  public void removeHabboItem(HabboItem item) {
-    this.itemManager.removeHabboItem(item);
-  }
-
-  public Set<HabboItem> getFloorItems() {
-    return this.itemManager.getFloorItems();
-  }
-
-  public Set<HabboItem> getWallItems() {
-    return this.itemManager.getWallItems();
-  }
-
-  public Set<HabboItem> getPostItNotes() {
-    return this.itemManager.getPostItNotes();
-  }
-
-  public void addHabbo(Habbo habbo) {
-    this.unitManager.addHabbo(habbo);
-  }
-
-  public void kickHabbo(Habbo habbo, boolean alert) {
-    this.unitManager.kickHabbo(habbo, alert);
-  }
-
-  public void removeHabbo(Habbo habbo) {
-    this.cleanupYoutubeWatcher(habbo);
-    this.unitManager.removeHabbo(habbo);
-  }
-
-  public void removeHabbo(Habbo habbo, boolean sendRemovePacket) {
-    this.cleanupYoutubeWatcher(habbo);
-    this.unitManager.removeHabbo(habbo, sendRemovePacket);
-  }
-
-  private void cleanupYoutubeWatcher(Habbo habbo) {
-    if (habbo == null) return;
-    int userId = habbo.getHabboInfo().getId();
-
-    // If the broadcast sender leaves, stop the broadcast for everyone
-    if (!this.youtubeCurrentVideo.isEmpty()
-            && habbo.getHabboInfo().getUsername().equals(this.youtubeSenderName)) {
-      this.clearYoutubeVideo();
-      this.sendComposer(new com.eu.habbo.messages.outgoing.rooms.youtube.YouTubeRoomBroadcastComposer("", "", java.util.Collections.emptyList()).compose());
-    }
-
-    if (this.youtubeWatchers.remove(userId)) {
-      this.sendComposer(new com.eu.habbo.messages.outgoing.rooms.youtube.YouTubeRoomWatchersComposer(this.youtubeWatchers).compose());
-    }
-  }
-
-  public void addBot(Bot bot) {
-    this.unitManager.addBot(bot);
-  }
-
-  public void addPet(Pet pet) {
-    this.unitManager.addPet(pet);
-  }
-
-  public Bot getBot(int botId) {
-    return this.unitManager.getBot(botId);
-  }
-
-  public Bot getBot(RoomUnit roomUnit) {
-    return this.unitManager.getBot(roomUnit);
-  }
-
-  public Bot getBotByRoomUnitId(int id) {
-    return this.unitManager.getBotByRoomUnitId(id);
-  }
-
-  public List<Bot> getBots(String name) {
-    return this.unitManager.getBots(name);
-  }
-
-  public boolean hasBotsAt(final int x, final int y) {
-    return this.unitManager.hasBotsAt(x, y);
-  }
-
-  public Pet getPet(int petId) {
-    return this.unitManager.getPet(petId);
-  }
-
-  public Pet getPet(RoomUnit roomUnit) {
-    return this.unitManager.getPet(roomUnit);
-  }
-
-  public boolean removeBot(Bot bot) {
-    return this.unitManager.removeBot(bot);
-  }
-
-  public void placePet(Pet pet, short x, short y, double z, int rot) {
-    this.unitManager.placePet(pet, x, y, z, rot);
-  }
-
-  public Pet removePet(int petId) {
-    return this.unitManager.removePet(petId);
-  }
-
-  public boolean hasHabbosAt(int x, int y) {
-    return this.unitManager.hasHabbosAt(x, y);
-  }
-
-  public boolean hasPetsAt(int x, int y) {
-    return this.unitManager.hasPetsAt(x, y);
-  }
-
-  public Set<Bot> getBotsAt(RoomTile tile) {
-    return this.unitManager.getBotsAt(tile);
-  }
-
-  public Set<Pet> getPetsAt(RoomTile tile) {
-    return this.unitManager.getPetsAt(tile);
-  }
-
-  public Set<Habbo> getHabbosAt(short x, short y) {
-    return this.unitManager.getHabbosAt(x, y);
-  }
-
-  public Set<Habbo> getHabbosAt(RoomTile tile) {
-    return this.unitManager.getHabbosAt(tile);
-  }
-
-  public Set<RoomUnit> getHabbosAndBotsAt(short x, short y) {
-    return this.unitManager.getHabbosAndBotsAt(x, y);
-  }
-
-  public Set<RoomUnit> getHabbosAndBotsAt(RoomTile tile) {
-    return this.unitManager.getHabbosAndBotsAt(tile);
-  }
-
-  public Set<Habbo> getHabbosOnItem(HabboItem item) {
-    return this.unitManager.getHabbosOnItem(item);
-  }
-
-  public Set<Bot> getBotsOnItem(HabboItem item) {
-    return this.unitManager.getBotsOnItem(item);
-  }
-
-  public void teleportHabboToItem(Habbo habbo, HabboItem item) {
-    this.unitManager.teleportHabboToItem(habbo, item);
-  }
-
-  public void teleportHabboToLocation(Habbo habbo, short x, short y) {
-    this.unitManager.teleportHabboToLocation(habbo, x, y);
-  }
-
-  public void teleportRoomUnitToItem(RoomUnit roomUnit, HabboItem item) {
-    this.unitManager.teleportRoomUnitToItem(roomUnit, item);
-  }
-
-  public void teleportRoomUnitToLocation(RoomUnit roomUnit, short x, short y) {
-    this.unitManager.teleportRoomUnitToLocation(roomUnit, x, y);
-  }
-
-  public void teleportRoomUnitToLocation(RoomUnit roomUnit, short x, short y, double z) {
-    this.unitManager.teleportRoomUnitToLocation(roomUnit, x, y, z);
-  }
-
-  public void muteHabbo(Habbo habbo, int minutes) {
-    this.chatManager.muteHabbo(habbo, minutes);
-    this.sendComposer(new RoomUserIgnoredComposer(habbo, RoomUserIgnoredComposer.MUTED).compose());
-  }
-
-  public void unmuteHabbo(Habbo habbo) {
-    this.chatManager.unmuteHabbo(habbo);
-    this.sendComposer(new RoomUserIgnoredComposer(habbo, RoomUserIgnoredComposer.UNIGNORED).compose());
-  }
-
-  public boolean isMuted(Habbo habbo) {
-    return this.chatManager.isMuted(habbo);
-  }
-
-  public void habboEntered(Habbo habbo) {
-    this.unitManager.habboEntered(habbo);
-  }
-
-  public void floodMuteHabbo(Habbo habbo, int timeOut) {
-    this.chatManager.floodMuteHabbo(habbo, timeOut);
-  }
-
-  public void talk(Habbo habbo, RoomChatMessage roomChatMessage, RoomChatType chatType) {
-    this.chatManager.talk(habbo, roomChatMessage, chatType);
-  }
-
-  public void talk(final Habbo habbo, final RoomChatMessage roomChatMessage, RoomChatType chatType,
-                   boolean ignoreWired) {
-    this.chatManager.talk(habbo, roomChatMessage, chatType, ignoreWired);
-  }
-
-  public Set<RoomTile> getLockedTiles() {
-    return this.itemManager.getLockedTiles();
-  }
-
-  @Deprecated
-  public Set<HabboItem> getItemsAt(int x, int y) {
-    return this.itemManager.getItemsAt(x, y);
-  }
-
-  public Set<HabboItem> getItemsAt(RoomTile tile) {
-    return this.itemManager.getItemsAt(tile);
-  }
-
-  public Set<HabboItem> getItemsAt(RoomTile tile, boolean returnOnFirst) {
-    return this.itemManager.getItemsAt(tile, returnOnFirst);
-  }
-
-  public Set<HabboItem> getItemsAt(int x, int y, double minZ) {
-    return this.itemManager.getItemsAt(x, y, minZ);
-  }
-
-  public Set<HabboItem> getItemsAt(Class<? extends HabboItem> type, int x, int y) {
-    return this.itemManager.getItemsAt(type, x, y);
-  }
-
-  public boolean hasItemsAt(int x, int y) {
-    return this.itemManager.hasItemsAt(x, y);
-  }
-
-  public HabboItem getTopItemAt(int x, int y) {
-    return this.itemManager.getTopItemAt(x, y);
-  }
-
-  public HabboItem getTopItemAt(int x, int y, HabboItem exclude) {
-    return this.itemManager.getTopItemAt(x, y, exclude);
-  }
-
-  public HabboItem getTopItemAt(Set<RoomTile> tiles, HabboItem exclude) {
-    return this.itemManager.getTopItemAt(tiles, exclude);
-  }
-
-  public double getTopHeightAt(int x, int y) {
-    return this.itemManager.getTopHeightAt(x, y);
-  }
-
-  @Deprecated
-  public HabboItem getLowestChair(int x, int y) {
-    return this.itemManager.getLowestChair(x, y);
-  }
-
-  public HabboItem getLowestChair(RoomTile tile) {
-    return this.itemManager.getLowestChair(tile);
-  }
-
-  public HabboItem getTallestChair(RoomTile tile) {
-    return this.itemManager.getTallestChair(tile);
-  }
-
-  public double getStackHeight(short x, short y, boolean calculateHeightmap, HabboItem exclude) {
-    return this.tileManager.getStackHeight(x, y, calculateHeightmap, exclude);
-  }
-
-  public double getStackHeight(short x, short y, boolean calculateHeightmap) {
-    return this.tileManager.getStackHeight(x, y, calculateHeightmap);
-  }
-
-  public boolean hasObjectTypeAt(Class<?> type, int x, int y) {
-    return this.itemManager.hasObjectTypeAt(type, x, y);
-  }
-
-  public boolean canSitOrLayAt(int x, int y) {
-    return this.tileManager.canSitOrLayAt(x, y);
-  }
-
-  public boolean canSitAt(int x, int y) {
-    return this.tileManager.canSitAt(x, y);
-  }
-
-  boolean canWalkAt(RoomTile roomTile) {
-    return this.tileManager.canWalkAt(roomTile);
-  }
-
-  boolean canSitAt(Set<HabboItem> items) {
-    return this.tileManager.canSitAt(items);
-  }
-
-  public boolean canLayAt(int x, int y) {
-    return this.tileManager.canLayAt(x, y);
-  }
-
-  boolean canLayAt(Set<HabboItem> items) {
-    return this.tileManager.canLayAt(items);
-  }
-
-  public RoomTile getRandomWalkableTile() {
-    return this.tileManager.getRandomWalkableTile();
-  }
-
-  public RoomTile getRandomWalkableTilesAround(RoomUnit roomUnit, RoomTile tile, int radius) {
-    return this.tileManager.getRandomWalkableTilesAround(roomUnit, tile, radius);
-  }
-
-  public Habbo getHabbo(String username) {
-    return this.unitManager.getHabbo(username);
-  }
-
-  public Habbo getHabbo(RoomUnit roomUnit) {
-    return this.unitManager.getHabboByRoomUnit(roomUnit);
-  }
-
-  public Habbo getHabbo(int userId) {
-    return this.unitManager.getHabbo(userId);
-  }
-
-  public Habbo getHabboByRoomUnitId(int roomUnitId) {
-    return this.unitManager.getHabboByRoomUnitId(roomUnitId);
-  }
-
-  public void sendComposer(ServerMessage message) {
-    this.messagingManager.sendComposer(message);
-  }
-
-  public void sendComposers(Collection<ServerMessage> messages) {
-    this.messagingManager.sendComposers(messages);
-  }
-
-  public void sendComposerToHabbosWithRights(ServerMessage message) {
-    this.messagingManager.sendComposerToHabbosWithRights(message);
-  }
-
-  public void petChat(ServerMessage message) {
-    this.messagingManager.petChat(message);
-  }
-
-  public void botChat(ServerMessage message) {
-    this.messagingManager.botChat(message);
-  }
-
-  private void loadRights(Connection connection) {
-    this.rights.clear();
-    try (PreparedStatement statement = connection.prepareStatement(
-            "SELECT user_id FROM room_rights WHERE room_id = ?")) {
-      statement.setInt(1, this.id);
-      try (ResultSet set = statement.executeQuery()) {
-        while (set.next()) {
-          this.rights.add(set.getInt("user_id"));
-        }
-      }
-    } catch (SQLException e) {
-      LOGGER.error("Caught SQL exception", e);
-    }
-  }
-
-  private void loadBans(Connection connection) {
-    this.bannedHabbos.clear();
-
-    try (PreparedStatement statement = connection.prepareStatement(
-            "SELECT users.username, users.id, room_bans.* FROM room_bans INNER JOIN users ON room_bans.user_id = users.id WHERE ends > ? AND room_bans.room_id = ?")) {
-      statement.setInt(1, Emulator.getIntUnixTimestamp());
-      statement.setInt(2, this.id);
-      try (ResultSet set = statement.executeQuery()) {
-        while (set.next()) {
-          if (this.bannedHabbos.containsKey(set.getInt("user_id"))) {
-            continue;
-          }
-
-          this.bannedHabbos.put(set.getInt("user_id"), new RoomBan(set));
-        }
-      }
-    } catch (SQLException e) {
-      LOGGER.error("Caught SQL exception", e);
-    }
-  }
-
-  public RoomRightLevels getGuildRightLevel(Habbo habbo) {
-    int guildId = this.getGuildId();
-
-    if (guildId > 0 && habbo != null && habbo.getHabboInfo() != null) {
-      Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
-
-      if (guild == null) {
-        return RoomRightLevels.NONE;
-      }
-
-      GuildMember member = Emulator.getGameEnvironment().getGuildManager().getGuildMember(guild.getId(), habbo.getHabboInfo().getId());
-
-      if ((member != null) && (member.getRank() == GuildRank.ADMIN || member.getRank() == GuildRank.OWNER)) {
-        return RoomRightLevels.GUILD_ADMIN;
-      }
-
-      if ((member != null) && member.getMembershipStatus() == GuildMembershipStatus.MEMBER
-          && guild.getRights()) {
-        return RoomRightLevels.GUILD_RIGHTS;
-      }
-    }
-
-    return RoomRightLevels.NONE;
-  }
-
-  /**
-   * @deprecated Deprecated since 2.5.0. Use {@link #getGuildRightLevel(Habbo)} instead.
-   */
-  @Deprecated
-  public int guildRightLevel(Habbo habbo) {
-    return this.rightsManager.guildRightLevel(habbo);
-  }
-
-  public boolean isOwner(Habbo habbo) {
-    return this.rightsManager.isOwner(habbo);
-  }
-
-  public boolean hasRights(Habbo habbo) {
-    return this.rightsManager.hasRights(habbo);
-  }
-
-  public boolean hasExplicitRights(Habbo habbo) {
-    return habbo != null && this.rights.contains(habbo.getHabboInfo().getId());
-  }
-
-  public int getWiredInspectMask() {
-    this.ensureWiredSettingsLoaded();
-    return this.wiredInspectMask;
-  }
-
-  public int getWiredModifyMask() {
-    this.ensureWiredSettingsLoaded();
-    return this.wiredModifyMask;
-  }
-
-  public boolean canInspectWired(Habbo habbo) {
-    if (habbo == null) {
-      return false;
-    }
-
-    if (this.canManageWiredSettings(habbo)) {
-      return true;
-    }
-
-    this.ensureWiredSettingsLoaded();
-    return this.matchesWiredAccessMask(habbo, this.wiredInspectMask, true);
-  }
-
-  public boolean canModifyWired(Habbo habbo) {
-    if (habbo == null) {
-      return false;
-    }
-
-    if (this.canManageWiredSettings(habbo)) {
-      return true;
-    }
-
-    this.ensureWiredSettingsLoaded();
-    return this.matchesWiredAccessMask(habbo, this.wiredModifyMask, false);
-  }
-
-  public boolean canManageWiredSettings(Habbo habbo) {
-    return habbo != null && this.isOwner(habbo);
-  }
-
-  public boolean saveWiredSettings(int inspectMask, int modifyMask) {
-    int sanitizedInspectMask = sanitizeWiredInspectMask(inspectMask);
-    int sanitizedModifyMask = sanitizeWiredModifyMask(modifyMask);
-    sanitizedInspectMask |= sanitizedModifyMask;
-
-    synchronized (this.wiredSettingsLock) {
-      final int finalInspectMask = sanitizedInspectMask;
-      final int finalModifyMask = sanitizedModifyMask;
-      final int finalId = this.id;
-      final int previousInspectMask = this.wiredInspectMask;
-      final int previousModifyMask = this.wiredModifyMask;
-
-      this.wiredInspectMask = sanitizedInspectMask;
-      this.wiredModifyMask = sanitizedModifyMask;
-      this.wiredSettingsLoaded = true;
-
-      Emulator.getThreading().run(() -> {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement(
-                     "INSERT INTO room_wired_settings (room_id, inspect_mask, modify_mask) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE inspect_mask = VALUES(inspect_mask), modify_mask = VALUES(modify_mask)")) {
-          statement.setInt(1, finalId);
-          statement.setInt(2, finalInspectMask);
-          statement.setInt(3, finalModifyMask);
-          statement.executeUpdate();
+    Room(ResultSet set, RoomDependencies dependencies) throws SQLException {
+        this.cache = new HashMap<>(1000);
+        this.dependencies = Objects.requireNonNull(dependencies, "dependencies");
+        this.lifecycle = new RoomLifecycle(new RoomCycleTaskSlot());
+        this.itemPersistence = new RoomItemPersistence(this.dependencies.database());
+        this.persistence = new RoomPersistence(this.dependencies.database());
+        this.repository = new RoomRepository(this.dependencies.database());
+        RoomSnapshot.Initial initial = RoomSnapshot.readInitial(set);
+        this.id = initial.id();
+        this.ownerId = initial.ownerId();
+        this.userCountPersistence = this.createUserCountPersistence();
+        this.ownerName = initial.ownerName();
+        this.name = initial.name();
+        this.description = initial.description();
+        this.password = initial.password();
+        this.state = initial.state();
+        this.usersMax = initial.usersMax();
+        this.score = initial.score();
+        this.category = initial.category();
+        this.floorPaint = initial.floorPaint();
+        this.wallPaint = initial.wallPaint();
+        this.backgroundPaint = initial.backgroundPaint();
+        this.wallSize = initial.wallSize();
+        this.wallHeight = initial.wallHeight();
+        this.floorSize = initial.floorSize();
+        this.tags = initial.tags();
+        this.publicRoom = initial.publicRoom();
+        this.staffPromotedRoom = initial.staffPromotedRoom();
+        this.allowPets = initial.allowPets();
+        this.allowPetsEat = initial.allowPetsEat();
+        this.allowWalkthrough = initial.allowWalkthrough();
+        this.hideWall = initial.hideWall();
+        this.youtubeEnabled = initial.youtubeEnabled();
+        this.soundboardEnabled = initial.soundboardEnabled();
+        this.chatMode = initial.chatMode();
+        this.chatWeight = initial.chatWeight();
+        this.chatSpeed = initial.chatSpeed();
+        this.chatDistance = initial.chatDistance();
+        this.chatProtection = initial.chatProtection();
+        this.muteOption = initial.muteOption();
+        this.kickOption = initial.kickOption();
+        this.banOption = initial.banOption();
+        this.pollId = initial.pollId();
+        this.guild = initial.guild();
+        this.rollerSpeed = initial.rollerSpeed();
+        this.overrideModel = initial.overrideModel();
+        this.layoutName = initial.layoutName();
+        this.promoted = initial.promoted();
+        this.jukeboxActive = initial.jukeboxActive();
+        this.hideWired = initial.hideWired();
+        this.buildersClubTrialLocked = initial.buildersClubTrialLocked();
+        this.buildersClubOriginalState = initial.buildersClubOriginalState();
+
+        this.bannedHabbos = new Int2ObjectOpenHashMap<>();
+
+        try (Connection connection = this.dependencies.database().openConnection()) {
+            // Load bans eagerly (needed for entry check before loadData)
+            this.loadBans(connection);
         } catch (SQLException e) {
-          synchronized (this.wiredSettingsLock) {
-            if (this.wiredInspectMask == finalInspectMask && this.wiredModifyMask == finalModifyMask) {
-              this.wiredInspectMask = previousInspectMask;
-              this.wiredModifyMask = previousModifyMask;
+            LOGGER.error("Caught SQL exception", e);
+        }
+
+        RoomSnapshot snapshot = RoomSnapshot.complete(initial, set);
+        this.tradeMode = snapshot.postBanLoad().tradeMode();
+        this.moveDiagonally = snapshot.postBanLoad().moveDiagonally();
+        this.allowUnderpass = snapshot.postBanLoad().allowUnderpass();
+
+        this.allowBotsWalk = true;
+        this.allowEffects = true;
+        this.moodlightData = new Int2ObjectOpenHashMap<>(defaultMoodData);
+
+        for (String s : snapshot.postBanLoad().moodlightData().split(";")) {
+            RoomMoodlightData data = RoomMoodlightData.fromString(s);
+            this.moodlightData.put(data.getId(), data);
+        }
+
+        this.mutedHabbos = new Int2IntOpenHashMap();
+        this.games = ConcurrentHashMap.newKeySet();
+
+        this.rights = new IntArrayList();
+        this.userVotes = new ArrayList<>();
+
+        // Initialize managers
+        this.initializeManagers();
+        this.loader = this.createLoader();
+    }
+
+    /**
+     * Initializes all manager instances for this room.
+     */
+    private void initializeManagers() {
+        this.initializeManagers(new RoomChatManager(this));
+    }
+
+    private void initializeManagers(RoomChatManager chatManager) {
+        this.tileManager = new RoomTileManager(this);
+        this.gameManager = new RoomGameManager(this);
+        this.tradeManager = new RoomTradeManager(this);
+        this.promotionManager = new RoomPromotionManager(this);
+        this.wordQuizManager = new RoomWordQuizManager(this);
+        this.rightsManager = new RoomRightsManager(this);
+        this.unitManager = new RoomUnitManager(this);
+        this.itemManager = new RoomItemManager(this);
+        this.chatManager = chatManager;
+        this.rollerManager = new RoomRollerManager(this);
+        this.messagingManager = new RoomMessagingManager(this);
+        this.cycleManager = new RoomCycleManager(this);
+        this.userVariableManager = new RoomUserVariableManager(this);
+        this.furniVariableManager = new RoomFurniVariableManager(this);
+        this.roomVariableManager = new RoomVariableManager(this);
+    }
+
+    // ==================== MANAGER GETTERS ====================
+
+    /**
+     * Gets the tile manager for this room.
+     */
+    public RoomTileManager getTileManager() {
+        return this.tileManager;
+    }
+
+    /**
+     * Gets the game manager for this room.
+     */
+    public RoomGameManager getGameManager() {
+        return this.gameManager;
+    }
+
+    /**
+     * Gets the trade manager for this room.
+     */
+    public RoomTradeManager getTradeManager() {
+        return this.tradeManager;
+    }
+
+    /**
+     * Gets the promotion manager for this room.
+     */
+    public RoomPromotionManager getPromotionManager() {
+        return this.promotionManager;
+    }
+
+    /**
+     * Gets the word quiz manager for this room.
+     */
+    public RoomWordQuizManager getWordQuizManager() {
+        return this.wordQuizManager;
+    }
+
+    /**
+     * Gets the rights manager for this room.
+     */
+    public RoomRightsManager getRightsManager() {
+        return this.rightsManager;
+    }
+
+    /**
+     * Gets the unit manager for this room.
+     */
+    public RoomUnitManager getUnitManager() {
+        return this.unitManager;
+    }
+
+    /**
+     * Gets the item manager for this room.
+     */
+    public RoomItemManager getItemManager() {
+        return this.itemManager;
+    }
+
+    /**
+     * Gets the chat manager for this room.
+     */
+    public RoomChatManager getChatManager() {
+        return this.chatManager;
+    }
+
+    /**
+     * Gets the messaging manager for this room.
+     */
+    public RoomMessagingManager getMessagingManager() {
+        return this.messagingManager;
+    }
+
+    /**
+     * Gets the cycle manager for this room.
+     */
+    public RoomCycleManager getCycleManager() {
+        return this.cycleManager;
+    }
+
+    public RoomUserVariableManager getUserVariableManager() {
+        return this.userVariableManager;
+    }
+
+    public RoomFurniVariableManager getFurniVariableManager() {
+        return this.furniVariableManager;
+    }
+
+    public RoomVariableManager getRoomVariableManager() {
+        return this.roomVariableManager;
+    }
+
+    /**
+     * Gets the roller manager for this room.
+     */
+    public RoomRollerManager getRollerManager() {
+        return this.rollerManager;
+    }
+
+    /**
+     * Checks if the room is currently loading data.
+     */
+    public boolean isLoadingInProgress() {
+        return this.lifecycle.isLoading();
+    }
+
+    /**
+     * Checks if the room data is loaded or is currently being loaded.
+     */
+    public boolean isLoadedOrLoading() {
+        return this.lifecycle.isLoadedOrLoading();
+    }
+
+    long beginLoadTransition() {
+        return this.lifecycle.beginLoad();
+    }
+
+    boolean publishLoadTransition(long generation, Supplier<ScheduledFuture<?>> cycleScheduler) {
+        return this.lifecycle.publishLoad(generation, cycleScheduler);
+    }
+
+    boolean beginUnloadTransition() {
+        return this.lifecycle.beginUnload();
+    }
+
+    void finishUnloadTransition() {
+        this.lifecycle.finishUnload();
+    }
+
+    void quiesceCycleTask() {
+        synchronized (this) {
+            this.lifecycle.quiesceCycle();
+        }
+    }
+
+    void resetIdleCycles() {
+        this.lifecycle.resetIdleCycles();
+    }
+
+    boolean advanceIdleUnload(boolean empty) {
+        return this.lifecycle.advanceIdleUnload(empty);
+    }
+
+    private void failLoadTransition(long generation) {
+        this.lifecycle.failLoad(generation);
+    }
+
+    /**
+     * Starts loading room data asynchronously in the background.
+     * This allows the room to start loading before the user fully enters,
+     * reducing perceived load time.
+     */
+    public void startBackgroundLoad() {
+        this.lifecycle.startBackgroundLoad(LOAD_COORDINATOR, this::loadDataInternal);
+    }
+
+    /**
+     * Waits for background loading to complete if it's in progress.
+     * If loading hasn't started yet, starts loading synchronously.
+     */
+    public void waitForLoad() {
+        if (this.lifecycle.isLoaded()) {
+            return;
+        }
+        CompletableFuture<Void> future = this.lifecycle.loadingFuture();
+
+        if (future != null) {
+            try {
+                future.join();
+            } catch (Exception e) {
+                LOGGER.error("Error waiting for room load", e);
             }
-          }
-          LOGGER.error("Caught SQL exception while saving wired room settings", e);
+        } else {
+            this.loadData();
         }
-      });
-
-      this.pushWiredSettingsToCurrentHabbos();
-      return true;
-    }
-  }
-
-  public void giveRights(Habbo habbo) {
-    if (habbo == null) {
-      return;
     }
 
-    this.giveRights(habbo.getHabboInfo().getId());
-  }
+    public void loadData() {
+        RoomLifecycle.LoadAttempt attempt = this.lifecycle.beginOrJoinLoad();
+        CompletableFuture<Void> futureToWait = attempt.future();
 
-  public void giveRights(int userId) {
-    this.rightsManager.giveRights(userId);
-
-    if (!this.rights.contains(userId)) {
-      this.rights.add(userId);
-    }
-
-    this.pushWiredSettingsToCurrentHabbos();
-  }
-
-  public void removeRights(int userId) {
-    this.rightsManager.removeRights(userId);
-    this.rights.rem(userId);
-    this.pushWiredSettingsToCurrentHabbos();
-  }
-
-  public void removeAllRights() {
-    this.rightsManager.removeAllRights();
-    this.rights.clear();
-    this.pushWiredSettingsToCurrentHabbos();
-  }
-
-  void refreshRightsInRoom() {
-    this.rightsManager.refreshRightsInRoom();
-  }
-
-  public void refreshRightsForHabbo(Habbo habbo) {
-    this.rightsManager.refreshRightsForHabbo(habbo);
-  }
-
-  public Map<Integer, String> getUsersWithRights() {
-    return this.rightsManager.getUsersWithRights();
-  }
-
-  public void unbanHabbo(int userId) {
-    this.rightsManager.unbanHabbo(userId);
-  }
-
-  public boolean isBanned(Habbo habbo) {
-    return this.rightsManager.isBanned(habbo);
-  }
-
-  public Int2ObjectMap<RoomBan> getBannedHabbos() {
-    return this.bannedHabbos;
-  }
-
-  private void ensureWiredSettingsLoaded() {
-    if (this.wiredSettingsLoaded) {
-      return;
-    }
-
-    synchronized (this.wiredSettingsLock) {
-      if (this.wiredSettingsLoaded) {
-        return;
-      }
-
-      this.wiredInspectMask = WIRED_ACCESS_DEFAULT_INSPECT_MASK;
-      this.wiredModifyMask = WIRED_ACCESS_DEFAULT_MODIFY_MASK;
-
-      try {
-        RoomRepository.WiredSettings settings =
-            this.repository.findWiredSettings(this.id);
-        this.wiredInspectMask =
-            sanitizeWiredInspectMask(settings.inspectMask());
-        this.wiredModifyMask =
-            sanitizeWiredModifyMask(settings.modifyMask());
-      } catch (SQLException e) {
-        LOGGER.error("Caught SQL exception while loading wired room settings", e);
-      }
-
-      this.wiredSettingsLoaded = true;
-    }
-  }
-
-  private boolean matchesWiredAccessMask(Habbo habbo, int mask, boolean allowEveryone) {
-    if (habbo == null) {
-      return false;
-    }
-
-    if (allowEveryone && hasWiredAccess(mask, WIRED_ACCESS_EVERYONE)) {
-      return true;
-    }
-
-    if (hasWiredAccess(mask, WIRED_ACCESS_USERS_WITH_RIGHTS) && this.hasExplicitRights(habbo)) {
-      return true;
-    }
-
-    if (hasWiredAccess(mask, WIRED_ACCESS_GROUP_ADMINS) && this.isRoomGroupAdmin(habbo)) {
-      return true;
-    }
-
-    return hasWiredAccess(mask, WIRED_ACCESS_GROUP_MEMBERS) && this.isRoomGroupMember(habbo);
-  }
-
-  private boolean isRoomGroupMember(Habbo habbo) {
-    return habbo != null && this.guild > 0 && habbo.getHabboStats().hasGuild(this.guild);
-  }
-
-  private boolean isRoomGroupAdmin(Habbo habbo) {
-    if (!this.isRoomGroupMember(habbo)) {
-      return false;
-    }
-
-    GuildMember member = Emulator.getGameEnvironment().getGuildManager().getGuildMember(this.guild, habbo.getHabboInfo().getId());
-
-    if (member == null) {
-      return false;
-    }
-
-    GuildRank rank = member.getRank();
-    return rank == GuildRank.OWNER || rank == GuildRank.ADMIN;
-  }
-
-  private static boolean hasWiredAccess(int mask, int permissionMask) {
-    return (mask & permissionMask) != 0;
-  }
-
-  private static int sanitizeWiredInspectMask(int mask) {
-    int sanitizedMask = mask & WIRED_ACCESS_ALLOWED_INSPECT_MASK;
-
-    if (hasWiredAccess(sanitizedMask, WIRED_ACCESS_GROUP_MEMBERS)) {
-      sanitizedMask |= WIRED_ACCESS_GROUP_ADMINS;
-    }
-
-    return sanitizedMask;
-  }
-
-  private static int sanitizeWiredModifyMask(int mask) {
-    int sanitizedMask = mask & WIRED_ACCESS_ALLOWED_MODIFY_MASK;
-
-    if (hasWiredAccess(sanitizedMask, WIRED_ACCESS_GROUP_MEMBERS)) {
-      sanitizedMask |= WIRED_ACCESS_GROUP_ADMINS;
-    }
-
-    return sanitizedMask;
-  }
-
-  private void pushWiredSettingsToCurrentHabbos() {
-    for (Habbo currentHabbo : this.getCurrentHabbos().values()) {
-      if (currentHabbo == null || currentHabbo.getClient() == null) {
-        continue;
-      }
-
-      currentHabbo.getClient().sendResponse(new WiredRoomSettingsDataComposer(this, currentHabbo));
-    }
-  }
-
-  public void addRoomBan(RoomBan roomBan) {
-    this.rightsManager.addRoomBan(roomBan);
-  }
-
-  public void makeSit(Habbo habbo) {
-    if (habbo.getRoomUnit() == null) {
-      return;
-    }
-
-    if (habbo.getRoomUnit().hasStatus(RoomUnitStatus.SIT) || !habbo.getRoomUnit()
-            .canForcePosture()) {
-      return;
-    }
-
-    this.dance(habbo, DanceType.NONE);
-    habbo.getRoomUnit().cmdSit = true;
-    habbo.getRoomUnit().setBodyRotation(
-            RoomUserRotation.values()[habbo.getRoomUnit().getBodyRotation().getValue()
-                    - habbo.getRoomUnit().getBodyRotation().getValue() % 2]);
-    habbo.getRoomUnit().setStatus(RoomUnitStatus.SIT, 0.5 + "");
-    this.sendComposer(new RoomUserStatusComposer(habbo.getRoomUnit()).compose());
-    WiredManager.triggerUserPerformsAction(this, habbo.getRoomUnit(), WiredUserActionType.SIT, -1);
-  }
-
-  public void makeStand(Habbo habbo) {
-    if (habbo.getRoomUnit() == null) {
-      return;
-    }
-
-    HabboItem item = this.getTopItemAt(habbo.getRoomUnit().getX(), habbo.getRoomUnit().getY());
-    if (item == null || !item.getBaseItem().allowSit() || !item.getBaseItem().allowLay()) {
-      boolean wasSittingOrLaying = habbo.getRoomUnit().hasStatus(RoomUnitStatus.SIT)
-              || habbo.getRoomUnit().hasStatus(RoomUnitStatus.LAY);
-      habbo.getRoomUnit().cmdStand = true;
-      habbo.getRoomUnit().setBodyRotation(
-              RoomUserRotation.values()[habbo.getRoomUnit().getBodyRotation().getValue()
-                      - habbo.getRoomUnit().getBodyRotation().getValue() % 2]);
-      habbo.getRoomUnit().removeStatus(RoomUnitStatus.SIT);
-      habbo.getRoomUnit().removeStatus(RoomUnitStatus.LAY);
-      this.sendComposer(new RoomUserStatusComposer(habbo.getRoomUnit()).compose());
-
-      if (wasSittingOrLaying) {
-        WiredManager.triggerUserPerformsAction(this, habbo.getRoomUnit(), WiredUserActionType.STAND, -1);
-      }
-    }
-  }
-
-  public void giveEffect(Habbo habbo, int effectId, int duration) {
-    this.unitManager.giveEffect(habbo, effectId, duration);
-  }
-
-  public void giveEffect(RoomUnit roomUnit, int effectId, int duration) {
-    this.unitManager.giveEffect(roomUnit, effectId, duration);
-  }
-
-  public void giveHandItem(Habbo habbo, int handItem) {
-    this.unitManager.giveHandItem(habbo, handItem);
-  }
-
-  public void giveHandItem(RoomUnit roomUnit, int handItem) {
-    this.unitManager.giveHandItem(roomUnit, handItem);
-  }
-
-  public void updateItem(HabboItem item) {
-    this.itemManager.updateItem(item);
-  }
-
-  public void updateItemState(HabboItem item) {
-    this.itemManager.updateItemState(item);
-  }
-
-  public int getUserFurniCount(int userId) {
-    return this.itemManager.getFurniOwnerCount().get(userId);
-  }
-
-  public int getUserUniqueFurniCount(int userId) {
-    return this.itemManager.getUserUniqueFurniCount(userId);
-  }
-
-  public void ejectUserFurni(int userId) {
-    this.itemManager.ejectUserFurni(userId);
-  }
-
-  public void ejectUserItem(HabboItem item) {
-    this.itemManager.ejectUserItem(item);
-  }
-
-
-  public void ejectAll() {
-    this.itemManager.ejectAll();
-  }
-
-
-  public void ejectAll(Habbo habbo) {
-    this.itemManager.ejectAll(habbo);
-  }
-
-  public void refreshGuild(Guild guild) {
-    if (guild.getRoomId() == this.id) {
-      Set<GuildMember> members = Emulator.getGameEnvironment().getGuildManager()
-              .getGuildMembers(guild.getId());
-
-      for (Habbo habbo : this.getHabbos()) {
-        Optional<GuildMember> member = members.stream()
-                .filter(m -> m.getUserId() == habbo.getHabboInfo().getId()).findAny();
-
-        if (!member.isPresent()) {
-          continue;
+        // Wait for existing load outside the lock
+        if (futureToWait != null) {
+            try {
+                futureToWait.join();
+            } catch (Exception e) {
+                LOGGER.error("Error waiting for room load", e);
+            }
+            return;
         }
 
-        habbo.getClient()
-                .sendResponse(new GuildInfoComposer(guild, habbo.getClient(), false, member.get()));
-      }
-    }
-
-    this.refreshGuildRightsInRoom();
-  }
-
-  public void refreshGuildColors(Guild guild) {
-    if (guild.getRoomId() == this.id) {
-      Int2ObjectMap<HabboItem> items = this.itemManager.getRoomItems();
-      synchronized (items) {
-      for (HabboItem habboItem : items.values()) {
-        if (habboItem instanceof InteractionGuildFurni) {
-          if (((InteractionGuildFurni) habboItem).getGuildId() == guild.getId()) {
-            this.updateItem(habboItem);
-          }
+        // Load if needed
+        if (attempt.generation() >= 0L) {
+            this.loadDataInternal(attempt.generation());
         }
-      }
-      }
     }
-  }
 
-  public void refreshGuildRightsInRoom() {
-    for (Habbo habbo : this.getHabbos()) {
-      if (habbo.getHabboInfo().getCurrentRoom() == this) {
-        if (habbo.getHabboInfo().getId() != this.ownerId) {
-          if (!(habbo.hasPermission(Permission.ACC_ANYROOMOWNER) || habbo.hasPermission(
-                  Permission.ACC_MOVEROTATE))) {
-            this.refreshRightsForHabbo(habbo);
-          }
+    /**
+     * Internal method that performs the actual room data loading.
+     * Uses parallel loading for independent operations to reduce total load time.
+     */
+    private void loadDataInternal(long generation) {
+        try {
+            this.performLoadData(generation);
+        } catch (Exception exception) {
+            LOGGER.error("Caught exception during room load", exception);
+        } finally {
+            this.failLoadTransition(generation);
         }
-      }
     }
-  }
 
-  public void idle(Habbo habbo) {
-    this.unitManager.idle(habbo);
-  }
-
-  public void unIdle(Habbo habbo) {
-    this.unitManager.unIdle(habbo);
-  }
-
-  public void dance(Habbo habbo, DanceType danceType) {
-    this.unitManager.dance(habbo, danceType);
-  }
-
-  public void dance(RoomUnit unit, DanceType danceType) {
-    this.unitManager.dance(unit, danceType);
-  }
-
-  public void addToWordFilter(String word) {
-    this.chatManager.addToWordFilter(word);
-  }
-
-  public void removeFromWordFilter(String word) {
-    this.chatManager.removeFromWordFilter(word);
-  }
-
-  public void handleWordQuiz(Habbo habbo, String answer) {
-    this.wordQuizManager.handleWordQuiz(habbo, answer);
-  }
-
-  public void startWordQuiz(String question, int duration) {
-    this.wordQuizManager.startWordQuiz(question, duration);
-  }
-
-  public boolean hasActiveWordQuiz() {
-    return this.wordQuizManager.hasActiveWordQuiz();
-  }
-
-  public boolean hasVotedInWordQuiz(Habbo habbo) {
-    return this.wordQuizManager.hasVotedInWordQuiz(habbo);
-  }
-
-  public void alert(String message) {
-    this.messagingManager.alert(message);
-  }
-
-  public int itemCount() {
-    return this.itemManager.itemCount();
-  }
-
-  public void setJukeBoxActive(boolean jukeBoxActive) {
-    this.jukeboxActive = jukeBoxActive;
-    this.needsUpdate = true;
-  }
-
-  public boolean isHideWired() {
-    return this.hideWired;
-  }
-
-  public void setHideWired(boolean hideWired) {
-    this.hideWired = hideWired;
-
-    if (this.hideWired) {
-      for (HabboItem item : this.roomSpecialTypes.getTriggers()) {
-        this.sendComposer(new RemoveFloorItemComposer(item).compose());
-      }
-
-      for (HabboItem item : this.roomSpecialTypes.getEffects()) {
-        this.sendComposer(new RemoveFloorItemComposer(item).compose());
-      }
-
-      for (HabboItem item : this.roomSpecialTypes.getConditions()) {
-        this.sendComposer(new RemoveFloorItemComposer(item).compose());
-      }
-
-      for (HabboItem item : this.roomSpecialTypes.getExtras()) {
-        this.sendComposer(new RemoveFloorItemComposer(item).compose());
-      }
-    } else {
-      this.sendComposer(new RoomFloorItemsComposer(this.itemManager.getFurniOwnerNames(),
-              this.roomSpecialTypes.getTriggers()).compose());
-      this.sendComposer(new RoomFloorItemsComposer(this.itemManager.getFurniOwnerNames(),
-              this.roomSpecialTypes.getEffects()).compose());
-      this.sendComposer(new RoomFloorItemsComposer(this.itemManager.getFurniOwnerNames(),
-              this.roomSpecialTypes.getConditions()).compose());
-      this.sendComposer(new RoomFloorItemsComposer(this.itemManager.getFurniOwnerNames(),
-              this.roomSpecialTypes.getExtras()).compose());
+    private void performLoadData(long generation) {
+        this.loader.load(generation);
     }
-  }
 
-  public FurnitureMovementError canPlaceFurnitureAt(HabboItem item, Habbo habbo, RoomTile tile,
-                                                    int rotation) {
-    return this.itemManager.canPlaceFurnitureAt(item, habbo, tile, rotation);
-  }
-
-  public FurnitureMovementError furnitureFitsAt(RoomTile tile, HabboItem item, int rotation) {
-    return this.itemManager.furnitureFitsAt(tile, item, rotation);
-  }
-
-  public FurnitureMovementError furnitureFitsAt(RoomTile tile, HabboItem item, int rotation,
-                                                boolean checkForUnits) {
-    return this.itemManager.furnitureFitsAt(tile, item, rotation, checkForUnits);
-  }
-
-  public FurnitureMovementError furnitureFitsAtWithPhysics(RoomTile tile, HabboItem item, int rotation,
-                                                           boolean checkForUnits, WiredMovementPhysics physics) {
-    return this.itemManager.furnitureFitsAtWithPhysics(tile, item, rotation, checkForUnits, physics);
-  }
-
-  public FurnitureMovementError placeFloorFurniAt(HabboItem item, RoomTile tile, int rotation,
-                                                  Habbo owner) {
-    return this.itemManager.placeFloorFurniAt(item, tile, rotation, owner);
-  }
-
-  public FurnitureMovementError placeWallFurniAt(HabboItem item, String wallPosition, Habbo owner) {
-    return this.itemManager.placeWallFurniAt(item, wallPosition, owner);
-  }
-
-  public FurnitureMovementError moveFurniTo(HabboItem item, RoomTile tile, int rotation,
-                                            Habbo actor) {
-    return this.itemManager.moveFurniTo(item, tile, rotation, actor);
-  }
-
-  public FurnitureMovementError moveFurniTo(HabboItem item, RoomTile tile, int rotation,
-                                            Habbo actor, boolean sendUpdates) {
-    return this.itemManager.moveFurniTo(item, tile, rotation, actor, sendUpdates);
-  }
-
-  public FurnitureMovementError moveFurniTo(HabboItem item, RoomTile tile, int rotation,
-                                            Habbo actor, boolean sendUpdates, boolean checkForUnits) {
-    return this.itemManager.moveFurniTo(item, tile, rotation, actor, sendUpdates, checkForUnits);
-  }
-
-  public FurnitureMovementError moveFurniTo(HabboItem item, RoomTile tile, int rotation, double z, Habbo actor) {
-    return this.itemManager.moveFurniTo(item, tile, rotation, z, actor, true, true);
-  }
-
-  public FurnitureMovementError moveFurniTo(HabboItem item, RoomTile tile, int rotation, double z, Habbo actor, boolean sendUpdates) {
-    return this.itemManager.moveFurniTo(item, tile, rotation, z, actor, sendUpdates, true);
-  }
-
-  public FurnitureMovementError moveFurniTo(HabboItem item, RoomTile tile, int rotation, double z, Habbo actor, boolean sendUpdates, boolean checkForUnits) {
-    return this.itemManager.moveFurniTo(item, tile, rotation, z, actor, sendUpdates, checkForUnits);
-  }
-
-  public FurnitureMovementError moveFurniToWithPhysics(HabboItem item, RoomTile tile, int rotation,
-                                                       Habbo actor, boolean sendUpdates, boolean checkForUnits, WiredMovementPhysics physics) {
-    return this.itemManager.moveFurniToWithPhysics(item, tile, rotation, actor, sendUpdates, checkForUnits, physics);
-  }
-
-  public FurnitureMovementError moveFurniToWithPhysics(HabboItem item, RoomTile tile, int rotation, double z,
-                                                       Habbo actor, boolean sendUpdates, boolean checkForUnits, WiredMovementPhysics physics) {
-    return this.itemManager.moveFurniToWithPhysics(item, tile, rotation, z, actor, sendUpdates, checkForUnits, physics);
-  }
-
-  public FurnitureMovementError slideFurniTo(HabboItem item, RoomTile tile, int rotation) {
-    return this.itemManager.slideFurniTo(item, tile, rotation);
-  }
-
-
-
-  public Set<RoomUnit> getRoomUnits() {
-    return this.unitManager.getRoomUnits();
-  }
-
-  public Set<RoomUnit> getRoomUnits(RoomTile atTile) {
-    return this.unitManager.getRoomUnits(atTile);
-  }
-
-  public Collection<RoomUnit> getRoomUnitsAt(RoomTile tile) {
-    return this.unitManager.getRoomUnitsAt(tile);
-  }
-
-  public long getEstimatedMemoryUsage() {
-    long bytes = 1024 * 10; // Base footprint
-    if (this.itemManager != null) {
-      bytes += this.itemManager.itemCount() * 512L;
+    private RoomLoader createLoader() {
+        return new RoomLoader(
+                new RoomLoadOperations(), () -> Emulator.getThreading().getService());
     }
-    bytes += this.getUserCount() * 2048L;
-    if (this.layout != null) {
-      bytes += this.layout.getMapSize() * 128L;
+
+    private final class RoomCycleTaskSlot implements RoomLifecycle.CycleTaskSlot {
+
+        @Override
+        public ScheduledFuture<?> get() {
+            return Room.this.roomCycleTask;
+        }
+
+        @Override
+        public void set(ScheduledFuture<?> task) {
+            Room.this.roomCycleTask = task;
+        }
     }
-    com.eu.habbo.habbohotel.wired.tick.WiredTickService wired = com.eu.habbo.habbohotel.wired.tick.WiredTickService.getInstance();
-    if (wired != null) {
-      bytes += wired.getTickableCount(this.getId()) * 256L;
+
+    private final class RoomLoadOperations implements RoomLoader.Operations {
+
+        @Override
+        public int roomId() {
+            return Room.this.id;
+        }
+
+        @Override
+        public boolean prepare(long generation) {
+            return Room.this.lifecycle.prepareLoad(generation);
+        }
+
+        @Override
+        public void initialize() {
+            synchronized (Room.this.roomUnitLock) {
+                Room.this.unitManager.clear();
+            }
+            Room.this.roomSpecialTypes = new RoomSpecialTypes();
+        }
+
+        @Override
+        public void loadLayout() {
+            try {
+                Room.this.loadLayout();
+            } catch (Exception exception) {
+                LOGGER.error("Caught exception loading layout", exception);
+            }
+        }
+
+        @Override
+        public boolean shouldLoadPromotion() {
+            return Room.this.promoted;
+        }
+
+        @Override
+        public void loadPromotion() {
+            try (Connection connection = Room.this.dependencies.database().openConnection()) {
+                Room.this.promotionManager.loadPromotion(true, connection);
+                Room.this.promotion = Room.this.promotionManager.getPromotion();
+                Room.this.promoted = Room.this.promotionManager.getPromotedFlag();
+            } catch (Exception exception) {
+                LOGGER.error("Caught exception loading promotion", exception);
+            }
+        }
+
+        @Override
+        public void loadItems() {
+            withConnection("Caught exception loading items", Room.this::loadItems);
+        }
+
+        @Override
+        public void loadRights() {
+            withConnection("Caught exception loading rights", Room.this::loadRights);
+        }
+
+        @Override
+        public void loadWordFilter() {
+            withConnection("Caught exception loading word filter", Room.this::loadWordFilter);
+        }
+
+        @Override
+        public void loadBots() {
+            withConnection("Caught exception loading bots", Room.this::loadBots);
+        }
+
+        @Override
+        public void loadPets() {
+            withConnection("Caught exception loading pets", Room.this::loadPets);
+        }
+
+        @Override
+        public void loadHeightmap() {
+            try {
+                Room.this.loadHeightmap();
+            } catch (Exception exception) {
+                LOGGER.error("Caught exception loading heightmap", exception);
+            }
+        }
+
+        @Override
+        public void loadWiredData() {
+            withConnection("Caught exception loading wired data", Room.this::loadWiredData);
+        }
+
+        @Override
+        public void resetIdleCycles() {
+            Room.this.cycleManager.resetIdleCycles();
+        }
+
+        @Override
+        public boolean finish(long generation) {
+            Room.this.traxManager = new TraxManager(Room.this, Room.this.dependencies.database());
+
+            if (Room.this.jukeboxActive) {
+                Room.this.traxManager.play(0);
+                for (HabboItem item : Room.this.roomSpecialTypes.getItemsOfType(InteractionJukeBox.class)) {
+                    item.setExtradata("1");
+                    Room.this.updateItem(item);
+                }
+            }
+
+            for (HabboItem item : Room.this.roomSpecialTypes.getItemsOfType(InteractionFireworks.class)) {
+                item.setExtradata("1");
+                Room.this.updateItem(item);
+            }
+
+            synchronized (Room.this) {
+                try {
+                    if (Room.this.publishLoadTransition(
+                            generation,
+                            () -> Emulator.getThreading()
+                                    .getService()
+                                    .scheduleAtFixedRate(Room.this, 500, 500, TimeUnit.MILLISECONDS))) {
+                        Emulator.getPluginManager().fireEvent(new RoomLoadedEvent(Room.this));
+                        return true;
+                    }
+                } catch (Exception exception) {
+                    Room.this.failLoadTransition(generation);
+                    LOGGER.error("Caught exception publishing room load", exception);
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void reportFailure(String message, Exception exception) {
+            LOGGER.error(message, exception);
+        }
+
+        private void withConnection(String failureMessage, LoadWithConnection operation) {
+            try (Connection connection = Room.this.dependencies.database().openConnection()) {
+                operation.load(connection);
+            } catch (Exception exception) {
+                LOGGER.error(failureMessage, exception);
+            }
+        }
     }
-    return bytes;
-  }
+
+    @FunctionalInterface
+    private interface LoadWithConnection {
+        void load(Connection connection);
+    }
+
+    private synchronized void loadLayout() {
+        if (this.layout == null) {
+            if (this.overrideModel) {
+                this.layout = Emulator.getGameEnvironment().getRoomManager().loadCustomLayout(this);
+            } else {
+                this.layout = Emulator.getGameEnvironment().getRoomManager().loadLayout(this.layoutName, this);
+            }
+        }
+    }
+
+    private synchronized void loadHeightmap() {
+        if (this.layout != null) {
+            for (short x = 0; x < this.layout.getMapSizeX(); x++) {
+                for (short y = 0; y < this.layout.getMapSizeY(); y++) {
+                    RoomTile tile = this.layout.getTile(x, y);
+                    if (tile != null) {
+                        this.updateTile(tile);
+                    }
+                }
+            }
+        } else {
+            LOGGER.error("Unknown Room Layout for Room (ID: {})", this.id);
+        }
+    }
+
+    private synchronized void loadItems(Connection connection) {
+        this.itemManager.loadItems(connection);
+    }
+
+    private synchronized void loadWiredData(Connection connection) {
+        this.itemManager.loadWiredData(connection);
+    }
+
+    private synchronized void loadBots(Connection connection) {
+        this.unitManager.clearBots();
+
+        try (PreparedStatement statement = connection.prepareStatement(
+                "SELECT users.username AS owner_name, bots.* FROM bots INNER JOIN users ON bots.user_id = users.id WHERE room_id = ?")) {
+            statement.setInt(1, this.id);
+            try (ResultSet set = statement.executeQuery()) {
+                while (set.next()) {
+                    Bot b = Emulator.getGameEnvironment().getBotManager().loadBot(set);
+
+                    if (b != null) {
+                        b.setRoom(this);
+                        b.setRoomUnit(new RoomUnit());
+                        b.getRoomUnit().setPathFinderRoom(this);
+                        b.getRoomUnit()
+                                .setLocation(this.layout.getTile((short) set.getInt("x"), (short) set.getInt("y")));
+                        if (b.getRoomUnit().getCurrentLocation() == null) {
+                            b.getRoomUnit().setLocation(this.getLayout().getDoorTile());
+                            b.getRoomUnit()
+                                    .setRotation(RoomUserRotation.fromValue(
+                                            this.getLayout().getDoorDirection()));
+                        } else {
+                            b.getRoomUnit().setZ(set.getDouble("z"));
+                            b.getRoomUnit().setPreviousLocationZ(set.getDouble("z"));
+                            b.getRoomUnit().setRotation(RoomUserRotation.values()[set.getInt("rot")]);
+                        }
+                        b.getRoomUnit().setRoomUnitType(RoomUnitType.BOT);
+                        b.getRoomUnit().setDanceType(DanceType.values()[set.getInt("dance")]);
+                        // b.getRoomUnit().setCanWalk(set.getBoolean("freeroam"));
+                        b.getRoomUnit().setInRoom(true);
+                        this.giveEffect(b.getRoomUnit(), set.getInt("effect"), Integer.MAX_VALUE);
+                        this.addBot(b);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+    }
+
+    private synchronized void loadPets(Connection connection) {
+        this.unitManager.clearPets();
+
+        try (PreparedStatement statement = connection.prepareStatement(
+                "SELECT users.username as pet_owner_name, users_pets.* FROM users_pets INNER JOIN users ON users_pets.user_id = users.id WHERE room_id = ?")) {
+            statement.setInt(1, this.id);
+            try (ResultSet set = statement.executeQuery()) {
+                while (set.next()) {
+                    try {
+                        Pet pet = PetManager.loadPet(set);
+                        pet.setRoom(this);
+                        pet.setRoomUnit(new RoomUnit());
+                        pet.getRoomUnit().setPathFinderRoom(this);
+                        pet.getRoomUnit()
+                                .setLocation(this.layout.getTile((short) set.getInt("x"), (short) set.getInt("y")));
+                        if (pet.getRoomUnit().getCurrentLocation() == null) {
+                            pet.getRoomUnit().setLocation(this.getLayout().getDoorTile());
+                            pet.getRoomUnit()
+                                    .setRotation(RoomUserRotation.fromValue(
+                                            this.getLayout().getDoorDirection()));
+                        } else {
+                            pet.getRoomUnit().setZ(set.getDouble("z"));
+                            pet.getRoomUnit().setRotation(RoomUserRotation.values()[set.getInt("rot")]);
+                        }
+                        pet.getRoomUnit().setRoomUnitType(RoomUnitType.PET);
+                        pet.getRoomUnit().setCanWalk(true);
+                        this.addPet(pet);
+
+                        this.getFurniOwnerNames().put(pet.getUserId(), set.getString("pet_owner_name"));
+                    } catch (SQLException e) {
+                        LOGGER.error("Caught SQL exception", e);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+    }
+
+    private synchronized void loadWordFilter(Connection connection) {
+        this.chatManager.loadWordFilter(connection);
+    }
+
+    public void updateTile(RoomTile tile) {
+        this.tileManager.updateTile(tile);
+    }
+
+    public void updateTiles(Collection<RoomTile> tiles) {
+        this.tileManager.updateTiles(tiles);
+    }
+
+    public RoomTileState calculateTileState(RoomTile tile) {
+        return this.tileManager.calculateTileState(tile);
+    }
+
+    public RoomTileState calculateTileState(RoomTile tile, HabboItem exclude) {
+        return this.tileManager.calculateTileState(tile, exclude);
+    }
+
+    public boolean tileWalkable(RoomTile t) {
+        return this.tileManager.tileWalkable(t);
+    }
+
+    public boolean tileWalkable(short x, short y) {
+        return this.tileManager.tileWalkable(x, y);
+    }
+
+    public void pickUpItem(HabboItem item, Habbo picker) {
+        this.itemManager.pickUpItem(item, picker);
+    }
+
+    public void updateHabbosAt(Rectangle rectangle) {
+        for (short i = (short) rectangle.x; i < rectangle.x + rectangle.width; i++) {
+            for (short j = (short) rectangle.y; j < rectangle.y + rectangle.height; j++) {
+                this.updateHabbosAt(i, j);
+            }
+        }
+    }
+
+    public void updateHabbo(Habbo habbo) {
+        this.updateRoomUnit(habbo.getRoomUnit());
+    }
+
+    public void updateRoomUnit(RoomUnit roomUnit) {
+        HabboItem item = this.getTopItemAt(roomUnit.getX(), roomUnit.getY());
+
+        if ((item == null && !roomUnit.cmdSit)
+                || (item != null && !item.getBaseItem().allowSit())) {
+            roomUnit.removeStatus(RoomUnitStatus.SIT);
+        }
+
+        double oldZ = roomUnit.getZ();
+
+        if (item != null) {
+            if (item.getBaseItem().allowSit()) {
+                roomUnit.setZ(item.getZ());
+            } else {
+                roomUnit.setZ(item.getZ() + Item.getCurrentHeight(item));
+            }
+
+            if (oldZ != roomUnit.getZ()) {
+                this.scheduledTasks.add(() -> {
+                    try {
+                        item.onWalkOn(roomUnit, Room.this, null);
+                    } catch (Exception e) {
+
+                    }
+                });
+            }
+        }
+
+        this.sendComposer(new RoomUserStatusComposer(roomUnit).compose());
+    }
+
+    public void updateHabbosAt(short x, short y) {
+        this.unitManager.updateHabbosAt(x, y);
+    }
+
+    public void updateHabbosAt(short x, short y, Collection<Habbo> habbos) {
+        this.unitManager.updateHabbosAt(x, y, habbos);
+    }
+
+    public void updateBotsAt(short x, short y) {
+        this.unitManager.updateBotsAt(x, y);
+    }
+
+    public void updatePetsAt(short x, short y) {
+        this.unitManager.updatePetsAt(x, y);
+    }
+
+    public void pickupPetsForHabbo(Habbo habbo) {
+        this.unitManager.pickupPetsForHabbo(habbo);
+    }
+
+    public void startTrade(Habbo userOne, Habbo userTwo) {
+        this.tradeManager.startTrade(userOne, userTwo);
+    }
+
+    public void stopTrade(RoomTrade trade) {
+        this.tradeManager.stopTrade(trade);
+    }
+
+    public RoomTrade getActiveTradeForHabbo(Habbo user) {
+        return this.tradeManager.getActiveTradeForHabbo(user);
+    }
+
+    public synchronized void dispose() {
+        this.lifecycle.dispose(
+                this.preventUnloading,
+                () -> Emulator.getPluginManager()
+                        .fireEvent(new RoomUnloadingEvent(this))
+                        .isCancelled(),
+                this::disposeState,
+                () -> Emulator.getPluginManager().fireEvent(new RoomUnloadedEvent(this)));
+    }
+
+    private void disposeState(boolean wasLoaded) {
+        if (wasLoaded) {
+            try {
+                if (this.traxManager != null && !this.traxManager.disposed()) {
+                    this.traxManager.dispose();
+                }
+
+                this.scheduledTasks.clear();
+                this.scheduledComposers.clear();
+
+                synchronized (this.mutedHabbos) {
+                    this.mutedHabbos.clear();
+                }
+
+                for (InteractionGameTimer timer :
+                        this.getRoomSpecialTypes().getGameTimers().values()) {
+                    if (timer instanceof InteractionGameUpCounter) {
+                        ((InteractionGameUpCounter) timer).resetOnRoomUnload(this);
+                    } else {
+                        timer.setRunning(false);
+                    }
+                }
+
+                for (Game game : this.games) {
+                    game.dispose();
+                }
+                this.games.clear();
+
+                removeAllPets(ownerId);
+
+                this.itemManager.saveAllPendingItems();
+
+                // Unregister all wired tickables for this room from the tick service
+                com.eu.habbo.habbohotel.wired.core.WiredManager.unregisterRoomTickables(this);
+
+                if (this.roomSpecialTypes != null) {
+                    this.roomSpecialTypes.dispose();
+                }
+
+                // Clear wired engine caches for this room
+                if (com.eu.habbo.habbohotel.wired.core.WiredManager.getStackIndex() != null) {
+                    com.eu.habbo.habbohotel.wired.core.WiredManager.getStackIndex()
+                            .invalidateAll(this);
+                }
+                if (com.eu.habbo.habbohotel.wired.core.WiredManager.getEngine() != null) {
+                    com.eu.habbo.habbohotel.wired.core.WiredManager.getEngine().clearRoomRecursionDepth(this.id);
+                    com.eu.habbo.habbohotel.wired.core.WiredManager.getEngine().clearRoomRateLimiters(this.id);
+                    com.eu.habbo.habbohotel.wired.core.WiredManager.getEngine().clearRoomBan(this.id);
+                    com.eu.habbo.habbohotel.wired.core.WiredManager.getEngine().clearRoomDiagnostics(this.id);
+                }
+
+                this.itemManager.clear();
+
+                this.unitManager.clearQueue();
+
+                for (Habbo habbo : this.getCurrentHabbos().values()) {
+                    Emulator.getGameEnvironment().getRoomManager().leaveRoom(habbo, this);
+                }
+
+                this.sendComposer(new HotelViewComposer().compose());
+
+                // Save bots BEFORE clearing - must happen before unitManager.clear()
+                for (Bot bot : this.getCurrentBots().values()) {
+                    bot.needsUpdate(true);
+                    bot.run(); // Run synchronously to ensure DB is updated before room reload
+                }
+
+                // Save ALL remaining pets (including owner's pets) BEFORE clearing
+                for (Pet pet : this.getCurrentPets().values()) {
+                    pet.needsUpdate = true;
+                    pet.run(); // Run synchronously to ensure DB is updated before room reload
+                }
+
+                this.unitManager.clear();
+                this.unitManager.clearBots();
+                this.unitManager.clearPets();
+            } catch (Exception e) {
+                LOGGER.error("Caught exception", e);
+            }
+        }
+
+        try {
+            this.wordQuiz = "";
+            this.yesVotes = 0;
+            this.noVotes = 0;
+            this.updateDatabaseUserCount();
+            this.layout = null;
+        } catch (Exception e) {
+            LOGGER.error("Caught exception", e);
+        }
+    }
+
+    @Override
+    public int compareTo(Room o) {
+        if (o.getUserCount() != this.getUserCount()) {
+            return o.getCurrentHabbos().size() - this.getCurrentHabbos().size();
+        }
+
+        return this.id - o.id;
+    }
+
+    @Override
+    public void serialize(ServerMessage message) {
+        message.appendInt(this.id);
+        message.appendString(this.name);
+        if (this.isPublicRoom()) {
+            message.appendInt(0);
+            message.appendString("");
+        } else {
+            message.appendInt(this.ownerId);
+            message.appendString(this.ownerName);
+        }
+        message.appendInt(this.state.getState());
+        message.appendInt(this.getUserCount());
+        message.appendInt(this.usersMax);
+        message.appendString(this.description);
+        message.appendInt(0);
+        message.appendInt(this.score);
+        message.appendInt(0);
+        message.appendInt(this.category);
+
+        String[] tags =
+                Arrays.stream(this.tags.split(";")).filter(t -> !t.isEmpty()).toArray(String[]::new);
+        message.appendInt(tags.length);
+        for (String s : tags) {
+            message.appendString(s);
+        }
+
+        int base = 0;
+
+        if (this.getGuildId() > 0) {
+            base = base | 2;
+        }
+
+        if (this.isPromoted()) {
+            base = base | 4;
+        }
+
+        if (!this.isPublicRoom()) {
+            base = base | 8;
+        }
+
+        message.appendInt(base);
+
+        if (this.getGuildId() > 0) {
+            Guild g = Emulator.getGameEnvironment().getGuildManager().getGuild(this.getGuildId());
+            if (g != null) {
+                message.appendInt(g.getId());
+                message.appendString(g.getName());
+                message.appendString(g.getBadge());
+            } else {
+                message.appendInt(0);
+                message.appendString("");
+                message.appendString("");
+            }
+        }
+
+        if (this.promoted) {
+            message.appendString(this.promotion.getTitle());
+            message.appendString(this.promotion.getDescription());
+            message.appendInt((this.promotion.getEndTimestamp() - Emulator.getIntUnixTimestamp()) / 60);
+        }
+    }
+
+    @Override
+    public void run() {
+        synchronized (this) {
+            boolean runCycle = this.lifecycle.isLoaded();
+
+            if (runCycle) {
+                try {
+                    long startTime = System.nanoTime();
+                    this.lastCycleThread = Thread.currentThread().getName();
+                    // Run cycle directly instead of scheduling on thread pool
+                    // This ensures all cycle tasks in the same tick execute synchronously
+                    // preventing wired desync issues
+                    this.cycle();
+                    this.lastCycleCpuMs = (System.nanoTime() - startTime) / 1000000.0;
+                } catch (Exception e) {
+                    LOGGER.error("Caught exception", e);
+                }
+            }
+
+            this.save();
+        }
+    }
+
+    public void save() {
+        if (this.needsUpdate) {
+            try {
+                this.persistence.save(this.persistenceState());
+                this.needsUpdate = false;
+            } catch (SQLException e) {
+                LOGGER.error("Caught SQL exception", e);
+            }
+        }
+    }
+
+    private RoomPersistence.State persistenceState() {
+        return new RoomPersistence.State(
+                this.id,
+                this.ownerId,
+                this.ownerName,
+                this.name,
+                this.description,
+                this.password,
+                this.state,
+                this.usersMax,
+                this.category,
+                this.score,
+                this.floorPaint,
+                this.wallPaint,
+                this.backgroundPaint,
+                this.wallSize,
+                this.wallHeight,
+                this.floorSize,
+                List.copyOf(this.moodlightData.values()),
+                this.tags,
+                this.allowPets,
+                this.allowPetsEat,
+                this.allowWalkthrough,
+                this.hideWall,
+                this.chatMode,
+                this.chatWeight,
+                this.chatSpeed,
+                this.chatDistance,
+                this.chatProtection,
+                this.muteOption,
+                this.kickOption,
+                this.banOption,
+                this.pollId,
+                this.guild,
+                this.rollerSpeed,
+                this.overrideModel,
+                this.staffPromotedRoom,
+                this.promoted,
+                this.tradeMode,
+                this.moveDiagonally,
+                this.jukeboxActive,
+                this.hideWired,
+                this.allowUnderpass,
+                this.youtubeEnabled,
+                this.buildersClubTrialLocked,
+                this.buildersClubOriginalState);
+    }
+
+    void savePendingItems(List<HabboItem> items) {
+        try {
+            this.itemPersistence.save(items);
+        } catch (SQLException exception) {
+            LOGGER.error("Caught SQL exception saving room items", exception);
+        }
+    }
+
+    /**
+     * Updates the user count in the database.
+     * Made public for access by RoomUnitManager.
+     */
+    public void updateDatabaseUserCount() {
+        try {
+            this.repository.updateUserCount(this.id, this.getUserCount());
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+    }
+
+    void scheduleDatabaseUserCountUpdate() {
+        this.userCountPersistence.schedule();
+    }
+
+    private RoomUserCountPersistence createUserCountPersistence() {
+        return new RoomUserCountPersistence(
+                this::getUserCount,
+                userCount -> this.repository.updateUserCount(this.id, userCount),
+                this.dependencies.persistence()::execute);
+    }
+
+    private void cycle() {
+        this.cycleManager.cycle();
+    }
+
+    public int getId() {
+        return this.id;
+    }
+
+    public int getOwnerId() {
+        return this.ownerId;
+    }
+
+    public void setOwnerId(int ownerId) {
+        int previousOwnerId = this.ownerId;
+        this.ownerId = ownerId;
+
+        BiConsumer<Room, Integer> listener = this.ownerChangeListener;
+        if (listener != null && previousOwnerId != ownerId) {
+            listener.accept(this, previousOwnerId);
+        }
+    }
+
+    void setOwnerChangeListener(BiConsumer<Room, Integer> ownerChangeListener) {
+        this.ownerChangeListener = ownerChangeListener;
+    }
+
+    public String getOwnerName() {
+        return this.ownerName;
+    }
+
+    public void setOwnerName(String ownerName) {
+        this.ownerName = ownerName;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+
+        if (this.name.length() > 50) {
+            this.name = this.name.substring(0, 50);
+        }
+
+        if (this.hasGuild()) {
+            Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(this.guild);
+
+            if (guild != null) {
+                guild.setRoomName(name);
+            }
+        }
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+
+        if (this.description.length() > 250) {
+            this.description = this.description.substring(0, 250);
+        }
+    }
+
+    public RoomLayout getLayout() {
+        return this.layout;
+    }
+
+    RoomLayout currentLayout() {
+        return this.layout;
+    }
+
+    public void setLayout(RoomLayout layout) {
+        this.layout = layout;
+    }
+
+    public boolean hasCustomLayout() {
+        return this.overrideModel;
+    }
+
+    public void setHasCustomLayout(boolean overrideModel) {
+        this.overrideModel = overrideModel;
+    }
+
+    public String getPassword() {
+        return this.password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+
+        if (this.password.length() > 20) {
+            this.password = this.password.substring(0, 20);
+        }
+    }
+
+    public RoomState getState() {
+        return this.state;
+    }
+
+    public void setState(RoomState state) {
+        this.state = state;
+    }
+
+    public boolean isBuildersClubTrialLocked() {
+        return this.buildersClubTrialLocked;
+    }
+
+    public void setBuildersClubTrialLocked(boolean buildersClubTrialLocked) {
+        this.buildersClubTrialLocked = buildersClubTrialLocked;
+    }
+
+    public RoomState getBuildersClubOriginalState() {
+        return this.buildersClubOriginalState;
+    }
+
+    public void setBuildersClubOriginalState(RoomState buildersClubOriginalState) {
+        this.buildersClubOriginalState = buildersClubOriginalState;
+    }
+
+    public int getUsersMax() {
+        return this.usersMax;
+    }
+
+    public void setUsersMax(int usersMax) {
+        this.usersMax = usersMax;
+    }
+
+    public int getScore() {
+        return this.score;
+    }
+
+    public void setScore(int score) {
+        this.score = score;
+    }
+
+    public int getCategory() {
+        return this.category;
+    }
+
+    public void setCategory(int category) {
+        this.category = category;
+    }
+
+    public String getFloorPaint() {
+        return this.floorPaint;
+    }
+
+    public void setFloorPaint(String floorPaint) {
+        this.floorPaint = floorPaint;
+    }
+
+    public String getWallPaint() {
+        return this.wallPaint;
+    }
+
+    public void setWallPaint(String wallPaint) {
+        this.wallPaint = wallPaint;
+    }
+
+    public String getBackgroundPaint() {
+        return this.backgroundPaint;
+    }
+
+    public void setBackgroundPaint(String backgroundPaint) {
+        this.backgroundPaint = backgroundPaint;
+    }
+
+    public int getWallSize() {
+        return this.wallSize;
+    }
+
+    public void setWallSize(int wallSize) {
+        this.wallSize = wallSize;
+    }
+
+    public int getWallHeight() {
+        return this.wallHeight;
+    }
+
+    public void setWallHeight(int wallHeight) {
+        this.wallHeight = wallHeight;
+    }
+
+    public int getFloorSize() {
+        return this.floorSize;
+    }
+
+    public void setFloorSize(int floorSize) {
+        this.floorSize = floorSize;
+    }
+
+    public String getTags() {
+        return this.tags;
+    }
+
+    public void setTags(String tags) {
+        this.tags = tags;
+    }
+
+    public int getTradeMode() {
+        return this.tradeMode;
+    }
+
+    public void setTradeMode(int tradeMode) {
+        this.tradeMode = tradeMode;
+    }
+
+    public boolean moveDiagonally() {
+        return this.moveDiagonally;
+    }
+
+    public void moveDiagonally(boolean moveDiagonally) {
+        this.moveDiagonally = moveDiagonally;
+        this.layout.moveDiagonally(this.moveDiagonally);
+        this.needsUpdate = true;
+    }
+
+    public int getGuildId() {
+        return this.guild;
+    }
+
+    public boolean hasGuild() {
+        return this.getGuildId() != 0;
+    }
+
+    public boolean belongsToGuild() {
+        return this.guild > 0;
+    }
+
+    public void setGuild(int guild) {
+        this.guild = guild;
+    }
+
+    public String getGuildName() {
+        if (this.hasGuild()) {
+            Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(this.guild);
+
+            if (guild != null) {
+                return guild.getName();
+            }
+        }
+
+        return "";
+    }
+
+    public boolean isPublicRoom() {
+        return this.publicRoom;
+    }
+
+    public void setPublicRoom(boolean publicRoom) {
+        this.publicRoom = publicRoom;
+    }
+
+    public boolean isStaffPromotedRoom() {
+        return this.staffPromotedRoom;
+    }
+
+    public void setStaffPromotedRoom(boolean staffPromotedRoom) {
+        this.staffPromotedRoom = staffPromotedRoom;
+    }
+
+    public boolean isAllowPets() {
+        return this.allowPets;
+    }
+
+    public void setAllowPets(boolean allowPets) {
+        this.allowPets = allowPets;
+        if (!allowPets) {
+            removeAllPets(ownerId);
+        }
+    }
+
+    public boolean isAllowPetsEat() {
+        return this.allowPetsEat;
+    }
+
+    public void setAllowPetsEat(boolean allowPetsEat) {
+        this.allowPetsEat = allowPetsEat;
+    }
+
+    public boolean isAllowWalkthrough() {
+        return this.allowWalkthrough;
+    }
+
+    public void setAllowWalkthrough(boolean allowWalkthrough) {
+        this.allowWalkthrough = allowWalkthrough;
+    }
+
+    public boolean isAllowUnderpass() {
+        return this.allowUnderpass;
+    }
+
+    public void setAllowUnderpass(boolean allowUnderpass) {
+        this.allowUnderpass = allowUnderpass;
+    }
+
+    public boolean isAllowBotsWalk() {
+        return this.allowBotsWalk;
+    }
+
+    public void setAllowBotsWalk(boolean allowBotsWalk) {
+        this.allowBotsWalk = allowBotsWalk;
+    }
+
+    public boolean isAllowEffects() {
+        return this.allowEffects;
+    }
+
+    public void setAllowEffects(boolean allowEffects) {
+        this.allowEffects = allowEffects;
+    }
+
+    public boolean isHideWall() {
+        return this.hideWall;
+    }
+
+    public void setHideWall(boolean hideWall) {
+        this.hideWall = hideWall;
+    }
+
+    public Color getBackgroundTonerColor() {
+        Color color = new Color(0, 0, 0);
+        Int2ObjectMap<HabboItem> items = this.itemManager.getRoomItems();
+
+        synchronized (items) {
+            for (HabboItem object : items.values()) {
+                if (object instanceof InteractionBackgroundToner) {
+                    String[] extraData = object.getExtradata().split(":");
+
+                    if (extraData.length == 4) {
+                        if (extraData[0].equalsIgnoreCase("1")) {
+                            return Color.getHSBColor(
+                                    Integer.parseInt(extraData[1]),
+                                    Integer.parseInt(extraData[2]),
+                                    Integer.parseInt(extraData[3]));
+                        }
+                    }
+                }
+            }
+        }
+
+        return color;
+    }
+
+    public int getChatMode() {
+        return this.chatMode;
+    }
+
+    public void setChatMode(int chatMode) {
+        this.chatMode = chatMode;
+    }
+
+    public int getChatWeight() {
+        return this.chatWeight;
+    }
+
+    public void setChatWeight(int chatWeight) {
+        this.chatWeight = chatWeight;
+    }
+
+    public int getChatSpeed() {
+        return this.chatSpeed;
+    }
+
+    public void setChatSpeed(int chatSpeed) {
+        this.chatSpeed = chatSpeed;
+    }
+
+    public int getChatDistance() {
+        return this.chatDistance;
+    }
+
+    public void setChatDistance(int chatDistance) {
+        this.chatDistance = chatDistance;
+    }
+
+    public void removeAllPets() {
+        this.unitManager.removeAllPets();
+    }
+
+    /**
+     * Removes all pets from the room except if the owner id is excludeUserId
+     *
+     * @param excludeUserId Habbo id to keep pets
+     */
+    public void removeAllPets(int excludeUserId) {
+        this.unitManager.removeAllPets(excludeUserId);
+    }
+
+    public int getChatProtection() {
+        return this.chatProtection;
+    }
+
+    public void setChatProtection(int chatProtection) {
+        this.chatProtection = chatProtection;
+    }
+
+    public int getMuteOption() {
+        return this.muteOption;
+    }
+
+    public void setMuteOption(int muteOption) {
+        this.muteOption = muteOption;
+    }
+
+    public int getKickOption() {
+        return this.kickOption;
+    }
+
+    public void setKickOption(int kickOption) {
+        this.kickOption = kickOption;
+    }
+
+    public int getBanOption() {
+        return this.banOption;
+    }
+
+    public void setBanOption(int banOption) {
+        this.banOption = banOption;
+    }
+
+    public int getPollId() {
+        return this.pollId;
+    }
+
+    public void setPollId(int pollId) {
+        this.pollId = pollId;
+    }
+
+    public int getRollerSpeed() {
+        return this.rollerSpeed;
+    }
+
+    public void setRollerSpeed(int rollerSpeed) {
+        this.rollerSpeed = rollerSpeed;
+        this.needsUpdate = true;
+    }
+
+    public String[] filterAnything() {
+        return new String[] {this.getOwnerName(), this.getGuildName(), this.getDescription(), this.getPromotionDesc()};
+    }
+
+    public long getCycleTimestamp() {
+        return this.cycleManager.getCycleTimestamp();
+    }
+
+    public boolean isPromoted() {
+        return this.promotionManager.isPromoted();
+    }
+
+    public RoomPromotion getPromotion() {
+        return this.promotion;
+    }
+
+    public String getPromotionDesc() {
+        if (this.promotion != null) {
+            return this.promotion.getDescription();
+        }
+
+        return "";
+    }
+
+    public void createPromotion(String title, String description, int category) {
+        this.promotionManager.createPromotion(title, description, category);
+    }
+
+    public boolean addGame(Game game) {
+        return this.gameManager.addGame(game);
+    }
+
+    public boolean deleteGame(Game game) {
+        return this.gameManager.deleteGame(game);
+    }
+
+    public Game getGame(Class<? extends Game> gameType) {
+        return this.gameManager.getGame(gameType);
+    }
+
+    public Game getGameOrCreate(Class<? extends Game> gameType) {
+        return this.gameManager.getGameOrCreate(gameType);
+    }
+
+    public Set<Game> getGames() {
+        return this.gameManager.getGames();
+    }
+
+    public int getUserCount() {
+        return this.unitManager.getHabboCount();
+    }
+
+    public ConcurrentHashMap<Integer, Habbo> getCurrentHabbos() {
+        return this.unitManager.getCurrentHabbos();
+    }
+
+    public Collection<Habbo> getHabbos() {
+        return this.unitManager.getHabbos();
+    }
+
+    public Int2ObjectMap<Habbo> getHabboQueue() {
+        return this.unitManager.getHabboQueue();
+    }
+
+    public Int2ObjectMap<String> getFurniOwnerNames() {
+        return this.itemManager.getFurniOwnerNames();
+    }
+
+    public String getFurniOwnerName(int userId) {
+        return this.itemManager.getFurniOwnerName(userId);
+    }
+
+    public Int2IntMap getFurniOwnerCount() {
+        return this.itemManager.getFurniOwnerCount();
+    }
+
+    public Int2ObjectMap<RoomMoodlightData> getMoodlightData() {
+        return this.moodlightData;
+    }
+
+    public int getLastTimerReset() {
+        return this.lastTimerReset;
+    }
+
+    public void setLastTimerReset(int lastTimerReset) {
+        this.lastTimerReset = lastTimerReset;
+    }
+
+    public void addToQueue(Habbo habbo) {
+        this.unitManager.addToQueue(habbo);
+    }
+
+    public boolean removeFromQueue(Habbo habbo) {
+        try {
+            this.sendComposer(new HideDoorbellComposer(habbo.getHabboInfo().getUsername()).compose());
+
+            return this.unitManager.removeFromQueue(habbo.getHabboInfo().getId()) != null;
+        } catch (Exception e) {
+            LOGGER.error("Caught exception", e);
+        }
+
+        return true;
+    }
+
+    public Int2ObjectMap<Bot> getCurrentBots() {
+        return this.unitManager.getCurrentBots();
+    }
+
+    public Int2ObjectMap<Pet> getCurrentPets() {
+        return this.unitManager.getCurrentPets();
+    }
+
+    public Set<String> getWordFilterWords() {
+        return this.chatManager.getWordFilterWords();
+    }
+
+    public RoomSpecialTypes getRoomSpecialTypes() {
+        return this.roomSpecialTypes;
+    }
+
+    /**
+     * Alias for getRoomSpecialTypes() for shorter access.
+     */
+    public RoomSpecialTypes getSpecialTypes() {
+        return this.roomSpecialTypes;
+    }
+
+    public boolean isPreLoaded() {
+        return this.lifecycle.isPreloaded();
+    }
+
+    public boolean isLoaded() {
+        return this.lifecycle.isLoaded();
+    }
+
+    public void setNeedsUpdate(boolean needsUpdate) {
+        this.needsUpdate = needsUpdate;
+    }
+
+    public IntList getRights() {
+        return this.rights;
+    }
+
+    public boolean isMuted() {
+        return this.muted;
+    }
+
+    public void setMuted(boolean muted) {
+        this.muted = muted;
+    }
+
+    public TraxManager getTraxManager() {
+        return this.traxManager;
+    }
+
+    public void addHabboItem(HabboItem item) {
+        this.itemManager.addHabboItem(item);
+    }
+
+    public HabboItem getHabboItem(int id) {
+        return this.itemManager.getHabboItem(id);
+    }
+
+    void removeHabboItem(int id) {
+        this.itemManager.removeHabboItem(id);
+    }
+
+    public void removeHabboItem(HabboItem item) {
+        this.itemManager.removeHabboItem(item);
+    }
+
+    public Set<HabboItem> getFloorItems() {
+        return this.itemManager.getFloorItems();
+    }
+
+    public Set<HabboItem> getWallItems() {
+        return this.itemManager.getWallItems();
+    }
+
+    public Set<HabboItem> getPostItNotes() {
+        return this.itemManager.getPostItNotes();
+    }
+
+    public void addHabbo(Habbo habbo) {
+        this.unitManager.addHabbo(habbo);
+    }
+
+    public void kickHabbo(Habbo habbo, boolean alert) {
+        this.unitManager.kickHabbo(habbo, alert);
+    }
+
+    public void removeHabbo(Habbo habbo) {
+        this.cleanupYoutubeWatcher(habbo);
+        this.unitManager.removeHabbo(habbo);
+    }
+
+    public void removeHabbo(Habbo habbo, boolean sendRemovePacket) {
+        this.cleanupYoutubeWatcher(habbo);
+        this.unitManager.removeHabbo(habbo, sendRemovePacket);
+    }
+
+    private void cleanupYoutubeWatcher(Habbo habbo) {
+        if (habbo == null) return;
+        int userId = habbo.getHabboInfo().getId();
+
+        // If the broadcast sender leaves, stop the broadcast for everyone
+        if (!this.youtubeCurrentVideo.isEmpty()
+                && habbo.getHabboInfo().getUsername().equals(this.youtubeSenderName)) {
+            this.clearYoutubeVideo();
+            this.sendComposer(new com.eu.habbo.messages.outgoing.rooms.youtube.YouTubeRoomBroadcastComposer(
+                            "", "", java.util.Collections.emptyList())
+                    .compose());
+        }
+
+        if (this.youtubeWatchers.remove(userId)) {
+            this.sendComposer(
+                    new com.eu.habbo.messages.outgoing.rooms.youtube.YouTubeRoomWatchersComposer(this.youtubeWatchers)
+                            .compose());
+        }
+    }
+
+    public void addBot(Bot bot) {
+        this.unitManager.addBot(bot);
+    }
+
+    public void addPet(Pet pet) {
+        this.unitManager.addPet(pet);
+    }
+
+    public Bot getBot(int botId) {
+        return this.unitManager.getBot(botId);
+    }
+
+    public Bot getBot(RoomUnit roomUnit) {
+        return this.unitManager.getBot(roomUnit);
+    }
+
+    public Bot getBotByRoomUnitId(int id) {
+        return this.unitManager.getBotByRoomUnitId(id);
+    }
+
+    public List<Bot> getBots(String name) {
+        return this.unitManager.getBots(name);
+    }
+
+    public boolean hasBotsAt(final int x, final int y) {
+        return this.unitManager.hasBotsAt(x, y);
+    }
+
+    public Pet getPet(int petId) {
+        return this.unitManager.getPet(petId);
+    }
+
+    public Pet getPet(RoomUnit roomUnit) {
+        return this.unitManager.getPet(roomUnit);
+    }
+
+    public boolean removeBot(Bot bot) {
+        return this.unitManager.removeBot(bot);
+    }
+
+    public void placePet(Pet pet, short x, short y, double z, int rot) {
+        this.unitManager.placePet(pet, x, y, z, rot);
+    }
+
+    public Pet removePet(int petId) {
+        return this.unitManager.removePet(petId);
+    }
+
+    public boolean hasHabbosAt(int x, int y) {
+        return this.unitManager.hasHabbosAt(x, y);
+    }
+
+    public boolean hasPetsAt(int x, int y) {
+        return this.unitManager.hasPetsAt(x, y);
+    }
+
+    public Set<Bot> getBotsAt(RoomTile tile) {
+        return this.unitManager.getBotsAt(tile);
+    }
+
+    public Set<Pet> getPetsAt(RoomTile tile) {
+        return this.unitManager.getPetsAt(tile);
+    }
+
+    public Set<Habbo> getHabbosAt(short x, short y) {
+        return this.unitManager.getHabbosAt(x, y);
+    }
+
+    public Set<Habbo> getHabbosAt(RoomTile tile) {
+        return this.unitManager.getHabbosAt(tile);
+    }
+
+    public Set<RoomUnit> getHabbosAndBotsAt(short x, short y) {
+        return this.unitManager.getHabbosAndBotsAt(x, y);
+    }
+
+    public Set<RoomUnit> getHabbosAndBotsAt(RoomTile tile) {
+        return this.unitManager.getHabbosAndBotsAt(tile);
+    }
+
+    public Set<Habbo> getHabbosOnItem(HabboItem item) {
+        return this.unitManager.getHabbosOnItem(item);
+    }
+
+    public Set<Bot> getBotsOnItem(HabboItem item) {
+        return this.unitManager.getBotsOnItem(item);
+    }
+
+    public void teleportHabboToItem(Habbo habbo, HabboItem item) {
+        this.unitManager.teleportHabboToItem(habbo, item);
+    }
+
+    public void teleportHabboToLocation(Habbo habbo, short x, short y) {
+        this.unitManager.teleportHabboToLocation(habbo, x, y);
+    }
+
+    public void teleportRoomUnitToItem(RoomUnit roomUnit, HabboItem item) {
+        this.unitManager.teleportRoomUnitToItem(roomUnit, item);
+    }
+
+    public void teleportRoomUnitToLocation(RoomUnit roomUnit, short x, short y) {
+        this.unitManager.teleportRoomUnitToLocation(roomUnit, x, y);
+    }
+
+    public void teleportRoomUnitToLocation(RoomUnit roomUnit, short x, short y, double z) {
+        this.unitManager.teleportRoomUnitToLocation(roomUnit, x, y, z);
+    }
+
+    public void muteHabbo(Habbo habbo, int minutes) {
+        this.chatManager.muteHabbo(habbo, minutes);
+        this.sendComposer(new RoomUserIgnoredComposer(habbo, RoomUserIgnoredComposer.MUTED).compose());
+    }
+
+    public void unmuteHabbo(Habbo habbo) {
+        this.chatManager.unmuteHabbo(habbo);
+        this.sendComposer(new RoomUserIgnoredComposer(habbo, RoomUserIgnoredComposer.UNIGNORED).compose());
+    }
+
+    public boolean isMuted(Habbo habbo) {
+        return this.chatManager.isMuted(habbo);
+    }
+
+    public void habboEntered(Habbo habbo) {
+        this.unitManager.habboEntered(habbo);
+    }
+
+    public void floodMuteHabbo(Habbo habbo, int timeOut) {
+        this.chatManager.floodMuteHabbo(habbo, timeOut);
+    }
+
+    public void talk(Habbo habbo, RoomChatMessage roomChatMessage, RoomChatType chatType) {
+        this.chatManager.talk(habbo, roomChatMessage, chatType);
+    }
+
+    public void talk(
+            final Habbo habbo, final RoomChatMessage roomChatMessage, RoomChatType chatType, boolean ignoreWired) {
+        this.chatManager.talk(habbo, roomChatMessage, chatType, ignoreWired);
+    }
+
+    public Set<RoomTile> getLockedTiles() {
+        return this.itemManager.getLockedTiles();
+    }
+
+    @Deprecated
+    public Set<HabboItem> getItemsAt(int x, int y) {
+        return this.itemManager.getItemsAt(x, y);
+    }
+
+    public Set<HabboItem> getItemsAt(RoomTile tile) {
+        return this.itemManager.getItemsAt(tile);
+    }
+
+    public Set<HabboItem> getItemsAt(RoomTile tile, boolean returnOnFirst) {
+        return this.itemManager.getItemsAt(tile, returnOnFirst);
+    }
+
+    public Set<HabboItem> getItemsAt(int x, int y, double minZ) {
+        return this.itemManager.getItemsAt(x, y, minZ);
+    }
+
+    public Set<HabboItem> getItemsAt(Class<? extends HabboItem> type, int x, int y) {
+        return this.itemManager.getItemsAt(type, x, y);
+    }
+
+    public boolean hasItemsAt(int x, int y) {
+        return this.itemManager.hasItemsAt(x, y);
+    }
+
+    public HabboItem getTopItemAt(int x, int y) {
+        return this.itemManager.getTopItemAt(x, y);
+    }
+
+    public HabboItem getTopItemAt(int x, int y, HabboItem exclude) {
+        return this.itemManager.getTopItemAt(x, y, exclude);
+    }
+
+    public HabboItem getTopItemAt(Set<RoomTile> tiles, HabboItem exclude) {
+        return this.itemManager.getTopItemAt(tiles, exclude);
+    }
+
+    public double getTopHeightAt(int x, int y) {
+        return this.itemManager.getTopHeightAt(x, y);
+    }
+
+    @Deprecated
+    public HabboItem getLowestChair(int x, int y) {
+        return this.itemManager.getLowestChair(x, y);
+    }
+
+    public HabboItem getLowestChair(RoomTile tile) {
+        return this.itemManager.getLowestChair(tile);
+    }
+
+    public HabboItem getTallestChair(RoomTile tile) {
+        return this.itemManager.getTallestChair(tile);
+    }
+
+    public double getStackHeight(short x, short y, boolean calculateHeightmap, HabboItem exclude) {
+        return this.tileManager.getStackHeight(x, y, calculateHeightmap, exclude);
+    }
+
+    public double getStackHeight(short x, short y, boolean calculateHeightmap) {
+        return this.tileManager.getStackHeight(x, y, calculateHeightmap);
+    }
+
+    public boolean hasObjectTypeAt(Class<?> type, int x, int y) {
+        return this.itemManager.hasObjectTypeAt(type, x, y);
+    }
+
+    public boolean canSitOrLayAt(int x, int y) {
+        return this.tileManager.canSitOrLayAt(x, y);
+    }
+
+    public boolean canSitAt(int x, int y) {
+        return this.tileManager.canSitAt(x, y);
+    }
+
+    boolean canWalkAt(RoomTile roomTile) {
+        return this.tileManager.canWalkAt(roomTile);
+    }
+
+    boolean canSitAt(Set<HabboItem> items) {
+        return this.tileManager.canSitAt(items);
+    }
+
+    public boolean canLayAt(int x, int y) {
+        return this.tileManager.canLayAt(x, y);
+    }
+
+    boolean canLayAt(Set<HabboItem> items) {
+        return this.tileManager.canLayAt(items);
+    }
+
+    public RoomTile getRandomWalkableTile() {
+        return this.tileManager.getRandomWalkableTile();
+    }
+
+    public RoomTile getRandomWalkableTilesAround(RoomUnit roomUnit, RoomTile tile, int radius) {
+        return this.tileManager.getRandomWalkableTilesAround(roomUnit, tile, radius);
+    }
+
+    public Habbo getHabbo(String username) {
+        return this.unitManager.getHabbo(username);
+    }
+
+    public Habbo getHabbo(RoomUnit roomUnit) {
+        return this.unitManager.getHabboByRoomUnit(roomUnit);
+    }
+
+    public Habbo getHabbo(int userId) {
+        return this.unitManager.getHabbo(userId);
+    }
+
+    public Habbo getHabboByRoomUnitId(int roomUnitId) {
+        return this.unitManager.getHabboByRoomUnitId(roomUnitId);
+    }
+
+    public void sendComposer(ServerMessage message) {
+        this.messagingManager.sendComposer(message);
+    }
+
+    public void sendComposers(Collection<ServerMessage> messages) {
+        this.messagingManager.sendComposers(messages);
+    }
+
+    public void sendComposerToHabbosWithRights(ServerMessage message) {
+        this.messagingManager.sendComposerToHabbosWithRights(message);
+    }
+
+    public void petChat(ServerMessage message) {
+        this.messagingManager.petChat(message);
+    }
+
+    public void botChat(ServerMessage message) {
+        this.messagingManager.botChat(message);
+    }
+
+    private void loadRights(Connection connection) {
+        this.rights.clear();
+        try (PreparedStatement statement =
+                connection.prepareStatement("SELECT user_id FROM room_rights WHERE room_id = ?")) {
+            statement.setInt(1, this.id);
+            try (ResultSet set = statement.executeQuery()) {
+                while (set.next()) {
+                    this.rights.add(set.getInt("user_id"));
+                }
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+    }
+
+    private void loadBans(Connection connection) {
+        this.bannedHabbos.clear();
+
+        try (PreparedStatement statement = connection.prepareStatement(
+                "SELECT users.username, users.id, room_bans.* FROM room_bans INNER JOIN users ON room_bans.user_id = users.id WHERE ends > ? AND room_bans.room_id = ?")) {
+            statement.setInt(1, Emulator.getIntUnixTimestamp());
+            statement.setInt(2, this.id);
+            try (ResultSet set = statement.executeQuery()) {
+                while (set.next()) {
+                    if (this.bannedHabbos.containsKey(set.getInt("user_id"))) {
+                        continue;
+                    }
+
+                    this.bannedHabbos.put(set.getInt("user_id"), new RoomBan(set));
+                }
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+    }
+
+    public RoomRightLevels getGuildRightLevel(Habbo habbo) {
+        int guildId = this.getGuildId();
+
+        if (guildId > 0 && habbo != null && habbo.getHabboInfo() != null) {
+            Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
+
+            if (guild == null) {
+                return RoomRightLevels.NONE;
+            }
+
+            GuildMember member = Emulator.getGameEnvironment()
+                    .getGuildManager()
+                    .getGuildMember(guild.getId(), habbo.getHabboInfo().getId());
+
+            if ((member != null) && (member.getRank() == GuildRank.ADMIN || member.getRank() == GuildRank.OWNER)) {
+                return RoomRightLevels.GUILD_ADMIN;
+            }
+
+            if ((member != null) && member.getMembershipStatus() == GuildMembershipStatus.MEMBER && guild.getRights()) {
+                return RoomRightLevels.GUILD_RIGHTS;
+            }
+        }
+
+        return RoomRightLevels.NONE;
+    }
+
+    /**
+     * @deprecated Deprecated since 2.5.0. Use {@link #getGuildRightLevel(Habbo)} instead.
+     */
+    @Deprecated
+    public int guildRightLevel(Habbo habbo) {
+        return this.rightsManager.guildRightLevel(habbo);
+    }
+
+    public boolean isOwner(Habbo habbo) {
+        return this.rightsManager.isOwner(habbo);
+    }
+
+    public boolean hasRights(Habbo habbo) {
+        return this.rightsManager.hasRights(habbo);
+    }
+
+    public boolean hasExplicitRights(Habbo habbo) {
+        return habbo != null && this.rights.contains(habbo.getHabboInfo().getId());
+    }
+
+    public int getWiredInspectMask() {
+        this.ensureWiredSettingsLoaded();
+        return this.wiredInspectMask;
+    }
+
+    public int getWiredModifyMask() {
+        this.ensureWiredSettingsLoaded();
+        return this.wiredModifyMask;
+    }
+
+    public boolean canInspectWired(Habbo habbo) {
+        if (habbo == null) {
+            return false;
+        }
+
+        if (this.canManageWiredSettings(habbo)) {
+            return true;
+        }
+
+        this.ensureWiredSettingsLoaded();
+        return this.matchesWiredAccessMask(habbo, this.wiredInspectMask, true);
+    }
+
+    public boolean canModifyWired(Habbo habbo) {
+        if (habbo == null) {
+            return false;
+        }
+
+        if (this.canManageWiredSettings(habbo)) {
+            return true;
+        }
+
+        this.ensureWiredSettingsLoaded();
+        return this.matchesWiredAccessMask(habbo, this.wiredModifyMask, false);
+    }
+
+    public boolean canManageWiredSettings(Habbo habbo) {
+        return habbo != null && this.isOwner(habbo);
+    }
+
+    public boolean saveWiredSettings(int inspectMask, int modifyMask) {
+        int sanitizedInspectMask = sanitizeWiredInspectMask(inspectMask);
+        int sanitizedModifyMask = sanitizeWiredModifyMask(modifyMask);
+        sanitizedInspectMask |= sanitizedModifyMask;
+
+        synchronized (this.wiredSettingsLock) {
+            final int finalInspectMask = sanitizedInspectMask;
+            final int finalModifyMask = sanitizedModifyMask;
+            final int finalId = this.id;
+            final int previousInspectMask = this.wiredInspectMask;
+            final int previousModifyMask = this.wiredModifyMask;
+
+            this.wiredInspectMask = sanitizedInspectMask;
+            this.wiredModifyMask = sanitizedModifyMask;
+            this.wiredSettingsLoaded = true;
+
+            Emulator.getThreading().run(() -> {
+                try (Connection connection =
+                                Emulator.getDatabase().getDataSource().getConnection();
+                        PreparedStatement statement = connection.prepareStatement(
+                                "INSERT INTO room_wired_settings (room_id, inspect_mask, modify_mask) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE inspect_mask = VALUES(inspect_mask), modify_mask = VALUES(modify_mask)")) {
+                    statement.setInt(1, finalId);
+                    statement.setInt(2, finalInspectMask);
+                    statement.setInt(3, finalModifyMask);
+                    statement.executeUpdate();
+                } catch (SQLException e) {
+                    synchronized (this.wiredSettingsLock) {
+                        if (this.wiredInspectMask == finalInspectMask && this.wiredModifyMask == finalModifyMask) {
+                            this.wiredInspectMask = previousInspectMask;
+                            this.wiredModifyMask = previousModifyMask;
+                        }
+                    }
+                    LOGGER.error("Caught SQL exception while saving wired room settings", e);
+                }
+            });
+
+            this.pushWiredSettingsToCurrentHabbos();
+            return true;
+        }
+    }
+
+    public void giveRights(Habbo habbo) {
+        if (habbo == null) {
+            return;
+        }
+
+        this.giveRights(habbo.getHabboInfo().getId());
+    }
+
+    public void giveRights(int userId) {
+        this.rightsManager.giveRights(userId);
+
+        if (!this.rights.contains(userId)) {
+            this.rights.add(userId);
+        }
+
+        this.pushWiredSettingsToCurrentHabbos();
+    }
+
+    public void removeRights(int userId) {
+        this.rightsManager.removeRights(userId);
+        this.rights.rem(userId);
+        this.pushWiredSettingsToCurrentHabbos();
+    }
+
+    public void removeAllRights() {
+        this.rightsManager.removeAllRights();
+        this.rights.clear();
+        this.pushWiredSettingsToCurrentHabbos();
+    }
+
+    void refreshRightsInRoom() {
+        this.rightsManager.refreshRightsInRoom();
+    }
+
+    public void refreshRightsForHabbo(Habbo habbo) {
+        this.rightsManager.refreshRightsForHabbo(habbo);
+    }
+
+    public Map<Integer, String> getUsersWithRights() {
+        return this.rightsManager.getUsersWithRights();
+    }
+
+    public void unbanHabbo(int userId) {
+        this.rightsManager.unbanHabbo(userId);
+    }
+
+    public boolean isBanned(Habbo habbo) {
+        return this.rightsManager.isBanned(habbo);
+    }
+
+    public Int2ObjectMap<RoomBan> getBannedHabbos() {
+        return this.bannedHabbos;
+    }
+
+    private void ensureWiredSettingsLoaded() {
+        if (this.wiredSettingsLoaded) {
+            return;
+        }
+
+        synchronized (this.wiredSettingsLock) {
+            if (this.wiredSettingsLoaded) {
+                return;
+            }
+
+            this.wiredInspectMask = WIRED_ACCESS_DEFAULT_INSPECT_MASK;
+            this.wiredModifyMask = WIRED_ACCESS_DEFAULT_MODIFY_MASK;
+
+            try {
+                RoomRepository.WiredSettings settings = this.repository.findWiredSettings(this.id);
+                this.wiredInspectMask = sanitizeWiredInspectMask(settings.inspectMask());
+                this.wiredModifyMask = sanitizeWiredModifyMask(settings.modifyMask());
+            } catch (SQLException e) {
+                LOGGER.error("Caught SQL exception while loading wired room settings", e);
+            }
+
+            this.wiredSettingsLoaded = true;
+        }
+    }
+
+    private boolean matchesWiredAccessMask(Habbo habbo, int mask, boolean allowEveryone) {
+        if (habbo == null) {
+            return false;
+        }
+
+        if (allowEveryone && hasWiredAccess(mask, WIRED_ACCESS_EVERYONE)) {
+            return true;
+        }
+
+        if (hasWiredAccess(mask, WIRED_ACCESS_USERS_WITH_RIGHTS) && this.hasExplicitRights(habbo)) {
+            return true;
+        }
+
+        if (hasWiredAccess(mask, WIRED_ACCESS_GROUP_ADMINS) && this.isRoomGroupAdmin(habbo)) {
+            return true;
+        }
+
+        return hasWiredAccess(mask, WIRED_ACCESS_GROUP_MEMBERS) && this.isRoomGroupMember(habbo);
+    }
+
+    private boolean isRoomGroupMember(Habbo habbo) {
+        return habbo != null && this.guild > 0 && habbo.getHabboStats().hasGuild(this.guild);
+    }
+
+    private boolean isRoomGroupAdmin(Habbo habbo) {
+        if (!this.isRoomGroupMember(habbo)) {
+            return false;
+        }
+
+        GuildMember member = Emulator.getGameEnvironment()
+                .getGuildManager()
+                .getGuildMember(this.guild, habbo.getHabboInfo().getId());
+
+        if (member == null) {
+            return false;
+        }
+
+        GuildRank rank = member.getRank();
+        return rank == GuildRank.OWNER || rank == GuildRank.ADMIN;
+    }
+
+    private static boolean hasWiredAccess(int mask, int permissionMask) {
+        return (mask & permissionMask) != 0;
+    }
+
+    private static int sanitizeWiredInspectMask(int mask) {
+        int sanitizedMask = mask & WIRED_ACCESS_ALLOWED_INSPECT_MASK;
+
+        if (hasWiredAccess(sanitizedMask, WIRED_ACCESS_GROUP_MEMBERS)) {
+            sanitizedMask |= WIRED_ACCESS_GROUP_ADMINS;
+        }
+
+        return sanitizedMask;
+    }
+
+    private static int sanitizeWiredModifyMask(int mask) {
+        int sanitizedMask = mask & WIRED_ACCESS_ALLOWED_MODIFY_MASK;
+
+        if (hasWiredAccess(sanitizedMask, WIRED_ACCESS_GROUP_MEMBERS)) {
+            sanitizedMask |= WIRED_ACCESS_GROUP_ADMINS;
+        }
+
+        return sanitizedMask;
+    }
+
+    private void pushWiredSettingsToCurrentHabbos() {
+        for (Habbo currentHabbo : this.getCurrentHabbos().values()) {
+            if (currentHabbo == null || currentHabbo.getClient() == null) {
+                continue;
+            }
+
+            currentHabbo.getClient().sendResponse(new WiredRoomSettingsDataComposer(this, currentHabbo));
+        }
+    }
+
+    public void addRoomBan(RoomBan roomBan) {
+        this.rightsManager.addRoomBan(roomBan);
+    }
+
+    public void makeSit(Habbo habbo) {
+        if (habbo.getRoomUnit() == null) {
+            return;
+        }
+
+        if (habbo.getRoomUnit().hasStatus(RoomUnitStatus.SIT)
+                || !habbo.getRoomUnit().canForcePosture()) {
+            return;
+        }
+
+        this.dance(habbo, DanceType.NONE);
+        habbo.getRoomUnit().cmdSit = true;
+        habbo.getRoomUnit()
+                .setBodyRotation(
+                        RoomUserRotation.values()[
+                                habbo.getRoomUnit().getBodyRotation().getValue()
+                                        - habbo.getRoomUnit().getBodyRotation().getValue() % 2]);
+        habbo.getRoomUnit().setStatus(RoomUnitStatus.SIT, 0.5 + "");
+        this.sendComposer(new RoomUserStatusComposer(habbo.getRoomUnit()).compose());
+        WiredManager.triggerUserPerformsAction(this, habbo.getRoomUnit(), WiredUserActionType.SIT, -1);
+    }
+
+    public void makeStand(Habbo habbo) {
+        if (habbo.getRoomUnit() == null) {
+            return;
+        }
+
+        HabboItem item = this.getTopItemAt(
+                habbo.getRoomUnit().getX(), habbo.getRoomUnit().getY());
+        if (item == null
+                || !item.getBaseItem().allowSit()
+                || !item.getBaseItem().allowLay()) {
+            boolean wasSittingOrLaying = habbo.getRoomUnit().hasStatus(RoomUnitStatus.SIT)
+                    || habbo.getRoomUnit().hasStatus(RoomUnitStatus.LAY);
+            habbo.getRoomUnit().cmdStand = true;
+            habbo.getRoomUnit()
+                    .setBodyRotation(
+                            RoomUserRotation.values()[
+                                    habbo.getRoomUnit().getBodyRotation().getValue()
+                                            - habbo.getRoomUnit()
+                                                            .getBodyRotation()
+                                                            .getValue()
+                                                    % 2]);
+            habbo.getRoomUnit().removeStatus(RoomUnitStatus.SIT);
+            habbo.getRoomUnit().removeStatus(RoomUnitStatus.LAY);
+            this.sendComposer(new RoomUserStatusComposer(habbo.getRoomUnit()).compose());
+
+            if (wasSittingOrLaying) {
+                WiredManager.triggerUserPerformsAction(this, habbo.getRoomUnit(), WiredUserActionType.STAND, -1);
+            }
+        }
+    }
+
+    public void giveEffect(Habbo habbo, int effectId, int duration) {
+        this.unitManager.giveEffect(habbo, effectId, duration);
+    }
+
+    public void giveEffect(RoomUnit roomUnit, int effectId, int duration) {
+        this.unitManager.giveEffect(roomUnit, effectId, duration);
+    }
+
+    public void giveHandItem(Habbo habbo, int handItem) {
+        this.unitManager.giveHandItem(habbo, handItem);
+    }
+
+    public void giveHandItem(RoomUnit roomUnit, int handItem) {
+        this.unitManager.giveHandItem(roomUnit, handItem);
+    }
+
+    public void updateItem(HabboItem item) {
+        this.itemManager.updateItem(item);
+    }
+
+    public void updateItemState(HabboItem item) {
+        this.itemManager.updateItemState(item);
+    }
+
+    public int getUserFurniCount(int userId) {
+        return this.itemManager.getFurniOwnerCount().get(userId);
+    }
+
+    public int getUserUniqueFurniCount(int userId) {
+        return this.itemManager.getUserUniqueFurniCount(userId);
+    }
+
+    public void ejectUserFurni(int userId) {
+        this.itemManager.ejectUserFurni(userId);
+    }
+
+    public void ejectUserItem(HabboItem item) {
+        this.itemManager.ejectUserItem(item);
+    }
+
+    public void ejectAll() {
+        this.itemManager.ejectAll();
+    }
+
+    public void ejectAll(Habbo habbo) {
+        this.itemManager.ejectAll(habbo);
+    }
+
+    public void refreshGuild(Guild guild) {
+        if (guild.getRoomId() == this.id) {
+            Set<GuildMember> members =
+                    Emulator.getGameEnvironment().getGuildManager().getGuildMembers(guild.getId());
+
+            for (Habbo habbo : this.getHabbos()) {
+                Optional<GuildMember> member = members.stream()
+                        .filter(m -> m.getUserId() == habbo.getHabboInfo().getId())
+                        .findAny();
+
+                if (!member.isPresent()) {
+                    continue;
+                }
+
+                habbo.getClient().sendResponse(new GuildInfoComposer(guild, habbo.getClient(), false, member.get()));
+            }
+        }
+
+        this.refreshGuildRightsInRoom();
+    }
+
+    public void refreshGuildColors(Guild guild) {
+        if (guild.getRoomId() == this.id) {
+            Int2ObjectMap<HabboItem> items = this.itemManager.getRoomItems();
+            synchronized (items) {
+                for (HabboItem habboItem : items.values()) {
+                    if (habboItem instanceof InteractionGuildFurni) {
+                        if (((InteractionGuildFurni) habboItem).getGuildId() == guild.getId()) {
+                            this.updateItem(habboItem);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void refreshGuildRightsInRoom() {
+        for (Habbo habbo : this.getHabbos()) {
+            if (habbo.getHabboInfo().getCurrentRoom() == this) {
+                if (habbo.getHabboInfo().getId() != this.ownerId) {
+                    if (!(habbo.hasPermission(Permission.ACC_ANYROOMOWNER)
+                            || habbo.hasPermission(Permission.ACC_MOVEROTATE))) {
+                        this.refreshRightsForHabbo(habbo);
+                    }
+                }
+            }
+        }
+    }
+
+    public void idle(Habbo habbo) {
+        this.unitManager.idle(habbo);
+    }
+
+    public void unIdle(Habbo habbo) {
+        this.unitManager.unIdle(habbo);
+    }
+
+    public void dance(Habbo habbo, DanceType danceType) {
+        this.unitManager.dance(habbo, danceType);
+    }
+
+    public void dance(RoomUnit unit, DanceType danceType) {
+        this.unitManager.dance(unit, danceType);
+    }
+
+    public void addToWordFilter(String word) {
+        this.chatManager.addToWordFilter(word);
+    }
+
+    public void removeFromWordFilter(String word) {
+        this.chatManager.removeFromWordFilter(word);
+    }
+
+    public void handleWordQuiz(Habbo habbo, String answer) {
+        this.wordQuizManager.handleWordQuiz(habbo, answer);
+    }
+
+    public void startWordQuiz(String question, int duration) {
+        this.wordQuizManager.startWordQuiz(question, duration);
+    }
+
+    public boolean hasActiveWordQuiz() {
+        return this.wordQuizManager.hasActiveWordQuiz();
+    }
+
+    public boolean hasVotedInWordQuiz(Habbo habbo) {
+        return this.wordQuizManager.hasVotedInWordQuiz(habbo);
+    }
+
+    public void alert(String message) {
+        this.messagingManager.alert(message);
+    }
+
+    public int itemCount() {
+        return this.itemManager.itemCount();
+    }
+
+    public void setJukeBoxActive(boolean jukeBoxActive) {
+        this.jukeboxActive = jukeBoxActive;
+        this.needsUpdate = true;
+    }
+
+    public boolean isHideWired() {
+        return this.hideWired;
+    }
+
+    public void setHideWired(boolean hideWired) {
+        this.hideWired = hideWired;
+
+        if (this.hideWired) {
+            for (HabboItem item : this.roomSpecialTypes.getTriggers()) {
+                this.sendComposer(new RemoveFloorItemComposer(item).compose());
+            }
+
+            for (HabboItem item : this.roomSpecialTypes.getEffects()) {
+                this.sendComposer(new RemoveFloorItemComposer(item).compose());
+            }
+
+            for (HabboItem item : this.roomSpecialTypes.getConditions()) {
+                this.sendComposer(new RemoveFloorItemComposer(item).compose());
+            }
+
+            for (HabboItem item : this.roomSpecialTypes.getExtras()) {
+                this.sendComposer(new RemoveFloorItemComposer(item).compose());
+            }
+        } else {
+            this.sendComposer(new RoomFloorItemsComposer(
+                            this.itemManager.getFurniOwnerNames(), this.roomSpecialTypes.getTriggers())
+                    .compose());
+            this.sendComposer(new RoomFloorItemsComposer(
+                            this.itemManager.getFurniOwnerNames(), this.roomSpecialTypes.getEffects())
+                    .compose());
+            this.sendComposer(new RoomFloorItemsComposer(
+                            this.itemManager.getFurniOwnerNames(), this.roomSpecialTypes.getConditions())
+                    .compose());
+            this.sendComposer(
+                    new RoomFloorItemsComposer(this.itemManager.getFurniOwnerNames(), this.roomSpecialTypes.getExtras())
+                            .compose());
+        }
+    }
+
+    public FurnitureMovementError canPlaceFurnitureAt(HabboItem item, Habbo habbo, RoomTile tile, int rotation) {
+        return this.itemManager.canPlaceFurnitureAt(item, habbo, tile, rotation);
+    }
+
+    public FurnitureMovementError furnitureFitsAt(RoomTile tile, HabboItem item, int rotation) {
+        return this.itemManager.furnitureFitsAt(tile, item, rotation);
+    }
+
+    public FurnitureMovementError furnitureFitsAt(RoomTile tile, HabboItem item, int rotation, boolean checkForUnits) {
+        return this.itemManager.furnitureFitsAt(tile, item, rotation, checkForUnits);
+    }
+
+    public FurnitureMovementError furnitureFitsAtWithPhysics(
+            RoomTile tile, HabboItem item, int rotation, boolean checkForUnits, WiredMovementPhysics physics) {
+        return this.itemManager.furnitureFitsAtWithPhysics(tile, item, rotation, checkForUnits, physics);
+    }
+
+    public FurnitureMovementError placeFloorFurniAt(HabboItem item, RoomTile tile, int rotation, Habbo owner) {
+        return this.itemManager.placeFloorFurniAt(item, tile, rotation, owner);
+    }
+
+    public FurnitureMovementError placeWallFurniAt(HabboItem item, String wallPosition, Habbo owner) {
+        return this.itemManager.placeWallFurniAt(item, wallPosition, owner);
+    }
+
+    public FurnitureMovementError moveFurniTo(HabboItem item, RoomTile tile, int rotation, Habbo actor) {
+        return this.itemManager.moveFurniTo(item, tile, rotation, actor);
+    }
+
+    public FurnitureMovementError moveFurniTo(
+            HabboItem item, RoomTile tile, int rotation, Habbo actor, boolean sendUpdates) {
+        return this.itemManager.moveFurniTo(item, tile, rotation, actor, sendUpdates);
+    }
+
+    public FurnitureMovementError moveFurniTo(
+            HabboItem item, RoomTile tile, int rotation, Habbo actor, boolean sendUpdates, boolean checkForUnits) {
+        return this.itemManager.moveFurniTo(item, tile, rotation, actor, sendUpdates, checkForUnits);
+    }
+
+    public FurnitureMovementError moveFurniTo(HabboItem item, RoomTile tile, int rotation, double z, Habbo actor) {
+        return this.itemManager.moveFurniTo(item, tile, rotation, z, actor, true, true);
+    }
+
+    public FurnitureMovementError moveFurniTo(
+            HabboItem item, RoomTile tile, int rotation, double z, Habbo actor, boolean sendUpdates) {
+        return this.itemManager.moveFurniTo(item, tile, rotation, z, actor, sendUpdates, true);
+    }
+
+    public FurnitureMovementError moveFurniTo(
+            HabboItem item,
+            RoomTile tile,
+            int rotation,
+            double z,
+            Habbo actor,
+            boolean sendUpdates,
+            boolean checkForUnits) {
+        return this.itemManager.moveFurniTo(item, tile, rotation, z, actor, sendUpdates, checkForUnits);
+    }
+
+    public FurnitureMovementError moveFurniToWithPhysics(
+            HabboItem item,
+            RoomTile tile,
+            int rotation,
+            Habbo actor,
+            boolean sendUpdates,
+            boolean checkForUnits,
+            WiredMovementPhysics physics) {
+        return this.itemManager.moveFurniToWithPhysics(
+                item, tile, rotation, actor, sendUpdates, checkForUnits, physics);
+    }
+
+    public FurnitureMovementError moveFurniToWithPhysics(
+            HabboItem item,
+            RoomTile tile,
+            int rotation,
+            double z,
+            Habbo actor,
+            boolean sendUpdates,
+            boolean checkForUnits,
+            WiredMovementPhysics physics) {
+        return this.itemManager.moveFurniToWithPhysics(
+                item, tile, rotation, z, actor, sendUpdates, checkForUnits, physics);
+    }
+
+    public FurnitureMovementError slideFurniTo(HabboItem item, RoomTile tile, int rotation) {
+        return this.itemManager.slideFurniTo(item, tile, rotation);
+    }
+
+    public Set<RoomUnit> getRoomUnits() {
+        return this.unitManager.getRoomUnits();
+    }
+
+    public Set<RoomUnit> getRoomUnits(RoomTile atTile) {
+        return this.unitManager.getRoomUnits(atTile);
+    }
+
+    public Collection<RoomUnit> getRoomUnitsAt(RoomTile tile) {
+        return this.unitManager.getRoomUnitsAt(tile);
+    }
+
+    public long getEstimatedMemoryUsage() {
+        long bytes = 1024 * 10; // Base footprint
+        if (this.itemManager != null) {
+            bytes += this.itemManager.itemCount() * 512L;
+        }
+        bytes += this.getUserCount() * 2048L;
+        if (this.layout != null) {
+            bytes += this.layout.getMapSize() * 128L;
+        }
+        com.eu.habbo.habbohotel.wired.tick.WiredTickService wired =
+                com.eu.habbo.habbohotel.wired.tick.WiredTickService.getInstance();
+        if (wired != null) {
+            bytes += wired.getTickableCount(this.getId()) * 256L;
+        }
+        return bytes;
+    }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatMessage.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatMessage.java
@@ -9,24 +9,24 @@ import com.eu.habbo.messages.ISerialize;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.Incoming;
 import com.eu.habbo.messages.incoming.MessageHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RoomChatMessage implements Runnable, ISerialize, DatabaseLoggable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RoomChatMessage.class);
-    private static final String QUERY = "INSERT INTO chatlogs_room (user_from_id, user_to_id, message, timestamp, room_id) VALUES (?, ?, ?, ?, ?)";
+    private static final String QUERY =
+            "INSERT INTO chatlogs_room (user_from_id, user_to_id, message, timestamp, room_id) VALUES (?, ?, ?, ?, ?)";
 
     private static final List<String> chatColors = Arrays.asList("@red@", "@cyan@", "@blue@", "@green@", "@purple@");
-    public static int MAXIMUM_LENGTH = 100;
-    //Configuration. Loaded from database & updated accordingly.
-    public static boolean SAVE_ROOM_CHATS = false;
-    public static int[] BANNED_BUBBLES = {};
+    public static volatile int MAXIMUM_LENGTH = 100;
+    // Configuration. Loaded from database & updated accordingly.
+    public static volatile boolean SAVE_ROOM_CHATS = false;
+    public static volatile int[] BANNED_BUBBLES = {};
     private final Habbo habbo;
     public int roomId;
     public boolean isCommand = false;
@@ -38,12 +38,13 @@ public class RoomChatMessage implements Runnable, ISerialize, DatabaseLoggable {
     private RoomChatMessageBubbles bubble;
     private Habbo targetHabbo;
     private byte emotion;
-	private String RoomChatColour; // Added Chatcolor
+    private String RoomChatColour; // Added Chatcolor
 
     public RoomChatMessage(MessageHandler message) {
         if (message.packet.getMessageId() == Incoming.RoomUserWhisperEvent) {
             String data = message.packet.readString();
-            this.targetHabbo = message.client.getHabbo().getHabboInfo().getCurrentRoom().getHabbo(data.split(" ")[0]);
+            this.targetHabbo =
+                    message.client.getHabbo().getHabboInfo().getCurrentRoom().getHabbo(data.split(" ")[0]);
             this.message = data.substring(data.split(" ")[0].length() + 1);
         } else {
             this.message = message.packet.readString();
@@ -125,7 +126,12 @@ public class RoomChatMessage implements Runnable, ISerialize, DatabaseLoggable {
             this.emotion = 1;
         } else if (this.message.contains(":@") || this.message.contains(">:(")) {
             this.emotion = 2;
-        } else if (this.message.contains(":o") || this.message.contains(":O") || this.message.contains(":0") || this.message.contains("O.o") || this.message.contains("o.O") || this.message.contains("O.O")) {
+        } else if (this.message.contains(":o")
+                || this.message.contains(":O")
+                || this.message.contains(":0")
+                || this.message.contains("O.o")
+                || this.message.contains("o.O")
+                || this.message.contains("O.O")) {
             this.emotion = 3;
         } else if (this.message.contains(":(") || this.message.contains(":-(") || this.message.contains(":[")) {
             this.emotion = 4;
@@ -134,8 +140,7 @@ public class RoomChatMessage implements Runnable, ISerialize, DatabaseLoggable {
 
     @Override
     public void run() {
-        if (this.habbo == null)
-            return;
+        if (this.habbo == null) return;
 
         if (this.message.length() > RoomChatMessage.MAXIMUM_LENGTH) {
             try {
@@ -201,11 +206,12 @@ public class RoomChatMessage implements Runnable, ISerialize, DatabaseLoggable {
             message.appendInt(this.getEmotion());
             message.appendInt(this.getBubble().getType());
             message.appendInt(0);
-			message.appendString(this.RoomChatColour); //Added packet for room chat
+            message.appendString(this.RoomChatColour); // Added packet for room chat
             message.appendInt(this.getMessage().length());
 
             // Custom prefix data
-            UserCustomizationData customizationData = (this.habbo != null) ? UserCustomizationData.fromHabbo(this.habbo) : UserCustomizationData.empty();
+            UserCustomizationData customizationData =
+                    (this.habbo != null) ? UserCustomizationData.fromHabbo(this.habbo) : UserCustomizationData.empty();
             message.appendString(customizationData.prefixText);
             message.appendString(customizationData.prefixColor);
             message.appendString(customizationData.prefixIcon);
@@ -225,7 +231,8 @@ public class RoomChatMessage implements Runnable, ISerialize, DatabaseLoggable {
             }
         }
 
-        if (Emulator.getConfig().getBoolean("hotel.wordfilter.enabled") && Emulator.getConfig().getBoolean("hotel.wordfilter.rooms")) {
+        if (Emulator.getConfig().getBoolean("hotel.wordfilter.enabled")
+                && Emulator.getConfig().getBoolean("hotel.wordfilter.rooms")) {
             if (!this.habbo.hasPermission(Permission.ACC_CHAT_NO_FILTER)) {
                 if (!Emulator.getGameEnvironment().getWordFilter().autoReportCheck(this)) {
                     if (!Emulator.getGameEnvironment().getWordFilter().hideMessageCheck(this.message)) {
@@ -257,8 +264,7 @@ public class RoomChatMessage implements Runnable, ISerialize, DatabaseLoggable {
 
         if (this.targetHabbo != null)
             statement.setInt(2, this.targetHabbo.getHabboInfo().getId());
-        else
-            statement.setInt(2, 0);
+        else statement.setInt(2, 0);
 
         statement.setString(3, this.unfilteredMessage);
         statement.setInt(4, this.timestamp);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLayout.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLayout.java
@@ -15,487 +15,489 @@ import org.slf4j.LoggerFactory;
 
 public class RoomLayout {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(RoomLayout.class);
-  protected static final int BASICMOVEMENTCOST = 10;
-  protected static final int DIAGONALMOVEMENTCOST = 14;
-  public static double MAXIMUM_STEP_HEIGHT = 1.5;
-  public static boolean ALLOW_FALLING = true;
-  public static double UNDERPASS_HEIGHT = 1.5;
-  public boolean CANMOVEDIAGONALY = true;
-  private String name;
-  private short doorX;
-  private short doorY;
-  private short doorZ;
-  private int doorDirection;
-  private String heightmap;
-  private int mapSize;
-  private int mapSizeX;
-  private int mapSizeY;
-  private RoomTile[][] roomTiles;
-  private RoomTile doorTile;
-  private Room room;
-  private Pathfinder pathfinder;
+    private static final Logger LOGGER = LoggerFactory.getLogger(RoomLayout.class);
+    protected static final int BASICMOVEMENTCOST = 10;
+    protected static final int DIAGONALMOVEMENTCOST = 14;
+    public static volatile double MAXIMUM_STEP_HEIGHT = 1.5;
+    public static volatile boolean ALLOW_FALLING = true;
+    public static double UNDERPASS_HEIGHT = 1.5;
+    public boolean CANMOVEDIAGONALY = true;
+    private String name;
+    private short doorX;
+    private short doorY;
+    private short doorZ;
+    private int doorDirection;
+    private String heightmap;
+    private int mapSize;
+    private int mapSizeX;
+    private int mapSizeY;
+    private RoomTile[][] roomTiles;
+    private RoomTile doorTile;
+    private Room room;
+    private Pathfinder pathfinder;
 
-  public RoomLayout(ResultSet set, Room room) throws SQLException {
-    this.room = room;
-    try {
-      this.name = set.getString("name");
-      this.doorX = set.getShort("door_x");
-      this.doorY = set.getShort("door_y");
+    public RoomLayout(ResultSet set, Room room) throws SQLException {
+        this.room = room;
+        try {
+            this.name = set.getString("name");
+            this.doorX = set.getShort("door_x");
+            this.doorY = set.getShort("door_y");
 
-      this.doorDirection = set.getInt("door_dir");
-      this.heightmap = set.getString("heightmap");
+            this.doorDirection = set.getInt("door_dir");
+            this.heightmap = set.getString("heightmap");
 
-      this.parse();
-      this.pathfinder = new PathfinderImpl(this.room, MAXIMUM_STEP_HEIGHT,
-          Emulator.getConfig().getBoolean("pathfinder.step.allow.falling", true),
-          Emulator.getConfig().getBoolean("pathfinder.retro-style.diagonals", false));
-    } catch (Exception e) {
-      LOGGER.error("Caught exception", e);
-    }
-  }
-
-  public RoomLayout(RoomManager.RoomLayoutData data, Room room) {
-    this.room = room;
-    try {
-      this.name = data.name;
-      this.doorX = (short) data.doorX;
-      this.doorY = (short) data.doorY;
-
-      this.doorDirection = data.doorDir;
-      this.heightmap = data.heightmap;
-
-      this.parse();
-      this.pathfinder = new PathfinderImpl(this.room, MAXIMUM_STEP_HEIGHT,
-          Emulator.getConfig().getBoolean("pathfinder.step.allow.falling", true),
-          Emulator.getConfig().getBoolean("pathfinder.retro-style.diagonals", false));
-    } catch (Exception e) {
-      LOGGER.error("Caught exception", e);
-    }
-  }
-
-  public static boolean squareInSquare(Rectangle outerSquare, Rectangle innerSquare) {
-    if (outerSquare.x > innerSquare.x) {
-      return false;
+            this.parse();
+            this.pathfinder = new PathfinderImpl(
+                    this.room,
+                    MAXIMUM_STEP_HEIGHT,
+                    Emulator.getConfig().getBoolean("pathfinder.step.allow.falling", true),
+                    Emulator.getConfig().getBoolean("pathfinder.retro-style.diagonals", false));
+        } catch (Exception e) {
+            LOGGER.error("Caught exception", e);
+        }
     }
 
-    if (outerSquare.y > innerSquare.y) {
-      return false;
+    public RoomLayout(RoomManager.RoomLayoutData data, Room room) {
+        this.room = room;
+        try {
+            this.name = data.name;
+            this.doorX = (short) data.doorX;
+            this.doorY = (short) data.doorY;
+
+            this.doorDirection = data.doorDir;
+            this.heightmap = data.heightmap;
+
+            this.parse();
+            this.pathfinder = new PathfinderImpl(
+                    this.room,
+                    MAXIMUM_STEP_HEIGHT,
+                    Emulator.getConfig().getBoolean("pathfinder.step.allow.falling", true),
+                    Emulator.getConfig().getBoolean("pathfinder.retro-style.diagonals", false));
+        } catch (Exception e) {
+            LOGGER.error("Caught exception", e);
+        }
     }
 
-    if (outerSquare.x + outerSquare.width < innerSquare.x + innerSquare.width) {
-      return false;
-    }
-
-    return outerSquare.y + outerSquare.height >= innerSquare.y + innerSquare.height;
-  }
-
-  public static boolean tileInSquare(Rectangle square, RoomTile tile) {
-    return (square.contains(tile.x, tile.y));
-  }
-
-  public static boolean pointInSquare(int x1, int y1, int x2, int y2, int pointX, int pointY) {
-    return (pointX >= x1 && pointY >= y1) && (pointX <= x2 && pointY <= y2);
-  }
-
-  public static boolean tilesAdjecent(RoomTile one, RoomTile two) {
-    return !(one == null || two == null) && !(Math.abs(one.x - two.x) > 1) && !(
-        Math.abs(one.y - two.y) > 1);
-  }
-
-  public static Rectangle getRectangle(int x, int y, int width, int length, int rotation) {
-    rotation = (rotation % 8);
-
-    if (rotation == 2 || rotation == 6) {
-      return new Rectangle(x, y, length, width);
-    }
-
-    return new Rectangle(x, y, width, length);
-  }
-
-  public static boolean tilesAdjecent(RoomTile tile, RoomTile comparator, int width, int length,
-      int rotation) {
-    Rectangle rectangle = getRectangle(comparator.x, comparator.y, width, length, rotation);
-    rectangle = new Rectangle(rectangle.x - 1, rectangle.y - 1, rectangle.width + 2,
-        rectangle.height + 2);
-
-    return rectangle.contains(tile.x, tile.y);
-  }
-
-  public void parse() {
-    String[] modelTemp = this.heightmap.replace("\n", "").split(Character.toString('\r'));
-
-    this.mapSize = 0;
-    this.mapSizeX = modelTemp[0].length();
-    this.mapSizeY = modelTemp.length;
-    this.roomTiles = new RoomTile[this.mapSizeX][this.mapSizeY];
-
-    for (short y = 0; y < this.mapSizeY; y++) {
-      // A row shorter/longer than the model width (or empty) cannot be parsed
-      // per-square. Previously such tiles were left null while tileExists()
-      // still reported them present, causing NPEs in the coordinate accessors.
-      // Fill them with INVALID tiles so every in-bounds coordinate is non-null.
-      boolean validRow = !modelTemp[y].isEmpty() && modelTemp[y].length() == this.mapSizeX;
-
-      for (short x = 0; x < this.mapSizeX; x++) {
-        if (!validRow) {
-          this.roomTiles[x][y] = new RoomTile(x, y, (short) 0, RoomTileState.INVALID, true);
-          continue;
+    public static boolean squareInSquare(Rectangle outerSquare, Rectangle innerSquare) {
+        if (outerSquare.x > innerSquare.x) {
+            return false;
         }
 
-        String square = modelTemp[y].substring(x, x + 1).trim().toLowerCase();
-        RoomTileState state = RoomTileState.OPEN;
-        short height = 0;
-        if (square.equalsIgnoreCase("x")) {
-          state = RoomTileState.INVALID;
-        } else {
-          if (square.isEmpty()) {
-            height = 0;
-          } else if (Emulator.isNumeric(square)) {
-            height = Short.parseShort(square);
-          } else {
-            height = (short) (10 + "ABCDEFGHIJKLMNOPQRSTUVWXYZ".indexOf(square.toUpperCase()));
-          }
+        if (outerSquare.y > innerSquare.y) {
+            return false;
         }
-        this.mapSize += 1;
 
-        this.roomTiles[x][y] = new RoomTile(x, y, height, state, true);
-      }
-    }
-
-    this.doorTile = (this.doorX >= 0 && this.doorX < this.mapSizeX && this.doorY >= 0 && this.doorY < this.mapSizeY)
-        ? this.roomTiles[this.doorX][this.doorY]
-        : null;
-
-    if (this.doorTile != null) {
-      this.doorTile.setAllowStack(false);
-      RoomTile doorFrontTile = this.getTileInFront(this.doorTile, this.doorDirection);
-
-      if (doorFrontTile != null && this.tileExists(doorFrontTile.x, doorFrontTile.y)) {
-        if (this.roomTiles[doorFrontTile.x][doorFrontTile.y].state != RoomTileState.INVALID) {
-          if (this.doorZ != this.roomTiles[doorFrontTile.x][doorFrontTile.y].z
-              || this.roomTiles[this.doorX][this.doorY].state
-              != this.roomTiles[doorFrontTile.x][doorFrontTile.y].state) {
-            this.doorZ = this.roomTiles[doorFrontTile.x][doorFrontTile.y].z;
-            this.roomTiles[this.doorX][this.doorY].state = RoomTileState.OPEN;
-          }
+        if (outerSquare.x + outerSquare.width < innerSquare.x + innerSquare.width) {
+            return false;
         }
-      }
-    }
-  }
 
-  public String getName() {
-    return this.name;
-  }
-
-  public short getDoorX() {
-    return this.doorX;
-  }
-
-  public void setDoorX(short doorX) {
-    this.doorX = doorX;
-  }
-
-  public short getDoorY() {
-    return this.doorY;
-  }
-
-  public void setDoorY(short doorY) {
-    this.doorY = doorY;
-  }
-
-  public int getDoorZ() {
-    return this.doorZ;
-  }
-
-  public RoomTile getDoorTile() {
-    return this.doorTile;
-  }
-
-  public int getDoorDirection() {
-    return this.doorDirection;
-  }
-
-  public void setDoorDirection(int doorDirection) {
-    this.doorDirection = doorDirection;
-  }
-
-  public String getHeightmap() {
-    return this.heightmap;
-  }
-
-  public void setHeightmap(String heightMap) {
-    this.heightmap = heightMap;
-  }
-
-  public int getMapSize() {
-    return this.mapSize;
-  }
-
-  public int getMapSizeX() {
-    return this.mapSizeX;
-  }
-
-  public int getMapSizeY() {
-    return this.mapSizeY;
-  }
-
-  public short getHeightAtSquare(int x, int y) {
-    if (x < 0 || y < 0 || x >= this.getMapSizeX() || y >= this.getMapSizeY()) {
-      return 0;
+        return outerSquare.y + outerSquare.height >= innerSquare.y + innerSquare.height;
     }
 
-    return this.roomTiles[x][y].z;
-  }
-
-  public double getStackHeightAtSquare(int x, int y) {
-    if (x < 0 || y < 0 || x >= this.getMapSizeX() || y >= this.getMapSizeY()) {
-      return 0;
+    public static boolean tileInSquare(Rectangle square, RoomTile tile) {
+        return (square.contains(tile.x, tile.y));
     }
 
-    return this.roomTiles[x][y].getStackHeight();
-  }
-
-  public double getRelativeHeightAtSquare(int x, int y) {
-    if (x < 0 || y < 0 || x >= this.getMapSizeX() || y >= this.getMapSizeY()) {
-      return 0;
+    public static boolean pointInSquare(int x1, int y1, int x2, int y2, int pointX, int pointY) {
+        return (pointX >= x1 && pointY >= y1) && (pointX <= x2 && pointY <= y2);
     }
 
-    return this.roomTiles[x][y].relativeHeight();
-  }
+    public static boolean tilesAdjecent(RoomTile one, RoomTile two) {
+        return !(one == null || two == null) && !(Math.abs(one.x - two.x) > 1) && !(Math.abs(one.y - two.y) > 1);
+    }
 
-  public double getFloorAltitude(int x, int y) {
-    short baseHeight = this.getHeightAtSquare(x, y);
-    int target = baseHeight + 1;
+    public static Rectangle getRectangle(int x, int y, int width, int length, int rotation) {
+        rotation = (rotation % 8);
 
-    for (int dy = -1; dy <= 1; dy++) {
-      for (int dx = -1; dx <= 1; dx++) {
-        if (dx == 0 && dy == 0) continue;
-        if (this.getHeightAtSquare(x + dx, y + dy) == target) {
-          return baseHeight + 0.5;
+        if (rotation == 2 || rotation == 6) {
+            return new Rectangle(x, y, length, width);
         }
-      }
+
+        return new Rectangle(x, y, width, length);
     }
 
-    return baseHeight;
-  }
+    public static boolean tilesAdjecent(RoomTile tile, RoomTile comparator, int width, int length, int rotation) {
+        Rectangle rectangle = getRectangle(comparator.x, comparator.y, width, length, rotation);
+        rectangle = new Rectangle(rectangle.x - 1, rectangle.y - 1, rectangle.width + 2, rectangle.height + 2);
 
-  public RoomTile getTile(short x, short y) {
-    if (this.tileExists(x, y)) {
-      return this.roomTiles[x][y];
+        return rectangle.contains(tile.x, tile.y);
     }
 
-    return null;
-  }
+    public void parse() {
+        String[] modelTemp = this.heightmap.replace("\n", "").split(Character.toString('\r'));
 
-  public boolean tileExists(short x, short y) {
-    return !(x < 0 || y < 0 || x >= this.getMapSizeX() || y >= this.getMapSizeY());
-  }
+        this.mapSize = 0;
+        this.mapSizeX = modelTemp[0].length();
+        this.mapSizeY = modelTemp.length;
+        this.roomTiles = new RoomTile[this.mapSizeX][this.mapSizeY];
 
-  public boolean tileWalkable(short x, short y) {
-    return this.tileExists(x, y) && this.roomTiles[x][y].state == RoomTileState.OPEN
-        && this.roomTiles[x][y].isWalkable();
-  }
+        for (short y = 0; y < this.mapSizeY; y++) {
+            // A row shorter/longer than the model width (or empty) cannot be parsed
+            // per-square. Previously such tiles were left null while tileExists()
+            // still reported them present, causing NPEs in the coordinate accessors.
+            // Fill them with INVALID tiles so every in-bounds coordinate is non-null.
+            boolean validRow = !modelTemp[y].isEmpty() && modelTemp[y].length() == this.mapSizeX;
 
-  public boolean isVoidTile(short x, short y) {
-    if (!this.tileExists(x, y)) {
-      return true;
-    }
-    return this.roomTiles[x][y].state == RoomTileState.INVALID;
-  }
+            for (short x = 0; x < this.mapSizeX; x++) {
+                if (!validRow) {
+                    this.roomTiles[x][y] = new RoomTile(x, y, (short) 0, RoomTileState.INVALID, true);
+                    continue;
+                }
 
-  public String getRelativeMap() {
-    return this.heightmap.replace("\r\n", "\r");
-  }//re
+                String square = modelTemp[y].substring(x, x + 1).trim().toLowerCase();
+                RoomTileState state = RoomTileState.OPEN;
+                short height = 0;
+                if (square.equalsIgnoreCase("x")) {
+                    state = RoomTileState.INVALID;
+                } else {
+                    if (square.isEmpty()) {
+                        height = 0;
+                    } else if (Emulator.isNumeric(square)) {
+                        height = Short.parseShort(square);
+                    } else {
+                        height = (short) (10 + "ABCDEFGHIJKLMNOPQRSTUVWXYZ".indexOf(square.toUpperCase()));
+                    }
+                }
+                this.mapSize += 1;
 
-  public void moveDiagonally(boolean value) {
-    this.CANMOVEDIAGONALY = value;
-  }
-
-  public RoomTile getTileInFront(RoomTile tile, int rotation) {
-    return this.getTileInFront(tile, rotation, 0);
-  }
-
-  public RoomTile getTileInFront(RoomTile tile, int rotation, int offset) {
-    int offsetX = 0;
-    int offsetY = 0;
-
-    rotation = rotation % 8;
-    switch (rotation) {
-      case 0:
-        offsetY--;
-        break;
-      case 1:
-        offsetX++;
-        offsetY--;
-        break;
-      case 2:
-        offsetX++;
-        break;
-      case 3:
-        offsetX++;
-        offsetY++;
-        break;
-      case 4:
-        offsetY++;
-        break;
-      case 5:
-        offsetX--;
-        offsetY++;
-        break;
-      case 6:
-        offsetX--;
-        break;
-      case 7:
-        offsetX--;
-        offsetY--;
-        break;
-    }
-
-    short x = tile.x;
-    short y = tile.y;
-
-    for (int i = 0; i <= offset; i++) {
-      x += offsetX;
-      y += offsetY;
-    }
-
-    return this.getTile(x, y);
-  }
-
-  public List<RoomTile> getTilesInFront(RoomTile tile, int rotation, int amount) {
-    List<RoomTile> tiles = new ArrayList<>(amount);
-    RoomTile previous = tile;
-    for (int i = 0; i < amount; i++) {
-      RoomTile t = this.getTileInFront(previous, rotation, i);
-
-      if (t != null) {
-        tiles.add(t);
-      } else {
-        break;
-      }
-    }
-
-    return tiles;
-  }
-
-  public List<RoomTile> getTilesAround(RoomTile tile) {
-    return getTilesAround(tile, 0);
-  }
-
-  public List<RoomTile> getTilesAround(RoomTile tile, int directionOffset) {
-    return getTilesAround(tile, directionOffset, true);
-  }
-
-  public List<RoomTile> getTilesAround(RoomTile tile, int directionOffset, boolean diagonal) {
-    List<RoomTile> tiles = new ArrayList<>(diagonal ? 8 : 4);
-
-    if (tile != null) {
-      for (int i = 0; i < 8; i += (diagonal ? 1 : 2)) {
-        RoomTile t = this.getTileInFront(tile, (i + directionOffset) % 8);
-        if (t != null) {
-          tiles.add(t);
-        }
-      }
-    }
-
-    return tiles;
-  }
-
-  public List<RoomTile> getWalkableTilesAround(RoomTile tile) {
-    return getWalkableTilesAround(tile, 0);
-  }
-
-  public List<RoomTile> getWalkableTilesAround(RoomTile tile, int directionOffset) {
-    List<RoomTile> availableTiles = new ArrayList<>(this.getTilesAround(tile, directionOffset));
-
-    List<RoomTile> toRemove = new ArrayList<>();
-
-    for (RoomTile t : availableTiles) {
-      if (t == null || t.state != RoomTileState.OPEN || !t.isWalkable()) {
-        toRemove.add(t);
-      }
-    }
-
-    for (RoomTile t : toRemove) {
-      availableTiles.remove(t);
-    }
-
-    return availableTiles;
-  }
-
-  public boolean fitsOnMap(RoomTile tile, int width, int length, int rotation) {
-    if (tile != null) {
-      if (rotation == 0 || rotation == 4) {
-        for (short i = tile.x; i <= (tile.x + (width - 1)); i++) {
-          for (short j = tile.y; j <= (tile.y + (length - 1)); j++) {
-            RoomTile t = this.getTile(i, j);
-
-            if (t == null || t.getState() == RoomTileState.INVALID) {
-              return false;
+                this.roomTiles[x][y] = new RoomTile(x, y, height, state, true);
             }
-          }
         }
-      } else if (rotation == 2 || rotation == 6) {
-        for (short i = tile.x; i <= (tile.x + (length - 1)); i++) {
-          for (short j = tile.y; j <= (tile.y + (width - 1)); j++) {
-            RoomTile t = this.getTile(i, j);
 
-            if (t == null || t.getState() == RoomTileState.INVALID) {
-              return false;
+        this.doorTile = (this.doorX >= 0 && this.doorX < this.mapSizeX && this.doorY >= 0 && this.doorY < this.mapSizeY)
+                ? this.roomTiles[this.doorX][this.doorY]
+                : null;
+
+        if (this.doorTile != null) {
+            this.doorTile.setAllowStack(false);
+            RoomTile doorFrontTile = this.getTileInFront(this.doorTile, this.doorDirection);
+
+            if (doorFrontTile != null && this.tileExists(doorFrontTile.x, doorFrontTile.y)) {
+                if (this.roomTiles[doorFrontTile.x][doorFrontTile.y].state != RoomTileState.INVALID) {
+                    if (this.doorZ != this.roomTiles[doorFrontTile.x][doorFrontTile.y].z
+                            || this.roomTiles[this.doorX][this.doorY].state
+                                    != this.roomTiles[doorFrontTile.x][doorFrontTile.y].state) {
+                        this.doorZ = this.roomTiles[doorFrontTile.x][doorFrontTile.y].z;
+                        this.roomTiles[this.doorX][this.doorY].state = RoomTileState.OPEN;
+                    }
+                }
             }
-          }
         }
-      } else if (rotation == 1 || rotation == 3 || rotation == 5 || rotation == 7) {
-        RoomTile t = this.getTile(tile.x, tile.y);
-        if (t == null || t.getState() == RoomTileState.INVALID) {
-          return false;
-        }
-      }
     }
 
-    return true;
-  }
+    public String getName() {
+        return this.name;
+    }
 
-  public Set<RoomTile> getTilesAt(RoomTile tile, int width, int length, int rotation) {
-    Set<RoomTile> pointList = new HashSet<>(width * length);
+    public short getDoorX() {
+        return this.doorX;
+    }
 
-    if (tile != null) {
-      if (rotation == 0 || rotation == 4) {
-        for (short i = tile.x; i <= (tile.x + (width - 1)); i++) {
-          for (short j = tile.y; j <= (tile.y + (length - 1)); j++) {
-            RoomTile t = this.getTile(i, j);
+    public void setDoorX(short doorX) {
+        this.doorX = doorX;
+    }
+
+    public short getDoorY() {
+        return this.doorY;
+    }
+
+    public void setDoorY(short doorY) {
+        this.doorY = doorY;
+    }
+
+    public int getDoorZ() {
+        return this.doorZ;
+    }
+
+    public RoomTile getDoorTile() {
+        return this.doorTile;
+    }
+
+    public int getDoorDirection() {
+        return this.doorDirection;
+    }
+
+    public void setDoorDirection(int doorDirection) {
+        this.doorDirection = doorDirection;
+    }
+
+    public String getHeightmap() {
+        return this.heightmap;
+    }
+
+    public void setHeightmap(String heightMap) {
+        this.heightmap = heightMap;
+    }
+
+    public int getMapSize() {
+        return this.mapSize;
+    }
+
+    public int getMapSizeX() {
+        return this.mapSizeX;
+    }
+
+    public int getMapSizeY() {
+        return this.mapSizeY;
+    }
+
+    public short getHeightAtSquare(int x, int y) {
+        if (x < 0 || y < 0 || x >= this.getMapSizeX() || y >= this.getMapSizeY()) {
+            return 0;
+        }
+
+        return this.roomTiles[x][y].z;
+    }
+
+    public double getStackHeightAtSquare(int x, int y) {
+        if (x < 0 || y < 0 || x >= this.getMapSizeX() || y >= this.getMapSizeY()) {
+            return 0;
+        }
+
+        return this.roomTiles[x][y].getStackHeight();
+    }
+
+    public double getRelativeHeightAtSquare(int x, int y) {
+        if (x < 0 || y < 0 || x >= this.getMapSizeX() || y >= this.getMapSizeY()) {
+            return 0;
+        }
+
+        return this.roomTiles[x][y].relativeHeight();
+    }
+
+    public double getFloorAltitude(int x, int y) {
+        short baseHeight = this.getHeightAtSquare(x, y);
+        int target = baseHeight + 1;
+
+        for (int dy = -1; dy <= 1; dy++) {
+            for (int dx = -1; dx <= 1; dx++) {
+                if (dx == 0 && dy == 0) continue;
+                if (this.getHeightAtSquare(x + dx, y + dy) == target) {
+                    return baseHeight + 0.5;
+                }
+            }
+        }
+
+        return baseHeight;
+    }
+
+    public RoomTile getTile(short x, short y) {
+        if (this.tileExists(x, y)) {
+            return this.roomTiles[x][y];
+        }
+
+        return null;
+    }
+
+    public boolean tileExists(short x, short y) {
+        return !(x < 0 || y < 0 || x >= this.getMapSizeX() || y >= this.getMapSizeY());
+    }
+
+    public boolean tileWalkable(short x, short y) {
+        return this.tileExists(x, y)
+                && this.roomTiles[x][y].state == RoomTileState.OPEN
+                && this.roomTiles[x][y].isWalkable();
+    }
+
+    public boolean isVoidTile(short x, short y) {
+        if (!this.tileExists(x, y)) {
+            return true;
+        }
+        return this.roomTiles[x][y].state == RoomTileState.INVALID;
+    }
+
+    public String getRelativeMap() {
+        return this.heightmap.replace("\r\n", "\r");
+    } // re
+
+    public void moveDiagonally(boolean value) {
+        this.CANMOVEDIAGONALY = value;
+    }
+
+    public RoomTile getTileInFront(RoomTile tile, int rotation) {
+        return this.getTileInFront(tile, rotation, 0);
+    }
+
+    public RoomTile getTileInFront(RoomTile tile, int rotation, int offset) {
+        int offsetX = 0;
+        int offsetY = 0;
+
+        rotation = rotation % 8;
+        switch (rotation) {
+            case 0:
+                offsetY--;
+                break;
+            case 1:
+                offsetX++;
+                offsetY--;
+                break;
+            case 2:
+                offsetX++;
+                break;
+            case 3:
+                offsetX++;
+                offsetY++;
+                break;
+            case 4:
+                offsetY++;
+                break;
+            case 5:
+                offsetX--;
+                offsetY++;
+                break;
+            case 6:
+                offsetX--;
+                break;
+            case 7:
+                offsetX--;
+                offsetY--;
+                break;
+        }
+
+        short x = tile.x;
+        short y = tile.y;
+
+        for (int i = 0; i <= offset; i++) {
+            x += offsetX;
+            y += offsetY;
+        }
+
+        return this.getTile(x, y);
+    }
+
+    public List<RoomTile> getTilesInFront(RoomTile tile, int rotation, int amount) {
+        List<RoomTile> tiles = new ArrayList<>(amount);
+        RoomTile previous = tile;
+        for (int i = 0; i < amount; i++) {
+            RoomTile t = this.getTileInFront(previous, rotation, i);
 
             if (t != null) {
-              pointList.add(t);
+                tiles.add(t);
+            } else {
+                break;
             }
-          }
         }
-      } else if (rotation == 2 || rotation == 6) {
-        for (short i = tile.x; i <= (tile.x + (length - 1)); i++) {
-          for (short j = tile.y; j <= (tile.y + (width - 1)); j++) {
-            RoomTile t = this.getTile(i, j);
 
-            if (t != null) {
-              pointList.add(t);
-            }
-          }
-        }
-      } else if (rotation == 1 || rotation == 3 || rotation == 5 || rotation == 7) {
-        RoomTile t = this.getTile(tile.x, tile.y);
-        if (t != null) {
-          pointList.add(t);
-        }
-      }
+        return tiles;
     }
-    return pointList;
-  }
 
-  public Pathfinder getPathfinder() {
-    return pathfinder;
-  }
+    public List<RoomTile> getTilesAround(RoomTile tile) {
+        return getTilesAround(tile, 0);
+    }
 
-  public void setPathfinder(Pathfinder pathfinder) {
-    this.pathfinder = pathfinder;
-  }
+    public List<RoomTile> getTilesAround(RoomTile tile, int directionOffset) {
+        return getTilesAround(tile, directionOffset, true);
+    }
+
+    public List<RoomTile> getTilesAround(RoomTile tile, int directionOffset, boolean diagonal) {
+        List<RoomTile> tiles = new ArrayList<>(diagonal ? 8 : 4);
+
+        if (tile != null) {
+            for (int i = 0; i < 8; i += (diagonal ? 1 : 2)) {
+                RoomTile t = this.getTileInFront(tile, (i + directionOffset) % 8);
+                if (t != null) {
+                    tiles.add(t);
+                }
+            }
+        }
+
+        return tiles;
+    }
+
+    public List<RoomTile> getWalkableTilesAround(RoomTile tile) {
+        return getWalkableTilesAround(tile, 0);
+    }
+
+    public List<RoomTile> getWalkableTilesAround(RoomTile tile, int directionOffset) {
+        List<RoomTile> availableTiles = new ArrayList<>(this.getTilesAround(tile, directionOffset));
+
+        List<RoomTile> toRemove = new ArrayList<>();
+
+        for (RoomTile t : availableTiles) {
+            if (t == null || t.state != RoomTileState.OPEN || !t.isWalkable()) {
+                toRemove.add(t);
+            }
+        }
+
+        for (RoomTile t : toRemove) {
+            availableTiles.remove(t);
+        }
+
+        return availableTiles;
+    }
+
+    public boolean fitsOnMap(RoomTile tile, int width, int length, int rotation) {
+        if (tile != null) {
+            if (rotation == 0 || rotation == 4) {
+                for (short i = tile.x; i <= (tile.x + (width - 1)); i++) {
+                    for (short j = tile.y; j <= (tile.y + (length - 1)); j++) {
+                        RoomTile t = this.getTile(i, j);
+
+                        if (t == null || t.getState() == RoomTileState.INVALID) {
+                            return false;
+                        }
+                    }
+                }
+            } else if (rotation == 2 || rotation == 6) {
+                for (short i = tile.x; i <= (tile.x + (length - 1)); i++) {
+                    for (short j = tile.y; j <= (tile.y + (width - 1)); j++) {
+                        RoomTile t = this.getTile(i, j);
+
+                        if (t == null || t.getState() == RoomTileState.INVALID) {
+                            return false;
+                        }
+                    }
+                }
+            } else if (rotation == 1 || rotation == 3 || rotation == 5 || rotation == 7) {
+                RoomTile t = this.getTile(tile.x, tile.y);
+                if (t == null || t.getState() == RoomTileState.INVALID) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public Set<RoomTile> getTilesAt(RoomTile tile, int width, int length, int rotation) {
+        Set<RoomTile> pointList = new HashSet<>(width * length);
+
+        if (tile != null) {
+            if (rotation == 0 || rotation == 4) {
+                for (short i = tile.x; i <= (tile.x + (width - 1)); i++) {
+                    for (short j = tile.y; j <= (tile.y + (length - 1)); j++) {
+                        RoomTile t = this.getTile(i, j);
+
+                        if (t != null) {
+                            pointList.add(t);
+                        }
+                    }
+                }
+            } else if (rotation == 2 || rotation == 6) {
+                for (short i = tile.x; i <= (tile.x + (length - 1)); i++) {
+                    for (short j = tile.y; j <= (tile.y + (width - 1)); j++) {
+                        RoomTile t = this.getTile(i, j);
+
+                        if (t != null) {
+                            pointList.add(t);
+                        }
+                    }
+                }
+            } else if (rotation == 1 || rotation == 3 || rotation == 5 || rotation == 7) {
+                RoomTile t = this.getTile(tile.x, tile.y);
+                if (t != null) {
+                    pointList.add(t);
+                }
+            }
+        }
+        return pointList;
+    }
+
+    public Pathfinder getPathfinder() {
+        return pathfinder;
+    }
+
+    public void setPathfinder(Pathfinder pathfinder) {
+        this.pathfinder = pathfinder;
+    }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLayout.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomLayout.java
@@ -354,15 +354,15 @@ public class RoomLayout {
                 break;
         }
 
-        short x = tile.x;
-        short y = tile.y;
+        int x = tile.x;
+        int y = tile.y;
 
         for (int i = 0; i <= offset; i++) {
             x += offsetX;
             y += offsetY;
         }
 
-        return this.getTile(x, y);
+        return this.getTile((short) x, (short) y);
     }
 
     public List<RoomTile> getTilesInFront(RoomTile tile, int rotation, int amount) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -135,10 +135,10 @@ public class RoomManager {
 
     private static final int page = 0;
     // Configuration. Loaded from database & updated accordingly.
-    public static int MAXIMUM_ROOMS_USER = 25;
-    public static int MAXIMUM_ROOMS_HC = 35;
-    public static int HOME_ROOM_ID = 0;
-    public static boolean SHOW_PUBLIC_IN_POPULAR_TAB = false;
+    public static volatile int MAXIMUM_ROOMS_USER = 25;
+    public static volatile int MAXIMUM_ROOMS_HC = 35;
+    public static volatile int HOME_ROOM_ID = 0;
+    public static volatile boolean SHOW_PUBLIC_IN_POPULAR_TAB = false;
     private final Map<Integer, RoomCategory> roomCategories;
     private final RoomModelRepository roomModelRepository;
     private final RoomRepository roomRepository;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTrade.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTrade.java
@@ -8,25 +8,30 @@ import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
+import com.eu.habbo.messages.outgoing.trading.TradeAcceptedComposer;
+import com.eu.habbo.messages.outgoing.trading.TradeCloseWindowComposer;
+import com.eu.habbo.messages.outgoing.trading.TradeClosedComposer;
+import com.eu.habbo.messages.outgoing.trading.TradeCompleteComposer;
+import com.eu.habbo.messages.outgoing.trading.TradeStartComposer;
+import com.eu.habbo.messages.outgoing.trading.TradeUpdateComposer;
+import com.eu.habbo.messages.outgoing.trading.TradingWaitingConfirmComposer;
 import com.eu.habbo.messages.outgoing.users.UserCreditsComposer;
-import com.eu.habbo.messages.outgoing.trading.*;
 import com.eu.habbo.plugin.events.trading.TradeConfirmEvent;
 import com.eu.habbo.plugin.events.users.UserCreditsEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RoomTrade {
     private static final Logger LOGGER = LoggerFactory.getLogger(RoomTrade.class);
-    //Configuration. Loaded from database & updated accordingly.
-    public static boolean TRADING_ENABLED = true;
-    public static boolean TRADING_REQUIRES_PERK = true;
+    // Configuration. Loaded from database & updated accordingly.
+    public static volatile boolean TRADING_ENABLED = true;
+    public static volatile boolean TRADING_REQUIRES_PERK = true;
     public static final int MAX_OFFERED_ITEMS = 100;
 
     private final List<RoomTradeUser> users;
@@ -51,7 +56,8 @@ public class RoomTrade {
             if (!roomTradeUser.getHabbo().getRoomUnit().hasStatus(RoomUnitStatus.TRADING)) {
                 roomTradeUser.getHabbo().getRoomUnit().setStatus(RoomUnitStatus.TRADING, "");
                 if (!roomTradeUser.getHabbo().getRoomUnit().isWalking())
-                    this.room.sendComposer(new RoomUserStatusComposer(roomTradeUser.getHabbo().getRoomUnit()).compose());
+                    this.room.sendComposer(
+                            new RoomUserStatusComposer(roomTradeUser.getHabbo().getRoomUnit()).compose());
             }
         }
     }
@@ -63,8 +69,10 @@ public class RoomTrade {
     public synchronized void offerItem(Habbo habbo, HabboItem item) {
         RoomTradeUser user = this.getRoomTradeUserForHabbo(habbo);
 
-        if (user == null || item == null || user.getItems().contains(item) || user.getItems().size() >= MAX_OFFERED_ITEMS)
-            return;
+        if (user == null
+                || item == null
+                || user.getItems().contains(item)
+                || user.getItems().size() >= MAX_OFFERED_ITEMS) return;
 
         habbo.getInventory().getItemsComponent().removeHabboItem(item);
         user.getItems().add(item);
@@ -76,12 +84,10 @@ public class RoomTrade {
     public synchronized void offerMultipleItems(Habbo habbo, Set<HabboItem> items) {
         RoomTradeUser user = this.getRoomTradeUserForHabbo(habbo);
 
-        if (user == null || items == null)
-            return;
+        if (user == null || items == null) return;
 
         for (HabboItem item : items) {
-            if (user.getItems().size() >= MAX_OFFERED_ITEMS)
-                break;
+            if (user.getItems().size() >= MAX_OFFERED_ITEMS) break;
 
             if (!user.getItems().contains(item)) {
                 habbo.getInventory().getItemsComponent().removeHabboItem(item);
@@ -96,8 +102,7 @@ public class RoomTrade {
     public synchronized void removeItem(Habbo habbo, HabboItem item) {
         RoomTradeUser user = this.getRoomTradeUserForHabbo(habbo);
 
-        if (user == null || item == null || !user.getItems().contains(item))
-            return;
+        if (user == null || item == null || !user.getItems().contains(item)) return;
 
         habbo.getInventory().getItemsComponent().addItem(item);
         user.getItems().remove(item);
@@ -109,16 +114,14 @@ public class RoomTrade {
     public synchronized void accept(Habbo habbo, boolean value) {
         RoomTradeUser user = this.getRoomTradeUserForHabbo(habbo);
 
-        if (user == null)
-            return;
+        if (user == null) return;
 
         user.setAccepted(value);
 
         this.sendMessageToUsers(new TradeAcceptedComposer(user));
         boolean accepted = true;
         for (RoomTradeUser roomTradeUser : this.users) {
-            if (!roomTradeUser.getAccepted())
-                accepted = false;
+            if (!roomTradeUser.getAccepted()) accepted = false;
         }
         if (accepted) {
             this.sendMessageToUsers(new TradingWaitingConfirmComposer());
@@ -134,16 +137,14 @@ public class RoomTrade {
 
         RoomTradeUser user = this.getRoomTradeUserForHabbo(habbo);
 
-        if (user == null)
-            return;
+        if (user == null) return;
 
         user.confirm();
 
         this.sendMessageToUsers(new TradeAcceptedComposer(user));
         boolean accepted = true;
         for (RoomTradeUser roomTradeUser : this.users) {
-            if (!roomTradeUser.getConfirmed())
-                accepted = false;
+            if (!roomTradeUser.getConfirmed()) accepted = false;
         }
         if (accepted) {
             this.completed = true;
@@ -167,7 +168,8 @@ public class RoomTrade {
         for (RoomTradeUser roomTradeUser : this.users) {
             for (HabboItem item : roomTradeUser.getItems()) {
                 if (roomTradeUser.getHabbo().getInventory().getItemsComponent().getHabboItem(item.getId()) != null) {
-                    this.sendMessageToUsers(new TradeClosedComposer(roomTradeUser.getHabbo().getRoomUnit().getId(), TradeClosedComposer.ITEMS_NOT_FOUND));
+                    this.sendMessageToUsers(new TradeClosedComposer(
+                            roomTradeUser.getHabbo().getRoomUnit().getId(), TradeClosedComposer.ITEMS_NOT_FOUND));
                     return false;
                 }
             }
@@ -222,35 +224,30 @@ public class RoomTrade {
         final int committedCreditsForUserTwo = creditsForUserTwo;
 
         try {
-            LedgerWalletMutation.coordinated(
-                    userOne.getHabbo(),
-                    userTwo.getHabbo(),
-                    () -> {
-                        RoomTradeTransaction.CommitResult commit =
-                                RoomTradeTransaction.execute(
-                                        userOne.getHabbo(),
-                                        userTwo.getHabbo(),
-                                        userOne.getItems(),
-                                        userTwo.getItems(),
-                                        committedCreditsForUserOne,
-                                        committedCreditsForUserTwo,
-                                        Emulator.getConfig().getBoolean("hotel.log.trades"));
-                        applyCommittedCreditBalance(
-                                userOne.getHabbo(),
-                                commit.userOneCreditBalance());
-                        applyCommittedCreditBalance(
-                                userTwo.getHabbo(),
-                                commit.userTwoCreditBalance());
-                        return commit;
-                    });
+            LedgerWalletMutation.coordinated(userOne.getHabbo(), userTwo.getHabbo(), () -> {
+                RoomTradeTransaction.CommitResult commit = RoomTradeTransaction.execute(
+                        userOne.getHabbo(),
+                        userTwo.getHabbo(),
+                        userOne.getItems(),
+                        userTwo.getItems(),
+                        committedCreditsForUserOne,
+                        committedCreditsForUserTwo,
+                        Emulator.getConfig().getBoolean("hotel.log.trades"));
+                applyCommittedCreditBalance(userOne.getHabbo(), commit.userOneCreditBalance());
+                applyCommittedCreditBalance(userTwo.getHabbo(), commit.userTwoCreditBalance());
+                return commit;
+            });
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
-            this.sendMessageToUsers(new TradeClosedComposer(userOne.getHabbo().getRoomUnit().getId(), TradeClosedComposer.ITEMS_NOT_FOUND));
+            this.sendMessageToUsers(new TradeClosedComposer(
+                    userOne.getHabbo().getRoomUnit().getId(), TradeClosedComposer.ITEMS_NOT_FOUND));
             return false;
         }
 
-        for (HabboItem item : itemsUserOne) item.setUserId(userTwo.getHabbo().getHabboInfo().getId());
-        for (HabboItem item : itemsUserTwo) item.setUserId(userOne.getHabbo().getHabboInfo().getId());
+        for (HabboItem item : itemsUserOne)
+            item.setUserId(userTwo.getHabbo().getHabboInfo().getId());
+        for (HabboItem item : itemsUserTwo)
+            item.setUserId(userOne.getHabbo().getHabboInfo().getId());
 
         userOne.clearItems();
         userTwo.clearItems();
@@ -275,14 +272,10 @@ public class RoomTrade {
         return Emulator.getPluginManager().fireEvent(event).isCancelled() ? 0 : Math.max(0, event.credits);
     }
 
-    private static void applyCommittedCreditBalance(
-            Habbo habbo,
-            Integer committedBalance) {
+    private static void applyCommittedCreditBalance(Habbo habbo, Integer committedBalance) {
         if (committedBalance == null) return;
         LedgerWalletMutation.applyCommitted(
-                habbo,
-                com.eu.habbo.habbohotel.economy.EconomyLedger.CREDITS,
-                committedBalance);
+                habbo, com.eu.habbo.habbohotel.economy.EconomyLedger.CREDITS, committedBalance);
     }
 
     private static void publishCommittedCredits(Habbo habbo, int credits) {
@@ -323,7 +316,8 @@ public class RoomTrade {
             user.clearItems();
         }
         this.updateWindow();
-        this.sendMessageToUsers(new TradeClosedComposer(habbo.getHabboInfo().getId(), TradeClosedComposer.USER_CANCEL_TRADE));
+        this.sendMessageToUsers(
+                new TradeClosedComposer(habbo.getHabboInfo().getId(), TradeClosedComposer.USER_CANCEL_TRADE));
         this.room.stopTrade(this);
     }
 
@@ -331,8 +325,7 @@ public class RoomTrade {
         for (RoomTradeUser user : this.users) {
             Habbo habbo = user.getHabbo();
 
-            if (habbo == null)
-                continue;
+            if (habbo == null) continue;
 
             habbo.getRoomUnit().removeStatus(RoomUnitStatus.TRADING);
             this.room.sendComposer(new RoomUserStatusComposer(habbo.getRoomUnit()).compose());
@@ -341,8 +334,7 @@ public class RoomTrade {
 
     public RoomTradeUser getRoomTradeUserForHabbo(Habbo habbo) {
         for (RoomTradeUser roomTradeUser : this.users) {
-            if (roomTradeUser.getHabbo() == habbo)
-                return roomTradeUser;
+            if (roomTradeUser.getHabbo() == habbo) return roomTradeUser;
         }
         return null;
     }
@@ -401,7 +393,8 @@ public class RoomTrade {
     public static int getCreditsByItem(HabboItem item) {
         if (!Emulator.getConfig().getBoolean("redeem.currency.trade")) return 0;
 
-        if (!item.getBaseItem().getName().startsWith("CF_") && !item.getBaseItem().getName().startsWith("CFC_")) return 0;
+        if (!item.getBaseItem().getName().startsWith("CF_")
+                && !item.getBaseItem().getName().startsWith("CFC_")) return 0;
 
         try {
             return Integer.parseInt(item.getBaseItem().getName().split("_")[1]);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/TraxManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/TraxManager.java
@@ -17,9 +17,6 @@ import com.eu.habbo.messages.outgoing.inventory.RemoveHabboItemComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.jukebox.JukeBoxMySongsComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.jukebox.JukeBoxNowPlayingMessageComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.jukebox.JukeBoxPlayListComposer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -28,10 +25,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TraxManager implements Disposable {
-    public static int NORMAL_JUKEBOX_LIMIT = 10;
-    public static int LARGE_JUKEBOX_LIMIT = 20;
+    public static volatile int NORMAL_JUKEBOX_LIMIT = 10;
+    public static volatile int LARGE_JUKEBOX_LIMIT = 20;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TraxManager.class);
     private final Room room;
@@ -52,24 +51,20 @@ public class TraxManager implements Disposable {
         this(room, RoomDependencies.runtime().database());
     }
 
-    TraxManager(
-            Room room,
-            RoomDependencies.ConnectionProvider database) {
+    TraxManager(Room room, RoomDependencies.ConnectionProvider database) {
         this.room = room;
         this.database = Objects.requireNonNull(database, "database");
 
-        //Check if room has a Jukebox already on DB
+        // Check if room has a Jukebox already on DB
         this.jukeBox = this.loadRoomJukebox();
 
         if (this.jukeBox == null) {
-            //Check again if there's a jukebox on room but has not been saved on DB before
-            for (HabboItem item : room.getRoomSpecialTypes().getItemsOfType(InteractionJukeBox.class))
-            {
+            // Check again if there's a jukebox on room but has not been saved on DB before
+            for (HabboItem item : room.getRoomSpecialTypes().getItemsOfType(InteractionJukeBox.class)) {
                 this.jukeBox = (InteractionJukeBox) item;
             }
 
-            if(this.jukeBox != null)
-            {
+            if (this.jukeBox != null) {
                 this.loadPlaylist();
                 this.songsLimit = this.getSongsLimit(this.jukeBox);
             }
@@ -80,12 +75,15 @@ public class TraxManager implements Disposable {
     }
 
     public InteractionJukeBox loadRoomJukebox() {
-        try (Connection connection = this.database.openConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM room_trax WHERE room_id = ?")) {
+        try (Connection connection = this.database.openConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("SELECT * FROM room_trax WHERE room_id = ?")) {
             statement.setInt(1, this.room.getId());
             try (ResultSet set = statement.executeQuery()) {
                 if (set.next()) {
-                    HabboItem jukebox = Emulator.getGameEnvironment().getItemManager().loadHabboItem(set.getInt("trax_item_id"));
-                    if(jukebox != null) {
+                    HabboItem jukebox =
+                            Emulator.getGameEnvironment().getItemManager().loadHabboItem(set.getInt("trax_item_id"));
+                    if (jukebox != null) {
                         if (!(jukebox instanceof InteractionJukeBox)) {
                             return null;
                         } else {
@@ -102,22 +100,25 @@ public class TraxManager implements Disposable {
     }
 
     public void loadPlaylist() {
-        if(this.jukeBox == null) return;
+        if (this.jukeBox == null) return;
 
         this.songs.clear();
 
-        try (Connection connection = this.database.openConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM trax_playlist WHERE trax_item_id = ?")) {
+        try (Connection connection = this.database.openConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("SELECT * FROM trax_playlist WHERE trax_item_id = ?")) {
             statement.setInt(1, this.jukeBox.getId());
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
-                    HabboItem musicDisc = Emulator.getGameEnvironment().getItemManager().loadHabboItem(set.getInt("item_id"));
-                    if(musicDisc != null) {
-                        if (!(musicDisc instanceof  InteractionMusicDisc) || musicDisc.getRoomId() != -1) {
-                            this.deleteSongFromCurrentPlaylist(
-                                    this.jukeBox.getId(),
-                                    musicDisc.getId());
+                    HabboItem musicDisc =
+                            Emulator.getGameEnvironment().getItemManager().loadHabboItem(set.getInt("item_id"));
+                    if (musicDisc != null) {
+                        if (!(musicDisc instanceof InteractionMusicDisc) || musicDisc.getRoomId() != -1) {
+                            this.deleteSongFromCurrentPlaylist(this.jukeBox.getId(), musicDisc.getId());
                         } else {
-                            SoundTrack track = Emulator.getGameEnvironment().getItemManager().getSoundTrack(((InteractionMusicDisc) musicDisc).getSongId());
+                            SoundTrack track = Emulator.getGameEnvironment()
+                                    .getItemManager()
+                                    .getSoundTrack(((InteractionMusicDisc) musicDisc).getSongId());
 
                             if (track != null) {
                                 this.songs.add((InteractionMusicDisc) musicDisc);
@@ -125,7 +126,6 @@ public class TraxManager implements Disposable {
                             }
                         }
                     }
-
                 }
             }
         } catch (SQLException e) {
@@ -133,12 +133,8 @@ public class TraxManager implements Disposable {
         }
     }
 
-    public static void deleteSongFromPlaylist(int jukebox_id, int song_id)
-    {
-        deleteSongFromPlaylist(
-                jukebox_id,
-                song_id,
-                RoomDependencies.runtime().database());
+    public static void deleteSongFromPlaylist(int jukebox_id, int song_id) {
+        deleteSongFromPlaylist(jukebox_id, song_id, RoomDependencies.runtime().database());
     }
 
     private void deleteSongFromCurrentPlaylist(int jukeboxId, int songId) {
@@ -146,10 +142,10 @@ public class TraxManager implements Disposable {
     }
 
     private static void deleteSongFromPlaylist(
-            int jukeboxId,
-            int songId,
-            RoomDependencies.ConnectionProvider database) {
-        try (Connection connection = database.openConnection(); PreparedStatement statement =  connection.prepareStatement("DELETE FROM trax_playlist WHERE trax_item_id = ? AND item_id = ? LIMIT 1")) {
+            int jukeboxId, int songId, RoomDependencies.ConnectionProvider database) {
+        try (Connection connection = database.openConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "DELETE FROM trax_playlist WHERE trax_item_id = ? AND item_id = ? LIMIT 1")) {
             statement.setInt(1, jukeboxId);
             statement.setInt(2, songId);
             statement.execute();
@@ -159,15 +155,15 @@ public class TraxManager implements Disposable {
     }
 
     public void addTraxOnRoom(InteractionJukeBox jukeBox) {
-        if(this.jukeBox != null) return;
+        if (this.jukeBox != null) return;
 
-        try (Connection connection = this.database.openConnection(); PreparedStatement statement_1 = connection.prepareStatement("INSERT INTO room_trax (room_id, trax_item_id) VALUES (?, ?)"))
-        {
+        try (Connection connection = this.database.openConnection();
+                PreparedStatement statement_1 =
+                        connection.prepareStatement("INSERT INTO room_trax (room_id, trax_item_id) VALUES (?, ?)")) {
             statement_1.setInt(1, this.room.getId());
             statement_1.setInt(2, jukeBox.getId());
             statement_1.execute();
-        }
-        catch (SQLException e) {
+        } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
             return;
         }
@@ -178,14 +174,14 @@ public class TraxManager implements Disposable {
     }
 
     public void removeTraxOnRoom(InteractionJukeBox jukeBox) {
-        if(this.jukeBox.getId() != jukeBox.getId()) return;
+        if (this.jukeBox.getId() != jukeBox.getId()) return;
 
-        try (Connection connection = this.database.openConnection(); PreparedStatement statement_1 = connection.prepareStatement("DELETE FROM room_trax WHERE room_id = ?"))
-        {
+        try (Connection connection = this.database.openConnection();
+                PreparedStatement statement_1 =
+                        connection.prepareStatement("DELETE FROM room_trax WHERE room_id = ?")) {
             statement_1.setInt(1, this.room.getId());
             statement_1.execute();
-        }
-        catch (SQLException e) {
+        } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
             return;
         }
@@ -199,10 +195,12 @@ public class TraxManager implements Disposable {
         if (this.isPlaying()) {
             if (this.timePlaying() >= this.totalLength) {
                 this.play(0);
-                //restart
+                // restart
             }
 
-            if (this.currentSong() != null && Emulator.getIntUnixTimestamp() >= this.startedTimestamp + this.currentSong().getLength()) {
+            if (this.currentSong() != null
+                    && Emulator.getIntUnixTimestamp()
+                            >= this.startedTimestamp + this.currentSong().getLength()) {
                 this.play((this.playingIndex + 1) % this.songs.size());
             }
         }
@@ -234,7 +232,13 @@ public class TraxManager implements Disposable {
                 }
             }
 
-            this.room.sendComposer(new JukeBoxNowPlayingMessageComposer(Emulator.getGameEnvironment().getItemManager().getSoundTrack(this.currentlyPlaying.getSongId()), this.playingIndex, 0).compose());
+            this.room.sendComposer(new JukeBoxNowPlayingMessageComposer(
+                            Emulator.getGameEnvironment()
+                                    .getItemManager()
+                                    .getSoundTrack(this.currentlyPlaying.getSongId()),
+                            this.playingIndex,
+                            0)
+                    .compose());
         } else {
             this.stop();
         }
@@ -242,7 +246,10 @@ public class TraxManager implements Disposable {
 
     public void stop() {
         if (this.starter != null && this.cycleStartedTimestamp > 0) {
-            AchievementManager.progressAchievement(this.starter, Emulator.getGameEnvironment().getAchievementManager().getAchievement("MusicPlayer"), (Emulator.getIntUnixTimestamp() - cycleStartedTimestamp) / 60);
+            AchievementManager.progressAchievement(
+                    this.starter,
+                    Emulator.getGameEnvironment().getAchievementManager().getAchievement("MusicPlayer"),
+                    (Emulator.getIntUnixTimestamp() - cycleStartedTimestamp) / 60);
         }
 
         this.room.setJukeBoxActive(false);
@@ -260,29 +267,33 @@ public class TraxManager implements Disposable {
 
     public SoundTrack currentSong() {
         if (!this.songs.isEmpty() && this.playingIndex < this.songs.size()) {
-            return Emulator.getGameEnvironment().getItemManager().getSoundTrack(this.songs.get(this.playingIndex).getSongId());
+            return Emulator.getGameEnvironment()
+                    .getItemManager()
+                    .getSoundTrack(this.songs.get(this.playingIndex).getSongId());
         }
         return null;
     }
 
     public void addSong(InteractionMusicDisc musicDisc, Habbo habbo) {
-        if(this.jukeBox == null) return;
+        if (this.jukeBox == null) return;
 
-        if(this.songsLimit < this.songs.size() + 1)
-        {
-            ServerMessage msg = new BubbleAlertComposer("${playlist.editor.alert.playlist.full.title}", "${playlist.editor.alert.playlist.full}").compose();
+        if (this.songsLimit < this.songs.size() + 1) {
+            ServerMessage msg = new BubbleAlertComposer(
+                            "${playlist.editor.alert.playlist.full.title}", "${playlist.editor.alert.playlist.full}")
+                    .compose();
             habbo.getClient().sendResponse(msg);
             return;
         }
 
         SoundTrack track = Emulator.getGameEnvironment().getItemManager().getSoundTrack(musicDisc.getSongId());
 
-        if (track != null)
-        {
+        if (track != null) {
             this.totalLength += track.getLength();
             this.songs.add(musicDisc);
 
-            try (Connection connection = this.database.openConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO trax_playlist (trax_item_id, item_id) VALUES (?, ?)")) {
+            try (Connection connection = this.database.openConnection();
+                    PreparedStatement statement = connection.prepareStatement(
+                            "INSERT INTO trax_playlist (trax_item_id, item_id) VALUES (?, ?)")) {
                 statement.setInt(1, this.jukeBox.getId());
                 statement.setInt(2, musicDisc.getId());
                 statement.execute();
@@ -305,7 +316,7 @@ public class TraxManager implements Disposable {
     }
 
     public void removeSong(int itemId) {
-        if(this.songs.isEmpty()) return;
+        if (this.songs.isEmpty()) return;
 
         InteractionMusicDisc musicDisc = this.getSong(itemId);
 
@@ -314,7 +325,10 @@ public class TraxManager implements Disposable {
 
             deleteSongFromPlaylist(this.jukeBox.getId(), itemId);
 
-            this.totalLength -= Emulator.getGameEnvironment().getItemManager().getSoundTrack(musicDisc.getSongId()).getLength();
+            this.totalLength -= Emulator.getGameEnvironment()
+                    .getItemManager()
+                    .getSoundTrack(musicDisc.getSongId())
+                    .getLength();
             if (this.currentlyPlaying == musicDisc) {
                 this.play(this.playingIndex);
             }
@@ -341,22 +355,26 @@ public class TraxManager implements Disposable {
         this.sendUpdatedSongList();
     }
 
-    public static void removeAllSongs(InteractionJukeBox jukebox)
-    {
-        try (Connection connection = RoomDependencies.runtime().database().openConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM trax_playlist WHERE trax_item_id = ?")) {
+    public static void removeAllSongs(InteractionJukeBox jukebox) {
+        try (Connection connection = RoomDependencies.runtime().database().openConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("SELECT * FROM trax_playlist WHERE trax_item_id = ?")) {
             statement.setInt(1, jukebox.getId());
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
-                    HabboItem musicDisc = Emulator.getGameEnvironment().getItemManager().loadHabboItem(set.getInt("item_id"));
+                    HabboItem musicDisc =
+                            Emulator.getGameEnvironment().getItemManager().loadHabboItem(set.getInt("item_id"));
                     deleteSongFromPlaylist(jukebox.getId(), set.getInt("item_id"));
 
-                    if(musicDisc != null) {
+                    if (musicDisc != null) {
                         if (musicDisc instanceof InteractionMusicDisc && musicDisc.getRoomId() == -1) {
                             musicDisc.setRoomId(0);
                             musicDisc.needsUpdate(true);
                             Emulator.getThreading().run(musicDisc);
 
-                            Habbo owner = Emulator.getGameEnvironment().getHabboManager().getHabbo(musicDisc.getUserId());
+                            Habbo owner = Emulator.getGameEnvironment()
+                                    .getHabboManager()
+                                    .getHabbo(musicDisc.getUserId());
 
                             if (owner != null) {
                                 owner.getInventory().getItemsComponent().addItem(musicDisc);
@@ -416,7 +434,13 @@ public class TraxManager implements Disposable {
 
     public void updateCurrentPlayingSong(Habbo habbo) {
         if (this.isPlaying()) {
-            habbo.getClient().sendResponse(new JukeBoxNowPlayingMessageComposer(Emulator.getGameEnvironment().getItemManager().getSoundTrack(this.currentlyPlaying.getSongId()), this.playingIndex, 1000 * (Emulator.getIntUnixTimestamp() - this.startedTimestamp)));
+            habbo.getClient()
+                    .sendResponse(new JukeBoxNowPlayingMessageComposer(
+                            Emulator.getGameEnvironment()
+                                    .getItemManager()
+                                    .getSoundTrack(this.currentlyPlaying.getSongId()),
+                            this.playingIndex,
+                            1000 * (Emulator.getIntUnixTimestamp() - this.startedTimestamp)));
         } else {
             habbo.getClient().sendResponse(new JukeBoxNowPlayingMessageComposer(null, -1, 0));
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInventory.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInventory.java
@@ -3,18 +3,25 @@ package com.eu.habbo.habbohotel.users;
 import com.eu.habbo.habbohotel.catalog.marketplace.MarketPlace;
 import com.eu.habbo.habbohotel.catalog.marketplace.MarketPlaceOffer;
 import com.eu.habbo.habbohotel.catalog.marketplace.MarketPlaceState;
-import com.eu.habbo.habbohotel.users.inventory.*;
+import com.eu.habbo.habbohotel.users.inventory.BadgesComponent;
+import com.eu.habbo.habbohotel.users.inventory.BotsComponent;
+import com.eu.habbo.habbohotel.users.inventory.EffectsComponent;
+import com.eu.habbo.habbohotel.users.inventory.ItemsComponent;
+import com.eu.habbo.habbohotel.users.inventory.NickIconsComponent;
+import com.eu.habbo.habbohotel.users.inventory.PetsComponent;
+import com.eu.habbo.habbohotel.users.inventory.PrefixesComponent;
+import com.eu.habbo.habbohotel.users.inventory.UserVisualSettingsComponent;
+import com.eu.habbo.habbohotel.users.inventory.WardrobeComponent;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Set;
 
 public class HabboInventory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HabboInventory.class);
 
-    //Configuration. Loaded from database & updated accordingly.
-    public static int MAXIMUM_ITEMS = 10000;
+    // Configuration. Loaded from database & updated accordingly.
+    public static volatile int MAXIMUM_ITEMS = 10000;
     private final Set<MarketPlaceOffer> items;
     private final Habbo habbo;
     private WardrobeComponent wardrobeComponent;
@@ -205,8 +212,7 @@ public class HabboInventory {
     public MarketPlaceOffer getOffer(int id) {
         synchronized (this.items) {
             for (MarketPlaceOffer offer : this.items) {
-                if (offer.getOfferId() == id)
-                    return offer;
+                if (offer.getOfferId() == id) return offer;
             }
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboManager.java
@@ -1,15 +1,19 @@
 package com.eu.habbo.habbohotel.users;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.database.SqlQueries;
 import com.eu.habbo.habbohotel.economy.EconomyLedger;
 import com.eu.habbo.habbohotel.economy.EconomyOperation;
 import com.eu.habbo.habbohotel.economy.EconomyOperationId;
-import com.eu.habbo.database.SqlQueries;
 import com.eu.habbo.habbohotel.modtool.ModToolBan;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.permissions.Rank;
 import com.eu.habbo.messages.ServerMessage;
-import com.eu.habbo.messages.outgoing.catalog.*;
+import com.eu.habbo.messages.outgoing.catalog.CatalogModeComposer;
+import com.eu.habbo.messages.outgoing.catalog.CatalogUpdatedComposer;
+import com.eu.habbo.messages.outgoing.catalog.DiscountComposer;
+import com.eu.habbo.messages.outgoing.catalog.GiftConfigurationComposer;
+import com.eu.habbo.messages.outgoing.catalog.RecyclerLogicComposer;
 import com.eu.habbo.messages.outgoing.catalog.marketplace.MarketplaceConfigComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.GenericAlertComposer;
 import com.eu.habbo.messages.outgoing.modtool.ModToolComposer;
@@ -17,9 +21,6 @@ import com.eu.habbo.messages.outgoing.users.UserPerksComposer;
 import com.eu.habbo.messages.outgoing.users.UserPermissionsComposer;
 import com.eu.habbo.plugin.events.users.UserRankChangedEvent;
 import com.eu.habbo.plugin.events.users.UserRegisteredEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -31,13 +32,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HabboManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HabboManager.class);
 
-    //Configuration. Loaded from database & updated accordingly.
-    public static String WELCOME_MESSAGE = "";
+    // Configuration. Loaded from database & updated accordingly.
+    public static volatile String WELCOME_MESSAGE = "";
     public static boolean NAMECHANGE_ENABLED = false;
 
     private final ConcurrentHashMap<Integer, Habbo> onlineHabbos;
@@ -54,18 +57,15 @@ public class HabboManager {
 
         this.onlineHabbos = new ConcurrentHashMap<>();
         this.onlineHabbosByName = new ConcurrentHashMap<>();
-        this.disconnectPersistence =
-                new DisconnectPersistenceGate(persistenceExecutor);
+        this.disconnectPersistence = new DisconnectPersistenceGate(persistenceExecutor);
 
         LOGGER.info("Habbo Manager -> Loaded! ({} MS)", System.currentTimeMillis() - millis);
     }
 
     public static HabboInfo getOfflineHabboInfo(int id) {
         try {
-            return SqlQueries.queryOne(
-                    "SELECT * FROM users WHERE id = ? LIMIT 1",
-                    HabboInfo::new,
-                    id).orElse(null);
+            return SqlQueries.queryOne("SELECT * FROM users WHERE id = ? LIMIT 1", HabboInfo::new, id)
+                    .orElse(null);
         } catch (SqlQueries.DataAccessException e) {
             LOGGER.error("Caught SQL exception", e);
             return null;
@@ -74,10 +74,8 @@ public class HabboManager {
 
     public static HabboInfo getOfflineHabboInfo(String username) {
         try {
-            return SqlQueries.queryOne(
-                    "SELECT * FROM users WHERE username = ? LIMIT 1",
-                    HabboInfo::new,
-                    username).orElse(null);
+            return SqlQueries.queryOne("SELECT * FROM users WHERE username = ? LIMIT 1", HabboInfo::new, username)
+                    .orElse(null);
         } catch (SqlQueries.DataAccessException e) {
             LOGGER.error("Caught SQL exception", e);
             return null;
@@ -107,7 +105,8 @@ public class HabboManager {
         int userId = 0;
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT id FROM users WHERE auth_ticket = ? AND (auth_ticket_expires_at IS NULL OR auth_ticket_expires_at >= NOW()) LIMIT 1")) {
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT id FROM users WHERE auth_ticket = ? AND (auth_ticket_expires_at IS NULL OR auth_ticket_expires_at >= NOW()) LIMIT 1")) {
             statement.setString(1, sso);
             try (ResultSet s = statement.executeQuery()) {
                 if (s.next()) {
@@ -139,9 +138,9 @@ public class HabboManager {
             return null;
         }
 
-
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT * FROM users WHERE auth_ticket = ? AND (auth_ticket_expires_at IS NULL OR auth_ticket_expires_at >= NOW()) LIMIT 1")) {
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT * FROM users WHERE auth_ticket = ? AND (auth_ticket_expires_at IS NULL OR auth_ticket_expires_at >= NOW()) LIMIT 1")) {
             statement.setString(1, sso);
             try (ResultSet set = statement.executeQuery()) {
                 if (set.next()) {
@@ -172,25 +171,19 @@ public class HabboManager {
         if (this.disconnectPersistence.await(userId)) {
             return true;
         }
-        LOGGER.warn(
-                "Interrupted while waiting for disconnect persistence for user {}",
-                userId);
+        LOGGER.warn("Interrupted while waiting for disconnect persistence for user {}", userId);
         return false;
     }
 
-    DisconnectPersistenceGate.Registration beginDisconnectPersistence(
-            int userId) {
+    DisconnectPersistenceGate.Registration beginDisconnectPersistence(int userId) {
         return this.disconnectPersistence.begin(userId);
     }
 
-    void submitDisconnectPersistence(
-            DisconnectPersistenceGate.Registration registration,
-            Runnable persistence) {
+    void submitDisconnectPersistence(DisconnectPersistenceGate.Registration registration, Runnable persistence) {
         this.disconnectPersistence.submit(registration, persistence);
     }
 
-    void cancelDisconnectPersistence(
-            DisconnectPersistenceGate.Registration registration) {
+    void cancelDisconnectPersistence(DisconnectPersistenceGate.Registration registration) {
         this.disconnectPersistence.cancel(registration);
     }
 
@@ -243,9 +236,7 @@ public class HabboManager {
 
     public synchronized void dispose() {
 
-
-//
-
+        //
 
         LOGGER.info("Habbo Manager -> Disposed!");
     }
@@ -278,7 +269,6 @@ public class HabboManager {
         }
     }
 
-
     public void setRank(int userId, int rankId) throws Exception {
         Habbo habbo = this.getHabbo(userId);
 
@@ -291,7 +281,7 @@ public class HabboManager {
             if (!oldRank.getBadge().isEmpty()) {
                 habbo.deleteBadge(habbo.getInventory().getBadgesComponent().getBadge(oldRank.getBadge()));
             }
-            if(oldRank.getRoomEffect() > 0) {
+            if (oldRank.getRoomEffect() > 0) {
                 habbo.getInventory().getEffectsComponent().effects.remove(oldRank.getRoomEffect());
             }
 
@@ -301,8 +291,10 @@ public class HabboManager {
                 habbo.addBadge(newRank.getBadge());
             }
 
-            if(newRank.getRoomEffect() > 0) {
-                habbo.getInventory().getEffectsComponent().createRankEffect(habbo.getHabboInfo().getRank().getRoomEffect());
+            if (newRank.getRoomEffect() > 0) {
+                habbo.getInventory()
+                        .getEffectsComponent()
+                        .createRankEffect(habbo.getHabboInfo().getRank().getRoomEffect());
             }
 
             habbo.getClient().sendResponse(new UserPermissionsComposer(habbo));
@@ -319,7 +311,9 @@ public class HabboManager {
             habbo.getClient().sendResponse(new MarketplaceConfigComposer());
             habbo.getClient().sendResponse(new GiftConfigurationComposer());
             habbo.getClient().sendResponse(new RecyclerLogicComposer());
-            habbo.alert(Emulator.getTexts().getValue("commands.generic.cmd_give_rank.new_rank").replace("id", newRank.getName()));
+            habbo.alert(Emulator.getTexts()
+                    .getValue("commands.generic.cmd_give_rank.new_rank")
+                    .replace("id", newRank.getName()));
         } else {
             try {
                 SqlQueries.update("UPDATE users SET `rank` = ? WHERE id = ? LIMIT 1", rankId, userId);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/clothingvalidation/ClothingValidationManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/clothingvalidation/ClothingValidationManager.java
@@ -3,25 +3,24 @@ package com.eu.habbo.habbohotel.users.clothingvalidation;
 import com.eu.habbo.habbohotel.users.Habbo;
 import it.unimi.dsi.fastutil.ints.IntCollection;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ClothingValidationManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClothingValidationManager.class);
 
-    public static String FIGUREDATA_URL = "";
-    public static boolean VALIDATE_ON_HC_EXPIRE = false;
-    public static boolean VALIDATE_ON_LOGIN = false;
-    public static boolean VALIDATE_ON_CHANGE_LOOKS = false;
-    public static boolean VALIDATE_ON_MIMIC = false;
-    public static boolean VALIDATE_ON_MANNEQUIN = false;
-    public static boolean VALIDATE_ON_FBALLGATE = false;
+    public static volatile String FIGUREDATA_URL = "";
+    public static volatile boolean VALIDATE_ON_HC_EXPIRE = false;
+    public static volatile boolean VALIDATE_ON_LOGIN = false;
+    public static volatile boolean VALIDATE_ON_CHANGE_LOOKS = false;
+    public static volatile boolean VALIDATE_ON_MIMIC = false;
+    public static volatile boolean VALIDATE_ON_MANNEQUIN = false;
+    public static volatile boolean VALIDATE_ON_FBALLGATE = false;
 
     private static final Figuredata FIGUREDATA = new Figuredata();
 
@@ -49,7 +48,11 @@ public class ClothingValidationManager {
      * @return Cleaned figure string
      */
     public static String validateLook(Habbo habbo) {
-        return validateLook(habbo.getHabboInfo().getLook(), habbo.getHabboInfo().getGender().name(), habbo.getHabboStats().hasActiveClub(), habbo.getInventory().getWardrobeComponent().getClothingSets());
+        return validateLook(
+                habbo.getHabboInfo().getLook(),
+                habbo.getHabboInfo().getGender().name(),
+                habbo.getHabboStats().hasActiveClub(),
+                habbo.getInventory().getWardrobeComponent().getClothingSets());
     }
 
     /**
@@ -60,7 +63,11 @@ public class ClothingValidationManager {
      * @return Cleaned figure string
      */
     public static String validateLook(Habbo habbo, String look, String gender) {
-        return validateLook(look, gender, habbo.getHabboStats().hasActiveClub(), habbo.getInventory().getWardrobeComponent().getClothingSets());
+        return validateLook(
+                look,
+                gender,
+                habbo.getHabboStats().hasActiveClub(),
+                habbo.getInventory().getWardrobeComponent().getClothingSets());
     }
 
     /**
@@ -93,8 +100,7 @@ public class ClothingValidationManager {
      * @return Cleaned figure string
      */
     public static String validateLook(String look, String gender, boolean isHC, IntCollection ownedClothing) {
-        if(FIGUREDATA.palettes.size() == 0 || FIGUREDATA.settypes.size() == 0)
-            return look;
+        if (FIGUREDATA.palettes.size() == 0 || FIGUREDATA.settypes.size() == 0) return look;
 
         String[] newLookParts = look.split(Pattern.quote("."));
         ArrayList<String> lookParts = new ArrayList<>();
@@ -102,42 +108,38 @@ public class ClothingValidationManager {
         Map<String, String[]> parts = new HashMap<>();
 
         // add mandatory settypes
-        for(String lookpart : newLookParts) {
+        for (String lookpart : newLookParts) {
             if (lookpart.contains("-")) {
                 String[] data = lookpart.split(Pattern.quote("-"));
                 FiguredataSettype settype = FIGUREDATA.settypes.get(data[0]);
-                if(settype != null) {
+                if (settype != null) {
                     parts.put(data[0], data);
                 }
             }
         }
 
-        FIGUREDATA.settypes.entrySet().stream().filter(x -> !parts.containsKey(x.getKey())).forEach(x ->
-        {
-            FiguredataSettype settype = x.getValue();
+        FIGUREDATA.settypes.entrySet().stream()
+                .filter(x -> !parts.containsKey(x.getKey()))
+                .forEach(x -> {
+                    FiguredataSettype settype = x.getValue();
 
-            if(gender.equalsIgnoreCase("M") && !isHC && !settype.mandatoryMale0)
-                return;
+                    if (gender.equalsIgnoreCase("M") && !isHC && !settype.mandatoryMale0) return;
 
-            if(gender.equalsIgnoreCase("F") && !isHC && !settype.mandatoryFemale0)
-                return;
+                    if (gender.equalsIgnoreCase("F") && !isHC && !settype.mandatoryFemale0) return;
 
-            if(gender.equalsIgnoreCase("M") && isHC && !settype.mandatoryMale1)
-                return;
+                    if (gender.equalsIgnoreCase("M") && isHC && !settype.mandatoryMale1) return;
 
-            if(gender.equalsIgnoreCase("F") && isHC && !settype.mandatoryFemale1)
-                return;
+                    if (gender.equalsIgnoreCase("F") && isHC && !settype.mandatoryFemale1) return;
 
-            parts.put(x.getKey(), new String[] { x.getKey() });
-        });
-
+                    parts.put(x.getKey(), new String[] {x.getKey()});
+                });
 
         parts.forEach((key, data) -> {
             try {
                 if (data.length >= 1) {
                     FiguredataSettype settype = FIGUREDATA.settypes.get(data[0]);
                     if (settype == null) {
-                        //throw new Exception("Set type " + data[0] + " does not exist");
+                        // throw new Exception("Set type " + data[0] + " does not exist");
                         return;
                     }
 
@@ -152,18 +154,18 @@ public class ClothingValidationManager {
                     setId = Integer.parseInt(data.length >= 2 ? data[1] : "-1");
                     set = settype.getSet(setId);
 
-                    if (set == null || (set.club && !isHC) || !set.selectable || (set.sellable && !ownedClothing.contains(set.id)) || (!set.gender.equalsIgnoreCase("U") && !set.gender.equalsIgnoreCase(gender))) {
-                        if (gender.equalsIgnoreCase("M") && !isHC && !settype.mandatoryMale0)
-                            return;
+                    if (set == null
+                            || (set.club && !isHC)
+                            || !set.selectable
+                            || (set.sellable && !ownedClothing.contains(set.id))
+                            || (!set.gender.equalsIgnoreCase("U") && !set.gender.equalsIgnoreCase(gender))) {
+                        if (gender.equalsIgnoreCase("M") && !isHC && !settype.mandatoryMale0) return;
 
-                        if (gender.equalsIgnoreCase("F") && !isHC && !settype.mandatoryFemale0)
-                            return;
+                        if (gender.equalsIgnoreCase("F") && !isHC && !settype.mandatoryFemale0) return;
 
-                        if (gender.equalsIgnoreCase("M") && isHC && !settype.mandatoryMale1)
-                            return;
+                        if (gender.equalsIgnoreCase("M") && isHC && !settype.mandatoryMale1) return;
 
-                        if (gender.equalsIgnoreCase("F") && isHC && !settype.mandatoryFemale1)
-                            return;
+                        if (gender.equalsIgnoreCase("F") && isHC && !settype.mandatoryFemale1) return;
 
                         set = settype.getFirstNonHCSetForGender(gender);
                         setId = set.id;
@@ -204,12 +206,11 @@ public class ClothingValidationManager {
                     lookParts.add(String.join("-", dataParts));
                 }
             } catch (Exception e) {
-                //habbo.alert(e.getMessage());
+                // habbo.alert(e.getMessage());
                 LOGGER.error("Error in clothing validation", e);
             }
         });
 
         return String.join(".", lookParts);
     }
-
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/SubscriptionHabboClub.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/SubscriptionHabboClub.java
@@ -13,10 +13,9 @@ import com.eu.habbo.habbohotel.users.clothingvalidation.ClothingValidationManage
 import com.eu.habbo.messages.outgoing.catalog.ClubCenterDataComposer;
 import com.eu.habbo.messages.outgoing.generic.PickMonthlyClubGiftNotificationComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserDataComposer;
-import com.eu.habbo.messages.outgoing.users.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.eu.habbo.messages.outgoing.users.UpdateUserLookComposer;
+import com.eu.habbo.messages.outgoing.users.UserClubComposer;
+import com.eu.habbo.messages.outgoing.users.UserPermissionsComposer;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -26,6 +25,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Beny
@@ -33,28 +34,34 @@ import java.util.TreeMap;
 public class SubscriptionHabboClub extends Subscription {
     private static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionHabboClub.class);
 
-    public static boolean HC_PAYDAY_ENABLED = false;
-    public static int HC_PAYDAY_NEXT_DATE = Integer.MAX_VALUE; // yyyy-MM-dd HH:mm:ss
-    public static String HC_PAYDAY_INTERVAL = "";
-    public static String HC_PAYDAY_QUERY = "";
-    public static TreeMap<Integer, Integer> HC_PAYDAY_STREAK = new TreeMap<>();
-    public static String HC_PAYDAY_CURRENCY = "";
-    public static Double HC_PAYDAY_KICKBACK_PERCENTAGE = 0.1;
-    public static String ACHIEVEMENT_NAME = "";
-    public static boolean DISCOUNT_ENABLED = false;
-    public static int DISCOUNT_DAYS_BEFORE_END = 7;
+    public static volatile boolean HC_PAYDAY_ENABLED = false;
+    public static volatile int HC_PAYDAY_NEXT_DATE = Integer.MAX_VALUE; // yyyy-MM-dd HH:mm:ss
+    public static volatile String HC_PAYDAY_INTERVAL = "";
+    public static volatile String HC_PAYDAY_QUERY = "";
+    public static volatile TreeMap<Integer, Integer> HC_PAYDAY_STREAK = new TreeMap<>();
+    public static volatile String HC_PAYDAY_CURRENCY = "";
+    public static volatile Double HC_PAYDAY_KICKBACK_PERCENTAGE = 0.1;
+    public static volatile String ACHIEVEMENT_NAME = "";
+    public static volatile boolean DISCOUNT_ENABLED = false;
+    public static volatile int DISCOUNT_DAYS_BEFORE_END = 7;
 
     /**
      * When true "coins spent" will be calculated from the timestamp the user joins HC instead of from the last HC pay day execution timestamp
      */
-    public static boolean HC_PAYDAY_COINSSPENT_RESET_ON_EXPIRE = false;
+    public static volatile boolean HC_PAYDAY_COINSSPENT_RESET_ON_EXPIRE = false;
 
     /**
      * Boolean indicating if HC pay day currency executing. Prevents double execution
      */
     public static boolean isExecuting = false;
 
-    public SubscriptionHabboClub(Integer id, Integer userId, String subscriptionType, Integer timestampStart, Integer duration, Boolean active) {
+    public SubscriptionHabboClub(
+            Integer id,
+            Integer userId,
+            String subscriptionType,
+            Integer timestampStart,
+            Integer duration,
+            Boolean active) {
         super(id, userId, subscriptionType, timestampStart, duration, active);
     }
 
@@ -75,7 +82,9 @@ public class SubscriptionHabboClub extends Subscription {
 
         stats.maxFriends = Messenger.MAXIMUM_FRIENDS_HC;
         stats.maxRooms = RoomManager.MAXIMUM_ROOMS_HC;
-        stats.lastHCPayday = HC_PAYDAY_COINSSPENT_RESET_ON_EXPIRE ? Emulator.getIntUnixTimestamp() : HC_PAYDAY_NEXT_DATE - Emulator.timeStringToSeconds(HC_PAYDAY_INTERVAL);
+        stats.lastHCPayday = HC_PAYDAY_COINSSPENT_RESET_ON_EXPIRE
+                ? Emulator.getIntUnixTimestamp()
+                : HC_PAYDAY_NEXT_DATE - Emulator.timeStringToSeconds(HC_PAYDAY_INTERVAL);
         Emulator.getThreading().run(stats);
 
         progressAchievement(habboInfo);
@@ -84,16 +93,23 @@ public class SubscriptionHabboClub extends Subscription {
         if (habbo != null && habbo.getClient() != null) {
 
             if (habbo.getHabboStats().getRemainingClubGifts() > 0) {
-                habbo.getClient().sendResponse(new PickMonthlyClubGiftNotificationComposer(habbo.getHabboStats().getRemainingClubGifts()));
+                habbo.getClient()
+                        .sendResponse(new PickMonthlyClubGiftNotificationComposer(
+                                habbo.getHabboStats().getRemainingClubGifts()));
             }
 
             if ((Emulator.getIntUnixTimestamp() - habbo.getHabboStats().hcMessageLastModified) < 60) {
-                Emulator.getThreading().run(() -> {
-                    habbo.getClient().sendResponse(new UserClubComposer(habbo));
-                    habbo.getClient().sendResponse(new UserPermissionsComposer(habbo));
-                }, (Emulator.getIntUnixTimestamp() - habbo.getHabboStats().hcMessageLastModified));
+                Emulator.getThreading()
+                        .run(
+                                () -> {
+                                    habbo.getClient().sendResponse(new UserClubComposer(habbo));
+                                    habbo.getClient().sendResponse(new UserPermissionsComposer(habbo));
+                                },
+                                (Emulator.getIntUnixTimestamp() - habbo.getHabboStats().hcMessageLastModified));
             } else {
-                habbo.getClient().sendResponse(new UserClubComposer(habbo, SubscriptionHabboClub.HABBO_CLUB, UserClubComposer.RESPONSE_TYPE_NORMAL));
+                habbo.getClient()
+                        .sendResponse(new UserClubComposer(
+                                habbo, SubscriptionHabboClub.HABBO_CLUB, UserClubComposer.RESPONSE_TYPE_NORMAL));
                 habbo.getClient().sendResponse(new UserPermissionsComposer(habbo));
             }
         }
@@ -112,7 +128,9 @@ public class SubscriptionHabboClub extends Subscription {
         if (amount < 0) {
             Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(this.getUserId());
             if (habbo != null && habbo.getClient() != null) {
-                habbo.getClient().sendResponse(new UserClubComposer(habbo, SubscriptionHabboClub.HABBO_CLUB, UserClubComposer.RESPONSE_TYPE_NORMAL));
+                habbo.getClient()
+                        .sendResponse(new UserClubComposer(
+                                habbo, SubscriptionHabboClub.HABBO_CLUB, UserClubComposer.RESPONSE_TYPE_NORMAL));
                 habbo.getClient().sendResponse(new UserPermissionsComposer(habbo));
             }
         }
@@ -131,7 +149,9 @@ public class SubscriptionHabboClub extends Subscription {
         Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(this.getUserId());
 
         if (habbo != null && habbo.getClient() != null) {
-            habbo.getClient().sendResponse(new UserClubComposer(habbo, SubscriptionHabboClub.HABBO_CLUB, UserClubComposer.RESPONSE_TYPE_NORMAL));
+            habbo.getClient()
+                    .sendResponse(new UserClubComposer(
+                            habbo, SubscriptionHabboClub.HABBO_CLUB, UserClubComposer.RESPONSE_TYPE_NORMAL));
             habbo.getClient().sendResponse(new UserPermissionsComposer(habbo));
         }
     }
@@ -157,7 +177,8 @@ public class SubscriptionHabboClub extends Subscription {
         Emulator.getThreading().run(stats);
 
         if (habbo != null && ClothingValidationManager.VALIDATE_ON_HC_EXPIRE) {
-            habboInfo.setLook(ClothingValidationManager.validateLook(habbo, habboInfo.getLook(), habboInfo.getGender().name()));
+            habboInfo.setLook(ClothingValidationManager.validateLook(
+                    habbo, habboInfo.getLook(), habboInfo.getGender().name()));
             Emulator.getThreading().run(habbo.getHabboInfo());
 
             if (habbo.getClient() != null) {
@@ -170,7 +191,9 @@ public class SubscriptionHabboClub extends Subscription {
         }
 
         if (habbo != null && habbo.getClient() != null) {
-            habbo.getClient().sendResponse(new UserClubComposer(habbo, SubscriptionHabboClub.HABBO_CLUB, UserClubComposer.RESPONSE_TYPE_NORMAL));
+            habbo.getClient()
+                    .sendResponse(new UserClubComposer(
+                            habbo, SubscriptionHabboClub.HABBO_CLUB, UserClubComposer.RESPONSE_TYPE_NORMAL));
             habbo.getClient().sendResponse(new UserPermissionsComposer(habbo));
         }
     }
@@ -204,7 +227,8 @@ public class SubscriptionHabboClub extends Subscription {
         }
 
         if (HC_PAYDAY_ENABLED && activeSub != null) {
-            currentHcStreak = (int) Math.floor((Emulator.getIntUnixTimestamp() - activeSub.getTimestampStart()) / (60 * 60 * 24.0));
+            currentHcStreak = (int)
+                    Math.floor((Emulator.getIntUnixTimestamp() - activeSub.getTimestampStart()) / (60 * 60 * 24.0));
             if (currentHcStreak < 1) {
                 currentHcStreak = 0;
             }
@@ -221,7 +245,8 @@ public class SubscriptionHabboClub extends Subscription {
             queryParams.put("@timestamp_end", HC_PAYDAY_NEXT_DATE);
 
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                 PreparedStatement statement = Database.preparedStatementWithParams(connection, HC_PAYDAY_QUERY, queryParams)) {
+                    PreparedStatement statement =
+                            Database.preparedStatementWithParams(connection, HC_PAYDAY_QUERY, queryParams)) {
 
                 try (ResultSet set = statement.executeQuery()) {
                     while (set.next()) {
@@ -240,15 +265,16 @@ public class SubscriptionHabboClub extends Subscription {
 
         return new ClubCenterDataComposer(
                 currentHcStreak,
-                (firstEverSub != null ? new SimpleDateFormat("dd-MM-yyyy").format(new Date(firstEverSub.getTimestampStart() * 1000L)) : ""),
+                (firstEverSub != null
+                        ? new SimpleDateFormat("dd-MM-yyyy").format(new Date(firstEverSub.getTimestampStart() * 1000L))
+                        : ""),
                 HC_PAYDAY_KICKBACK_PERCENTAGE,
                 0,
                 0,
                 totalCreditsSpent,
                 creditRewardForStreakBonus,
                 creditRewardForMonthlySpent,
-                timeUntilPayday
-        );
+                timeUntilPayday);
     }
 
     /**
@@ -259,7 +285,10 @@ public class SubscriptionHabboClub extends Subscription {
         int timestampNow = Emulator.getIntUnixTimestamp();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT user_id FROM `users_subscriptions` WHERE subscription_type = '" + Subscription.HABBO_CLUB + "' AND `active` = 1 AND `timestamp_start` < ? AND (`timestamp_start` + `duration`) > ? GROUP BY user_id")) {
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT user_id FROM `users_subscriptions` WHERE subscription_type = '"
+                                + Subscription.HABBO_CLUB
+                                + "' AND `active` = 1 AND `timestamp_start` < ? AND (`timestamp_start` + `duration`) > ? GROUP BY user_id")) {
             statement.setInt(1, timestampNow);
             statement.setInt(2, timestampNow);
 
@@ -267,19 +296,36 @@ public class SubscriptionHabboClub extends Subscription {
                 while (set.next()) {
                     try {
                         int userId = set.getInt("user_id");
-                        HabboInfo habboInfo = Emulator.getGameEnvironment().getHabboManager().getHabboInfo(userId);
+                        HabboInfo habboInfo =
+                                Emulator.getGameEnvironment().getHabboManager().getHabboInfo(userId);
                         HabboStats stats = habboInfo.getHabboStats();
                         ClubCenterDataComposer calculated = calculatePayday(habboInfo);
-                        int totalReward = (calculated.creditRewardForMonthlySpent + calculated.creditRewardForStreakBonus);
+                        int totalReward =
+                                (calculated.creditRewardForMonthlySpent + calculated.creditRewardForStreakBonus);
                         if (totalReward > 0) {
-                            boolean claimed = claimPayDay(Emulator.getGameEnvironment().getHabboManager().getHabbo(userId), totalReward, HC_PAYDAY_CURRENCY);
-                            HcPayDayLogEntry le = new HcPayDayLogEntry(timestampNow, userId, calculated.currentHcStreak, calculated.totalCreditsSpent, calculated.creditRewardForMonthlySpent, calculated.creditRewardForStreakBonus, totalReward, HC_PAYDAY_CURRENCY, claimed);
+                            boolean claimed = claimPayDay(
+                                    Emulator.getGameEnvironment()
+                                            .getHabboManager()
+                                            .getHabbo(userId),
+                                    totalReward,
+                                    HC_PAYDAY_CURRENCY);
+                            HcPayDayLogEntry le = new HcPayDayLogEntry(
+                                    timestampNow,
+                                    userId,
+                                    calculated.currentHcStreak,
+                                    calculated.totalCreditsSpent,
+                                    calculated.creditRewardForMonthlySpent,
+                                    calculated.creditRewardForStreakBonus,
+                                    totalReward,
+                                    HC_PAYDAY_CURRENCY,
+                                    claimed);
                             Emulator.getThreading().run(le);
                         }
                         stats.lastHCPayday = timestampNow;
                         Emulator.getThreading().run(stats);
                     } catch (Exception e) {
-                        SubscriptionManager.LOGGER.error("Exception processing HC payday for user #{}", set.getInt("user_id"), e);
+                        SubscriptionManager.LOGGER.error(
+                                "Exception processing HC payday for user #{}", set.getInt("user_id"), e);
                     }
                 }
             }
@@ -288,14 +334,18 @@ public class SubscriptionHabboClub extends Subscription {
             date = Emulator.modifyDate(date, HC_PAYDAY_INTERVAL);
             HC_PAYDAY_NEXT_DATE = (int) (date.getTime() / 1000L);
 
-            try (PreparedStatement stm2 = connection.prepareStatement("UPDATE `emulator_settings` SET `value` = ? WHERE `key` = ?")) {
+            try (PreparedStatement stm2 =
+                    connection.prepareStatement("UPDATE `emulator_settings` SET `value` = ? WHERE `key` = ?")) {
                 SimpleDateFormat sdf = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
                 stm2.setString(1, sdf.format(date));
                 stm2.setString(2, "subscriptions.hc.payday.next_date");
                 stm2.execute();
             }
 
-            try (PreparedStatement stm2 = connection.prepareStatement("UPDATE users_settings SET last_hc_payday = ? WHERE user_id IN (SELECT user_id FROM `users_subscriptions` WHERE subscription_type = '" + Subscription.HABBO_CLUB + "' AND `active` = 1 AND `timestamp_start` < ? AND (`timestamp_start` + `duration`) > ? GROUP BY user_id)")) {
+            try (PreparedStatement stm2 = connection.prepareStatement(
+                    "UPDATE users_settings SET last_hc_payday = ? WHERE user_id IN (SELECT user_id FROM `users_subscriptions` WHERE subscription_type = '"
+                            + Subscription.HABBO_CLUB
+                            + "' AND `active` = 1 AND `timestamp_start` < ? AND (`timestamp_start` + `duration`) > ? GROUP BY user_id)")) {
                 stm2.setInt(1, timestampNow);
                 stm2.setInt(2, timestampNow);
                 stm2.setInt(3, timestampNow);
@@ -318,11 +368,14 @@ public class SubscriptionHabboClub extends Subscription {
         progressAchievement(habbo.getHabboInfo());
 
         if (habbo.getHabboStats().getRemainingClubGifts() > 0) {
-            habbo.getClient().sendResponse(new PickMonthlyClubGiftNotificationComposer(habbo.getHabboStats().getRemainingClubGifts()));
+            habbo.getClient()
+                    .sendResponse(new PickMonthlyClubGiftNotificationComposer(
+                            habbo.getHabboStats().getRemainingClubGifts()));
         }
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT * FROM `logs_hc_payday` WHERE user_id = ? AND claimed = 0")) {
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT * FROM `logs_hc_payday` WHERE user_id = ? AND claimed = 0")) {
             statement.setInt(1, habbo.getHabboInfo().getId());
 
             try (ResultSet set = statement.executeQuery()) {
@@ -334,13 +387,15 @@ public class SubscriptionHabboClub extends Subscription {
                         String currency = set.getString("currency");
 
                         if (claimPayDay(habbo, totalPayout, currency)) {
-                            try (PreparedStatement stm2 = connection.prepareStatement("UPDATE logs_hc_payday SET claimed = 1 WHERE id = ?")) {
+                            try (PreparedStatement stm2 =
+                                    connection.prepareStatement("UPDATE logs_hc_payday SET claimed = 1 WHERE id = ?")) {
                                 stm2.setInt(1, logId);
                                 stm2.execute();
                             }
                         }
                     } catch (Exception e) {
-                        SubscriptionManager.LOGGER.error("Exception processing HC payday for user #{}", set.getInt("user_id"), e);
+                        SubscriptionManager.LOGGER.error(
+                                "Exception processing HC payday for user #{}", set.getInt("user_id"), e);
                     }
                 }
             }
@@ -366,11 +421,10 @@ public class SubscriptionHabboClub extends Subscription {
      * @return Boolean indicating success of the operation
      */
     public static boolean claimPayDay(Habbo habbo, int amount, String currency) {
-        if(habbo == null)
-            return false;
+        if (habbo == null) return false;
 
         int pointCurrency;
-        switch(currency.toLowerCase()) {
+        switch (currency.toLowerCase()) {
             case "credits":
             case "coins":
             case "credit":
@@ -396,9 +450,10 @@ public class SubscriptionHabboClub extends Subscription {
                 pointCurrency = -1;
                 try {
                     pointCurrency = Integer.parseInt(currency);
-                }
-                catch (NumberFormatException ex) {
-                    LOGGER.error("Couldn't convert the type point currency {} on HC PayDay. The number must be a integer and positive.", pointCurrency);
+                } catch (NumberFormatException ex) {
+                    LOGGER.error(
+                            "Couldn't convert the type point currency {} on HC PayDay. The number must be a integer and positive.",
+                            pointCurrency);
                 }
 
                 if (pointCurrency >= 0) {
@@ -407,27 +462,31 @@ public class SubscriptionHabboClub extends Subscription {
                 break;
         }
 
-        habbo.alert(Emulator.getTexts().getValue("subscriptions.hc.payday.message", "Woohoo HC Payday has arrived! You have received %amount% credits to your purse. Enjoy!").replace("%amount%", "" + amount));
+        habbo.alert(Emulator.getTexts()
+                .getValue(
+                        "subscriptions.hc.payday.message",
+                        "Woohoo HC Payday has arrived! You have received %amount% credits to your purse. Enjoy!")
+                .replace("%amount%", "" + amount));
 
         return true;
     }
 
     private static void progressAchievement(HabboInfo habboInfo) {
         HabboStats stats = habboInfo.getHabboStats();
-        Achievement achievement = Emulator.getGameEnvironment().getAchievementManager().getAchievement(ACHIEVEMENT_NAME);
-        if(achievement != null) {
+        Achievement achievement =
+                Emulator.getGameEnvironment().getAchievementManager().getAchievement(ACHIEVEMENT_NAME);
+        if (achievement != null) {
             int currentProgress = stats.getAchievementProgress(achievement);
-            if(currentProgress == -1) {
+            if (currentProgress == -1) {
                 currentProgress = 0;
             }
 
-            int progressToSet = (int)Math.ceil(stats.getPastTimeAsClub() / 2678400.0);
+            int progressToSet = (int) Math.ceil(stats.getPastTimeAsClub() / 2678400.0);
             int toIncrease = Math.max(progressToSet - currentProgress, 0);
 
-            if(toIncrease > 0) {
+            if (toIncrease > 0) {
                 AchievementManager.progressAchievement(habboInfo.getId(), achievement, toIncrease);
             }
         }
     }
-
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEngine.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEngine.java
@@ -4,15 +4,11 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredExtra;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraFilterFurni;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraFilterFurniByVariable;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraFilterUser;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraFilterUsersByVariable;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraExecutionLimit;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraOrEval;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraRandom;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraUnseen;
-import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboClicksUser;
 import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboSaysKeyword;
 import com.eu.habbo.habbohotel.rooms.Room;
@@ -29,11 +25,19 @@ import com.eu.habbo.messages.outgoing.generic.alerts.GenericAlertComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.ItemStateComposer;
 import com.eu.habbo.plugin.events.furniture.wired.WiredStackExecutedEvent;
 import com.eu.habbo.plugin.events.furniture.wired.WiredStackTriggeredEvent;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The central engine for processing wired events.
@@ -69,43 +73,43 @@ public final class WiredEngine {
     private static final Logger LOGGER = LoggerFactory.getLogger(WiredEngine.class);
 
     /** Maximum recursion depth to prevent infinite loops (e.g., collision + chase) */
-    public static int MAX_RECURSION_DEPTH = 10;
+    public static volatile int MAX_RECURSION_DEPTH = 10;
 
     /** Maximum events of same type per room within rate limit window before banning */
-    public static int MAX_EVENTS_PER_WINDOW = 100;
+    public static volatile int MAX_EVENTS_PER_WINDOW = 100;
 
     /** Time window for counting rapid events (milliseconds) */
-    public static long RATE_LIMIT_WINDOW_MS = 10000;
+    public static volatile long RATE_LIMIT_WINDOW_MS = 10000;
 
     /** Duration to ban wired execution in a room after abuse detected (milliseconds) */
-    public static long WIRED_BAN_DURATION_MS = 600000;
+    public static volatile long WIRED_BAN_DURATION_MS = 600000;
 
     /** Monitor usage window in milliseconds */
-    public static int MONITOR_USAGE_WINDOW_MS = 1000;
+    public static volatile int MONITOR_USAGE_WINDOW_MS = 1000;
 
     /** Monitor execution cap per room window */
-    public static int MONITOR_USAGE_LIMIT = 50000;
+    public static volatile int MONITOR_USAGE_LIMIT = 50000;
 
     /** Maximum delayed events allowed per room at the same time */
-    public static int MONITOR_DELAYED_EVENTS_LIMIT = 50000;
+    public static volatile int MONITOR_DELAYED_EVENTS_LIMIT = 50000;
 
     /** Average execution threshold that marks overload */
-    public static int MONITOR_OVERLOAD_AVERAGE_MS = 50;
+    public static volatile int MONITOR_OVERLOAD_AVERAGE_MS = 50;
 
     /** Peak execution threshold that marks overload */
-    public static int MONITOR_OVERLOAD_PEAK_MS = 150;
+    public static volatile int MONITOR_OVERLOAD_PEAK_MS = 150;
 
     /** Consecutive overloaded windows required before recording overload */
-    public static int MONITOR_OVERLOAD_CONSECUTIVE_WINDOWS = 2;
+    public static volatile int MONITOR_OVERLOAD_CONSECUTIVE_WINDOWS = 2;
 
     /** Usage percentage threshold that marks a room as heavy */
-    public static int MONITOR_HEAVY_USAGE_PERCENT = 70;
+    public static volatile int MONITOR_HEAVY_USAGE_PERCENT = 70;
 
     /** Consecutive windows above threshold before marking heavy */
-    public static int MONITOR_HEAVY_CONSECUTIVE_WINDOWS = 5;
+    public static volatile int MONITOR_HEAVY_CONSECUTIVE_WINDOWS = 5;
 
     /** Delayed queue percentage threshold that contributes to heavy state */
-    public static int MONITOR_HEAVY_DELAYED_PERCENT = 60;
+    public static volatile int MONITOR_HEAVY_DELAYED_PERCENT = 60;
 
     private final WiredServices services;
     private final WiredStackIndex index;
@@ -191,14 +195,21 @@ public final class WiredEngine {
         int currentDepth = roomRecursionDepth.merge(roomId, 1, Integer::sum);
         if (currentDepth > MAX_RECURSION_DEPTH) {
             roomRecursionDepth.merge(roomId, -1, Integer::sum);
-            getDiagnostics(roomId).recordRecursionTimeout(
-                    System.currentTimeMillis(),
-                    String.format("Recursion depth %d/%d while handling %s", currentDepth, MAX_RECURSION_DEPTH, event.getType().name()),
-                    event.getType().name(),
-                    0
-            );
-            LOGGER.warn("Wired recursion limit reached in room {} (depth: {}). " +
-                    "Possible infinite loop detected (e.g., collision + chase). Aborting.", roomId, currentDepth);
+            getDiagnostics(roomId)
+                    .recordRecursionTimeout(
+                            System.currentTimeMillis(),
+                            String.format(
+                                    "Recursion depth %d/%d while handling %s",
+                                    currentDepth,
+                                    MAX_RECURSION_DEPTH,
+                                    event.getType().name()),
+                            event.getType().name(),
+                            0);
+            LOGGER.warn(
+                    "Wired recursion limit reached in room {} (depth: {}). "
+                            + "Possible infinite loop detected (e.g., collision + chase). Aborting.",
+                    roomId,
+                    currentDepth);
             debug(room, "RECURSION LIMIT REACHED - aborting to prevent crash");
             return false;
         }
@@ -242,8 +253,11 @@ public final class WiredEngine {
         int currentDepth = roomRecursionDepth.merge(roomId, 1, Integer::sum);
         if (currentDepth > MAX_RECURSION_DEPTH) {
             roomRecursionDepth.merge(roomId, -1, Integer::sum);
-            LOGGER.warn("Wired recursion limit reached in room {} (depth: {}). " +
-                    "Possible infinite loop detected (source item execution). Aborting.", roomId, currentDepth);
+            LOGGER.warn(
+                    "Wired recursion limit reached in room {} (depth: {}). "
+                            + "Possible infinite loop detected (source item execution). Aborting.",
+                    roomId,
+                    currentDepth);
             debug(room, "RECURSION LIMIT REACHED - aborting source-item execution");
             return false;
         }
@@ -264,7 +278,12 @@ public final class WiredEngine {
             return false;
         }
 
-        debug(room, "Processing {} stacks for event type {} from source item {}", stacks.size(), event.getType(), sourceItemId);
+        debug(
+                room,
+                "Processing {} stacks for event type {} from source item {}",
+                stacks.size(),
+                event.getType(),
+                sourceItemId);
 
         boolean anyTriggered = false;
         boolean suppressSaysOutput = false;
@@ -285,8 +304,12 @@ public final class WiredEngine {
             } catch (WiredLimitException limitEx) {
                 debug(room, "Stack execution stopped (limit): {}", limitEx.getMessage());
             } catch (Exception ex) {
-                LOGGER.error("Error processing source wired stack in room {} for item {}: {}",
-                        room.getId(), sourceItemId, ex.getMessage(), ex);
+                LOGGER.error(
+                        "Error processing source wired stack in room {} for item {}: {}",
+                        room.getId(),
+                        sourceItemId,
+                        ex.getMessage(),
+                        ex);
                 debug(room, "Source stack error: {}", ex.getMessage());
             }
         }
@@ -414,11 +437,13 @@ public final class WiredEngine {
         String monitorSourceLabel = getMonitorSourceLabel(stack.triggerItem(), event);
         int monitorSourceId = getMonitorSourceId(stack.triggerItem());
 
-        debug(room, "Trigger matched: {} at item {} (conditions: {}, effects: {})",
-              event.getType(),
-              stack.triggerItem() != null ? stack.triggerItem().getId() : "null",
-              stack.conditions().size(),
-              stack.effects().size());
+        debug(
+                room,
+                "Trigger matched: {} at item {} (conditions: {}, effects: {})",
+                event.getType(),
+                stack.triggerItem() != null ? stack.triggerItem().getId() : "null",
+                stack.conditions().size(),
+                stack.effects().size());
 
         // Run selectors before conditions so targets are available
         List<InteractionWiredEffect> executedSelectors = Collections.emptyList();
@@ -432,16 +457,20 @@ public final class WiredEngine {
         }
 
         boolean conditionsPassedForExecution = getConditionOutcomeForExecution(stack, ctx, negateConditions);
-        List<IWiredEffect> executableEffects = getExecutableEffectsForCurrentExecution(stack, conditionsPassedForExecution);
+        List<IWiredEffect> executableEffects =
+                getExecutableEffectsForCurrentExecution(stack, conditionsPassedForExecution);
         boolean hasSpecialOutcome = conditionsPassedForExecution && hasSpecialTriggerOutcome(stack, event);
 
-        if (!shouldContinueAfterConditionCheck(stack, room, conditionsPassedForExecution, executableEffects, hasSpecialOutcome)) {
+        if (!shouldContinueAfterConditionCheck(
+                stack, room, conditionsPassedForExecution, executableEffects, hasSpecialOutcome)) {
             return false;
         }
 
         WiredExtraExecutionLimit executionLimitExtra = getExecutionLimitExtra(room, stack);
         if (executionLimitExtra != null && !executionLimitExtra.tryAcquireExecutionSlot(currentTime)) {
-            debug(room, "Execution limit blocked stack {} (max {} in {} ms)",
+            debug(
+                    room,
+                    "Execution limit blocked stack {} (max {} in {} ms)",
                     stack.triggerItem() != null ? stack.triggerItem().getId() : "null",
                     executionLimitExtra.getMaxExecutions(),
                     executionLimitExtra.getTimeWindowMs());
@@ -460,7 +489,10 @@ public final class WiredEngine {
                 monitorSourceLabel,
                 monitorSourceId,
                 buildStackMonitorReason(stack, event, stackCost))) {
-            debug(room, "Execution cap blocked stack {}", stack.triggerItem() != null ? stack.triggerItem().getId() : "null");
+            debug(
+                    room,
+                    "Execution cap blocked stack {}",
+                    stack.triggerItem() != null ? stack.triggerItem().getId() : "null");
             return false;
         }
 
@@ -470,9 +502,7 @@ public final class WiredEngine {
                 && event.getActor().isPresent()) {
             WiredTriggerHabboClicksUser clickUserTrigger = (WiredTriggerHabboClicksUser) stack.triggerItem();
             WiredTriggerHabboClicksUser.applyRuntimeOptions(
-                    event.getActor().get(),
-                    clickUserTrigger.isBlockMenuOpen(),
-                    clickUserTrigger.isDoNotRotate());
+                    event.getActor().get(), clickUserTrigger.isBlockMenuOpen(), clickUserTrigger.isDoNotRotate());
         }
 
         RoomUnit actor = event.getActor().orElse(null);
@@ -498,8 +528,7 @@ public final class WiredEngine {
                 System.currentTimeMillis(),
                 monitorSourceLabel,
                 monitorSourceId,
-                buildExecutionMonitorReason(stack, state.elapsedMs())
-        );
+                buildExecutionMonitorReason(stack, state.elapsedMs()));
 
         return true;
     }
@@ -534,7 +563,9 @@ public final class WiredEngine {
         String monitorSourceLabel = getMonitorSourceLabel(stack.triggerItem(), event);
         int monitorSourceId = getMonitorSourceId(stack.triggerItem());
 
-        debug(room, "Direct stack execution for item {} (conditions: {}, effects: {}, negated: {})",
+        debug(
+                room,
+                "Direct stack execution for item {} (conditions: {}, effects: {}, negated: {})",
                 stack.triggerItem() != null ? stack.triggerItem().getId() : "null",
                 stack.conditions().size(),
                 stack.effects().size(),
@@ -551,16 +582,20 @@ public final class WiredEngine {
         }
 
         boolean conditionsPassedForExecution = getConditionOutcomeForExecution(stack, ctx, negateConditions);
-        List<IWiredEffect> executableEffects = getExecutableEffectsForCurrentExecution(stack, conditionsPassedForExecution);
+        List<IWiredEffect> executableEffects =
+                getExecutableEffectsForCurrentExecution(stack, conditionsPassedForExecution);
         boolean hasSpecialOutcome = conditionsPassedForExecution && hasSpecialTriggerOutcome(stack, event);
 
-        if (!shouldContinueAfterConditionCheck(stack, room, conditionsPassedForExecution, executableEffects, hasSpecialOutcome)) {
+        if (!shouldContinueAfterConditionCheck(
+                stack, room, conditionsPassedForExecution, executableEffects, hasSpecialOutcome)) {
             return false;
         }
 
         WiredExtraExecutionLimit executionLimitExtra = getExecutionLimitExtra(room, stack);
         if (executionLimitExtra != null && !executionLimitExtra.tryAcquireExecutionSlot(currentTime)) {
-            debug(room, "Execution limit blocked direct stack {} (max {} in {} ms)",
+            debug(
+                    room,
+                    "Execution limit blocked direct stack {} (max {} in {} ms)",
                     stack.triggerItem() != null ? stack.triggerItem().getId() : "null",
                     executionLimitExtra.getMaxExecutions(),
                     executionLimitExtra.getTimeWindowMs());
@@ -578,7 +613,10 @@ public final class WiredEngine {
                 monitorSourceLabel,
                 monitorSourceId,
                 buildStackMonitorReason(stack, event, stackCost))) {
-            debug(room, "Execution cap blocked direct stack {}", stack.triggerItem() != null ? stack.triggerItem().getId() : "null");
+            debug(
+                    room,
+                    "Execution cap blocked direct stack {}",
+                    stack.triggerItem() != null ? stack.triggerItem().getId() : "null");
             return false;
         }
 
@@ -602,8 +640,7 @@ public final class WiredEngine {
                 System.currentTimeMillis(),
                 monitorSourceLabel,
                 monitorSourceId,
-                buildExecutionMonitorReason(stack, state.elapsedMs())
-        );
+                buildExecutionMonitorReason(stack, state.elapsedMs()));
 
         return true;
     }
@@ -641,7 +678,8 @@ public final class WiredEngine {
         }
 
         boolean conditionsPassedForExecution = getConditionOutcomeForExecution(stack, ctx, negateConditions);
-        List<IWiredEffect> executableEffects = getExecutableEffectsForCurrentExecution(stack, conditionsPassedForExecution);
+        List<IWiredEffect> executableEffects =
+                getExecutableEffectsForCurrentExecution(stack, conditionsPassedForExecution);
         return !executableEffects.isEmpty();
     }
 
@@ -773,8 +811,10 @@ public final class WiredEngine {
         }
 
         WiredEffectType effectType = ((InteractionWiredEffect) effect).getType();
-        return effectType == WiredEffectType.NEG_CALL_STACKS || effectType == WiredEffectType.NEG_SEND_SIGNAL
-                || effectType == WiredEffectType.NEG_SHOW_MESSAGE || effectType == WiredEffectType.NEG_LOG;
+        return effectType == WiredEffectType.NEG_CALL_STACKS
+                || effectType == WiredEffectType.NEG_SEND_SIGNAL
+                || effectType == WiredEffectType.NEG_SHOW_MESSAGE
+                || effectType == WiredEffectType.NEG_LOG;
     }
 
     private WiredTextInputCaptureSupport.CaptureResult resolveTextInputCapture(WiredStack stack, WiredEvent event) {
@@ -782,7 +822,8 @@ public final class WiredEngine {
             return WiredTextInputCaptureSupport.CaptureResult.noMatch();
         }
 
-        if (event.getType() != WiredEvent.Type.USER_SAYS || !(stack.triggerItem() instanceof WiredTriggerHabboSaysKeyword)) {
+        if (event.getType() != WiredEvent.Type.USER_SAYS
+                || !(stack.triggerItem() instanceof WiredTriggerHabboSaysKeyword)) {
             return stack.trigger().matches(stack.triggerItem(), event)
                     ? WiredTextInputCaptureSupport.CaptureResult.matched(new LinkedHashMap<>())
                     : WiredTextInputCaptureSupport.CaptureResult.noMatch();
@@ -797,10 +838,16 @@ public final class WiredEngine {
     private boolean evaluateConditions(WiredStack stack, WiredContext ctx) {
         List<IWiredCondition> conditions = stack.conditions();
 
-        return evaluateConditionsByMode(conditions, ctx, stack.conditionEvaluationMode(), stack.conditionEvaluationValue());
+        return evaluateConditionsByMode(
+                conditions, ctx, stack.conditionEvaluationMode(), stack.conditionEvaluationValue());
     }
 
-    private boolean shouldContinueAfterConditionCheck(WiredStack stack, Room room, boolean conditionsPassedForExecution, List<IWiredEffect> executableEffects, boolean hasSpecialOutcome) {
+    private boolean shouldContinueAfterConditionCheck(
+            WiredStack stack,
+            Room room,
+            boolean conditionsPassedForExecution,
+            List<IWiredEffect> executableEffects,
+            boolean hasSpecialOutcome) {
         if (stack.hasConditions()) {
             debug(room, "Evaluating {} conditions...", stack.conditions().size());
 
@@ -845,7 +892,8 @@ public final class WiredEngine {
     /**
      * Evaluate conditions according to the configured stack mode.
      */
-    private boolean evaluateConditionsByMode(List<IWiredCondition> conditions, WiredContext ctx, int evaluationMode, int evaluationValue) {
+    private boolean evaluateConditionsByMode(
+            List<IWiredCondition> conditions, WiredContext ctx, int evaluationMode, int evaluationValue) {
         if (conditions == null || conditions.isEmpty()) {
             return true;
         }
@@ -862,8 +910,15 @@ public final class WiredEngine {
             String conditionKey = getConditionGroupKey(condition);
 
             if (condition.operator() == WiredConditionOperator.OR) {
-                groupedOrResults.computeIfAbsent(conditionKey, ignored -> new ArrayList<>()).add(result);
-                debug(room, "  Condition (OR group {}) {}: {}", conditionKey, condition.getClass().getSimpleName(), result ? "PASS" : "FAIL");
+                groupedOrResults
+                        .computeIfAbsent(conditionKey, ignored -> new ArrayList<>())
+                        .add(result);
+                debug(
+                        room,
+                        "  Condition (OR group {}) {}: {}",
+                        conditionKey,
+                        condition.getClass().getSimpleName(),
+                        result ? "PASS" : "FAIL");
                 continue;
             }
 
@@ -887,9 +942,17 @@ public final class WiredEngine {
             debug(room, "  Condition (OR result {}) : {}", entry.getKey(), groupPassed ? "PASS" : "FAIL");
         }
 
-        boolean matches = WiredExtraOrEval.matchesMode(evaluationMode, matchedRequirements, totalRequirements, evaluationValue);
+        boolean matches =
+                WiredExtraOrEval.matchesMode(evaluationMode, matchedRequirements, totalRequirements, evaluationValue);
 
-        debug(room, "Condition eval mode {} value {} matched {}/{} logical requirements => {}", evaluationMode, evaluationValue, matchedRequirements, totalRequirements, matches ? "PASS" : "FAIL");
+        debug(
+                room,
+                "Condition eval mode {} value {} matched {}/{} logical requirements => {}",
+                evaluationMode,
+                evaluationValue,
+                matchedRequirements,
+                totalRequirements,
+                matches ? "PASS" : "FAIL");
         return matches;
     }
 
@@ -918,7 +981,11 @@ public final class WiredEngine {
                 toExecute = new ArrayList<>();
             } else if (randomExtra != null) {
                 toExecute = randomExtra.selectWiredEffects(effects);
-                debug(ctx.room(), "Random mode: selected {} effect(s), skip window {}", toExecute.size(), randomExtra.getSkipExecutions());
+                debug(
+                        ctx.room(),
+                        "Random mode: selected {} effect(s), skip window {}",
+                        toExecute.size(),
+                        randomExtra.getSkipExecutions());
             } else {
                 int randomIndex = new Random().nextInt(effects.size());
                 toExecute = Collections.singletonList(effects.get(randomIndex));
@@ -959,7 +1026,8 @@ public final class WiredEngine {
 
         WiredMoveCarryHelper.beginMovementCollection();
 
-        try (WiredInternalVariableSupport.UserMoveBatchScope ignored = WiredInternalVariableSupport.beginUserMoveBatch()) {
+        try (WiredInternalVariableSupport.UserMoveBatchScope ignored =
+                WiredInternalVariableSupport.beginUserMoveBatch()) {
             // Execute selected effects
             for (int effectIndex = 0; effectIndex < toExecute.size(); effectIndex++) {
                 IWiredEffect effect = toExecute.get(effectIndex);
@@ -1048,7 +1116,8 @@ public final class WiredEngine {
         return executedSelectors;
     }
 
-    private void executeSelectorList(List<IWiredEffect> selectors, WiredContext ctx, List<InteractionWiredEffect> executedSelectors) {
+    private void executeSelectorList(
+            List<IWiredEffect> selectors, WiredContext ctx, List<InteractionWiredEffect> executedSelectors) {
         for (IWiredEffect effect : selectors) {
             if (effect.requiresActor() && !ctx.hasActor()) {
                 continue;
@@ -1110,15 +1179,23 @@ public final class WiredEngine {
         scheduleFilteredSelectorState(room, wiredEffect, "3", animationToken, 240L, true);
     }
 
-    private void scheduleFilteredSelectorState(Room room, InteractionWiredEffect wiredEffect, String state, long animationToken, long delay, boolean clearToken) {
-        Emulator.getThreading().run(() -> setFilteredSelectorState(room, wiredEffect, state, animationToken, clearToken), delay);
+    private void scheduleFilteredSelectorState(
+            Room room,
+            InteractionWiredEffect wiredEffect,
+            String state,
+            long animationToken,
+            long delay,
+            boolean clearToken) {
+        Emulator.getThreading()
+                .run(() -> setFilteredSelectorState(room, wiredEffect, state, animationToken, clearToken), delay);
     }
 
     private void setFilteredSelectorState(Room room, InteractionWiredEffect wiredEffect, String state) {
         setFilteredSelectorState(room, wiredEffect, state, 0L, false);
     }
 
-    private void setFilteredSelectorState(Room room, InteractionWiredEffect wiredEffect, String state, long animationToken, boolean clearToken) {
+    private void setFilteredSelectorState(
+            Room room, InteractionWiredEffect wiredEffect, String state, long animationToken, boolean clearToken) {
         if (room == null || wiredEffect == null || room.isHideWired()) {
             return;
         }
@@ -1140,7 +1217,8 @@ public final class WiredEngine {
         }
     }
 
-    private void applySelectionFilterExtras(WiredStack stack, WiredContext ctx, List<InteractionWiredEffect> executedSelectors) {
+    private void applySelectionFilterExtras(
+            WiredStack stack, WiredContext ctx, List<InteractionWiredEffect> executedSelectors) {
         if (executedSelectors == null || executedSelectors.isEmpty()) {
             return;
         }
@@ -1179,8 +1257,13 @@ public final class WiredEngine {
                 System.currentTimeMillis(),
                 sourceLabel,
                 sourceId,
-                String.format("Scheduling delayed effect %s with delay %d tick(s)", effect.getClass().getSimpleName(), delay))) {
-            debug(ctx.room(), "Delayed events cap blocked effect {}", effect.getClass().getSimpleName());
+                String.format(
+                        "Scheduling delayed effect %s with delay %d tick(s)",
+                        effect.getClass().getSimpleName(), delay))) {
+            debug(
+                    ctx.room(),
+                    "Delayed events cap blocked effect {}",
+                    effect.getClass().getSimpleName());
             return;
         }
 
@@ -1191,27 +1274,30 @@ public final class WiredEngine {
         Room room = ctx.room();
         RoomUnit actor = ctx.actor().orElse(null);
 
-        Emulator.getThreading().run(() -> {
-            if (!room.isLoaded() || room.getHabbos().isEmpty()) {
-                diagnostics.completeDelayedEvent();
-                return;
-            }
+        Emulator.getThreading()
+                .run(
+                        () -> {
+                            if (!room.isLoaded() || room.getHabbos().isEmpty()) {
+                                diagnostics.completeDelayedEvent();
+                                return;
+                            }
 
-            try {
-                effect.execute(ctx);
+                            try {
+                                effect.execute(ctx);
 
-                // Activate box animation after execution
-                if (effect instanceof InteractionWiredEffect) {
-                    InteractionWiredEffect wiredEffect = (InteractionWiredEffect) effect;
-                    wiredEffect.setCooldown(System.currentTimeMillis());
-                    wiredEffect.activateBox(room, actor, System.currentTimeMillis());
-                }
-            } catch (Exception e) {
-                LOGGER.warn("Error executing delayed effect: {}", e.getMessage());
-            } finally {
-                diagnostics.completeDelayedEvent();
-            }
-        }, remainingDelayMs);
+                                // Activate box animation after execution
+                                if (effect instanceof InteractionWiredEffect) {
+                                    InteractionWiredEffect wiredEffect = (InteractionWiredEffect) effect;
+                                    wiredEffect.setCooldown(System.currentTimeMillis());
+                                    wiredEffect.activateBox(room, actor, System.currentTimeMillis());
+                                }
+                            } catch (Exception e) {
+                                LOGGER.warn("Error executing delayed effect: {}", e.getMessage());
+                            } finally {
+                                diagnostics.completeDelayedEvent();
+                            }
+                        },
+                        remainingDelayMs);
     }
 
     private void executeOrderedEffects(List<IWiredEffect> effects, WiredContext ctx, long currentTime) {
@@ -1230,7 +1316,9 @@ public final class WiredEngine {
                 continue;
             }
 
-            effectsByDelay.computeIfAbsent(effect.getDelay(), key -> new ArrayList<>()).add(effect);
+            effectsByDelay
+                    .computeIfAbsent(effect.getDelay(), key -> new ArrayList<>())
+                    .add(effect);
         }
 
         for (Map.Entry<Integer, List<IWiredEffect>> entry : effectsByDelay.entrySet()) {
@@ -1303,7 +1391,8 @@ public final class WiredEngine {
                 System.currentTimeMillis(),
                 sourceLabel,
                 sourceId,
-                String.format("Scheduling ordered batch with %d effect(s) and delay %d tick(s)", batch.size(), delay))) {
+                String.format(
+                        "Scheduling ordered batch with %d effect(s) and delay %d tick(s)", batch.size(), delay))) {
             debug(ctx.room(), "Delayed events cap blocked ordered batch with {} effect(s)", batch.size());
             return;
         }
@@ -1313,27 +1402,32 @@ public final class WiredEngine {
         long remainingDelayMs = Math.max(0L, delayMs - elapsedSinceTrigger);
         Room room = ctx.room();
 
-        Emulator.getThreading().run(() -> {
-            if (!room.isLoaded() || room.getHabbos().isEmpty()) {
-                diagnostics.completeDelayedEvent();
-                return;
-            }
+        Emulator.getThreading()
+                .run(
+                        () -> {
+                            if (!room.isLoaded() || room.getHabbos().isEmpty()) {
+                                diagnostics.completeDelayedEvent();
+                                return;
+                            }
 
-            try {
-                executeOrderedEffectBatch(batch, ctx, System.currentTimeMillis(), true);
-            } finally {
-                diagnostics.completeDelayedEvent();
-            }
-        }, remainingDelayMs);
+                            try {
+                                executeOrderedEffectBatch(batch, ctx, System.currentTimeMillis(), true);
+                            } finally {
+                                diagnostics.completeDelayedEvent();
+                            }
+                        },
+                        remainingDelayMs);
     }
 
-    private void executeOrderedEffectBatch(List<IWiredEffect> batch, WiredContext ctx, long executionTime, boolean useExecutionTimeForCooldown) {
+    private void executeOrderedEffectBatch(
+            List<IWiredEffect> batch, WiredContext ctx, long executionTime, boolean useExecutionTimeForCooldown) {
         Room room = ctx.room();
         RoomUnit actor = ctx.actor().orElse(null);
 
         WiredMoveCarryHelper.beginMovementCollection();
 
-        try (WiredInternalVariableSupport.UserMoveBatchScope ignored = WiredInternalVariableSupport.beginUserMoveBatch()) {
+        try (WiredInternalVariableSupport.UserMoveBatchScope ignored =
+                WiredInternalVariableSupport.beginUserMoveBatch()) {
             for (IWiredEffect effect : batch) {
                 try {
                     if (!useExecutionTimeForCooldown) {
@@ -1363,9 +1457,8 @@ public final class WiredEngine {
      * Get the next unseen index for round-robin selection.
      */
     private int getNextUnseenIndex(WiredStack stack, int effectCount) {
-        String key = stack.triggerItem() != null
-                ? String.valueOf(stack.triggerItem().getId())
-                : "default";
+        String key =
+                stack.triggerItem() != null ? String.valueOf(stack.triggerItem().getId()) : "default";
 
         return unseenIndices.compute(key, (k, current) -> {
             if (current == null) current = -1;
@@ -1400,8 +1493,7 @@ public final class WiredEngine {
                     event.getActor().orElse(null),
                     (InteractionWiredTrigger) stack.triggerItem(),
                     legacyEffects,
-                    legacyConditions
-            );
+                    legacyConditions);
 
             return !Emulator.getPluginManager().fireEvent(triggeredEvent).isCancelled();
         }
@@ -1427,13 +1519,13 @@ public final class WiredEngine {
                 }
             }
 
-            Emulator.getPluginManager().fireEvent(new WiredStackExecutedEvent(
-                    event.getRoom(),
-                    event.getActor().orElse(null),
-                    (InteractionWiredTrigger) stack.triggerItem(),
-                    legacyEffects,
-                    legacyConditions
-            ));
+            Emulator.getPluginManager()
+                    .fireEvent(new WiredStackExecutedEvent(
+                            event.getRoom(),
+                            event.getActor().orElse(null),
+                            (InteractionWiredTrigger) stack.triggerItem(),
+                            legacyEffects,
+                            legacyConditions));
         }
     }
 
@@ -1461,8 +1553,8 @@ public final class WiredEngine {
             return;
         }
 
-        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(
-                triggerItem.getX(), triggerItem.getY());
+        Collection<InteractionWiredExtra> extras =
+                room.getRoomSpecialTypes().getExtras(triggerItem.getX(), triggerItem.getY());
 
         if (extras != null) {
             for (InteractionWiredExtra extra : extras) {
@@ -1489,14 +1581,14 @@ public final class WiredEngine {
         return (extra instanceof WiredExtraExecutionLimit) ? (WiredExtraExecutionLimit) extra : null;
     }
 
-    private <T extends InteractionWiredExtra> InteractionWiredExtra getStackExtra(Room room, WiredStack stack, Class<T> extraClass) {
+    private <T extends InteractionWiredExtra> InteractionWiredExtra getStackExtra(
+            Room room, WiredStack stack, Class<T> extraClass) {
         if (room == null || stack == null || stack.triggerItem() == null || room.getRoomSpecialTypes() == null) {
             return null;
         }
 
-        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(
-                stack.triggerItem().getX(),
-                stack.triggerItem().getY());
+        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes()
+                .getExtras(stack.triggerItem().getX(), stack.triggerItem().getY());
 
         if (extras == null || extras.isEmpty()) {
             return null;
@@ -1655,12 +1747,7 @@ public final class WiredEngine {
         long now = System.currentTimeMillis();
         long killedUntil = bannedRooms.getOrDefault(roomId, 0L);
 
-        return getDiagnostics(roomId).snapshot(
-                getRecursionDepth(roomId),
-                MAX_RECURSION_DEPTH,
-                killedUntil,
-                now
-        );
+        return getDiagnostics(roomId).snapshot(getRecursionDepth(roomId), MAX_RECURSION_DEPTH, killedUntil, now);
     }
 
     /**
@@ -1688,12 +1775,14 @@ public final class WiredEngine {
      * @param room the room object
      */
     private void banRoom(int roomId, Room room, WiredEvent.Type eventType, int eventCount) {
-        getDiagnostics(roomId).recordKilled(
-                System.currentTimeMillis(),
-                String.format("Rate limit exceeded for %s with %d event(s) in %dms", eventType.name(), eventCount, RATE_LIMIT_WINDOW_MS),
-                eventType.name(),
-                0
-        );
+        getDiagnostics(roomId)
+                .recordKilled(
+                        System.currentTimeMillis(),
+                        String.format(
+                                "Rate limit exceeded for %s with %d event(s) in %dms",
+                                eventType.name(), eventCount, RATE_LIMIT_WINDOW_MS),
+                        eventType.name(),
+                        0);
 
         // Only actually ban the room if ban duration is configured (> 0)
         if (WIRED_BAN_DURATION_MS > 0) {
@@ -1703,30 +1792,42 @@ public final class WiredEngine {
             long banMinutes = WIRED_BAN_DURATION_MS / 60000;
 
             // Send alert to all users in the room
-            String roomAlertMessage = Emulator.getTexts().getValue("wired.abuse.room.alert")
+            String roomAlertMessage = Emulator.getTexts()
+                    .getValue("wired.abuse.room.alert")
                     .replace("%minutes%", String.valueOf(banMinutes));
             room.sendComposer(new GenericAlertComposer(roomAlertMessage).compose());
 
             // Send scripter bubble alert to staff with room link
             Map<String, String> keys = new HashMap<>();
             keys.put("title", Emulator.getTexts().getValue("wired.abuse.staff.title"));
-            keys.put("message", Emulator.getTexts().getValue("wired.abuse.staff.message")
-                    .replace("%roomname%", room.getName())
-                    .replace("%owner%", room.getOwnerName())
-                    .replace("%minutes%", String.valueOf(banMinutes)));
+            keys.put(
+                    "message",
+                    Emulator.getTexts()
+                            .getValue("wired.abuse.staff.message")
+                            .replace("%roomname%", room.getName())
+                            .replace("%owner%", room.getOwnerName())
+                            .replace("%minutes%", String.valueOf(banMinutes)));
             keys.put("linkUrl", "event:navigator/goto/" + roomId);
             keys.put("linkTitle", Emulator.getTexts().getValue("wired.abuse.staff.link"));
-            Emulator.getGameEnvironment().getHabboManager().sendPacketToHabbosWithPermission(
-                    new BubbleAlertComposer("admin.staffalert", keys).compose(),
-                    "acc_modtool_room_info"
-            );
+            Emulator.getGameEnvironment()
+                    .getHabboManager()
+                    .sendPacketToHabbosWithPermission(
+                            new BubbleAlertComposer("admin.staffalert", keys).compose(), "acc_modtool_room_info");
 
-            LOGGER.warn("Wired abuse detected in room {} ({}). Owner: {}. Wired banned for {} minutes.",
-                    roomId, room.getName(), room.getOwnerName(), banMinutes);
+            LOGGER.warn(
+                    "Wired abuse detected in room {} ({}). Owner: {}. Wired banned for {} minutes.",
+                    roomId,
+                    room.getName(),
+                    room.getOwnerName(),
+                    banMinutes);
         } else {
             // Ban duration is 0 - only log, do not spam alerts or put a ban entry
-            LOGGER.warn("Wired rate limit exceeded in room {} ({}) for event {} ({} events). Ban disabled (wired.abuse.ban.duration.ms=0).",
-                    roomId, room.getName(), eventType.name(), eventCount);
+            LOGGER.warn(
+                    "Wired rate limit exceeded in room {} ({}) for event {} ({} events). Ban disabled (wired.abuse.ban.duration.ms=0).",
+                    roomId,
+                    room.getName(),
+                    eventType.name(),
+                    eventCount);
         }
     }
 
@@ -1759,18 +1860,19 @@ public final class WiredEngine {
     }
 
     private WiredRoomDiagnostics getDiagnostics(int roomId) {
-        return roomDiagnostics.computeIfAbsent(roomId, ignored -> new WiredRoomDiagnostics(
-                MONITOR_USAGE_WINDOW_MS,
-                MONITOR_USAGE_LIMIT,
-                MONITOR_DELAYED_EVENTS_LIMIT,
-                MONITOR_OVERLOAD_AVERAGE_MS,
-                MONITOR_OVERLOAD_PEAK_MS,
-                MONITOR_HEAVY_USAGE_PERCENT,
-                MONITOR_HEAVY_CONSECUTIVE_WINDOWS,
-                MONITOR_OVERLOAD_CONSECUTIVE_WINDOWS,
-                MONITOR_HEAVY_DELAYED_PERCENT,
-                200
-        ));
+        return roomDiagnostics.computeIfAbsent(
+                roomId,
+                ignored -> new WiredRoomDiagnostics(
+                        MONITOR_USAGE_WINDOW_MS,
+                        MONITOR_USAGE_LIMIT,
+                        MONITOR_DELAYED_EVENTS_LIMIT,
+                        MONITOR_OVERLOAD_AVERAGE_MS,
+                        MONITOR_OVERLOAD_PEAK_MS,
+                        MONITOR_HEAVY_USAGE_PERCENT,
+                        MONITOR_HEAVY_CONSECUTIVE_WINDOWS,
+                        MONITOR_OVERLOAD_CONSECUTIVE_WINDOWS,
+                        MONITOR_HEAVY_DELAYED_PERCENT,
+                        200));
     }
 
     private int estimateStackCost(WiredStack stack, int recursionDepth) {
@@ -1800,7 +1902,9 @@ public final class WiredEngine {
     }
 
     private String getMonitorSourceLabel(HabboItem triggerItem, WiredEvent event) {
-        if (triggerItem != null && triggerItem.getBaseItem() != null && triggerItem.getBaseItem().getInteractionType() != null) {
+        if (triggerItem != null
+                && triggerItem.getBaseItem() != null
+                && triggerItem.getBaseItem().getInteractionType() != null) {
             return triggerItem.getBaseItem().getInteractionType().getName();
         }
 
@@ -1813,7 +1917,8 @@ public final class WiredEngine {
 
     private String buildStackMonitorReason(WiredStack stack, WiredEvent event, int stackCost) {
         if (stack == null) {
-            return String.format("Processing %s with estimated cost %d", event.getType().name(), stackCost);
+            return String.format(
+                    "Processing %s with estimated cost %d", event.getType().name(), stackCost);
         }
 
         int selectors = 0;
@@ -1840,8 +1945,7 @@ public final class WiredEngine {
                 stack.effects().size(),
                 selectors,
                 delayedEffects,
-                stackCost
-        );
+                stackCost);
     }
 
     private String buildExecutionMonitorReason(WiredStack stack, long elapsedMs) {
@@ -1851,10 +1955,7 @@ public final class WiredEngine {
 
         return String.format(
                 "Stack with %d condition(s) and %d effect(s) completed in %dms",
-                stack.conditions().size(),
-                stack.effects().size(),
-                elapsedMs
-        );
+                stack.conditions().size(), stack.effects().size(), elapsedMs);
     }
 
     /**

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredManager.java
@@ -10,9 +10,9 @@ import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectTrigg
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraExecutionLimit;
 import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboClicksUser;
 import com.eu.habbo.habbohotel.rooms.Room;
-import com.eu.habbo.habbohotel.rooms.RoomWiredDisableSupport;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.rooms.RoomWiredDisableSupport;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboBadge;
 import com.eu.habbo.habbohotel.users.HabboItem;
@@ -32,9 +32,6 @@ import com.eu.habbo.plugin.events.emulator.EmulatorLoadedEvent;
 import com.eu.habbo.plugin.events.users.UserWiredRewardReceived;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -44,6 +41,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Manager class for the wired runtime.
@@ -98,8 +97,10 @@ public final class WiredManager {
 
     /** Whether the engine is initialized */
     private static volatile boolean initialized = false;
+
     private static final ThreadLocal<Integer> EVENT_HANDLING_DEPTH = new ThreadLocal<>();
     private static final ThreadLocal<ArrayDeque<DeferredEffectEvent>> DEFERRED_EFFECT_EVENTS = new ThreadLocal<>();
+
     private WiredManager() {
         // Static utility class
     }
@@ -149,11 +150,15 @@ public final class WiredManager {
         initialized = true;
 
         if (!enabled || !exclusive) {
-            LOGGER.warn("wired.engine.enabled / wired.engine.exclusive are now compatibility-only flags. WiredManager runs as the exclusive engine runtime.");
+            LOGGER.warn(
+                    "wired.engine.enabled / wired.engine.exclusive are now compatibility-only flags. WiredManager runs as the exclusive engine runtime.");
         }
 
-        LOGGER.info("Wired Manager initialized - enabled: {}, exclusive runtime active, maxSteps: {}, debug: {}",
-                enabled, maxSteps, debug);
+        LOGGER.info(
+                "Wired Manager initialized - enabled: {}, exclusive runtime active, maxSteps: {}, debug: {}",
+                enabled,
+                maxSteps,
+                debug);
     }
 
     /**
@@ -276,7 +281,9 @@ public final class WiredManager {
                 while (deferredEvents != null && !deferredEvents.isEmpty()) {
                     DeferredEffectEvent deferredEvent = deferredEvents.pollFirst();
 
-                    if (deferredEvent == null || deferredEvent.event == null || RoomWiredDisableSupport.isWiredDisabled(deferredEvent.event.getRoom())) {
+                    if (deferredEvent == null
+                            || deferredEvent.event == null
+                            || RoomWiredDisableSupport.isWiredDisabled(deferredEvent.event.getRoom())) {
                         continue;
                     }
 
@@ -304,7 +311,10 @@ public final class WiredManager {
     }
 
     private static boolean dispatchEffectTriggeredEvent(WiredEvent event, boolean negateConditions) {
-        if (!isEnabled() || engine == null || event == null || RoomWiredDisableSupport.isWiredDisabled(event.getRoom())) {
+        if (!isEnabled()
+                || engine == null
+                || event == null
+                || RoomWiredDisableSupport.isWiredDisabled(event.getRoom())) {
             return false;
         }
 
@@ -445,7 +455,8 @@ public final class WiredManager {
         return shouldSuppressUserSaysOutput(room, user, message, -1, -1);
     }
 
-    public static boolean shouldSuppressUserSaysOutput(Room room, RoomUnit user, String message, int chatType, int chatStyle) {
+    public static boolean shouldSuppressUserSaysOutput(
+            Room room, RoomUnit user, String message, int chatType, int chatStyle) {
         if (!isEnabled() || engine == null || room == null || user == null) {
             return false;
         }
@@ -494,18 +505,31 @@ public final class WiredManager {
         return handleEvent(event);
     }
 
-    public static boolean triggerUserVariableChanged(Room room, int userId, int definitionItemId, boolean created, boolean deleted, WiredEvent.VariableChangeKind changeKind) {
+    public static boolean triggerUserVariableChanged(
+            Room room,
+            int userId,
+            int definitionItemId,
+            boolean created,
+            boolean deleted,
+            WiredEvent.VariableChangeKind changeKind) {
         if (!isEnabled() || room == null || definitionItemId <= 0) {
             return false;
         }
 
         Habbo habbo = room.getHabbo(userId);
         RoomUnit roomUnit = (habbo != null) ? habbo.getRoomUnit() : null;
-        WiredEvent event = WiredEvents.userVariableChanged(room, roomUnit, definitionItemId, created, deleted, changeKind);
+        WiredEvent event =
+                WiredEvents.userVariableChanged(room, roomUnit, definitionItemId, created, deleted, changeKind);
         return handleEvent(event);
     }
 
-    public static boolean triggerFurniVariableChanged(Room room, int furniId, int definitionItemId, boolean created, boolean deleted, WiredEvent.VariableChangeKind changeKind) {
+    public static boolean triggerFurniVariableChanged(
+            Room room,
+            int furniId,
+            int definitionItemId,
+            boolean created,
+            boolean deleted,
+            WiredEvent.VariableChangeKind changeKind) {
         if (!isEnabled() || room == null || furniId <= 0 || definitionItemId <= 0) {
             return false;
         }
@@ -515,7 +539,8 @@ public final class WiredManager {
         return handleEvent(event);
     }
 
-    public static boolean triggerRoomVariableChanged(Room room, int definitionItemId, WiredEvent.VariableChangeKind changeKind) {
+    public static boolean triggerRoomVariableChanged(
+            Room room, int definitionItemId, WiredEvent.VariableChangeKind changeKind) {
         if (!isEnabled() || room == null || definitionItemId <= 0) {
             return false;
         }
@@ -772,7 +797,8 @@ public final class WiredManager {
      * Compatibility bridge for code paths that still describe themselves as
      * legacy-triggered. Execution still goes through the new engine only.
      */
-    public static boolean triggerFromLegacy(WiredTriggerType triggerType, RoomUnit roomUnit, Room room, Object[] stuff) {
+    public static boolean triggerFromLegacy(
+            WiredTriggerType triggerType, RoomUnit roomUnit, Room room, Object[] stuff) {
         if (!isEnabled() || room == null) {
             return false;
         }
@@ -838,10 +864,10 @@ public final class WiredManager {
     // ========== Configuration Constants (moved from WiredHandler) ==========
 
     /** Maximum number of furniture items that can be selected in a single wired component */
-    public static int MAXIMUM_FURNI_SELECTION = 5;
+    public static volatile int MAXIMUM_FURNI_SELECTION = 5;
 
     /** Delay in milliseconds between teleport executions */
-    public static int TELEPORT_DELAY = 500;
+    public static volatile int TELEPORT_DELAY = 500;
 
     // ========== Debug Mode ==========
 
@@ -975,9 +1001,8 @@ public final class WiredManager {
             return null;
         }
 
-        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(
-                triggerItem.getX(),
-                triggerItem.getY());
+        Collection<InteractionWiredExtra> extras =
+                room.getRoomSpecialTypes().getExtras(triggerItem.getX(), triggerItem.getY());
 
         if (extras == null || extras.isEmpty()) {
             return null;
@@ -1003,8 +1028,7 @@ public final class WiredManager {
      * @param room the room
      */
     public static void resetTimers(Room room) {
-        if (!room.isLoaded())
-            return;
+        if (!room.isLoaded()) return;
 
         // Use the centralized tick service for timer resets
         WiredTickService.getInstance().resetRoomTimers(room);
@@ -1022,7 +1046,8 @@ public final class WiredManager {
      * @param callStackDepth current recursion depth for trigger stacks
      * @return true if any effects were executed
      */
-    public static boolean executeEffectsAtTiles(Collection<RoomTile> tiles, final RoomUnit roomUnit, final Room room, final int callStackDepth) {
+    public static boolean executeEffectsAtTiles(
+            Collection<RoomTile> tiles, final RoomUnit roomUnit, final Room room, final int callStackDepth) {
         if (tiles == null || tiles.isEmpty() || room == null || engine == null || stackIndex == null) {
             return false;
         }
@@ -1039,7 +1064,8 @@ public final class WiredManager {
                                 .actor(roomUnit)
                                 .callStackDepth(callStackDepth)
                                 .build();
-                        WiredContext ctx = new WiredContext(event, effect, DefaultWiredServices.getInstance(), new WiredState(100));
+                        WiredContext ctx = new WiredContext(
+                                event, effect, DefaultWiredServices.getInstance(), new WiredState(100));
                         effect.execute(ctx);
                         effect.setCooldown(millis);
                     }
@@ -1050,7 +1076,8 @@ public final class WiredManager {
         return true;
     }
 
-    public static boolean executeNegatedStacksAtTiles(Collection<RoomTile> tiles, final RoomUnit roomUnit, final Room room, final int callStackDepth) {
+    public static boolean executeNegatedStacksAtTiles(
+            Collection<RoomTile> tiles, final RoomUnit roomUnit, final Room room, final int callStackDepth) {
         if (tiles == null || tiles.isEmpty() || room == null || engine == null || stackIndex == null) {
             return false;
         }
@@ -1075,7 +1102,8 @@ public final class WiredManager {
         return handled;
     }
 
-    public static boolean executeNegatedTargetStacks(Iterable<HabboItem> triggerItems, final RoomUnit roomUnit, final Room room, final int callStackDepth) {
+    public static boolean executeNegatedTargetStacks(
+            Iterable<HabboItem> triggerItems, final RoomUnit roomUnit, final Room room, final int callStackDepth) {
         if (triggerItems == null || room == null || engine == null || stackIndex == null || room.getLayout() == null) {
             return false;
         }
@@ -1137,7 +1165,8 @@ public final class WiredManager {
     public static void dropRewards(int wiredId) {
         Emulator.getThreading().run(() -> {
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                 PreparedStatement statement = connection.prepareStatement("DELETE FROM wired_rewards_given WHERE wired_item = ?")) {
+                    PreparedStatement statement =
+                            connection.prepareStatement("DELETE FROM wired_rewards_given WHERE wired_item = ?")) {
                 statement.setInt(1, wiredId);
                 statement.execute();
             } catch (SQLException e) {
@@ -1148,7 +1177,8 @@ public final class WiredManager {
 
     private static void persistReward(int wiredId, int habboId, int rewardId, int timestamp) {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("INSERT INTO wired_rewards_given (wired_item, user_id, reward_id, timestamp) VALUES (?, ?, ?, ?)")) {
+                PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO wired_rewards_given (wired_item, user_id, reward_id, timestamp) VALUES (?, ?, ?, ?)")) {
             statement.setInt(1, wiredId);
             statement.setInt(2, habboId);
             statement.setInt(3, rewardId);
@@ -1159,7 +1189,8 @@ public final class WiredManager {
         }
     }
 
-    private static void completeReward(Habbo habbo, WiredEffectGiveReward wiredBox, WiredGiveRewardItem reward, int successCode) {
+    private static void completeReward(
+            Habbo habbo, WiredEffectGiveReward wiredBox, WiredGiveRewardItem reward, int successCode) {
         if (wiredBox.getLimit() > 0) {
             wiredBox.incrementGiven();
         }
@@ -1180,7 +1211,8 @@ public final class WiredManager {
             }
 
             if (habbo.getInventory().getBadgesComponent().hasBadge(rewardReceived.value)) {
-                habbo.getClient().sendResponse(new WiredRewardAlertComposer(WiredRewardAlertComposer.REWARD_ALREADY_RECEIVED));
+                habbo.getClient()
+                        .sendResponse(new WiredRewardAlertComposer(WiredRewardAlertComposer.REWARD_ALREADY_RECEIVED));
                 return false;
             }
 
@@ -1244,7 +1276,8 @@ public final class WiredManager {
             int type = 5;
 
             try {
-                int parsedType = Integer.parseInt(rewardType.replace("points", "").trim());
+                int parsedType =
+                        Integer.parseInt(rewardType.replace("points", "").trim());
                 if (parsedType > 0) {
                     type = parsedType;
                 }
@@ -1265,7 +1298,9 @@ public final class WiredManager {
                 return false;
             }
 
-            HabboItem item = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getHabboInfo().getId(), baseItem, 0, 0, "");
+            HabboItem item = Emulator.getGameEnvironment()
+                    .getItemManager()
+                    .createItem(habbo.getHabboInfo().getId(), baseItem, 0, 0, "");
             if (item == null) {
                 return false;
             }
@@ -1317,7 +1352,9 @@ public final class WiredManager {
         synchronized (wiredBox) {
             if (wiredBox.getLimit() > 0) {
                 if (wiredBox.getLimit() - wiredBox.getGiven() == 0) {
-                    habbo.getClient().sendResponse(new WiredRewardAlertComposer(WiredRewardAlertComposer.LIMITED_NO_MORE_AVAILABLE));
+                    habbo.getClient()
+                            .sendResponse(
+                                    new WiredRewardAlertComposer(WiredRewardAlertComposer.LIMITED_NO_MORE_AVAILABLE));
                     return false;
                 }
             }
@@ -1325,7 +1362,11 @@ public final class WiredManager {
             WiredGiveRewardItem rewardToGive = null;
             int failureCode = -1;
 
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT * FROM wired_rewards_given WHERE user_id = ? AND wired_item = ? ORDER BY timestamp DESC LIMIT ?", ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY)) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    PreparedStatement statement = connection.prepareStatement(
+                            "SELECT * FROM wired_rewards_given WHERE user_id = ? AND wired_item = ? ORDER BY timestamp DESC LIMIT ?",
+                            ResultSet.TYPE_SCROLL_INSENSITIVE,
+                            ResultSet.CONCUR_READ_ONLY)) {
                 statement.setInt(1, habbo.getHabboInfo().getId());
                 statement.setInt(2, wiredBox.getId());
                 statement.setInt(3, wiredBox.getRewardItems().size());
@@ -1356,13 +1397,15 @@ public final class WiredManager {
                             }
 
                             if (failureCode == -1 && wiredBox.getRewardTime() == WiredEffectGiveReward.LIMIT_N_HOURS) {
-                                if (!(Emulator.getIntUnixTimestamp() - set.getInt("timestamp") >= (3600 * wiredBox.getLimitationInterval()))) {
+                                if (!(Emulator.getIntUnixTimestamp() - set.getInt("timestamp")
+                                        >= (3600 * wiredBox.getLimitationInterval()))) {
                                     failureCode = WiredRewardAlertComposer.REWARD_ALREADY_RECEIVED_THIS_HOUR;
                                 }
                             }
 
                             if (failureCode == -1 && wiredBox.getRewardTime() == WiredEffectGiveReward.LIMIT_N_DAY) {
-                                if (!(Emulator.getIntUnixTimestamp() - set.getInt("timestamp") >= (86400 * wiredBox.getLimitationInterval()))) {
+                                if (!(Emulator.getIntUnixTimestamp() - set.getInt("timestamp")
+                                        >= (86400 * wiredBox.getLimitationInterval()))) {
                                     failureCode = WiredRewardAlertComposer.REWARD_ALREADY_RECEIVED_THIS_TODAY;
                                 }
                             }
@@ -1375,8 +1418,7 @@ public final class WiredManager {
                                     boolean found = false;
 
                                     while (set.next()) {
-                                        if (set.getInt("reward_id") == item.id)
-                                            found = true;
+                                        if (set.getInt("reward_id") == item.id) found = true;
                                     }
 
                                     if (!found) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -2,121 +2,460 @@ package com.eu.habbo.messages;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
-import com.eu.habbo.monitoring.EmulatorNetworkStats;
 import com.eu.habbo.messages.incoming.Incoming;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.incoming.achievements.RequestAchievementConfigurationEvent;
 import com.eu.habbo.messages.incoming.achievements.RequestAchievementsEvent;
 import com.eu.habbo.messages.incoming.ambassadors.AmbassadorAlertCommandEvent;
 import com.eu.habbo.messages.incoming.ambassadors.AmbassadorVisitCommandEvent;
-import com.eu.habbo.messages.incoming.camera.*;
-import com.eu.habbo.messages.incoming.catalog.*;
-import com.eu.habbo.messages.incoming.catalog.catalogadmin.*;
-import com.eu.habbo.messages.incoming.furnieditor.*;
-import com.eu.habbo.messages.incoming.catalog.marketplace.*;
+import com.eu.habbo.messages.incoming.camera.CameraPublishToWebEvent;
+import com.eu.habbo.messages.incoming.camera.CameraPurchaseEvent;
+import com.eu.habbo.messages.incoming.camera.CameraRoomPictureEvent;
+import com.eu.habbo.messages.incoming.camera.CameraRoomThumbnailEvent;
+import com.eu.habbo.messages.incoming.camera.RequestCameraConfigurationEvent;
+import com.eu.habbo.messages.incoming.catalog.BuildersClubPlaceRoomItemEvent;
+import com.eu.habbo.messages.incoming.catalog.BuildersClubPlaceWallItemEvent;
+import com.eu.habbo.messages.incoming.catalog.BuildersClubQueryFurniCountEvent;
+import com.eu.habbo.messages.incoming.catalog.CatalogBuyClubDiscountEvent;
+import com.eu.habbo.messages.incoming.catalog.CatalogBuyItemAsGiftEvent;
+import com.eu.habbo.messages.incoming.catalog.CatalogBuyItemEvent;
+import com.eu.habbo.messages.incoming.catalog.CatalogRequestClubDiscountEvent;
+import com.eu.habbo.messages.incoming.catalog.CatalogSearchedItemEvent;
+import com.eu.habbo.messages.incoming.catalog.CatalogSelectClubGiftEvent;
+import com.eu.habbo.messages.incoming.catalog.CheckPetNameEvent;
+import com.eu.habbo.messages.incoming.catalog.JukeBoxRequestTrackCodeEvent;
+import com.eu.habbo.messages.incoming.catalog.JukeBoxRequestTrackDataEvent;
+import com.eu.habbo.messages.incoming.catalog.PurchaseTargetOfferEvent;
+import com.eu.habbo.messages.incoming.catalog.RedeemVoucherEvent;
+import com.eu.habbo.messages.incoming.catalog.RequestCatalogModeEvent;
+import com.eu.habbo.messages.incoming.catalog.RequestCatalogPageEvent;
+import com.eu.habbo.messages.incoming.catalog.RequestClubDataEvent;
+import com.eu.habbo.messages.incoming.catalog.RequestClubGiftsEvent;
+import com.eu.habbo.messages.incoming.catalog.RequestDiscountEvent;
+import com.eu.habbo.messages.incoming.catalog.RequestGiftConfigurationEvent;
+import com.eu.habbo.messages.incoming.catalog.RequestMarketplaceConfigEvent;
+import com.eu.habbo.messages.incoming.catalog.RequestPetBreedsEvent;
+import com.eu.habbo.messages.incoming.catalog.TargetOfferStateEvent;
+import com.eu.habbo.messages.incoming.catalog.catalogadmin.CatalogAdminCreateOfferEvent;
+import com.eu.habbo.messages.incoming.catalog.catalogadmin.CatalogAdminCreatePageEvent;
+import com.eu.habbo.messages.incoming.catalog.catalogadmin.CatalogAdminDeleteOfferEvent;
+import com.eu.habbo.messages.incoming.catalog.catalogadmin.CatalogAdminDeletePageEvent;
+import com.eu.habbo.messages.incoming.catalog.catalogadmin.CatalogAdminLoadOfferEvent;
+import com.eu.habbo.messages.incoming.catalog.catalogadmin.CatalogAdminLoadPageEvent;
+import com.eu.habbo.messages.incoming.catalog.catalogadmin.CatalogAdminMoveOfferEvent;
+import com.eu.habbo.messages.incoming.catalog.catalogadmin.CatalogAdminMovePageEvent;
+import com.eu.habbo.messages.incoming.catalog.catalogadmin.CatalogAdminPublishEvent;
+import com.eu.habbo.messages.incoming.catalog.catalogadmin.CatalogAdminSaveOfferEvent;
+import com.eu.habbo.messages.incoming.catalog.catalogadmin.CatalogAdminSavePageEvent;
+import com.eu.habbo.messages.incoming.catalog.catalogadmin.CatalogAdminSavePageIconEvent;
+import com.eu.habbo.messages.incoming.catalog.catalogadmin.CatalogAdminSavePageImagesEvent;
+import com.eu.habbo.messages.incoming.catalog.marketplace.BuyItemEvent;
+import com.eu.habbo.messages.incoming.catalog.marketplace.RequestCreditsEvent;
+import com.eu.habbo.messages.incoming.catalog.marketplace.RequestItemInfoEvent;
+import com.eu.habbo.messages.incoming.catalog.marketplace.RequestOffersEvent;
+import com.eu.habbo.messages.incoming.catalog.marketplace.RequestOwnItemsEvent;
+import com.eu.habbo.messages.incoming.catalog.marketplace.RequestSellItemEvent;
+import com.eu.habbo.messages.incoming.catalog.marketplace.SellItemEvent;
+import com.eu.habbo.messages.incoming.catalog.marketplace.TakeBackItemEvent;
 import com.eu.habbo.messages.incoming.catalog.recycler.OpenRecycleBoxEvent;
 import com.eu.habbo.messages.incoming.catalog.recycler.RecycleEvent;
 import com.eu.habbo.messages.incoming.catalog.recycler.ReloadRecyclerEvent;
 import com.eu.habbo.messages.incoming.catalog.recycler.RequestRecyclerLogicEvent;
-import com.eu.habbo.messages.incoming.crafting.*;
+import com.eu.habbo.messages.incoming.crafting.CraftingAddRecipeEvent;
+import com.eu.habbo.messages.incoming.crafting.CraftingCraftItemEvent;
+import com.eu.habbo.messages.incoming.crafting.CraftingCraftSecretEvent;
+import com.eu.habbo.messages.incoming.crafting.RequestCraftingRecipesAvailableEvent;
+import com.eu.habbo.messages.incoming.crafting.RequestCraftingRecipesEvent;
+import com.eu.habbo.messages.incoming.earnings.ClaimAllEarningsRewardsEvent;
+import com.eu.habbo.messages.incoming.earnings.ClaimEarningsRewardEvent;
+import com.eu.habbo.messages.incoming.earnings.RequestEarningsCenterEvent;
 import com.eu.habbo.messages.incoming.events.calendar.AdventCalendarForceOpenEvent;
 import com.eu.habbo.messages.incoming.events.calendar.AdventCalendarOpenDayEvent;
-import com.eu.habbo.messages.incoming.earnings.*;
 import com.eu.habbo.messages.incoming.floorplaneditor.FloorPlanEditorRequestBlockedTilesEvent;
 import com.eu.habbo.messages.incoming.floorplaneditor.FloorPlanEditorRequestDoorSettingsEvent;
 import com.eu.habbo.messages.incoming.floorplaneditor.FloorPlanEditorSaveEvent;
-import com.eu.habbo.messages.incoming.friends.*;
-import com.eu.habbo.messages.incoming.gamecenter.*;
+import com.eu.habbo.messages.incoming.friends.AcceptFriendRequestEvent;
+import com.eu.habbo.messages.incoming.friends.AddFriendCategoryEvent;
+import com.eu.habbo.messages.incoming.friends.ChangeRelationEvent;
+import com.eu.habbo.messages.incoming.friends.DeclineFriendRequestEvent;
+import com.eu.habbo.messages.incoming.friends.FindNewFriendsEvent;
+import com.eu.habbo.messages.incoming.friends.FriendPrivateMessageEvent;
+import com.eu.habbo.messages.incoming.friends.FriendRequestEvent;
+import com.eu.habbo.messages.incoming.friends.InviteFriendsEvent;
+import com.eu.habbo.messages.incoming.friends.MarkMessengerReadEvent;
+import com.eu.habbo.messages.incoming.friends.MoveFriendToCategoryEvent;
+import com.eu.habbo.messages.incoming.friends.RemoveFriendCategoryEvent;
+import com.eu.habbo.messages.incoming.friends.RemoveFriendEvent;
+import com.eu.habbo.messages.incoming.friends.RenameFriendCategoryEvent;
+import com.eu.habbo.messages.incoming.friends.RequestFriendRequestsEvent;
+import com.eu.habbo.messages.incoming.friends.RequestFriendsEvent;
+import com.eu.habbo.messages.incoming.friends.RequestInitFriendsEvent;
+import com.eu.habbo.messages.incoming.friends.RequestMessengerConversationsEvent;
+import com.eu.habbo.messages.incoming.friends.RequestMessengerHistoryEvent;
+import com.eu.habbo.messages.incoming.friends.SearchUserEvent;
+import com.eu.habbo.messages.incoming.friends.SendMessengerMessageEvent;
+import com.eu.habbo.messages.incoming.friends.StalkFriendEvent;
+import com.eu.habbo.messages.incoming.furnieditor.FurniEditorBySpriteEvent;
+import com.eu.habbo.messages.incoming.furnieditor.FurniEditorDeleteEvent;
+import com.eu.habbo.messages.incoming.furnieditor.FurniEditorDetailEvent;
+import com.eu.habbo.messages.incoming.furnieditor.FurniEditorImportTextEvent;
+import com.eu.habbo.messages.incoming.furnieditor.FurniEditorInteractionsEvent;
+import com.eu.habbo.messages.incoming.furnieditor.FurniEditorRevertFurnidataEvent;
+import com.eu.habbo.messages.incoming.furnieditor.FurniEditorSearchEvent;
+import com.eu.habbo.messages.incoming.furnieditor.FurniEditorUpdateEvent;
+import com.eu.habbo.messages.incoming.furnieditor.FurniEditorUpdateFurnidataEvent;
+import com.eu.habbo.messages.incoming.gamecenter.GameCenterEvent;
+import com.eu.habbo.messages.incoming.gamecenter.GameCenterJoinGameEvent;
+import com.eu.habbo.messages.incoming.gamecenter.GameCenterLeaveGameEvent;
+import com.eu.habbo.messages.incoming.gamecenter.GameCenterLoadGameEvent;
+import com.eu.habbo.messages.incoming.gamecenter.GameCenterRequestAccountStatusEvent;
+import com.eu.habbo.messages.incoming.gamecenter.GameCenterRequestGameStatusEvent;
+import com.eu.habbo.messages.incoming.gamecenter.GameCenterRequestGamesEvent;
 import com.eu.habbo.messages.incoming.guardians.GuardianAcceptRequestEvent;
 import com.eu.habbo.messages.incoming.guardians.GuardianNoUpdatesWantedEvent;
 import com.eu.habbo.messages.incoming.guardians.GuardianVoteEvent;
-import com.eu.habbo.messages.incoming.guides.*;
-import com.eu.habbo.messages.incoming.guilds.*;
-import com.eu.habbo.messages.incoming.guilds.forums.*;
-import com.eu.habbo.messages.incoming.handshake.*;
+import com.eu.habbo.messages.incoming.guides.GuideCancelHelpRequestEvent;
+import com.eu.habbo.messages.incoming.guides.GuideCloseHelpRequestEvent;
+import com.eu.habbo.messages.incoming.guides.GuideHandleHelpRequestEvent;
+import com.eu.habbo.messages.incoming.guides.GuideInviteUserEvent;
+import com.eu.habbo.messages.incoming.guides.GuideRecommendHelperEvent;
+import com.eu.habbo.messages.incoming.guides.GuideReportHelperEvent;
+import com.eu.habbo.messages.incoming.guides.GuideUserMessageEvent;
+import com.eu.habbo.messages.incoming.guides.GuideUserTypingEvent;
+import com.eu.habbo.messages.incoming.guides.GuideVisitUserEvent;
+import com.eu.habbo.messages.incoming.guides.RequestGuideAssistanceEvent;
+import com.eu.habbo.messages.incoming.guides.RequestGuideToolEvent;
+import com.eu.habbo.messages.incoming.guilds.GetHabboGuildBadgesMessageEvent;
+import com.eu.habbo.messages.incoming.guilds.GuildAcceptMembershipEvent;
+import com.eu.habbo.messages.incoming.guilds.GuildChangeBadgeEvent;
+import com.eu.habbo.messages.incoming.guilds.GuildChangeColorsEvent;
+import com.eu.habbo.messages.incoming.guilds.GuildChangeNameDescEvent;
+import com.eu.habbo.messages.incoming.guilds.GuildChangeSettingsEvent;
+import com.eu.habbo.messages.incoming.guilds.GuildConfirmRemoveMemberEvent;
+import com.eu.habbo.messages.incoming.guilds.GuildDeclineMembershipEvent;
+import com.eu.habbo.messages.incoming.guilds.GuildDeleteEvent;
+import com.eu.habbo.messages.incoming.guilds.GuildRemoveAdminEvent;
+import com.eu.habbo.messages.incoming.guilds.GuildRemoveFavoriteEvent;
+import com.eu.habbo.messages.incoming.guilds.GuildRemoveMemberEvent;
+import com.eu.habbo.messages.incoming.guilds.GuildSetAdminEvent;
+import com.eu.habbo.messages.incoming.guilds.GuildSetFavoriteEvent;
+import com.eu.habbo.messages.incoming.guilds.RequestGuildBuyEvent;
+import com.eu.habbo.messages.incoming.guilds.RequestGuildBuyRoomsEvent;
+import com.eu.habbo.messages.incoming.guilds.RequestGuildFurniWidgetEvent;
+import com.eu.habbo.messages.incoming.guilds.RequestGuildInfoEvent;
+import com.eu.habbo.messages.incoming.guilds.RequestGuildJoinEvent;
+import com.eu.habbo.messages.incoming.guilds.RequestGuildManageEvent;
+import com.eu.habbo.messages.incoming.guilds.RequestGuildMembersEvent;
+import com.eu.habbo.messages.incoming.guilds.RequestGuildPartsEvent;
+import com.eu.habbo.messages.incoming.guilds.RequestOwnGuildsEvent;
+import com.eu.habbo.messages.incoming.guilds.forums.GuildForumDataEvent;
+import com.eu.habbo.messages.incoming.guilds.forums.GuildForumListEvent;
+import com.eu.habbo.messages.incoming.guilds.forums.GuildForumMarkAsReadEvent;
+import com.eu.habbo.messages.incoming.guilds.forums.GuildForumModerateMessageEvent;
+import com.eu.habbo.messages.incoming.guilds.forums.GuildForumModerateThreadEvent;
+import com.eu.habbo.messages.incoming.guilds.forums.GuildForumPostThreadEvent;
+import com.eu.habbo.messages.incoming.guilds.forums.GuildForumThreadUpdateEvent;
+import com.eu.habbo.messages.incoming.guilds.forums.GuildForumThreadsEvent;
+import com.eu.habbo.messages.incoming.guilds.forums.GuildForumThreadsMessagesEvent;
+import com.eu.habbo.messages.incoming.guilds.forums.GuildForumUpdateSettingsEvent;
+import com.eu.habbo.messages.incoming.handshake.CompleteDiffieHandshakeEvent;
+import com.eu.habbo.messages.incoming.handshake.InitDiffieHandshakeEvent;
+import com.eu.habbo.messages.incoming.handshake.MachineIDEvent;
+import com.eu.habbo.messages.incoming.handshake.PingEvent;
+import com.eu.habbo.messages.incoming.handshake.ReleaseVersionEvent;
+import com.eu.habbo.messages.incoming.handshake.SecureLoginEvent;
 import com.eu.habbo.messages.incoming.helper.MySanctionStatusEvent;
 import com.eu.habbo.messages.incoming.helper.RequestTalentTrackEvent;
-import com.eu.habbo.messages.incoming.hotelview.*;
-import com.eu.habbo.messages.incoming.inventory.*;
-import com.eu.habbo.messages.incoming.inventory.nickicons.*;
-import com.eu.habbo.messages.incoming.inventory.prefixes.*;
-import com.eu.habbo.messages.incoming.mentions.*;
-import com.eu.habbo.messages.incoming.modtool.*;
-import com.eu.habbo.messages.incoming.navigator.*;
+import com.eu.habbo.messages.incoming.hotelview.HotelViewClaimBadgeRewardEvent;
+import com.eu.habbo.messages.incoming.hotelview.HotelViewDataEvent;
+import com.eu.habbo.messages.incoming.hotelview.HotelViewEvent;
+import com.eu.habbo.messages.incoming.hotelview.HotelViewRequestBadgeRewardEvent;
+import com.eu.habbo.messages.incoming.hotelview.HotelViewRequestBonusRareEvent;
+import com.eu.habbo.messages.incoming.hotelview.HotelViewRequestLTDAvailabilityEvent;
+import com.eu.habbo.messages.incoming.hotelview.HotelViewRequestSecondsUntilEvent;
+import com.eu.habbo.messages.incoming.hotelview.RequestNewsListEvent;
+import com.eu.habbo.messages.incoming.inventory.HotelViewInventoryEvent;
+import com.eu.habbo.messages.incoming.inventory.RequestInventoryBadgeDelete;
+import com.eu.habbo.messages.incoming.inventory.RequestInventoryBadgesEvent;
+import com.eu.habbo.messages.incoming.inventory.RequestInventoryBotsEvent;
+import com.eu.habbo.messages.incoming.inventory.RequestInventoryItemsDelete;
+import com.eu.habbo.messages.incoming.inventory.RequestInventoryItemsEvent;
+import com.eu.habbo.messages.incoming.inventory.RequestInventoryPetDelete;
+import com.eu.habbo.messages.incoming.inventory.RequestInventoryPetsEvent;
+import com.eu.habbo.messages.incoming.inventory.nickicons.PurchaseNickIconEvent;
+import com.eu.habbo.messages.incoming.inventory.nickicons.RequestUserNickIconsEvent;
+import com.eu.habbo.messages.incoming.inventory.nickicons.SetActiveNickIconEvent;
+import com.eu.habbo.messages.incoming.inventory.prefixes.DeletePrefixEvent;
+import com.eu.habbo.messages.incoming.inventory.prefixes.PurchaseCatalogPrefixEvent;
+import com.eu.habbo.messages.incoming.inventory.prefixes.PurchasePrefixEvent;
+import com.eu.habbo.messages.incoming.inventory.prefixes.RequestUserPrefixesEvent;
+import com.eu.habbo.messages.incoming.inventory.prefixes.SetActivePrefixEvent;
+import com.eu.habbo.messages.incoming.inventory.prefixes.SetDisplayOrderEvent;
+import com.eu.habbo.messages.incoming.mentions.DeleteMentionEvent;
+import com.eu.habbo.messages.incoming.mentions.MarkMentionsReadEvent;
+import com.eu.habbo.messages.incoming.mentions.RequestMentionsEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolAlertEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolChangeRoomSettingsEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolCloseTicketEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolIssueChangeTopicEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolIssueDefaultSanctionEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolKickEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolPickTicketEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolReleaseTicketEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolRequestIssueChatlogEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolRequestRoomChatlogEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolRequestRoomInfoEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolRequestRoomUserChatlogEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolRequestRoomVisitsEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolRequestUserChatlogEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolRequestUserInfoEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolRoomAlertEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolSanctionAlertEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolSanctionBanEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolSanctionMuteEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolSanctionTradeLockEvent;
+import com.eu.habbo.messages.incoming.modtool.ModToolWarnEvent;
+import com.eu.habbo.messages.incoming.modtool.ReportBullyEvent;
+import com.eu.habbo.messages.incoming.modtool.ReportCommentEvent;
+import com.eu.habbo.messages.incoming.modtool.ReportEvent;
+import com.eu.habbo.messages.incoming.modtool.ReportFriendPrivateChatEvent;
+import com.eu.habbo.messages.incoming.modtool.ReportPhotoEvent;
+import com.eu.habbo.messages.incoming.modtool.ReportThreadEvent;
+import com.eu.habbo.messages.incoming.modtool.RequestReportRoomEvent;
+import com.eu.habbo.messages.incoming.modtool.RequestReportUserBullyingEvent;
+import com.eu.habbo.messages.incoming.navigator.AddSavedSearchEvent;
+import com.eu.habbo.messages.incoming.navigator.DeleteSavedSearchEvent;
+import com.eu.habbo.messages.incoming.navigator.GetCategoriesWithUserCountEvent;
+import com.eu.habbo.messages.incoming.navigator.NavigatorCategoryListModeEvent;
+import com.eu.habbo.messages.incoming.navigator.NavigatorCollapseCategoryEvent;
+import com.eu.habbo.messages.incoming.navigator.NavigatorUncollapseCategoryEvent;
+import com.eu.habbo.messages.incoming.navigator.NewNavigatorActionEvent;
+import com.eu.habbo.messages.incoming.navigator.RequestCanCreateRoomEvent;
+import com.eu.habbo.messages.incoming.navigator.RequestCreateRoomEvent;
+import com.eu.habbo.messages.incoming.navigator.RequestDeleteRoomEvent;
+import com.eu.habbo.messages.incoming.navigator.RequestHighestScoreRoomsEvent;
+import com.eu.habbo.messages.incoming.navigator.RequestMyRoomsEvent;
+import com.eu.habbo.messages.incoming.navigator.RequestNavigatorSettingsEvent;
+import com.eu.habbo.messages.incoming.navigator.RequestNewNavigatorDataEvent;
+import com.eu.habbo.messages.incoming.navigator.RequestNewNavigatorRoomsEvent;
+import com.eu.habbo.messages.incoming.navigator.RequestPopularRoomsEvent;
+import com.eu.habbo.messages.incoming.navigator.RequestPromotedRoomsEvent;
+import com.eu.habbo.messages.incoming.navigator.RequestRoomCategoriesEvent;
+import com.eu.habbo.messages.incoming.navigator.RequestTagsEvent;
+import com.eu.habbo.messages.incoming.navigator.SaveWindowSettingsEvent;
+import com.eu.habbo.messages.incoming.navigator.SearchRoomsByTagEvent;
+import com.eu.habbo.messages.incoming.navigator.SearchRoomsEvent;
+import com.eu.habbo.messages.incoming.navigator.SearchRoomsFriendsNowEvent;
+import com.eu.habbo.messages.incoming.navigator.SearchRoomsFriendsOwnEvent;
+import com.eu.habbo.messages.incoming.navigator.SearchRoomsInGroupEvent;
+import com.eu.habbo.messages.incoming.navigator.SearchRoomsMyFavouriteEvent;
+import com.eu.habbo.messages.incoming.navigator.SearchRoomsVisitedEvent;
+import com.eu.habbo.messages.incoming.navigator.SearchRoomsWithRightsEvent;
 import com.eu.habbo.messages.incoming.polls.AnswerPollEvent;
 import com.eu.habbo.messages.incoming.polls.CancelPollEvent;
 import com.eu.habbo.messages.incoming.polls.GetPollDataEvent;
-import com.eu.habbo.messages.incoming.rooms.*;
+import com.eu.habbo.messages.incoming.rooms.HandleDoorbellEvent;
+import com.eu.habbo.messages.incoming.rooms.RequestRoomDataEvent;
+import com.eu.habbo.messages.incoming.rooms.RequestRoomHeightmapEvent;
+import com.eu.habbo.messages.incoming.rooms.RequestRoomLoadEvent;
+import com.eu.habbo.messages.incoming.rooms.RequestRoomRightsEvent;
+import com.eu.habbo.messages.incoming.rooms.RequestRoomSettingsEvent;
+import com.eu.habbo.messages.incoming.rooms.RequestRoomWordFilterEvent;
+import com.eu.habbo.messages.incoming.rooms.RoomBackgroundEvent;
+import com.eu.habbo.messages.incoming.rooms.RoomFavoriteEvent;
+import com.eu.habbo.messages.incoming.rooms.RoomMuteEvent;
+import com.eu.habbo.messages.incoming.rooms.RoomPlacePaintEvent;
+import com.eu.habbo.messages.incoming.rooms.RoomRemoveAllRightsEvent;
+import com.eu.habbo.messages.incoming.rooms.RoomRemoveRightsEvent;
+import com.eu.habbo.messages.incoming.rooms.RoomRequestBannedUsersEvent;
+import com.eu.habbo.messages.incoming.rooms.RoomSettingsSaveEvent;
+import com.eu.habbo.messages.incoming.rooms.RoomStaffPickEvent;
+import com.eu.habbo.messages.incoming.rooms.RoomUnFavoriteEvent;
+import com.eu.habbo.messages.incoming.rooms.RoomVoteEvent;
+import com.eu.habbo.messages.incoming.rooms.RoomWordFilterModifyEvent;
+import com.eu.habbo.messages.incoming.rooms.SetHomeRoomEvent;
 import com.eu.habbo.messages.incoming.rooms.bots.BotPickupEvent;
 import com.eu.habbo.messages.incoming.rooms.bots.BotPlaceEvent;
 import com.eu.habbo.messages.incoming.rooms.bots.BotSaveSettingsEvent;
 import com.eu.habbo.messages.incoming.rooms.bots.BotSettingsEvent;
-import com.eu.habbo.messages.incoming.rooms.items.*;
-import com.eu.habbo.messages.incoming.rooms.items.jukebox.*;
+import com.eu.habbo.messages.incoming.rooms.items.AdvertisingSaveEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ChestDepositEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ChestDepositFurniEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ChestDepositInventoryItemEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ChestOpenEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ChestRequestLogEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ChestSaveNotificationsEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ChestSaveSettingsEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ChestStartDepositEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ChestUpgradeCapacityEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ChestWithdrawAllFurniEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ChestWithdrawEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ChestWithdrawFurniEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ClickFurniEvent;
+import com.eu.habbo.messages.incoming.rooms.items.CloseDiceEvent;
+import com.eu.habbo.messages.incoming.rooms.items.FootballGateSaveLookEvent;
+import com.eu.habbo.messages.incoming.rooms.items.MannequinSaveLookEvent;
+import com.eu.habbo.messages.incoming.rooms.items.MannequinSaveNameEvent;
+import com.eu.habbo.messages.incoming.rooms.items.MoodLightSaveSettingsEvent;
+import com.eu.habbo.messages.incoming.rooms.items.MoodLightSettingsEvent;
+import com.eu.habbo.messages.incoming.rooms.items.MoodLightTurnOnEvent;
+import com.eu.habbo.messages.incoming.rooms.items.MoveWallItemEvent;
+import com.eu.habbo.messages.incoming.rooms.items.PostItDeleteEvent;
+import com.eu.habbo.messages.incoming.rooms.items.PostItPlaceEvent;
+import com.eu.habbo.messages.incoming.rooms.items.PostItRequestDataEvent;
+import com.eu.habbo.messages.incoming.rooms.items.PostItSaveDataEvent;
+import com.eu.habbo.messages.incoming.rooms.items.RedeemClothingEvent;
+import com.eu.habbo.messages.incoming.rooms.items.RedeemItemEvent;
+import com.eu.habbo.messages.incoming.rooms.items.RoomPickupChooserEvent;
+import com.eu.habbo.messages.incoming.rooms.items.RoomPickupItemEvent;
+import com.eu.habbo.messages.incoming.rooms.items.RoomPlaceItemEvent;
+import com.eu.habbo.messages.incoming.rooms.items.RotateMoveItemEvent;
+import com.eu.habbo.messages.incoming.rooms.items.SavePostItStickyPoleEvent;
+import com.eu.habbo.messages.incoming.rooms.items.SetStackHelperHeightEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ToggleFloorItemEvent;
+import com.eu.habbo.messages.incoming.rooms.items.ToggleWallItemEvent;
+import com.eu.habbo.messages.incoming.rooms.items.TriggerColorWheelEvent;
+import com.eu.habbo.messages.incoming.rooms.items.TriggerDiceEvent;
+import com.eu.habbo.messages.incoming.rooms.items.TriggerOneWayGateEvent;
+import com.eu.habbo.messages.incoming.rooms.items.UpdateFurniturePositionEvent;
+import com.eu.habbo.messages.incoming.rooms.items.UseRandomStateItemEvent;
+import com.eu.habbo.messages.incoming.rooms.items.jukebox.JukeBoxAddSoundTrackEvent;
+import com.eu.habbo.messages.incoming.rooms.items.jukebox.JukeBoxEventOne;
+import com.eu.habbo.messages.incoming.rooms.items.jukebox.JukeBoxEventTwo;
+import com.eu.habbo.messages.incoming.rooms.items.jukebox.JukeBoxRemoveSoundTrackEvent;
+import com.eu.habbo.messages.incoming.rooms.items.jukebox.JukeBoxRequestPlayListEvent;
 import com.eu.habbo.messages.incoming.rooms.items.lovelock.LoveLockStartConfirmEvent;
 import com.eu.habbo.messages.incoming.rooms.items.rentablespace.RentSpaceCancelEvent;
 import com.eu.habbo.messages.incoming.rooms.items.rentablespace.RentSpaceEvent;
 import com.eu.habbo.messages.incoming.rooms.items.youtube.YoutubeRequestPlaylistChange;
 import com.eu.habbo.messages.incoming.rooms.items.youtube.YoutubeRequestPlaylists;
 import com.eu.habbo.messages.incoming.rooms.items.youtube.YoutubeRequestStateChange;
-import com.eu.habbo.messages.incoming.rooms.pets.*;
+import com.eu.habbo.messages.incoming.rooms.pets.BreedMonsterplantsEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.CompostMonsterplantEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.ConfirmPetBreedingEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.HorseRemoveSaddleEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.MovePetEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.PetPackageNameEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.PetPickupEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.PetPlaceEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.PetRideEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.PetRideSettingsEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.PetUseItemEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.RequestPetInformationEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.RequestPetTrainingPanelEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.ScratchPetEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.StopBreedingEvent;
+import com.eu.habbo.messages.incoming.rooms.pets.ToggleMonsterplantBreedableEvent;
 import com.eu.habbo.messages.incoming.rooms.promotions.BuyRoomPromotionEvent;
 import com.eu.habbo.messages.incoming.rooms.promotions.RequestPromotionRoomsEvent;
 import com.eu.habbo.messages.incoming.rooms.promotions.UpdateRoomPromotionEvent;
-import com.eu.habbo.messages.incoming.rooms.users.*;
-import com.eu.habbo.messages.incoming.trading.*;
+import com.eu.habbo.messages.incoming.rooms.users.ClickUserEvent;
+import com.eu.habbo.messages.incoming.rooms.users.IgnoreRoomUserEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RequestRoomUserTagsEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserActionEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserBanEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserDanceEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserDropHandItemEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserGiveHandItemEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserGiveRespectEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserGiveRightsEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserKickEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserLookAtPoint;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserMuteEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserRemoveRightsEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserShoutEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserSignEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserSitEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserStartTypingEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserStopTypingEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserTalkEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserWalkEvent;
+import com.eu.habbo.messages.incoming.rooms.users.RoomUserWhisperEvent;
+import com.eu.habbo.messages.incoming.rooms.users.UnIgnoreRoomUserEvent;
+import com.eu.habbo.messages.incoming.rooms.users.UnbanRoomUserEvent;
+import com.eu.habbo.messages.incoming.trading.TradeAcceptEvent;
+import com.eu.habbo.messages.incoming.trading.TradeCancelEvent;
+import com.eu.habbo.messages.incoming.trading.TradeCancelOfferItemEvent;
+import com.eu.habbo.messages.incoming.trading.TradeCloseEvent;
+import com.eu.habbo.messages.incoming.trading.TradeConfirmEvent;
+import com.eu.habbo.messages.incoming.trading.TradeOfferItemEvent;
+import com.eu.habbo.messages.incoming.trading.TradeOfferMultipleItemsEvent;
+import com.eu.habbo.messages.incoming.trading.TradeStartEvent;
+import com.eu.habbo.messages.incoming.trading.TradeUnAcceptEvent;
 import com.eu.habbo.messages.incoming.translation.TranslationLanguagesRequestEvent;
 import com.eu.habbo.messages.incoming.translation.TranslationTextRequestEvent;
 import com.eu.habbo.messages.incoming.unknown.RequestResolutionEvent;
 import com.eu.habbo.messages.incoming.unknown.UnknownEvent1;
-import com.eu.habbo.messages.incoming.users.*;
+import com.eu.habbo.messages.incoming.users.ActivateEffectEvent;
+import com.eu.habbo.messages.incoming.users.ChangeChatBubbleEvent;
+import com.eu.habbo.messages.incoming.users.ChangeInfostandBgEvent;
+import com.eu.habbo.messages.incoming.users.ChangeNameCheckUsernameEvent;
+import com.eu.habbo.messages.incoming.users.ConfirmChangeNameEvent;
+import com.eu.habbo.messages.incoming.users.EnableEffectEvent;
+import com.eu.habbo.messages.incoming.users.GetIgnoredUsersEvent;
+import com.eu.habbo.messages.incoming.users.PickNewUserGiftEvent;
+import com.eu.habbo.messages.incoming.users.RequestClubCenterEvent;
+import com.eu.habbo.messages.incoming.users.RequestMeMenuSettingsEvent;
+import com.eu.habbo.messages.incoming.users.RequestProfileFriendsEvent;
+import com.eu.habbo.messages.incoming.users.RequestUserCitizinShipEvent;
+import com.eu.habbo.messages.incoming.users.RequestUserClubEvent;
+import com.eu.habbo.messages.incoming.users.RequestUserCreditsEvent;
+import com.eu.habbo.messages.incoming.users.RequestUserDataEvent;
+import com.eu.habbo.messages.incoming.users.RequestUserProfileEvent;
+import com.eu.habbo.messages.incoming.users.RequestUserWardrobeEvent;
+import com.eu.habbo.messages.incoming.users.RequestWearingBadgesEvent;
+import com.eu.habbo.messages.incoming.users.SaveBlockCameraFollowEvent;
+import com.eu.habbo.messages.incoming.users.SaveIgnoreRoomInvitesEvent;
+import com.eu.habbo.messages.incoming.users.SaveMottoEvent;
+import com.eu.habbo.messages.incoming.users.SavePreferOldChatEvent;
+import com.eu.habbo.messages.incoming.users.SaveUserVolumesEvent;
+import com.eu.habbo.messages.incoming.users.SaveWardrobeEvent;
+import com.eu.habbo.messages.incoming.users.UpdateUIFlagsEvent;
+import com.eu.habbo.messages.incoming.users.UserActivityEvent;
+import com.eu.habbo.messages.incoming.users.UserNuxEvent;
+import com.eu.habbo.messages.incoming.users.UserSaveLookEvent;
+import com.eu.habbo.messages.incoming.users.UserWearBadgeEvent;
 import com.eu.habbo.messages.incoming.wired.WiredApplySetConditionsEvent;
 import com.eu.habbo.messages.incoming.wired.WiredConditionSaveDataEvent;
 import com.eu.habbo.messages.incoming.wired.WiredEffectSaveDataEvent;
 import com.eu.habbo.messages.incoming.wired.WiredMonitorRequestEvent;
 import com.eu.habbo.messages.incoming.wired.WiredRoomSettingsRequestEvent;
 import com.eu.habbo.messages.incoming.wired.WiredRoomSettingsSaveEvent;
+import com.eu.habbo.messages.incoming.wired.WiredTriggerSaveDataEvent;
 import com.eu.habbo.messages.incoming.wired.WiredUserInspectMoveEvent;
 import com.eu.habbo.messages.incoming.wired.WiredUserVariableManageEvent;
 import com.eu.habbo.messages.incoming.wired.WiredUserVariableUpdateEvent;
 import com.eu.habbo.messages.incoming.wired.WiredUserVariablesRequestEvent;
-import com.eu.habbo.messages.incoming.wired.WiredTriggerSaveDataEvent;
+import com.eu.habbo.monitoring.EmulatorNetworkStats;
 import com.eu.habbo.plugin.EventHandler;
 import com.eu.habbo.plugin.events.emulator.EmulatorConfigUpdatedEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PacketManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PacketManager.class);
-    private static final ClassValue<
-            Constructor<? extends MessageHandler>> HANDLER_CONSTRUCTORS =
-            new ClassValue<>() {
-                @Override
-                protected Constructor<? extends MessageHandler> computeValue(
-                        Class<?> type) {
-                    try {
-                        return type.asSubclass(MessageHandler.class)
-                                .getDeclaredConstructor();
-                    } catch (NoSuchMethodException exception) {
-                        throw new IllegalArgumentException(
-                                "Incoming handler has no default constructor: "
-                                        + type.getName(),
-                                exception);
-                    }
-                }
-            };
+    private static final ClassValue<Constructor<? extends MessageHandler>> HANDLER_CONSTRUCTORS = new ClassValue<>() {
+        @Override
+        protected Constructor<? extends MessageHandler> computeValue(Class<?> type) {
+            try {
+                return type.asSubclass(MessageHandler.class).getDeclaredConstructor();
+            } catch (NoSuchMethodException exception) {
+                throw new IllegalArgumentException(
+                        "Incoming handler has no default constructor: " + type.getName(), exception);
+            }
+        }
+    };
 
     private static final List<Integer> logList = new ArrayList<>();
-    public static boolean DEBUG_SHOW_PACKETS = false;
-    public static boolean MULTI_THREADED_PACKET_HANDLING = false;
+    public static volatile boolean DEBUG_SHOW_PACKETS = false;
+    public static volatile boolean MULTI_THREADED_PACKET_HANDLING = false;
     private final Map<Integer, Class<? extends MessageHandler>> incoming;
     private final Map<Integer, List<ICallable>> callables;
     private final PacketNames names;
@@ -175,11 +514,11 @@ public class PacketManager {
     }
 
     public void registerHandler(Integer header, Class<? extends MessageHandler> handler) throws Exception {
-        if (header < 0)
-            return;
+        if (header < 0) return;
 
         if (this.incoming.containsKey(header)) {
-            throw new Exception("Header already registered. Failed to register " + handler.getName() + " with header " + header);
+            throw new Exception(
+                    "Header already registered. Failed to register " + handler.getName() + " with header " + header);
         }
 
         this.incoming.putIfAbsent(header, handler);
@@ -203,8 +542,7 @@ public class PacketManager {
     }
 
     public void handlePacket(GameClient client, ClientMessage packet) {
-        if (client == null || Emulator.isShuttingDown)
-            return;
+        if (client == null || Emulator.isShuttingDown) return;
 
         try {
             EmulatorNetworkStats.recordIncoming(packet.bytesAvailable() + 6);
@@ -222,8 +560,7 @@ public class PacketManager {
                     return;
                 }
 
-                final MessageHandler handler =
-                        constructorFor(handlerClass).newInstance();
+                final MessageHandler handler = constructorFor(handlerClass).newInstance();
 
                 if (handler.getRatelimit() > 0) {
                     long now = System.currentTimeMillis();
@@ -232,10 +569,7 @@ public class PacketManager {
 
                     if (rateLimitGroup != null && !rateLimitGroup.isBlank()) {
                         rateLimited = !acquireGroupedRateLimit(
-                                client.groupedMessageRateLimitDeadlines,
-                                rateLimitGroup,
-                                handler.getRatelimit(),
-                                now);
+                                client.groupedMessageRateLimitDeadlines, rateLimitGroup, handler.getRatelimit(), now);
                     } else {
                         rateLimited = client.messageTimestamps.containsKey(handlerClass)
                                 && now - client.messageTimestamps.get(handlerClass) < handler.getRatelimit();
@@ -255,7 +589,11 @@ public class PacketManager {
                 }
 
                 if (logList.contains(packet.getMessageId()) && client.getHabbo() != null) {
-                    LOGGER.info("User {} sent packet {} with body {}", client.getHabbo().getHabboInfo().getUsername(), packet.getMessageId(), packet.getMessageBody());
+                    LOGGER.info(
+                            "User {} sent packet {} with body {}",
+                            client.getHabbo().getHabboInfo().getUsername(),
+                            packet.getMessageId(),
+                            packet.getMessageBody());
                 }
 
                 handler.client = client;
@@ -297,8 +635,7 @@ public class PacketManager {
         return this.incoming.containsKey(header);
     }
 
-    static Constructor<? extends MessageHandler> constructorFor(
-            Class<? extends MessageHandler> handlerClass) {
+    static Constructor<? extends MessageHandler> constructorFor(Class<? extends MessageHandler> handlerClass) {
         return HANDLER_CONSTRUCTORS.get(handlerClass);
     }
 
@@ -519,7 +856,7 @@ public class PacketManager {
         this.registerHandler(Incoming.RotateMoveItemEvent, RotateMoveItemEvent.class);
         this.registerHandler(Incoming.MoveWallItemEvent, MoveWallItemEvent.class);
         this.registerHandler(Incoming.RoomPickupItemEvent, RoomPickupItemEvent.class);
-		this.registerHandler(Incoming.RoomPickupChooserEvent, RoomPickupChooserEvent.class);
+        this.registerHandler(Incoming.RoomPickupChooserEvent, RoomPickupChooserEvent.class);
         this.registerHandler(Incoming.RoomPlacePaintEvent, RoomPlacePaintEvent.class);
         this.registerHandler(Incoming.RoomUserStartTypingEvent, RoomUserStartTypingEvent.class);
         this.registerHandler(Incoming.RoomUserStopTypingEvent, RoomUserStopTypingEvent.class);
@@ -568,7 +905,8 @@ public class PacketManager {
         this.registerHandler(Incoming.BotSaveSettingsEvent, BotSaveSettingsEvent.class);
         this.registerHandler(Incoming.BotSettingsEvent, BotSettingsEvent.class);
         this.registerHandler(Incoming.TriggerDiceEvent, TriggerDiceEvent.class);
-        this.registerHandler(Incoming.PressKeybindEvent, com.eu.habbo.messages.incoming.rooms.items.PressKeybindEvent.class);
+        this.registerHandler(
+                Incoming.PressKeybindEvent, com.eu.habbo.messages.incoming.rooms.items.PressKeybindEvent.class);
         this.registerHandler(Incoming.CloseDiceEvent, CloseDiceEvent.class);
         this.registerHandler(Incoming.TriggerColorWheelEvent, TriggerColorWheelEvent.class);
         this.registerHandler(Incoming.RedeemItemEvent, RedeemItemEvent.class);
@@ -705,12 +1043,12 @@ public class PacketManager {
         this.registerHandler(Incoming.GuildForumMarkAsReadEvent, GuildForumMarkAsReadEvent.class);
         this.registerHandler(Incoming.GetHabboGuildBadgesMessageEvent, GetHabboGuildBadgesMessageEvent.class);
 
-//        this.registerHandler(Incoming.GuildForumDataEvent,              GuildForumModerateMessageEvent.class);
-//        this.registerHandler(Incoming.GuildForumDataEvent,              GuildForumModerateThreadEvent.class);
-//        this.registerHandler(Incoming.GuildForumDataEvent,              GuildForumPostThreadEvent.class);
-//        this.registerHandler(Incoming.GuildForumDataEvent,              GuildForumThreadsEvent.class);
-//        this.registerHandler(Incoming.GuildForumDataEvent,              GuildForumThreadsMessagesEvent.class);
-//        this.registerHandler(Incoming.GuildForumDataEvent,              GuildForumUpdateSettingsEvent.class);
+        //        this.registerHandler(Incoming.GuildForumDataEvent,              GuildForumModerateMessageEvent.class);
+        //        this.registerHandler(Incoming.GuildForumDataEvent,              GuildForumModerateThreadEvent.class);
+        //        this.registerHandler(Incoming.GuildForumDataEvent,              GuildForumPostThreadEvent.class);
+        //        this.registerHandler(Incoming.GuildForumDataEvent,              GuildForumThreadsEvent.class);
+        //        this.registerHandler(Incoming.GuildForumDataEvent,              GuildForumThreadsMessagesEvent.class);
+        //        this.registerHandler(Incoming.GuildForumDataEvent,              GuildForumUpdateSettingsEvent.class);
     }
 
     void registerPets() throws Exception {
@@ -759,8 +1097,10 @@ public class PacketManager {
 
     void registerFloorPlanEditor() throws Exception {
         this.registerHandler(Incoming.FloorPlanEditorSaveEvent, FloorPlanEditorSaveEvent.class);
-        this.registerHandler(Incoming.FloorPlanEditorRequestBlockedTilesEvent, FloorPlanEditorRequestBlockedTilesEvent.class);
-        this.registerHandler(Incoming.FloorPlanEditorRequestDoorSettingsEvent, FloorPlanEditorRequestDoorSettingsEvent.class);
+        this.registerHandler(
+                Incoming.FloorPlanEditorRequestBlockedTilesEvent, FloorPlanEditorRequestBlockedTilesEvent.class);
+        this.registerHandler(
+                Incoming.FloorPlanEditorRequestDoorSettingsEvent, FloorPlanEditorRequestDoorSettingsEvent.class);
     }
 
     void registerAchievements() throws Exception {
@@ -812,51 +1152,120 @@ public class PacketManager {
         this.registerHandler(Incoming.GameCenterRequestGameStatusEvent, GameCenterRequestGameStatusEvent.class);
 
         // YouTube Room Broadcast
-        this.registerHandler(Incoming.YouTubeRoomPlayEvent, com.eu.habbo.messages.incoming.rooms.youtube.YouTubeRoomPlayEvent.class);
-        this.registerHandler(Incoming.YouTubeRoomWatchingEvent, com.eu.habbo.messages.incoming.rooms.youtube.YouTubeRoomWatchingEvent.class);
-        this.registerHandler(Incoming.YouTubeRoomSettingsEvent, com.eu.habbo.messages.incoming.rooms.youtube.YouTubeRoomSettingsEvent.class);
+        this.registerHandler(
+                Incoming.YouTubeRoomPlayEvent, com.eu.habbo.messages.incoming.rooms.youtube.YouTubeRoomPlayEvent.class);
+        this.registerHandler(
+                Incoming.YouTubeRoomWatchingEvent,
+                com.eu.habbo.messages.incoming.rooms.youtube.YouTubeRoomWatchingEvent.class);
+        this.registerHandler(
+                Incoming.YouTubeRoomSettingsEvent,
+                com.eu.habbo.messages.incoming.rooms.youtube.YouTubeRoomSettingsEvent.class);
 
         // Housekeeping (in-client admin panel)
-        this.registerHandler(Incoming.HousekeepingFindUserByNameEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingFindUserByNameEvent.class);
-        this.registerHandler(Incoming.HousekeepingFindUserByIdEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingFindUserByIdEvent.class);
-        this.registerHandler(Incoming.HousekeepingBanUserEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingBanUserEvent.class);
-        this.registerHandler(Incoming.HousekeepingUnbanUserEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingUnbanUserEvent.class);
-        this.registerHandler(Incoming.HousekeepingMuteUserEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingMuteUserEvent.class);
-        this.registerHandler(Incoming.HousekeepingKickUserEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingKickUserEvent.class);
-        this.registerHandler(Incoming.HousekeepingForceDisconnectUserEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingForceDisconnectUserEvent.class);
-        this.registerHandler(Incoming.HousekeepingSetUserRankEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingSetUserRankEvent.class);
-        this.registerHandler(Incoming.HousekeepingTradeLockUserEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingTradeLockUserEvent.class);
-        this.registerHandler(Incoming.HousekeepingResetUserPasswordEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingResetUserPasswordEvent.class);
-        this.registerHandler(Incoming.HousekeepingFindRoomByIdEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingFindRoomByIdEvent.class);
-        this.registerHandler(Incoming.HousekeepingSearchRoomsEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingSearchRoomsEvent.class);
-        this.registerHandler(Incoming.HousekeepingRoomStateEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingRoomStateEvent.class);
-        this.registerHandler(Incoming.HousekeepingMuteRoomEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingMuteRoomEvent.class);
-        this.registerHandler(Incoming.HousekeepingKickAllFromRoomEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingKickAllFromRoomEvent.class);
-        this.registerHandler(Incoming.HousekeepingTransferRoomOwnershipEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingTransferRoomOwnershipEvent.class);
-        this.registerHandler(Incoming.HousekeepingDeleteRoomEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingDeleteRoomEvent.class);
-        this.registerHandler(Incoming.HousekeepingGiveCreditsEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingGiveCreditsEvent.class);
-        this.registerHandler(Incoming.HousekeepingGiveCurrencyEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingGiveCurrencyEvent.class);
-        this.registerHandler(Incoming.HousekeepingGrantItemEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingGrantItemEvent.class);
-        this.registerHandler(Incoming.HousekeepingSetHcSubscriptionEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingSetHcSubscriptionEvent.class);
-        this.registerHandler(Incoming.HousekeepingSendHotelAlertEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingSendHotelAlertEvent.class);
-        this.registerHandler(Incoming.HousekeepingGetDashboardEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingGetDashboardEvent.class);
-        this.registerHandler(Incoming.HousekeepingListActionLogEvent, com.eu.habbo.messages.incoming.housekeeping.HousekeepingListActionLogEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingFindUserByNameEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingFindUserByNameEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingFindUserByIdEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingFindUserByIdEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingBanUserEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingBanUserEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingUnbanUserEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingUnbanUserEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingMuteUserEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingMuteUserEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingKickUserEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingKickUserEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingForceDisconnectUserEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingForceDisconnectUserEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingSetUserRankEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingSetUserRankEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingTradeLockUserEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingTradeLockUserEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingResetUserPasswordEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingResetUserPasswordEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingFindRoomByIdEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingFindRoomByIdEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingSearchRoomsEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingSearchRoomsEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingRoomStateEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingRoomStateEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingMuteRoomEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingMuteRoomEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingKickAllFromRoomEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingKickAllFromRoomEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingTransferRoomOwnershipEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingTransferRoomOwnershipEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingDeleteRoomEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingDeleteRoomEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingGiveCreditsEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingGiveCreditsEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingGiveCurrencyEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingGiveCurrencyEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingGrantItemEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingGrantItemEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingSetHcSubscriptionEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingSetHcSubscriptionEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingSendHotelAlertEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingSendHotelAlertEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingGetDashboardEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingGetDashboardEvent.class);
+        this.registerHandler(
+                Incoming.HousekeepingListActionLogEvent,
+                com.eu.habbo.messages.incoming.housekeeping.HousekeepingListActionLogEvent.class);
 
-        this.registerHandler(Incoming.RequestRareValuesEvent, com.eu.habbo.messages.incoming.rarevalues.RequestRareValuesEvent.class);
+        this.registerHandler(
+                Incoming.RequestRareValuesEvent,
+                com.eu.habbo.messages.incoming.rarevalues.RequestRareValuesEvent.class);
 
         this.registerHandler(Incoming.WheelOpenEvent, com.eu.habbo.messages.incoming.wheel.WheelOpenEvent.class);
         this.registerHandler(Incoming.WheelSpinEvent, com.eu.habbo.messages.incoming.wheel.WheelSpinEvent.class);
         this.registerHandler(Incoming.WheelBuySpinEvent, com.eu.habbo.messages.incoming.wheel.WheelBuySpinEvent.class);
-        this.registerHandler(Incoming.WheelAdminGetPrizesEvent, com.eu.habbo.messages.incoming.wheel.WheelAdminGetPrizesEvent.class);
-        this.registerHandler(Incoming.WheelAdminSavePrizesEvent, com.eu.habbo.messages.incoming.wheel.WheelAdminSavePrizesEvent.class);
+        this.registerHandler(
+                Incoming.WheelAdminGetPrizesEvent, com.eu.habbo.messages.incoming.wheel.WheelAdminGetPrizesEvent.class);
+        this.registerHandler(
+                Incoming.WheelAdminSavePrizesEvent,
+                com.eu.habbo.messages.incoming.wheel.WheelAdminSavePrizesEvent.class);
 
-        this.registerHandler(Incoming.SoundboardPlayEvent, com.eu.habbo.messages.incoming.soundboard.SoundboardPlayEvent.class);
-        this.registerHandler(Incoming.SoundboardSetEnabledEvent, com.eu.habbo.messages.incoming.soundboard.SoundboardSetEnabledEvent.class);
+        this.registerHandler(
+                Incoming.SoundboardPlayEvent, com.eu.habbo.messages.incoming.soundboard.SoundboardPlayEvent.class);
+        this.registerHandler(
+                Incoming.SoundboardSetEnabledEvent,
+                com.eu.habbo.messages.incoming.soundboard.SoundboardSetEnabledEvent.class);
 
-        this.registerHandler(Incoming.TraxEditorRequestSongsEvent, com.eu.habbo.messages.incoming.traxeditor.TraxEditorRequestSongsEvent.class);
-        this.registerHandler(Incoming.TraxEditorBuySongEvent, com.eu.habbo.messages.incoming.traxeditor.TraxEditorBuySongEvent.class);
-        this.registerHandler(Incoming.TraxEditorSaveSongEvent, com.eu.habbo.messages.incoming.traxeditor.TraxEditorSaveSongEvent.class);
-        this.registerHandler(Incoming.TraxEditorDeleteSongEvent, com.eu.habbo.messages.incoming.traxeditor.TraxEditorDeleteSongEvent.class);
+        this.registerHandler(
+                Incoming.TraxEditorRequestSongsEvent,
+                com.eu.habbo.messages.incoming.traxeditor.TraxEditorRequestSongsEvent.class);
+        this.registerHandler(
+                Incoming.TraxEditorBuySongEvent,
+                com.eu.habbo.messages.incoming.traxeditor.TraxEditorBuySongEvent.class);
+        this.registerHandler(
+                Incoming.TraxEditorSaveSongEvent,
+                com.eu.habbo.messages.incoming.traxeditor.TraxEditorSaveSongEvent.class);
+        this.registerHandler(
+                Incoming.TraxEditorDeleteSongEvent,
+                com.eu.habbo.messages.incoming.traxeditor.TraxEditorDeleteSongEvent.class);
     }
 
     void registerEarnings() throws Exception {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CheckPetNameEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CheckPetNameEvent.java
@@ -6,8 +6,8 @@ import com.eu.habbo.messages.outgoing.catalog.PetNameErrorComposer;
 import org.apache.commons.lang3.StringUtils;
 
 public class CheckPetNameEvent extends MessageHandler {
-    public static int PET_NAME_LENGTH_MINIMUM = Emulator.getConfig().getInt("hotel.pets.name.length.min");
-    public static int PET_NAME_LENGTH_MAXIMUM = Emulator.getConfig().getInt("hotel.pets.name.length.max");
+    public static volatile int PET_NAME_LENGTH_MINIMUM = Emulator.getConfig().getInt("hotel.pets.name.length.min");
+    public static volatile int PET_NAME_LENGTH_MAXIMUM = Emulator.getConfig().getInt("hotel.pets.name.length.max");
 
     @Override
     public void handle() throws Exception {
@@ -15,9 +15,11 @@ public class CheckPetNameEvent extends MessageHandler {
         this.packet.readInt(); // Name-validation type; this handler validates pet names only.
 
         if (petName.length() < PET_NAME_LENGTH_MINIMUM) {
-            this.client.sendResponse(new PetNameErrorComposer(PetNameErrorComposer.NAME_TO_SHORT, PET_NAME_LENGTH_MINIMUM + ""));
+            this.client.sendResponse(
+                    new PetNameErrorComposer(PetNameErrorComposer.NAME_TO_SHORT, PET_NAME_LENGTH_MINIMUM + ""));
         } else if (petName.length() > PET_NAME_LENGTH_MAXIMUM) {
-            this.client.sendResponse(new PetNameErrorComposer(PetNameErrorComposer.NAME_TO_LONG, PET_NAME_LENGTH_MAXIMUM + ""));
+            this.client.sendResponse(
+                    new PetNameErrorComposer(PetNameErrorComposer.NAME_TO_LONG, PET_NAME_LENGTH_MAXIMUM + ""));
         } else if (!StringUtils.isAlphanumeric(petName)) {
             this.client.sendResponse(new PetNameErrorComposer(PetNameErrorComposer.FORBIDDEN_CHAR, petName));
         } else {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/floorplaneditor/FloorPlanEditorSaveEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/floorplaneditor/FloorPlanEditorSaveEvent.java
@@ -2,7 +2,11 @@ package com.eu.habbo.messages.incoming.floorplaneditor;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.permissions.Permission;
-import com.eu.habbo.habbohotel.rooms.*;
+import com.eu.habbo.habbohotel.rooms.CustomRoomLayout;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomLayout;
+import com.eu.habbo.habbohotel.rooms.RoomTile;
+import com.eu.habbo.habbohotel.rooms.RoomTileState;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
@@ -13,9 +17,6 @@ import com.eu.habbo.messages.outgoing.generic.alerts.GenericAlertComposer;
 import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.rooms.ForwardToRoomComposer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -24,12 +25,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FloorPlanEditorSaveEvent extends MessageHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(FloorPlanEditorSaveEvent.class);
 
-    public static int MAXIMUM_FLOORPLAN_WIDTH_LENGTH = 64;
-    public static int MAXIMUM_FLOORPLAN_SIZE = 64 * 64;
+    public static volatile int MAXIMUM_FLOORPLAN_WIDTH_LENGTH = 64;
+    public static volatile int MAXIMUM_FLOORPLAN_SIZE = 64 * 64;
 
     private static final int SAVE_COOLDOWN_SECONDS = 3;
     private static final int MAX_AUTO_PICKUP_ITEMS = 500;
@@ -43,22 +46,24 @@ public class FloorPlanEditorSaveEvent extends MessageHandler {
     @Override
     public void handle() throws Exception {
         if (!this.client.getHabbo().hasPermission(Permission.ACC_FLOORPLAN_EDITOR)) {
-            this.client.sendResponse(new GenericAlertComposer(Emulator.getTexts().getValue("floorplan.permission")));
+            this.client.sendResponse(
+                    new GenericAlertComposer(Emulator.getTexts().getValue("floorplan.permission")));
             return;
         }
 
         Room room = this.client.getHabbo().getHabboInfo().getCurrentRoom();
 
-        if (room == null)
-            return;
+        if (room == null) return;
 
-        if (!(room.getOwnerId() == this.client.getHabbo().getHabboInfo().getId() || this.client.getHabbo().hasPermission(Permission.ACC_ANYROOMOWNER))) {
+        if (!(room.getOwnerId() == this.client.getHabbo().getHabboInfo().getId()
+                || this.client.getHabbo().hasPermission(Permission.ACC_ANYROOMOWNER))) {
             return;
         }
 
         long now = Emulator.getIntUnixTimestamp();
         if (now - this.client.getHabbo().getHabboStats().lastFloorplanSaveTimestamp < SAVE_COOLDOWN_SECONDS) {
-            this.client.sendResponse(new BubbleAlertComposer(BubbleAlertKeys.FLOORPLAN_EDITOR_ERROR.key, "Please wait a few seconds before saving again."));
+            this.client.sendResponse(new BubbleAlertComposer(
+                    BubbleAlertKeys.FLOORPLAN_EDITOR_ERROR.key, "Please wait a few seconds before saving again."));
             return;
         }
 
@@ -66,14 +71,19 @@ public class FloorPlanEditorSaveEvent extends MessageHandler {
         String map = this.packet.readString();
 
         if (map == null || map.length() > MAXIMUM_FLOORPLAN_SIZE) {
-            LOGGER.warn("Floorplan save rejected (oversize): user={} room={} mapLen={}",
-                    this.client.getHabbo().getHabboInfo().getId(), room.getId(), map == null ? 0 : map.length());
+            LOGGER.warn(
+                    "Floorplan save rejected (oversize): user={} room={} mapLen={}",
+                    this.client.getHabbo().getHabboInfo().getId(),
+                    room.getId(),
+                    map == null ? 0 : map.length());
             return;
         }
 
         if (!ALLOWED_MAP_CHARS.matcher(map).matches()) {
-            LOGGER.warn("Floorplan save rejected (illegal chars): user={} room={}",
-                    this.client.getHabbo().getHabboInfo().getId(), room.getId());
+            LOGGER.warn(
+                    "Floorplan save rejected (illegal chars): user={} room={}",
+                    this.client.getHabbo().getHabboInfo().getId(),
+                    room.getId());
             return;
         }
 
@@ -127,8 +137,7 @@ public class FloorPlanEditorSaveEvent extends MessageHandler {
         }
 
         int wallHeight = -1;
-        if (this.packet.bytesAvailable() >= 4)
-            wallHeight = this.packet.readInt();
+        if (this.packet.bytesAvailable() >= 4) wallHeight = this.packet.readInt();
 
         if (wallHeight < -1 || wallHeight > 15) {
             errors.add("${notification.floorplan_editor.error.message.invalid_walls_fixed_height}");
@@ -140,7 +149,8 @@ public class FloorPlanEditorSaveEvent extends MessageHandler {
         }
 
         if (errors.length() > 0) {
-            this.client.sendResponse(new BubbleAlertComposer(BubbleAlertKeys.FLOORPLAN_EDITOR_ERROR.key, errors.toString()));
+            this.client.sendResponse(
+                    new BubbleAlertComposer(BubbleAlertKeys.FLOORPLAN_EDITOR_ERROR.key, errors.toString()));
             return;
         }
 
@@ -185,7 +195,10 @@ public class FloorPlanEditorSaveEvent extends MessageHandler {
                     return;
                 }
 
-                if (tile != null && tile.state != RoomTileState.INVALID && height != tile.z && room.getTopItemAt(x, y) != null) {
+                if (tile != null
+                        && tile.state != RoomTileState.INVALID
+                        && height != tile.z
+                        && room.getTopItemAt(x, y) != null) {
                     if (autoPickup) {
                         Set<HabboItem> here = room.getItemsAt(x, y);
                         if (here != null) itemsToPickup.addAll(here);
@@ -215,17 +228,25 @@ public class FloorPlanEditorSaveEvent extends MessageHandler {
         }
 
         if (blockedX >= 0) {
-            this.client.sendResponse(new BubbleAlertComposer(BubbleAlertKeys.FLOORPLAN_EDITOR_ERROR.key,
-                    "${notification.floorplan_editor.error.message.change_blocked_by_room_item} (" + blockedX + ", " + blockedY + ")"));
+            this.client.sendResponse(new BubbleAlertComposer(
+                    BubbleAlertKeys.FLOORPLAN_EDITOR_ERROR.key,
+                    "${notification.floorplan_editor.error.message.change_blocked_by_room_item} (" + blockedX + ", "
+                            + blockedY + ")"));
             return;
         }
 
         if (autoPickup && !itemsToPickup.isEmpty()) {
             if (itemsToPickup.size() > MAX_AUTO_PICKUP_ITEMS) {
-                LOGGER.warn("Floorplan auto-pickup rejected (over cap): user={} room={} itemCount={} cap={}",
-                        this.client.getHabbo().getHabboInfo().getId(), room.getId(), itemsToPickup.size(), MAX_AUTO_PICKUP_ITEMS);
-                this.client.sendResponse(new BubbleAlertComposer(BubbleAlertKeys.FLOORPLAN_EDITOR_ERROR.key,
-                        "Too many items would be picked up (" + itemsToPickup.size() + " > " + MAX_AUTO_PICKUP_ITEMS + "). Remove some furniture manually and save again."));
+                LOGGER.warn(
+                        "Floorplan auto-pickup rejected (over cap): user={} room={} itemCount={} cap={}",
+                        this.client.getHabbo().getHabboInfo().getId(),
+                        room.getId(),
+                        itemsToPickup.size(),
+                        MAX_AUTO_PICKUP_ITEMS);
+                this.client.sendResponse(new BubbleAlertComposer(
+                        BubbleAlertKeys.FLOORPLAN_EDITOR_ERROR.key,
+                        "Too many items would be picked up (" + itemsToPickup.size() + " > " + MAX_AUTO_PICKUP_ITEMS
+                                + "). Remove some furniture manually and save again."));
                 return;
             }
 
@@ -245,8 +266,12 @@ public class FloorPlanEditorSaveEvent extends MessageHandler {
                 owner.getClient().sendResponse(new InventoryRefreshComposer());
             }
 
-            LOGGER.info("Floorplan auto-pickup: user={} room={} itemCount={} owners={}",
-                    this.client.getHabbo().getHabboInfo().getId(), room.getId(), itemsToPickup.size(), byOwner.size());
+            LOGGER.info(
+                    "Floorplan auto-pickup: user={} room={} itemCount={} owners={}",
+                    this.client.getHabbo().getHabboInfo().getId(),
+                    room.getId(),
+                    itemsToPickup.size(),
+                    byOwner.size());
         }
 
         RoomLayout layout = room.getLayout();
@@ -267,7 +292,9 @@ public class FloorPlanEditorSaveEvent extends MessageHandler {
             ((CustomRoomLayout) layout).needsUpdate(true);
             Emulator.getThreading().run((CustomRoomLayout) layout);
         } else {
-            layout = Emulator.getGameEnvironment().getRoomManager().insertCustomLayout(room, map, doorX, doorY, doorRotation);
+            layout = Emulator.getGameEnvironment()
+                    .getRoomManager()
+                    .insertCustomLayout(room, map, doorX, doorY, doorRotation);
         }
 
         if (layout != null) {
@@ -280,8 +307,13 @@ public class FloorPlanEditorSaveEvent extends MessageHandler {
             room.save();
 
             this.client.getHabbo().getHabboStats().lastFloorplanSaveTimestamp = now;
-            LOGGER.info("Floorplan saved: user={} room={} mapLen={} rows={} cols={}",
-                    this.client.getHabbo().getHabboInfo().getId(), room.getId(), map.length(), mapRows.length, firstRowSize);
+            LOGGER.info(
+                    "Floorplan saved: user={} room={} mapLen={} rows={} cols={}",
+                    this.client.getHabbo().getHabboInfo().getId(),
+                    room.getId(),
+                    map.length(),
+                    mapRows.length,
+                    firstRowSize);
 
             Collection<Habbo> habbos = new ArrayList<>(room.getUserCount());
             habbos.addAll(room.getHabbos());

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/hotelview/HotelViewRequestLTDAvailabilityEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/hotelview/HotelViewRequestLTDAvailabilityEvent.java
@@ -5,11 +5,11 @@ import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.hotelview.HotelViewNextLTDAvailableComposer;
 
 public class HotelViewRequestLTDAvailabilityEvent extends MessageHandler {
-    public static boolean ENABLED = false;
-    public static int TIMESTAMP;
-    public static int ITEM_ID;
-    public static int PAGE_ID;
-    public static String ITEM_NAME;
+    public static volatile boolean ENABLED = false;
+    public static volatile int TIMESTAMP;
+    public static volatile int ITEM_ID;
+    public static volatile int PAGE_ID;
+    public static volatile String ITEM_NAME;
 
     @Override
     public void handle() throws Exception {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/promotions/BuyRoomPromotionEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/promotions/BuyRoomPromotionEvent.java
@@ -13,7 +13,7 @@ import com.eu.habbo.messages.outgoing.navigator.NewNavigatorEventCategoriesCompo
 import com.eu.habbo.messages.outgoing.rooms.promotions.RoomPromotionMessageComposer;
 
 public class BuyRoomPromotionEvent extends MessageHandler {
-    public static String ROOM_PROMOTION_BADGE = "RADZZ";
+    public static volatile String ROOM_PROMOTION_BADGE = "RADZZ";
 
     @Override
     public void handle() throws Exception {
@@ -25,20 +25,20 @@ public class BuyRoomPromotionEvent extends MessageHandler {
         String description = this.packet.readString();
         int categoryId = this.packet.readInt();
 
-        if (NewNavigatorEventCategoriesComposer.CATEGORIES.stream().noneMatch(c -> c.getId() == categoryId))
-            return;
+        if (NewNavigatorEventCategoriesComposer.CATEGORIES.stream().noneMatch(c -> c.getId() == categoryId)) return;
 
         CatalogPage page = Emulator.getGameEnvironment().getCatalogManager().getCatalogPage(pageId);
 
-        if (page == null || !page.getLayout().equals("roomads"))
-            return;
+        if (page == null || !page.getLayout().equals("roomads")) return;
 
         CatalogItem item = page.getCatalogItem(itemId);
         if (item != null) {
             if (this.client.getHabbo().getHabboInfo().canBuy(item)) {
                 Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(roomId);
 
-                if (!(room.isOwner(this.client.getHabbo()) || room.hasRights(this.client.getHabbo()) || room.getGuildRightLevel(this.client.getHabbo()).equals(RoomRightLevels.GUILD_ADMIN))) {
+                if (!(room.isOwner(this.client.getHabbo())
+                        || room.hasRights(this.client.getHabbo())
+                        || room.getGuildRightLevel(this.client.getHabbo()).equals(RoomRightLevels.GUILD_ADMIN))) {
                     return;
                 }
 
@@ -60,7 +60,11 @@ public class BuyRoomPromotionEvent extends MessageHandler {
                     this.client.sendResponse(new PurchaseOKComposer());
                     room.sendComposer(new RoomPromotionMessageComposer(room, room.getPromotion()).compose());
 
-                    if (!this.client.getHabbo().getInventory().getBadgesComponent().hasBadge(BuyRoomPromotionEvent.ROOM_PROMOTION_BADGE)) {
+                    if (!this.client
+                            .getHabbo()
+                            .getInventory()
+                            .getBadgesComponent()
+                            .hasBadge(BuyRoomPromotionEvent.ROOM_PROMOTION_BADGE)) {
                         this.client.getHabbo().addBadge(BuyRoomPromotionEvent.ROOM_PROMOTION_BADGE);
                     }
                 } else {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/users/ChangeNameCheckUsernameEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/users/ChangeNameCheckUsernameEvent.java
@@ -4,17 +4,16 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.users.ChangeNameCheckResultComposer;
-
 import java.util.ArrayList;
 import java.util.List;
 
 public class ChangeNameCheckUsernameEvent extends MessageHandler {
-    public static String VALID_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-=!?@:,.";
+    public static volatile String VALID_CHARACTERS =
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-=!?@:,.";
 
     @Override
     public void handle() throws Exception {
-        if (!this.client.getHabbo().getHabboStats().allowNameChange)
-            return;
+        if (!this.client.getHabbo().getHabboStats().allowNameChange) return;
 
         String name = this.packet.readString();
 
@@ -25,13 +24,18 @@ public class ChangeNameCheckUsernameEvent extends MessageHandler {
             errorCode = ChangeNameCheckResultComposer.TOO_SHORT;
         } else if (name.length() > 15) {
             errorCode = ChangeNameCheckResultComposer.TOO_LONG;
-        } else if (name.equalsIgnoreCase(this.client.getHabbo().getHabboInfo().getUsername()) || HabboManager.getOfflineHabboInfo(name) != null || ConfirmChangeNameEvent.changingUsernames.contains(name.toLowerCase())) {
+        } else if (name.equalsIgnoreCase(this.client.getHabbo().getHabboInfo().getUsername())
+                || HabboManager.getOfflineHabboInfo(name) != null
+                || ConfirmChangeNameEvent.changingUsernames.contains(name.toLowerCase())) {
             errorCode = ChangeNameCheckResultComposer.TAKEN_WITH_SUGGESTIONS;
             suggestions.add(name + Emulator.getRandom().nextInt(9999));
             suggestions.add(name + Emulator.getRandom().nextInt(9999));
             suggestions.add(name + Emulator.getRandom().nextInt(9999));
             suggestions.add(name + Emulator.getRandom().nextInt(9999));
-        } else if (!Emulator.getGameEnvironment().getWordFilter().filter(name, this.client.getHabbo()).equalsIgnoreCase(name)) {
+        } else if (!Emulator.getGameEnvironment()
+                .getWordFilter()
+                .filter(name, this.client.getHabbo())
+                .equalsIgnoreCase(name)) {
             errorCode = ChangeNameCheckResultComposer.NOT_VALID;
         } else {
             String checkName = name;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/DiscountComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/DiscountComposer.java
@@ -5,11 +5,11 @@ import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 
 public class DiscountComposer extends MessageComposer {
-    public static int MAXIMUM_ALLOWED_ITEMS = 100;
-    public static int DISCOUNT_BATCH_SIZE = 6;
-    public static int DISCOUNT_AMOUNT_PER_BATCH = 1;
-    public static int MINIMUM_DISCOUNTS_FOR_BONUS = 1;
-    public static int[] ADDITIONAL_DISCOUNT_THRESHOLDS = new int[]{40, 99};
+    public static volatile int MAXIMUM_ALLOWED_ITEMS = 100;
+    public static volatile int DISCOUNT_BATCH_SIZE = 6;
+    public static volatile int DISCOUNT_AMOUNT_PER_BATCH = 1;
+    public static volatile int MINIMUM_DISCOUNTS_FOR_BONUS = 1;
+    public static volatile int[] ADDITIONAL_DISCOUNT_THRESHOLDS = new int[] {40, 99};
 
     @Override
     protected ServerMessage composeInternal() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/GiftConfigurationComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/GiftConfigurationComposer.java
@@ -4,14 +4,13 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 public class GiftConfigurationComposer extends MessageComposer {
-    public static List<Integer> BOX_TYPES = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 8);
-    public static List<Integer> RIBBON_TYPES = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    public static volatile List<Integer> BOX_TYPES = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 8);
+    public static volatile List<Integer> RIBBON_TYPES = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
     @Override
     protected ServerMessage composeInternal() {
@@ -19,8 +18,10 @@ public class GiftConfigurationComposer extends MessageComposer {
         this.response.appendBoolean(true);
         this.response.appendInt(Emulator.getConfig().getInt("hotel.gifts.special.price", 2));
 
-        this.response.appendInt(Emulator.getGameEnvironment().getCatalogManager().giftWrappers.size());
-        for (Integer i : Emulator.getGameEnvironment().getCatalogManager().giftWrappers.keySet()) {
+        this.response.appendInt(
+                Emulator.getGameEnvironment().getCatalogManager().giftWrappers.size());
+        for (Integer i :
+                Emulator.getGameEnvironment().getCatalogManager().giftWrappers.keySet()) {
             this.response.appendInt(i);
         }
 
@@ -34,9 +35,11 @@ public class GiftConfigurationComposer extends MessageComposer {
             this.response.appendInt(type);
         }
 
-        this.response.appendInt(Emulator.getGameEnvironment().getCatalogManager().giftFurnis.size());
+        this.response.appendInt(
+                Emulator.getGameEnvironment().getCatalogManager().giftFurnis.size());
 
-        for (Map.Entry<Integer, Integer> set : Emulator.getGameEnvironment().getCatalogManager().giftFurnis.entrySet()) {
+        for (Map.Entry<Integer, Integer> set :
+                Emulator.getGameEnvironment().getCatalogManager().giftFurnis.entrySet()) {
             this.response.appendInt(set.getKey());
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/navigator/NewNavigatorEventCategoriesComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/navigator/NewNavigatorEventCategoriesComposer.java
@@ -4,12 +4,11 @@ import com.eu.habbo.habbohotel.navigation.EventCategory;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-
 import java.util.ArrayList;
 import java.util.List;
 
 public class NewNavigatorEventCategoriesComposer extends MessageComposer {
-    public static List<EventCategory> CATEGORIES = new ArrayList<>();
+    public static volatile List<EventCategory> CATEGORIES = new ArrayList<>();
 
     @Override
     protected ServerMessage composeInternal() {

--- a/Emulator/src/main/java/com/eu/habbo/plugin/CatalogConfigurationBinder.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/CatalogConfigurationBinder.java
@@ -1,0 +1,117 @@
+package com.eu.habbo.plugin;
+
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.core.config.ConfigurationBinder;
+import com.eu.habbo.habbohotel.achievements.AchievementManager;
+import com.eu.habbo.habbohotel.catalog.CatalogManager;
+import com.eu.habbo.habbohotel.catalog.TargetOffer;
+import com.eu.habbo.habbohotel.catalog.marketplace.MarketPlace;
+import com.eu.habbo.habbohotel.items.ItemManager;
+import com.eu.habbo.messages.incoming.hotelview.HotelViewRequestLTDAvailabilityEvent;
+import com.eu.habbo.messages.outgoing.catalog.DiscountComposer;
+import com.eu.habbo.messages.outgoing.catalog.GiftConfigurationComposer;
+import java.util.Arrays;
+
+final class CatalogConfigurationBinder extends ConfigurationBinder {
+
+    private final boolean runtimeReady;
+
+    CatalogConfigurationBinder(ConfigurationManager configuration, boolean runtimeReady) {
+        super(configuration);
+        this.runtimeReady = runtimeReady;
+    }
+
+    void bind() {
+        this.apply(
+                "hotel.catalog.recycler.enabled",
+                () -> ItemManager.RECYCLER_ENABLED = this.configuration.getBoolean("hotel.catalog.recycler.enabled"));
+        this.apply(
+                "hotel.marketplace.enabled",
+                () -> MarketPlace.MARKETPLACE_ENABLED = this.configuration.getBoolean("hotel.marketplace.enabled"));
+        this.apply(
+                "hotel.marketplace.currency",
+                () -> MarketPlace.MARKETPLACE_CURRENCY = this.configuration.getInt("hotel.marketplace.currency"));
+        this.bindDiscountsAndOffers();
+        this.apply(
+                "hotel.catalog.purchase.cooldown",
+                () -> CatalogManager.PURCHASE_COOLDOWN = this.configuration.getInt("hotel.catalog.purchase.cooldown"));
+        this.apply(
+                "hotel.catalog.items.display.ordernum",
+                () -> CatalogManager.SORT_USING_ORDERNUM =
+                        this.configuration.getBoolean("hotel.catalog.items.display.ordernum"));
+        this.apply(
+                "hotel.talenttrack.enabled",
+                () -> AchievementManager.TALENTTRACK_ENABLED =
+                        this.configuration.getBoolean("hotel.talenttrack.enabled"));
+
+        if (this.runtimeReady) {
+            this.apply("hotel.gifts.box_types", () -> {
+                var boxTypes = Arrays.stream(this.configuration
+                                .getValue("hotel.gifts.box_types")
+                                .split(","))
+                        .mapToInt(Integer::parseInt)
+                        .boxed()
+                        .toList();
+                GiftConfigurationComposer.BOX_TYPES = boxTypes;
+            });
+            this.apply("hotel.gifts.ribbon_types", () -> {
+                var ribbonTypes = Arrays.stream(this.configuration
+                                .getValue("hotel.gifts.ribbon_types")
+                                .split(","))
+                        .mapToInt(Integer::parseInt)
+                        .boxed()
+                        .toList();
+                GiftConfigurationComposer.RIBBON_TYPES = ribbonTypes;
+            });
+        }
+    }
+
+    void bindDiscountsAndOffers() {
+        this.apply(
+                "discount.max.allowed.items",
+                () -> DiscountComposer.MAXIMUM_ALLOWED_ITEMS =
+                        this.configuration.getInt("discount.max.allowed.items", 100));
+        this.apply(
+                "discount.batch.size",
+                () -> DiscountComposer.DISCOUNT_BATCH_SIZE = this.configuration.getInt("discount.batch.size", 6));
+        this.apply(
+                "discount.batch.free.items",
+                () -> DiscountComposer.DISCOUNT_AMOUNT_PER_BATCH =
+                        this.configuration.getInt("discount.batch.free.items", 1));
+        this.apply(
+                "discount.bonus.min.discounts",
+                () -> DiscountComposer.MINIMUM_DISCOUNTS_FOR_BONUS =
+                        this.configuration.getInt("discount.bonus.min.discounts", 1));
+        this.apply("discount.additional.thresholds", () -> {
+            int[] thresholds = Arrays.stream(this.configuration
+                            .getValue("discount.additional.thresholds", "40;99")
+                            .split(";"))
+                    .mapToInt(Integer::parseInt)
+                    .toArray();
+            DiscountComposer.ADDITIONAL_DISCOUNT_THRESHOLDS = thresholds;
+        });
+        this.apply(
+                "hotel.view.ltdcountdown.enabled",
+                () -> HotelViewRequestLTDAvailabilityEvent.ENABLED =
+                        this.configuration.getBoolean("hotel.view.ltdcountdown.enabled"));
+        this.apply(
+                "hotel.view.ltdcountdown.timestamp",
+                () -> HotelViewRequestLTDAvailabilityEvent.TIMESTAMP =
+                        this.configuration.getInt("hotel.view.ltdcountdown.timestamp"));
+        this.apply(
+                "hotel.view.ltdcountdown.itemid",
+                () -> HotelViewRequestLTDAvailabilityEvent.ITEM_ID =
+                        this.configuration.getInt("hotel.view.ltdcountdown.itemid"));
+        this.apply(
+                "hotel.view.ltdcountdown.pageid",
+                () -> HotelViewRequestLTDAvailabilityEvent.PAGE_ID =
+                        this.configuration.getInt("hotel.view.ltdcountdown.pageid"));
+        this.apply(
+                "hotel.view.ltdcountdown.itemname",
+                () -> HotelViewRequestLTDAvailabilityEvent.ITEM_NAME =
+                        this.configuration.getValue("hotel.view.ltdcountdown.itemname"));
+        this.apply(
+                "hotel.targetoffer.id",
+                () -> TargetOffer.ACTIVE_TARGET_OFFER_ID = this.configuration.getInt("hotel.targetoffer.id"));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/plugin/NetworkConfigurationBinder.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/NetworkConfigurationBinder.java
@@ -1,0 +1,48 @@
+package com.eu.habbo.plugin;
+
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.core.config.ConfigurationBinder;
+import com.eu.habbo.habbohotel.messenger.Messenger;
+import com.eu.habbo.habbohotel.users.HabboManager;
+import com.eu.habbo.messages.PacketManager;
+import com.eu.habbo.messages.incoming.users.ChangeNameCheckUsernameEvent;
+
+final class NetworkConfigurationBinder extends ConfigurationBinder {
+
+    NetworkConfigurationBinder(ConfigurationManager configuration) {
+        super(configuration);
+    }
+
+    void bind() {
+        this.apply(
+                "save.private.chats",
+                () -> Messenger.SAVE_PRIVATE_CHATS = this.configuration.getBoolean("save.private.chats", false));
+        this.apply(
+                "hotel.users.max.friends",
+                () -> Messenger.MAXIMUM_FRIENDS = this.configuration.getInt("hotel.users.max.friends", 300));
+        this.apply(
+                "hotel.users.max.friends.hc",
+                () -> Messenger.MAXIMUM_FRIENDS_HC = this.configuration.getInt("hotel.users.max.friends.hc", 1100));
+        this.apply(
+                "debug.show.packets",
+                () -> PacketManager.DEBUG_SHOW_PACKETS = this.configuration.getBoolean("debug.show.packets"));
+        this.apply(
+                "io.client.multithreaded.handler",
+                () -> PacketManager.MULTI_THREADED_PACKET_HANDLING =
+                        this.configuration.getBoolean("io.client.multithreaded.handler"));
+        this.apply(
+                "hotel.welcome.alert.message",
+                () -> HabboManager.WELCOME_MESSAGE = this.configuration
+                        .getValue("hotel.welcome.alert.message")
+                        .replace("<br>", "<br/>")
+                        .replace("<br />", "<br/>")
+                        .replace("\\r", "\r")
+                        .replace("\\n", "\n")
+                        .replace("\\t", "\t"));
+        this.apply(
+                "allowed.username.characters",
+                () -> ChangeNameCheckUsernameEvent.VALID_CHARACTERS = this.configuration.getValue(
+                        "allowed.username.characters",
+                        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-=!?@:,."));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
@@ -2,53 +2,24 @@ package com.eu.habbo.plugin;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.core.Easter;
-import com.eu.habbo.habbohotel.achievements.AchievementManager;
-import com.eu.habbo.habbohotel.bots.Bot;
-import com.eu.habbo.habbohotel.bots.BotManager;
-import com.eu.habbo.habbohotel.catalog.CatalogManager;
-import com.eu.habbo.habbohotel.catalog.TargetOffer;
-import com.eu.habbo.habbohotel.catalog.marketplace.MarketPlace;
 import com.eu.habbo.habbohotel.games.freeze.FreezeGame;
 import com.eu.habbo.habbohotel.games.tag.TagGame;
-import com.eu.habbo.habbohotel.items.ItemManager;
-import com.eu.habbo.habbohotel.items.interactions.InteractionPostIt;
-import com.eu.habbo.habbohotel.items.interactions.InteractionRoller;
-import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectSendSignal;
 import com.eu.habbo.habbohotel.items.interactions.games.football.InteractionFootballGate;
-import com.eu.habbo.habbohotel.messenger.Messenger;
-import com.eu.habbo.habbohotel.modtool.WordFilter;
-import com.eu.habbo.habbohotel.navigation.EventCategory;
-import com.eu.habbo.habbohotel.navigation.NavigatorManager;
-import com.eu.habbo.habbohotel.pets.PetManager;
-import com.eu.habbo.habbohotel.rooms.*;
-import com.eu.habbo.habbohotel.users.clothingvalidation.ClothingValidationManager;
-import com.eu.habbo.habbohotel.users.HabboInventory;
-import com.eu.habbo.habbohotel.users.HabboManager;
-import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionHabboClub;
-import com.eu.habbo.habbohotel.wired.core.WiredEngine;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.highscores.WiredHighscoreManager;
 import com.eu.habbo.messages.PacketManager;
 import com.eu.habbo.messages.RuntimeValidationReport;
-import com.eu.habbo.messages.incoming.catalog.CheckPetNameEvent;
-import com.eu.habbo.messages.incoming.floorplaneditor.FloorPlanEditorSaveEvent;
-import com.eu.habbo.messages.incoming.hotelview.HotelViewRequestLTDAvailabilityEvent;
-import com.eu.habbo.messages.incoming.rooms.promotions.BuyRoomPromotionEvent;
-import com.eu.habbo.messages.incoming.users.ChangeNameCheckUsernameEvent;
-import com.eu.habbo.messages.outgoing.catalog.DiscountComposer;
-import com.eu.habbo.messages.outgoing.catalog.GiftConfigurationComposer;
-import com.eu.habbo.messages.outgoing.navigator.NewNavigatorEventCategoriesComposer;
 import com.eu.habbo.plugin.events.emulator.EmulatorConfigUpdatedEvent;
 import com.eu.habbo.plugin.events.emulator.EmulatorLoadedEvent;
 import com.eu.habbo.plugin.events.roomunit.RoomUnitLookAtPointEvent;
-import com.eu.habbo.plugin.events.users.*;
+import com.eu.habbo.plugin.events.users.UserDisconnectEvent;
+import com.eu.habbo.plugin.events.users.UserExitRoomEvent;
+import com.eu.habbo.plugin.events.users.UserSavedLookEvent;
+import com.eu.habbo.plugin.events.users.UserSavedMottoEvent;
+import com.eu.habbo.plugin.events.users.UserTakeStepEvent;
 import com.eu.habbo.threading.runnables.RoomTrashing;
-import com.eu.habbo.threading.runnables.ShutdownEmulator;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,12 +27,11 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PluginManager {
 
@@ -76,174 +46,16 @@ public class PluginManager {
 
     @EventHandler
     public static void globalOnConfigurationUpdated(EmulatorConfigUpdatedEvent event) {
+        var configuration = Emulator.getConfig();
+        boolean runtimeReady = Emulator.isReady;
+        new RoomConfigurationBinder(
+                        configuration, value -> Emulator.stringToDate(value).getTime() / 1000)
+                .bind();
+        new WiredConfigurationBinder(configuration).bind();
+        new NetworkConfigurationBinder(configuration).bind();
+        new CatalogConfigurationBinder(configuration, runtimeReady).bind();
 
-        ItemManager.RECYCLER_ENABLED = Emulator.getConfig().getBoolean("hotel.catalog.recycler.enabled");
-        MarketPlace.MARKETPLACE_ENABLED = Emulator.getConfig().getBoolean("hotel.marketplace.enabled");
-        MarketPlace.MARKETPLACE_CURRENCY = Emulator.getConfig().getInt("hotel.marketplace.currency");
-        Messenger.SAVE_PRIVATE_CHATS = Emulator.getConfig().getBoolean("save.private.chats", false);
-        PacketManager.DEBUG_SHOW_PACKETS = Emulator.getConfig().getBoolean("debug.show.packets");
-        PacketManager.MULTI_THREADED_PACKET_HANDLING = Emulator.getConfig().getBoolean("io.client.multithreaded.handler");
-        Room.HABBO_CHAT_DELAY = Emulator.getConfig().getBoolean("room.chat.delay", false);
-        Room.MUTEAREA_CAN_WHISPER = Emulator.getConfig().getBoolean("room.chat.mutearea.allow_whisper", false);
-        RoomChatMessage.SAVE_ROOM_CHATS = Emulator.getConfig().getBoolean("save.room.chats", false);
-        RoomLayout.MAXIMUM_STEP_HEIGHT = Emulator.getConfig().getDouble("pathfinder.step.maximum.height", 1.1);
-        RoomLayout.ALLOW_FALLING = Emulator.getConfig().getBoolean("pathfinder.step.allow.falling", true);
-        RoomTrade.TRADING_ENABLED = Emulator.getConfig().getBoolean("hotel.trading.enabled") && !ShutdownEmulator.instantiated;
-        RoomTrade.TRADING_REQUIRES_PERK = Emulator.getConfig().getBoolean("hotel.trading.requires.perk");
-        WordFilter.ENABLED_FRIENDCHAT = Emulator.getConfig().getBoolean("hotel.wordfilter.messenger");
-        DiscountComposer.MAXIMUM_ALLOWED_ITEMS = Emulator.getConfig().getInt("discount.max.allowed.items", 100);
-        DiscountComposer.DISCOUNT_BATCH_SIZE = Emulator.getConfig().getInt("discount.batch.size", 6);
-        DiscountComposer.DISCOUNT_AMOUNT_PER_BATCH = Emulator.getConfig().getInt("discount.batch.free.items", 1);
-        DiscountComposer.MINIMUM_DISCOUNTS_FOR_BONUS = Emulator.getConfig().getInt("discount.bonus.min.discounts", 1);
-        DiscountComposer.ADDITIONAL_DISCOUNT_THRESHOLDS = Arrays.stream(Emulator.getConfig().getValue("discount.additional.thresholds", "40;99").split(";")).mapToInt(Integer::parseInt).toArray();
-
-        BotManager.MINIMUM_CHAT_SPEED = Emulator.getConfig().getInt("hotel.bot.chat.minimum.interval");
-        BotManager.MAXIMUM_CHAT_LENGTH = Emulator.getConfig().getInt("hotel.bot.max.chatlength");
-        BotManager.MAXIMUM_NAME_LENGTH = Emulator.getConfig().getInt("hotel.bot.max.namelength");
-        BotManager.MAXIMUM_CHAT_SPEED = Emulator.getConfig().getInt("hotel.bot.max.chatdelay");
-        Bot.PLACEMENT_MESSAGES = Emulator.getConfig().getValue("hotel.bot.placement.messages", "Yo!;Hello I'm a real party animal!;Hello!").split(";");
-        Bot.BOT_LIMIT_WALKING_DISTANCE = Emulator.getConfig().getBoolean("hotel.bot.limit.walking.distance", true);
-        Bot.BOT_WALKING_DISTANCE_RADIUS = Emulator.getConfig().getInt("hotel.bot.limit.walking.distance.radius", 5);
-
-        HabboInventory.MAXIMUM_ITEMS = Emulator.getConfig().getInt("hotel.inventory.max.items");
-        Messenger.MAXIMUM_FRIENDS = Emulator.getConfig().getInt("hotel.users.max.friends", 300);
-        Messenger.MAXIMUM_FRIENDS_HC = Emulator.getConfig().getInt("hotel.users.max.friends.hc", 1100);
-        Room.MAXIMUM_BOTS = Emulator.getConfig().getInt("hotel.max.bots.room");
-        Room.MAXIMUM_PETS = Emulator.getConfig().getInt("hotel.pets.max.room");
-        Room.MAXIMUM_FURNI = Emulator.getConfig().getInt("hotel.room.furni.max", 2500);
-        Room.MAXIMUM_POSTITNOTES = Emulator.getConfig().getInt("hotel.room.stickies.max", 200);
-        Room.HAND_ITEM_TIME = Emulator.getConfig().getInt("hotel.rooms.handitem.time");
-        Room.IDLE_CYCLES = Emulator.getConfig().getInt("hotel.roomuser.idle.cycles", 240);
-        Room.IDLE_CYCLES_KICK = Emulator.getConfig().getInt("hotel.roomuser.idle.cycles.kick", 480);
-        Room.ROLLERS_MAXIMUM_ROLL_AVATARS = Emulator.getConfig().getInt("hotel.room.rollers.roll_avatars.max", 1);
-        RoomManager.MAXIMUM_ROOMS_USER = Emulator.getConfig().getInt("hotel.users.max.rooms", 50);
-        RoomManager.MAXIMUM_ROOMS_HC = Emulator.getConfig().getInt("hotel.users.max.rooms.hc", 75);
-        RoomManager.HOME_ROOM_ID = Emulator.getConfig().getInt("hotel.home.room");
-        WiredManager.MAXIMUM_FURNI_SELECTION = Emulator.getConfig().getInt("hotel.wired.furni.selection.count");
-        WiredManager.TELEPORT_DELAY = Emulator.getConfig().getInt("wired.effect.teleport.delay", 500);
-        WiredEffectSendSignal.MAX_SIGNAL_DEPTH = Emulator.getConfig().getInt("wired.signal.max.depth", 100);
-        WiredEngine.MAX_RECURSION_DEPTH = Emulator.getConfig().getInt("wired.abuse.max.recursion.depth", 10);
-        WiredEngine.MAX_EVENTS_PER_WINDOW = Emulator.getConfig().getInt("wired.abuse.max.events.per.window", 100);
-        WiredEngine.RATE_LIMIT_WINDOW_MS = Emulator.getConfig().getInt("wired.abuse.rate.limit.window.ms", 10000);
-        WiredEngine.WIRED_BAN_DURATION_MS = Emulator.getConfig().getInt("wired.abuse.ban.duration.ms", 600000);
-        WiredEngine.MONITOR_USAGE_WINDOW_MS = Emulator.getConfig().getInt("wired.monitor.usage.window.ms", 1000);
-        WiredEngine.MONITOR_USAGE_LIMIT = Emulator.getConfig().getInt("wired.monitor.usage.limit", 50000);
-        WiredEngine.MONITOR_DELAYED_EVENTS_LIMIT = Emulator.getConfig().getInt("wired.monitor.delayed.events.limit", 50000);
-        WiredEngine.MONITOR_OVERLOAD_AVERAGE_MS = Emulator.getConfig().getInt("wired.monitor.overload.average.ms", 50);
-        WiredEngine.MONITOR_OVERLOAD_PEAK_MS = Emulator.getConfig().getInt("wired.monitor.overload.peak.ms", 150);
-        WiredEngine.MONITOR_OVERLOAD_CONSECUTIVE_WINDOWS = Emulator.getConfig().getInt("wired.monitor.overload.consecutive.windows", 2);
-        WiredEngine.MONITOR_HEAVY_USAGE_PERCENT = Emulator.getConfig().getInt("wired.monitor.heavy.usage.percent", 70);
-        WiredEngine.MONITOR_HEAVY_CONSECUTIVE_WINDOWS = Emulator.getConfig().getInt("wired.monitor.heavy.consecutive.windows", 5);
-        WiredEngine.MONITOR_HEAVY_DELAYED_PERCENT = Emulator.getConfig().getInt("wired.monitor.heavy.delayed.percent", 60);
-
-        if (WiredManager.getEngine() != null) {
-            WiredManager.getEngine().clearAllDiagnostics();
-        }
-
-        NavigatorManager.MAXIMUM_RESULTS_PER_PAGE = Emulator.getConfig().getInt("hotel.navigator.search.maxresults");
-        NavigatorManager.CATEGORY_SORT_USING_ORDER_NUM = Emulator.getConfig().getBoolean("hotel.navigator.sort.ordernum");
-        RoomChatMessage.MAXIMUM_LENGTH = Emulator.getConfig().getInt("hotel.chat.max.length");
-        TraxManager.LARGE_JUKEBOX_LIMIT = Emulator.getConfig().getInt("hotel.jukebox.limit.large");
-        TraxManager.NORMAL_JUKEBOX_LIMIT = Emulator.getConfig().getInt("hotel.jukebox.limit.normal");
-
-        String[] bannedBubbles = Emulator.getConfig().getValue("commands.cmd_chatcolor.banned_numbers").split(";");
-        RoomChatMessage.BANNED_BUBBLES = new int[bannedBubbles.length];
-        for (int i = 0; i < RoomChatMessage.BANNED_BUBBLES.length; i++) {
-            try {
-                RoomChatMessage.BANNED_BUBBLES[i] = Integer.parseInt(bannedBubbles[i]);
-            } catch (Exception e) {
-                LOGGER.error("Caught exception", e);
-            }
-        }
-
-        HabboManager.WELCOME_MESSAGE = Emulator.getConfig().getValue("hotel.welcome.alert.message").replace("<br>", "<br/>").replace("<br />", "<br/>").replace("\\r", "\r").replace("\\n", "\n").replace("\\t", "\t");
-        Room.PREFIX_FORMAT = Emulator.getConfig().getValue("room.chat.prefix.format");
-        FloorPlanEditorSaveEvent.MAXIMUM_FLOORPLAN_WIDTH_LENGTH = Emulator.getConfig().getInt("hotel.floorplan.max.widthlength");
-        FloorPlanEditorSaveEvent.MAXIMUM_FLOORPLAN_SIZE = Emulator.getConfig().getInt("hotel.floorplan.max.totalarea");
-
-        HotelViewRequestLTDAvailabilityEvent.ENABLED = Emulator.getConfig().getBoolean("hotel.view.ltdcountdown.enabled");
-        HotelViewRequestLTDAvailabilityEvent.TIMESTAMP = Emulator.getConfig().getInt("hotel.view.ltdcountdown.timestamp");
-        HotelViewRequestLTDAvailabilityEvent.ITEM_ID = Emulator.getConfig().getInt("hotel.view.ltdcountdown.itemid");
-        HotelViewRequestLTDAvailabilityEvent.PAGE_ID = Emulator.getConfig().getInt("hotel.view.ltdcountdown.pageid");
-        HotelViewRequestLTDAvailabilityEvent.ITEM_NAME = Emulator.getConfig().getValue("hotel.view.ltdcountdown.itemname");
-        InteractionPostIt.STICKYPOLE_PREFIX_TEXT = Emulator.getConfig().getValue("hotel.room.stickypole.prefix");
-        TargetOffer.ACTIVE_TARGET_OFFER_ID = Emulator.getConfig().getInt("hotel.targetoffer.id");
-        WordFilter.DEFAULT_REPLACEMENT = Emulator.getConfig().getValue("hotel.wordfilter.replacement");
-        CatalogManager.PURCHASE_COOLDOWN = Emulator.getConfig().getInt("hotel.catalog.purchase.cooldown");
-        CatalogManager.SORT_USING_ORDERNUM = Emulator.getConfig().getBoolean("hotel.catalog.items.display.ordernum");
-        AchievementManager.TALENTTRACK_ENABLED = Emulator.getConfig().getBoolean("hotel.talenttrack.enabled");
-        InteractionRoller.NO_RULES = Emulator.getConfig().getBoolean("hotel.room.rollers.norules");
-        RoomManager.SHOW_PUBLIC_IN_POPULAR_TAB = Emulator.getConfig().getBoolean("hotel.navigator.populartab.publics");
-        CheckPetNameEvent.PET_NAME_LENGTH_MINIMUM = Emulator.getConfig().getInt("hotel.pets.name.length.min");
-        CheckPetNameEvent.PET_NAME_LENGTH_MAXIMUM = Emulator.getConfig().getInt("hotel.pets.name.length.max");
-
-
-        ChangeNameCheckUsernameEvent.VALID_CHARACTERS = Emulator.getConfig().getValue("allowed.username.characters", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-=!?@:,.");
-
-        BuyRoomPromotionEvent.ROOM_PROMOTION_BADGE = Emulator.getConfig().getValue("room.promotion.badge", "RADZZ");
-        BotManager.MAXIMUM_BOT_INVENTORY_SIZE = Emulator.getConfig().getInt("hotel.bots.max.inventory");
-        PetManager.MAXIMUM_PET_INVENTORY_SIZE = Emulator.getConfig().getInt("hotel.pets.max.inventory");
-
-
-        SubscriptionHabboClub.HC_PAYDAY_ENABLED = Emulator.getConfig().getBoolean("subscriptions.hc.payday.enabled", false);
-
-        try {
-            SubscriptionHabboClub.HC_PAYDAY_NEXT_DATE = (int) (Emulator.stringToDate(Emulator.getConfig().getValue("subscriptions.hc.payday.next_date")).getTime() / 1000);
-        }
-        catch(Exception e) { SubscriptionHabboClub.HC_PAYDAY_NEXT_DATE = Integer.MAX_VALUE; }
-
-        SubscriptionHabboClub.HC_PAYDAY_INTERVAL = Emulator.getConfig().getValue("subscriptions.hc.payday.interval");
-        SubscriptionHabboClub.HC_PAYDAY_QUERY = Emulator.getConfig().getValue("subscriptions.hc.payday.query");
-        SubscriptionHabboClub.HC_PAYDAY_CURRENCY = Emulator.getConfig().getValue("subscriptions.hc.payday.currency");
-        SubscriptionHabboClub.HC_PAYDAY_KICKBACK_PERCENTAGE = Emulator.getConfig().getInt("subscriptions.hc.payday.percentage", 10) / 100.0;
-        SubscriptionHabboClub.HC_PAYDAY_COINSSPENT_RESET_ON_EXPIRE = Emulator.getConfig().getBoolean("subscriptions.hc.payday.creditsspent_reset_on_expire", false);
-        SubscriptionHabboClub.ACHIEVEMENT_NAME = Emulator.getConfig().getValue("subscriptions.hc.achievement", "VipHC");
-        SubscriptionHabboClub.DISCOUNT_ENABLED = Emulator.getConfig().getBoolean("subscriptions.hc.discount.enabled", false);
-        SubscriptionHabboClub.DISCOUNT_DAYS_BEFORE_END = Emulator.getConfig().getInt("subscriptions.hc.discount.days_before_end", 7);
-
-        SubscriptionHabboClub.HC_PAYDAY_STREAK.clear();
-        for (String streak : Emulator.getConfig().getValue("subscriptions.hc.payday.streak", "7=5;30=10;60=15;90=20;180=25;365=30").split(Pattern.quote(";"))) {
-            if(streak.contains("=")) {
-                SubscriptionHabboClub.HC_PAYDAY_STREAK.put(Integer.parseInt(streak.split(Pattern.quote("="))[0]), Integer.parseInt(streak.split(Pattern.quote("="))[1]));
-            }
-        }
-
-        ClothingValidationManager.VALIDATE_ON_HC_EXPIRE = Emulator.getConfig().getBoolean("hotel.users.clothingvalidation.onhcexpired", false);
-        ClothingValidationManager.VALIDATE_ON_LOGIN = Emulator.getConfig().getBoolean("hotel.users.clothingvalidation.onlogin", false);
-        ClothingValidationManager.VALIDATE_ON_CHANGE_LOOKS = Emulator.getConfig().getBoolean("hotel.users.clothingvalidation.onchangelooks", false);
-        ClothingValidationManager.VALIDATE_ON_MIMIC = Emulator.getConfig().getBoolean("hotel.users.clothingvalidation.onmimic", false);
-        ClothingValidationManager.VALIDATE_ON_MANNEQUIN = Emulator.getConfig().getBoolean("hotel.users.clothingvalidation.onmannequin", false);
-        ClothingValidationManager.VALIDATE_ON_FBALLGATE = Emulator.getConfig().getBoolean("hotel.users.clothingvalidation.onfballgate", false);
-
-        String newUrl = Emulator.getConfig().getValue("gamedata.figuredata.url");
-        if(!ClothingValidationManager.FIGUREDATA_URL.equals(newUrl)) {
-            ClothingValidationManager.FIGUREDATA_URL = newUrl;
-            ClothingValidationManager.reloadFiguredata(newUrl);
-        }
-
-        if(newUrl.isEmpty()) {
-            ClothingValidationManager.VALIDATE_ON_HC_EXPIRE = false;
-            ClothingValidationManager.VALIDATE_ON_LOGIN = false;
-            ClothingValidationManager.VALIDATE_ON_CHANGE_LOOKS = false;
-            ClothingValidationManager.VALIDATE_ON_MIMIC = false;
-            ClothingValidationManager.VALIDATE_ON_MANNEQUIN = false;
-            ClothingValidationManager.VALIDATE_ON_FBALLGATE = false;
-        }
-
-
-        NewNavigatorEventCategoriesComposer.CATEGORIES.clear();
-        for (String category : Emulator.getConfig().getValue("navigator.eventcategories", "").split(";")) {
-            try {
-                NewNavigatorEventCategoriesComposer.CATEGORIES.add(new EventCategory(category));
-            } catch (Exception e) {
-                LOGGER.error("Caught exception", e);
-            }
-        }
-
-        if (Emulator.isReady) {
-            GiftConfigurationComposer.BOX_TYPES = Arrays.stream(Emulator.getConfig().getValue("hotel.gifts.box_types").split(",")).mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
-            GiftConfigurationComposer.RIBBON_TYPES = Arrays.stream(Emulator.getConfig().getValue("hotel.gifts.ribbon_types").split(",")).mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
-
+        if (runtimeReady) {
             Emulator.getGameEnvironment().getCreditsScheduler().reloadConfig();
             Emulator.getGameEnvironment().getPointsScheduler().reloadConfig();
             Emulator.getGameEnvironment().getPixelScheduler().reloadConfig();
@@ -263,13 +75,15 @@ public class PluginManager {
             }
         }
 
-        for (File file : Objects.requireNonNull(loc.listFiles(file -> file.getPath().toLowerCase().endsWith(".jar")))) {
+        for (File file : Objects.requireNonNull(
+                loc.listFiles(file -> file.getPath().toLowerCase().endsWith(".jar")))) {
             URLClassLoader urlClassLoader = null;
             InputStream stream = null;
             boolean retainPluginResources = false;
 
             try {
-                urlClassLoader = URLClassLoader.newInstance(new URL[]{file.toURI().toURL()});
+                urlClassLoader =
+                        URLClassLoader.newInstance(new URL[] {file.toURI().toURL()});
                 stream = urlClassLoader.getResourceAsStream("plugin.json");
 
                 if (stream == null) {
@@ -281,8 +95,10 @@ public class PluginManager {
                 if (stream.read(content) > 0) {
                     String body = new String(content, java.nio.charset.StandardCharsets.UTF_8);
 
-                    HabboPluginConfiguration pluginConfigurtion = PLUGIN_GSON.fromJson(body, HabboPluginConfiguration.class);
-                    RuntimeValidationReport validationReport = PluginRuntimeValidator.validatePluginClass(file.getName(), pluginConfigurtion, urlClassLoader);
+                    HabboPluginConfiguration pluginConfigurtion =
+                            PLUGIN_GSON.fromJson(body, HabboPluginConfiguration.class);
+                    RuntimeValidationReport validationReport = PluginRuntimeValidator.validatePluginClass(
+                            file.getName(), pluginConfigurtion, urlClassLoader);
 
                     if (validationReport.hasErrors()) {
                         validationReport.logErrors(LOGGER, "Plugin validation");
@@ -347,7 +163,9 @@ public class PluginManager {
                                 plugin.registeredEvents.put(eventClass.asSubclass(Event.class), new HashSet<>());
                             }
 
-                            plugin.registeredEvents.get(eventClass.asSubclass(Event.class)).add(method);
+                            plugin.registeredEvents
+                                    .get(eventClass.asSubclass(Event.class))
+                                    .add(method);
                         }
                     }
                 }
@@ -357,11 +175,16 @@ public class PluginManager {
 
     public <T extends Event> T fireEvent(T event) {
         for (Method method : this.methods) {
-            if (method.getParameterTypes().length == 1 && method.getParameterTypes()[0].isAssignableFrom(event.getClass())) {
+            if (method.getParameterTypes().length == 1
+                    && method.getParameterTypes()[0].isAssignableFrom(event.getClass())) {
                 try {
                     method.invoke(null, event);
                 } catch (Exception e) {
-                    LOGGER.error("Could not pass default event {} to {}: {}!", event.getClass().getName(), method.getClass().getName(), method.getName());
+                    LOGGER.error(
+                            "Could not pass default event {} to {}: {}!",
+                            event.getClass().getName(),
+                            method.getClass().getName(),
+                            method.getName());
                     LOGGER.error("Caught exception", e);
                 }
             }
@@ -370,14 +193,18 @@ public class PluginManager {
         for (HabboPlugin plugin : this.plugins) {
 
             if (plugin != null) {
-                Set<Method> methods = plugin.registeredEvents.get(event.getClass().asSubclass(Event.class));
+                Set<Method> methods =
+                        plugin.registeredEvents.get(event.getClass().asSubclass(Event.class));
 
                 if (methods != null) {
                     for (Method method : methods) {
                         try {
                             method.invoke(plugin, event);
                         } catch (Exception e) {
-                            LOGGER.error("Could not pass event {} to {}", event.getClass().getName(), plugin.configuration.name);
+                            LOGGER.error(
+                                    "Could not pass event {} to {}",
+                                    event.getClass().getName(),
+                                    plugin.configuration.name);
                             LOGGER.error("Caught exception", e);
                         }
                     }
@@ -437,7 +264,10 @@ public class PluginManager {
 
         this.loadPlugins();
 
-        LOGGER.info("Plugin Manager -> Loaded! {} plugins! ({} MS)", this.plugins.size(), System.currentTimeMillis() - millis);
+        LOGGER.info(
+                "Plugin Manager -> Loaded! {} plugins! ({} MS)",
+                this.plugins.size(),
+                System.currentTimeMillis() - millis);
 
         this.registerDefaultEvents();
     }
@@ -450,10 +280,12 @@ public class PluginManager {
             this.methods.add(TagGame.class.getMethod("onUserWalkEvent", UserTakeStepEvent.class));
             this.methods.add(FreezeGame.class.getMethod("onConfigurationUpdated", EmulatorConfigUpdatedEvent.class));
             this.methods.add(PacketManager.class.getMethod("onConfigurationUpdated", EmulatorConfigUpdatedEvent.class));
-            this.methods.add(InteractionFootballGate.class.getMethod("onUserDisconnectEvent", UserDisconnectEvent.class));
+            this.methods.add(
+                    InteractionFootballGate.class.getMethod("onUserDisconnectEvent", UserDisconnectEvent.class));
             this.methods.add(InteractionFootballGate.class.getMethod("onUserExitRoomEvent", UserExitRoomEvent.class));
             this.methods.add(InteractionFootballGate.class.getMethod("onUserSavedLookEvent", UserSavedLookEvent.class));
-            this.methods.add(PluginManager.class.getMethod("globalOnConfigurationUpdated", EmulatorConfigUpdatedEvent.class));
+            this.methods.add(
+                    PluginManager.class.getMethod("globalOnConfigurationUpdated", EmulatorConfigUpdatedEvent.class));
             this.methods.add(WiredHighscoreManager.class.getMethod("onEmulatorLoaded", EmulatorLoadedEvent.class));
             this.methods.add(WiredManager.class.getMethod("onEmulatorLoaded", EmulatorLoadedEvent.class));
         } catch (NoSuchMethodException e) {

--- a/Emulator/src/main/java/com/eu/habbo/plugin/RoomConfigurationBinder.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/RoomConfigurationBinder.java
@@ -1,0 +1,331 @@
+package com.eu.habbo.plugin;
+
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.core.config.ConfigurationBinder;
+import com.eu.habbo.habbohotel.bots.Bot;
+import com.eu.habbo.habbohotel.bots.BotManager;
+import com.eu.habbo.habbohotel.items.interactions.InteractionPostIt;
+import com.eu.habbo.habbohotel.items.interactions.InteractionRoller;
+import com.eu.habbo.habbohotel.modtool.WordFilter;
+import com.eu.habbo.habbohotel.navigation.EventCategory;
+import com.eu.habbo.habbohotel.navigation.NavigatorManager;
+import com.eu.habbo.habbohotel.pets.PetManager;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomChatMessage;
+import com.eu.habbo.habbohotel.rooms.RoomLayout;
+import com.eu.habbo.habbohotel.rooms.RoomManager;
+import com.eu.habbo.habbohotel.rooms.RoomTrade;
+import com.eu.habbo.habbohotel.rooms.TraxManager;
+import com.eu.habbo.habbohotel.users.HabboInventory;
+import com.eu.habbo.habbohotel.users.clothingvalidation.ClothingValidationManager;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionHabboClub;
+import com.eu.habbo.messages.incoming.catalog.CheckPetNameEvent;
+import com.eu.habbo.messages.incoming.floorplaneditor.FloorPlanEditorSaveEvent;
+import com.eu.habbo.messages.incoming.rooms.promotions.BuyRoomPromotionEvent;
+import com.eu.habbo.messages.outgoing.navigator.NewNavigatorEventCategoriesComposer;
+import com.eu.habbo.threading.runnables.ShutdownEmulator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.function.ToLongFunction;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class RoomConfigurationBinder extends ConfigurationBinder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RoomConfigurationBinder.class);
+    private final ToLongFunction<String> dateToEpochSeconds;
+
+    RoomConfigurationBinder(ConfigurationManager configuration, ToLongFunction<String> dateToEpochSeconds) {
+        super(configuration);
+        this.dateToEpochSeconds = dateToEpochSeconds;
+    }
+
+    void bind() {
+        this.bindRoomBehavior();
+        this.bindLimits();
+        this.bindNavigatorAndChat();
+        this.bindSubscriptions();
+        this.bindClothingValidation();
+        this.bindEventCategories();
+    }
+
+    private void bindRoomBehavior() {
+        this.apply(
+                "room.chat.delay",
+                () -> Room.HABBO_CHAT_DELAY = this.configuration.getBoolean("room.chat.delay", false));
+        this.apply(
+                "room.chat.mutearea.allow_whisper",
+                () -> Room.MUTEAREA_CAN_WHISPER =
+                        this.configuration.getBoolean("room.chat.mutearea.allow_whisper", false));
+        this.apply(
+                "save.room.chats",
+                () -> RoomChatMessage.SAVE_ROOM_CHATS = this.configuration.getBoolean("save.room.chats", false));
+        this.apply(
+                "pathfinder.step.maximum.height",
+                () -> RoomLayout.MAXIMUM_STEP_HEIGHT =
+                        this.configuration.getDouble("pathfinder.step.maximum.height", 1.1));
+        this.apply(
+                "pathfinder.step.allow.falling",
+                () -> RoomLayout.ALLOW_FALLING = this.configuration.getBoolean("pathfinder.step.allow.falling", true));
+        this.apply(
+                "hotel.trading.enabled",
+                () -> RoomTrade.TRADING_ENABLED =
+                        this.configuration.getBoolean("hotel.trading.enabled") && !ShutdownEmulator.instantiated);
+        this.apply(
+                "hotel.trading.requires.perk",
+                () -> RoomTrade.TRADING_REQUIRES_PERK = this.configuration.getBoolean("hotel.trading.requires.perk"));
+        this.apply(
+                "hotel.wordfilter.messenger",
+                () -> WordFilter.ENABLED_FRIENDCHAT = this.configuration.getBoolean("hotel.wordfilter.messenger"));
+        this.apply(
+                "hotel.wordfilter.replacement",
+                () -> WordFilter.DEFAULT_REPLACEMENT = this.configuration.getValue("hotel.wordfilter.replacement"));
+        this.apply(
+                "hotel.bot.chat.minimum.interval",
+                () -> BotManager.MINIMUM_CHAT_SPEED = this.configuration.getInt("hotel.bot.chat.minimum.interval"));
+        this.apply(
+                "hotel.bot.max.chatlength",
+                () -> BotManager.MAXIMUM_CHAT_LENGTH = this.configuration.getInt("hotel.bot.max.chatlength"));
+        this.apply(
+                "hotel.bot.max.namelength",
+                () -> BotManager.MAXIMUM_NAME_LENGTH = this.configuration.getInt("hotel.bot.max.namelength"));
+        this.apply(
+                "hotel.bot.max.chatdelay",
+                () -> BotManager.MAXIMUM_CHAT_SPEED = this.configuration.getInt("hotel.bot.max.chatdelay"));
+        this.apply("hotel.bot.placement.messages", () -> {
+            String[] messages = this.configuration
+                    .getValue("hotel.bot.placement.messages", "Yo!;Hello I'm a real party animal!;Hello!")
+                    .split(";");
+            Bot.PLACEMENT_MESSAGES = messages;
+        });
+        this.apply(
+                "hotel.bot.limit.walking.distance",
+                () -> Bot.BOT_LIMIT_WALKING_DISTANCE =
+                        this.configuration.getBoolean("hotel.bot.limit.walking.distance", true));
+        this.apply(
+                "hotel.bot.limit.walking.distance.radius",
+                () -> Bot.BOT_WALKING_DISTANCE_RADIUS =
+                        this.configuration.getInt("hotel.bot.limit.walking.distance.radius", 5));
+    }
+
+    private void bindLimits() {
+        this.apply(
+                "hotel.inventory.max.items",
+                () -> HabboInventory.MAXIMUM_ITEMS = this.configuration.getInt("hotel.inventory.max.items"));
+        this.apply("hotel.max.bots.room", () -> Room.MAXIMUM_BOTS = this.configuration.getInt("hotel.max.bots.room"));
+        this.apply("hotel.pets.max.room", () -> Room.MAXIMUM_PETS = this.configuration.getInt("hotel.pets.max.room"));
+        this.apply(
+                "hotel.room.furni.max",
+                () -> Room.MAXIMUM_FURNI = this.configuration.getInt("hotel.room.furni.max", 2500));
+        this.apply(
+                "hotel.room.stickies.max",
+                () -> Room.MAXIMUM_POSTITNOTES = this.configuration.getInt("hotel.room.stickies.max", 200));
+        this.apply(
+                "hotel.rooms.handitem.time",
+                () -> Room.HAND_ITEM_TIME = this.configuration.getInt("hotel.rooms.handitem.time"));
+        this.apply(
+                "hotel.roomuser.idle.cycles",
+                () -> Room.IDLE_CYCLES = this.configuration.getInt("hotel.roomuser.idle.cycles", 240));
+        this.apply(
+                "hotel.roomuser.idle.cycles.kick",
+                () -> Room.IDLE_CYCLES_KICK = this.configuration.getInt("hotel.roomuser.idle.cycles.kick", 480));
+        this.apply(
+                "hotel.room.rollers.roll_avatars.max",
+                () -> Room.ROLLERS_MAXIMUM_ROLL_AVATARS =
+                        this.configuration.getInt("hotel.room.rollers.roll_avatars.max", 1));
+        this.apply(
+                "hotel.users.max.rooms",
+                () -> RoomManager.MAXIMUM_ROOMS_USER = this.configuration.getInt("hotel.users.max.rooms", 50));
+        this.apply(
+                "hotel.users.max.rooms.hc",
+                () -> RoomManager.MAXIMUM_ROOMS_HC = this.configuration.getInt("hotel.users.max.rooms.hc", 75));
+        this.apply("hotel.home.room", () -> RoomManager.HOME_ROOM_ID = this.configuration.getInt("hotel.home.room"));
+        this.apply(
+                "hotel.bots.max.inventory",
+                () -> BotManager.MAXIMUM_BOT_INVENTORY_SIZE = this.configuration.getInt("hotel.bots.max.inventory"));
+        this.apply(
+                "hotel.pets.max.inventory",
+                () -> PetManager.MAXIMUM_PET_INVENTORY_SIZE = this.configuration.getInt("hotel.pets.max.inventory"));
+    }
+
+    private void bindNavigatorAndChat() {
+        this.apply(
+                "hotel.navigator.search.maxresults",
+                () -> NavigatorManager.MAXIMUM_RESULTS_PER_PAGE =
+                        this.configuration.getInt("hotel.navigator.search.maxresults"));
+        this.apply(
+                "hotel.navigator.sort.ordernum",
+                () -> NavigatorManager.CATEGORY_SORT_USING_ORDER_NUM =
+                        this.configuration.getBoolean("hotel.navigator.sort.ordernum"));
+        this.apply(
+                "hotel.chat.max.length",
+                () -> RoomChatMessage.MAXIMUM_LENGTH = this.configuration.getInt("hotel.chat.max.length"));
+        this.apply(
+                "hotel.jukebox.limit.large",
+                () -> TraxManager.LARGE_JUKEBOX_LIMIT = this.configuration.getInt("hotel.jukebox.limit.large"));
+        this.apply(
+                "hotel.jukebox.limit.normal",
+                () -> TraxManager.NORMAL_JUKEBOX_LIMIT = this.configuration.getInt("hotel.jukebox.limit.normal"));
+        this.apply("commands.cmd_chatcolor.banned_numbers", () -> {
+            String[] values = this.configuration
+                    .getValue("commands.cmd_chatcolor.banned_numbers")
+                    .split(";");
+            int[] bannedBubbles = new int[values.length];
+            for (int index = 0; index < values.length; index++) {
+                bannedBubbles[index] = Integer.parseInt(values[index]);
+            }
+            RoomChatMessage.BANNED_BUBBLES = bannedBubbles;
+        });
+        this.apply(
+                "room.chat.prefix.format",
+                () -> Room.PREFIX_FORMAT = this.configuration.getValue("room.chat.prefix.format"));
+        this.apply(
+                "hotel.floorplan.max.widthlength",
+                () -> FloorPlanEditorSaveEvent.MAXIMUM_FLOORPLAN_WIDTH_LENGTH =
+                        this.configuration.getInt("hotel.floorplan.max.widthlength"));
+        this.apply(
+                "hotel.floorplan.max.totalarea",
+                () -> FloorPlanEditorSaveEvent.MAXIMUM_FLOORPLAN_SIZE =
+                        this.configuration.getInt("hotel.floorplan.max.totalarea"));
+        this.apply(
+                "hotel.room.stickypole.prefix",
+                () -> InteractionPostIt.STICKYPOLE_PREFIX_TEXT =
+                        this.configuration.getValue("hotel.room.stickypole.prefix"));
+        this.apply(
+                "hotel.room.rollers.norules",
+                () -> InteractionRoller.NO_RULES = this.configuration.getBoolean("hotel.room.rollers.norules"));
+        this.apply(
+                "hotel.navigator.populartab.publics",
+                () -> RoomManager.SHOW_PUBLIC_IN_POPULAR_TAB =
+                        this.configuration.getBoolean("hotel.navigator.populartab.publics"));
+        this.apply(
+                "hotel.pets.name.length.min",
+                () -> CheckPetNameEvent.PET_NAME_LENGTH_MINIMUM =
+                        this.configuration.getInt("hotel.pets.name.length.min"));
+        this.apply(
+                "hotel.pets.name.length.max",
+                () -> CheckPetNameEvent.PET_NAME_LENGTH_MAXIMUM =
+                        this.configuration.getInt("hotel.pets.name.length.max"));
+        this.apply(
+                "room.promotion.badge",
+                () -> BuyRoomPromotionEvent.ROOM_PROMOTION_BADGE =
+                        this.configuration.getValue("room.promotion.badge", "RADZZ"));
+    }
+
+    private void bindSubscriptions() {
+        this.apply(
+                "subscriptions.hc.payday.enabled",
+                () -> SubscriptionHabboClub.HC_PAYDAY_ENABLED =
+                        this.configuration.getBoolean("subscriptions.hc.payday.enabled", false));
+        this.apply("subscriptions.hc.payday.next_date", () -> {
+            String value = this.configuration.getValue("subscriptions.hc.payday.next_date");
+            try {
+                SubscriptionHabboClub.HC_PAYDAY_NEXT_DATE = Math.toIntExact(this.dateToEpochSeconds.applyAsLong(value));
+            } catch (RuntimeException exception) {
+                SubscriptionHabboClub.HC_PAYDAY_NEXT_DATE = Integer.MAX_VALUE;
+            }
+        });
+        this.apply(
+                "subscriptions.hc.payday.interval",
+                () -> SubscriptionHabboClub.HC_PAYDAY_INTERVAL =
+                        this.configuration.getValue("subscriptions.hc.payday.interval"));
+        this.apply(
+                "subscriptions.hc.payday.query",
+                () -> SubscriptionHabboClub.HC_PAYDAY_QUERY =
+                        this.configuration.getValue("subscriptions.hc.payday.query"));
+        this.apply(
+                "subscriptions.hc.payday.currency",
+                () -> SubscriptionHabboClub.HC_PAYDAY_CURRENCY =
+                        this.configuration.getValue("subscriptions.hc.payday.currency"));
+        this.apply(
+                "subscriptions.hc.payday.percentage",
+                () -> SubscriptionHabboClub.HC_PAYDAY_KICKBACK_PERCENTAGE =
+                        this.configuration.getInt("subscriptions.hc.payday.percentage", 10) / 100.0);
+        this.apply(
+                "subscriptions.hc.payday.creditsspent_reset_on_expire",
+                () -> SubscriptionHabboClub.HC_PAYDAY_COINSSPENT_RESET_ON_EXPIRE =
+                        this.configuration.getBoolean("subscriptions.hc.payday.creditsspent_reset_on_expire", false));
+        this.apply(
+                "subscriptions.hc.achievement",
+                () -> SubscriptionHabboClub.ACHIEVEMENT_NAME =
+                        this.configuration.getValue("subscriptions.hc.achievement", "VipHC"));
+        this.apply(
+                "subscriptions.hc.discount.enabled",
+                () -> SubscriptionHabboClub.DISCOUNT_ENABLED =
+                        this.configuration.getBoolean("subscriptions.hc.discount.enabled", false));
+        this.apply(
+                "subscriptions.hc.discount.days_before_end",
+                () -> SubscriptionHabboClub.DISCOUNT_DAYS_BEFORE_END =
+                        this.configuration.getInt("subscriptions.hc.discount.days_before_end", 7));
+        this.apply("subscriptions.hc.payday.streak", () -> {
+            TreeMap<Integer, Integer> streaks = new TreeMap<>();
+            for (String streak : this.configuration
+                    .getValue("subscriptions.hc.payday.streak", "7=5;30=10;60=15;90=20;180=25;365=30")
+                    .split(Pattern.quote(";"))) {
+                if (streak.contains("=")) {
+                    String[] parts = streak.split(Pattern.quote("="));
+                    streaks.put(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]));
+                }
+            }
+            TreeMap<Integer, Integer> publishedStreaks = SubscriptionHabboClub.HC_PAYDAY_STREAK;
+            synchronized (publishedStreaks) {
+                publishedStreaks.clear();
+                publishedStreaks.putAll(streaks);
+            }
+            SubscriptionHabboClub.HC_PAYDAY_STREAK = publishedStreaks;
+        });
+    }
+
+    private void bindClothingValidation() {
+        this.apply("hotel.users.clothingvalidation", () -> {
+            ClothingValidationManager.VALIDATE_ON_HC_EXPIRE =
+                    this.configuration.getBoolean("hotel.users.clothingvalidation.onhcexpired", false);
+            ClothingValidationManager.VALIDATE_ON_LOGIN =
+                    this.configuration.getBoolean("hotel.users.clothingvalidation.onlogin", false);
+            ClothingValidationManager.VALIDATE_ON_CHANGE_LOOKS =
+                    this.configuration.getBoolean("hotel.users.clothingvalidation.onchangelooks", false);
+            ClothingValidationManager.VALIDATE_ON_MIMIC =
+                    this.configuration.getBoolean("hotel.users.clothingvalidation.onmimic", false);
+            ClothingValidationManager.VALIDATE_ON_MANNEQUIN =
+                    this.configuration.getBoolean("hotel.users.clothingvalidation.onmannequin", false);
+            ClothingValidationManager.VALIDATE_ON_FBALLGATE =
+                    this.configuration.getBoolean("hotel.users.clothingvalidation.onfballgate", false);
+
+            String newUrl = this.configuration.getValue("gamedata.figuredata.url");
+            if (!ClothingValidationManager.FIGUREDATA_URL.equals(newUrl)) {
+                ClothingValidationManager.FIGUREDATA_URL = newUrl;
+                ClothingValidationManager.reloadFiguredata(newUrl);
+            }
+            if (newUrl.isEmpty()) {
+                ClothingValidationManager.VALIDATE_ON_HC_EXPIRE = false;
+                ClothingValidationManager.VALIDATE_ON_LOGIN = false;
+                ClothingValidationManager.VALIDATE_ON_CHANGE_LOOKS = false;
+                ClothingValidationManager.VALIDATE_ON_MIMIC = false;
+                ClothingValidationManager.VALIDATE_ON_MANNEQUIN = false;
+                ClothingValidationManager.VALIDATE_ON_FBALLGATE = false;
+            }
+        });
+    }
+
+    private void bindEventCategories() {
+        this.apply("navigator.eventcategories", () -> {
+            List<EventCategory> categories = new ArrayList<>();
+            for (String category :
+                    this.configuration.getValue("navigator.eventcategories", "").split(";")) {
+                try {
+                    categories.add(new EventCategory(category));
+                } catch (Exception exception) {
+                    LOGGER.error("Invalid navigator event category {}", category, exception);
+                }
+            }
+            List<EventCategory> publishedCategories = NewNavigatorEventCategoriesComposer.CATEGORIES;
+            synchronized (publishedCategories) {
+                publishedCategories.clear();
+                publishedCategories.addAll(categories);
+            }
+            NewNavigatorEventCategoriesComposer.CATEGORIES = publishedCategories;
+        });
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/plugin/WiredConfigurationBinder.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/WiredConfigurationBinder.java
@@ -1,0 +1,83 @@
+package com.eu.habbo.plugin;
+
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.core.config.ConfigurationBinder;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectSendSignal;
+import com.eu.habbo.habbohotel.wired.core.WiredEngine;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+
+final class WiredConfigurationBinder extends ConfigurationBinder {
+
+    WiredConfigurationBinder(ConfigurationManager configuration) {
+        super(configuration);
+    }
+
+    void bind() {
+        this.apply(
+                "hotel.wired.furni.selection.count",
+                () -> WiredManager.MAXIMUM_FURNI_SELECTION =
+                        this.configuration.getInt("hotel.wired.furni.selection.count"));
+        this.apply(
+                "wired.effect.teleport.delay",
+                () -> WiredManager.TELEPORT_DELAY = this.configuration.getInt("wired.effect.teleport.delay", 500));
+        this.apply(
+                "wired.signal.max.depth",
+                () -> WiredEffectSendSignal.MAX_SIGNAL_DEPTH =
+                        this.configuration.getInt("wired.signal.max.depth", 100));
+        this.apply(
+                "wired.abuse.max.recursion.depth",
+                () -> WiredEngine.MAX_RECURSION_DEPTH =
+                        this.configuration.getInt("wired.abuse.max.recursion.depth", 10));
+        this.apply(
+                "wired.abuse.max.events.per.window",
+                () -> WiredEngine.MAX_EVENTS_PER_WINDOW =
+                        this.configuration.getInt("wired.abuse.max.events.per.window", 100));
+        this.apply(
+                "wired.abuse.rate.limit.window.ms",
+                () -> WiredEngine.RATE_LIMIT_WINDOW_MS =
+                        this.configuration.getInt("wired.abuse.rate.limit.window.ms", 10000));
+        this.apply(
+                "wired.abuse.ban.duration.ms",
+                () -> WiredEngine.WIRED_BAN_DURATION_MS =
+                        this.configuration.getInt("wired.abuse.ban.duration.ms", 600000));
+        this.apply(
+                "wired.monitor.usage.window.ms",
+                () -> WiredEngine.MONITOR_USAGE_WINDOW_MS =
+                        this.configuration.getInt("wired.monitor.usage.window.ms", 1000));
+        this.apply(
+                "wired.monitor.usage.limit",
+                () -> WiredEngine.MONITOR_USAGE_LIMIT = this.configuration.getInt("wired.monitor.usage.limit", 50000));
+        this.apply(
+                "wired.monitor.delayed.events.limit",
+                () -> WiredEngine.MONITOR_DELAYED_EVENTS_LIMIT =
+                        this.configuration.getInt("wired.monitor.delayed.events.limit", 50000));
+        this.apply(
+                "wired.monitor.overload.average.ms",
+                () -> WiredEngine.MONITOR_OVERLOAD_AVERAGE_MS =
+                        this.configuration.getInt("wired.monitor.overload.average.ms", 50));
+        this.apply(
+                "wired.monitor.overload.peak.ms",
+                () -> WiredEngine.MONITOR_OVERLOAD_PEAK_MS =
+                        this.configuration.getInt("wired.monitor.overload.peak.ms", 150));
+        this.apply(
+                "wired.monitor.overload.consecutive.windows",
+                () -> WiredEngine.MONITOR_OVERLOAD_CONSECUTIVE_WINDOWS =
+                        this.configuration.getInt("wired.monitor.overload.consecutive.windows", 2));
+        this.apply(
+                "wired.monitor.heavy.usage.percent",
+                () -> WiredEngine.MONITOR_HEAVY_USAGE_PERCENT =
+                        this.configuration.getInt("wired.monitor.heavy.usage.percent", 70));
+        this.apply(
+                "wired.monitor.heavy.consecutive.windows",
+                () -> WiredEngine.MONITOR_HEAVY_CONSECUTIVE_WINDOWS =
+                        this.configuration.getInt("wired.monitor.heavy.consecutive.windows", 5));
+        this.apply(
+                "wired.monitor.heavy.delayed.percent",
+                () -> WiredEngine.MONITOR_HEAVY_DELAYED_PERCENT =
+                        this.configuration.getInt("wired.monitor.heavy.delayed.percent", 60));
+
+        if (WiredManager.getEngine() != null) {
+            WiredManager.getEngine().clearAllDiagnostics();
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/core/ConfigurationSaveOwnershipTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/core/ConfigurationSaveOwnershipTest.java
@@ -1,0 +1,60 @@
+package com.eu.habbo.core;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.database.Database;
+import com.zaxxer.hikari.HikariDataSource;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ConfigurationSaveOwnershipTest {
+
+    @TempDir
+    Path tempDirectory;
+
+    @Test
+    void shutdownPersistsOnlyKeysChangedThroughTheRuntimeApi() throws Exception {
+        Path config = this.tempDirectory.resolve("config.ini");
+        Files.writeString(config, "first=value\nsecond=database-owned\n");
+        ConfigurationManager manager = new ConfigurationManager(config.toString());
+        manager.update("first", "changed");
+
+        HikariDataSource dataSource = mock(HikariDataSource.class);
+        Connection connection = mock(Connection.class);
+        PreparedStatement statement = mock(PreparedStatement.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(anyString())).thenReturn(statement);
+        Field databaseField = Emulator.class.getDeclaredField("database");
+        databaseField.setAccessible(true);
+        Database original = (Database) databaseField.get(null);
+        databaseField.set(null, databaseUsing(dataSource));
+
+        try {
+            manager.saveToDatabase();
+        } finally {
+            databaseField.set(null, original);
+        }
+
+        verify(statement, times(1)).executeUpdate();
+        verify(statement).setString(1, "changed");
+        verify(statement).setString(2, "first");
+    }
+
+    private static Database databaseUsing(HikariDataSource dataSource) throws Exception {
+        Constructor<Database> constructor =
+                Database.class.getDeclaredConstructor(HikariDataSource.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(dataSource);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/core/ConfigurationSaveOwnershipTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/core/ConfigurationSaveOwnershipTest.java
@@ -52,8 +52,7 @@ class ConfigurationSaveOwnershipTest {
     }
 
     private static Database databaseUsing(HikariDataSource dataSource) throws Exception {
-        Constructor<Database> constructor =
-                Database.class.getDeclaredConstructor(HikariDataSource.class);
+        Constructor<Database> constructor = Database.class.getDeclaredConstructor(HikariDataSource.class);
         constructor.setAccessible(true);
         return constructor.newInstance(dataSource);
     }

--- a/Emulator/src/test/java/com/eu/habbo/core/config/ConfigRegistryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/core/config/ConfigRegistryTest.java
@@ -1,0 +1,66 @@
+package com.eu.habbo.core.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.eu.habbo.core.ConfigurationManager;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ConfigRegistryTest {
+
+    @TempDir
+    Path tempDirectory;
+
+    @Test
+    void registryCoversBothShippedStartupTemplates() throws Exception {
+        Set<String> documented = ConfigRegistry.standard().names();
+        Set<String> configured = new HashSet<>();
+        configured.addAll(keys(Path.of("../config example/config.ini.example")));
+        configured.addAll(keys(Path.of("../e2e/config.ini.template")));
+
+        assertTrue(
+                documented.containsAll(configured),
+                () -> "Missing typed startup keys: "
+                        + configured.stream()
+                                .filter(key -> !documented.contains(key))
+                                .sorted()
+                                .toList());
+    }
+
+    @Test
+    void malformedKnownValuesAreReportedAndUnknownPluginKeysRemainAllowed() throws Exception {
+        Path config = this.tempDirectory.resolve("config.ini");
+        Files.writeString(config, "db.port=not-a-port\nplugin.example=value\n");
+        ConfigurationManager configuration = new ConfigurationManager(config.toString());
+
+        assertEquals(
+                java.util.List.of("db.port"),
+                ConfigRegistry.standard().validate(configuration).stream()
+                        .map(ConfigRegistry.ValidationIssue::key)
+                        .toList());
+    }
+
+    @Test
+    void generatedReferenceMatchesTheCommittedDocument() throws Exception {
+        assertEquals(
+                Files.readString(Path.of("../docs/configuration-reference.md")),
+                ConfigRegistry.standard().renderMarkdown());
+    }
+
+    private static Set<String> keys(Path path) throws Exception {
+        Set<String> keys = new HashSet<>();
+        for (String line : Files.readAllLines(path)) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("#") || !trimmed.contains("=")) {
+                continue;
+            }
+            keys.add(trimmed.substring(0, trimmed.indexOf('=')).trim());
+        }
+        return keys;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
@@ -1,17 +1,16 @@
 package com.eu.habbo.habbohotel.catalog;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class AtomicCatalogPurchaseContractTest {
     @Test
     void coordinatorCommitsAssetsAndConditionalChargesTogether() throws Exception {
-        String source = Files.readString(Path.of(
-                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java"));
+        String source = Files.readString(
+                Path.of("src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java"));
 
         int begin = source.indexOf("connection.setAutoCommit(false)");
         int persist = source.indexOf("work.persist(connection)", begin);
@@ -33,13 +32,13 @@ class AtomicCatalogPurchaseContractTest {
 
     @Test
     void catalogPublishesFurnitureOnlyAfterAtomicPurchaseReturns() throws Exception {
-        String source = Files.readString(Path.of(
-                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"));
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"))
+                .replaceAll("\\s+", "");
 
         int method = source.indexOf("purchaseFurnitureAtomically(");
         int transaction = source.indexOf("CatalogPurchaseTransaction.execute(", method);
         int inventory = source.indexOf("getItemsComponent().addItems(", transaction);
-        int success = source.indexOf("new PurchaseOKComposer(", transaction);
+        int success = source.indexOf("newPurchaseOKComposer(", transaction);
 
         assertTrue(method > -1);
         assertTrue(transaction > method);
@@ -49,8 +48,8 @@ class AtomicCatalogPurchaseContractTest {
 
     @Test
     void limitedFurnitureReservationUsesThePurchaseConnection() throws Exception {
-        String source = Files.readString(Path.of(
-                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java"));
+        String source = Files.readString(
+                Path.of("src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java"));
 
         assertTrue(source.contains("limitedSold(Connection connection, int catalogItemId"));
         assertTrue(source.contains("AND number = ? AND user_id = 0 LIMIT 1"));
@@ -59,8 +58,8 @@ class AtomicCatalogPurchaseContractTest {
 
     @Test
     void badgesAndEffectsPublishOnlyAfterTheirTransactionCommits() throws Exception {
-        String source = Files.readString(Path.of(
-                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"));
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"))
+                .replaceAll("\\s+", "");
 
         int method = source.indexOf("purchaseEntitlementsAtomically(");
         int transaction = source.indexOf("CatalogPurchaseTransaction.execute(", method);
@@ -79,8 +78,8 @@ class AtomicCatalogPurchaseContractTest {
 
     @Test
     void botsAndPetsPublishOnlyAfterTheirTransactionCommits() throws Exception {
-        String source = Files.readString(Path.of(
-                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"));
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"))
+                .replaceAll("\\s+", "");
 
         int method = source.indexOf("purchaseBotsAndPetsAtomically(");
         int transaction = source.indexOf("CatalogPurchaseTransaction.execute(", method);
@@ -99,10 +98,10 @@ class AtomicCatalogPurchaseContractTest {
 
     @Test
     void guildAndMusicFurnitureUseTheFurnitureTransaction() throws Exception {
-        String source = Files.readString(Path.of(
-                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"));
-        int transaction = source.indexOf("CatalogPurchaseTransaction.execute(",
-                source.indexOf("purchaseFurnitureAtomically("));
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"))
+                .replaceAll("\\s+", "");
+        int transaction =
+                source.indexOf("CatalogPurchaseTransaction.execute(", source.indexOf("purchaseFurnitureAtomically("));
         int guildPersist = source.indexOf("persistGuild(connection", transaction);
         int musicCreate = source.indexOf("createMusicDiscExtraData(", transaction);
         int inventory = source.indexOf("getItemsComponent().addItems(", transaction);

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogAssetTransactionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogAssetTransactionContractTest.java
@@ -1,21 +1,21 @@
 package com.eu.habbo.habbohotel.catalog;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class CatalogAssetTransactionContractTest {
     private static String itemManagerSource() throws Exception {
-        return Files.readString(Path.of(
-                "src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java"));
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java"))
+                .replaceAll("\\s+", "");
     }
 
     private static String method(String source, String signature) {
         int start = source.indexOf(signature);
-        int end = source.indexOf("\n    public ", start + signature.length());
+        int end = source.indexOf("public", start + signature.length());
+        if (end < 0) end = source.length();
         return source.substring(start, end);
     }
 
@@ -23,19 +23,18 @@ class CatalogAssetTransactionContractTest {
     void furnitureFactoriesCanShareTheCatalogTransactionConnection() throws Exception {
         String source = itemManagerSource();
 
-        assertTrue(source.contains("createItem(Connection connection, int habboId"));
-        assertTrue(source.contains("insertTeleportPair(Connection connection, int itemOneId, int itemTwoId)"));
-        assertTrue(source.contains("insertHopper(Connection connection, HabboItem hopper)"));
+        assertTrue(source.contains("createItem(Connectionconnection,inthabboId"));
+        assertTrue(source.contains("insertTeleportPair(Connectionconnection,intitemOneId,intitemTwoId)"));
+        assertTrue(source.contains("insertHopper(Connectionconnection,HabboItemhopper)"));
     }
 
     @Test
     void connectionAwareFactoriesDoNotOpenAnotherConnection() throws Exception {
         String source = itemManagerSource();
-        assertTrue(!method(source, "createItem(Connection connection, int habboId")
+        assertTrue(!method(source, "createItem(Connectionconnection,inthabboId")
                 .contains("getDataSource().getConnection()"));
-        assertTrue(!method(source, "insertTeleportPair(Connection connection")
-                .contains("getDataSource().getConnection()"));
-        assertTrue(!method(source, "insertHopper(Connection connection")
-                .contains("getDataSource().getConnection()"));
+        assertTrue(
+                !method(source, "insertTeleportPair(Connectionconnection").contains("getDataSource().getConnection()"));
+        assertTrue(!method(source, "insertHopper(Connectionconnection").contains("getDataSource().getConnection()"));
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogSpecialAssetTransactionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogSpecialAssetTransactionContractTest.java
@@ -1,40 +1,43 @@
 package com.eu.habbo.habbohotel.catalog;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class CatalogSpecialAssetTransactionContractTest {
     private static String source(String relativePath) throws Exception {
-        return Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/" + relativePath));
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/" + relativePath))
+                .replaceAll("\\s+", "");
     }
 
     @Test
     void specialAssetsAcceptTheOwningTransactionConnection() throws Exception {
-        assertTrue(source("bots/BotManager.java").contains(
-                "createBot(Connection connection, Map<String, String> data, String type, int ownerId)"));
-        assertTrue(source("users/HabboBadge.java").contains("insert(Connection connection)"));
-        assertTrue(source("pets/Pet.java").contains("save(Connection connection)"));
-        assertTrue(source("pets/PetManager.java").contains(
-                "createPet(Connection connection, Item item, String name, String race, String color, GameClient client)"));
-        assertTrue(source("users/inventory/EffectsComponent.java").contains(
-                "persistEffect(Connection connection, int userId, int effectId, int duration)"));
-        assertTrue(source("guilds/GuildManager.java").contains(
-                "persistGuild(Connection connection, int furniId, int guildId)"));
+        assertTrue(source("bots/BotManager.java")
+                .contains("createBot(Connectionconnection,Map<String,String>data,Stringtype,intownerId)"));
+        assertTrue(source("users/HabboBadge.java").contains("insert(Connectionconnection)"));
+        assertTrue(source("pets/Pet.java").contains("save(Connectionconnection)"));
+        assertTrue(source("pets/PetManager.java")
+                .contains(
+                        "createPet(Connectionconnection,Itemitem,Stringname,Stringrace,Stringcolor,GameClientclient)"));
+        assertTrue(source("users/inventory/EffectsComponent.java")
+                .contains("persistEffect(Connectionconnection,intuserId,inteffectId,intduration)"));
+        assertTrue(source("guilds/GuildManager.java")
+                .contains("persistGuild(Connectionconnection,intfurniId,intguildId)"));
     }
 
     @Test
     void connectionAwareMethodsPropagateSqlFailures() throws Exception {
-        assertTrue(source("bots/BotManager.java").contains(
-                "createBot(Connection connection, Map<String, String> data, String type, int ownerId) throws SQLException"));
-        assertTrue(source("users/HabboBadge.java").contains("insert(Connection connection) throws SQLException"));
-        assertTrue(source("pets/Pet.java").contains("save(Connection connection) throws SQLException"));
-        assertTrue(source("users/inventory/EffectsComponent.java").contains(
-                "persistEffect(Connection connection, int userId, int effectId, int duration) throws SQLException"));
-        assertTrue(source("guilds/GuildManager.java").contains(
-                "persistGuild(Connection connection, int furniId, int guildId) throws SQLException"));
+        assertTrue(
+                source("bots/BotManager.java")
+                        .contains(
+                                "createBot(Connectionconnection,Map<String,String>data,Stringtype,intownerId)throwsSQLException"));
+        assertTrue(source("users/HabboBadge.java").contains("insert(Connectionconnection)throwsSQLException"));
+        assertTrue(source("pets/Pet.java").contains("save(Connectionconnection)throwsSQLException"));
+        assertTrue(source("users/inventory/EffectsComponent.java")
+                .contains("persistEffect(Connectionconnection,intuserId,inteffectId,intduration)throwsSQLException"));
+        assertTrue(source("guilds/GuildManager.java")
+                .contains("persistGuild(Connectionconnection,intfurniId,intguildId)throwsSQLException"));
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/VoucherClaimContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/VoucherClaimContractTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-
 import org.junit.jupiter.api.Test;
 
 class VoucherClaimContractTest {
@@ -13,32 +12,35 @@ class VoucherClaimContractTest {
     }
 
     private static String catalogManagerSource() throws Exception {
-        return Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"));
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"))
+                .replaceAll("\\s+", "");
     }
 
     @Test
     void voucherClaimIsSynchronizedAndPersistsBeforeRewardEligibility() throws Exception {
         String source = voucherSource();
 
-        assertTrue(source.contains("public synchronized ClaimResult claimForUser(int userId)"),
+        assertTrue(
+                source.contains("public synchronized ClaimResult claimForUser(int userId)"),
                 "voucher claim should check limits and persist history under a per-voucher lock");
-        assertTrue(source.contains("private boolean insertHistoryEntry"),
+        assertTrue(
+                source.contains("private boolean insertHistoryEntry"),
                 "history insert should report database failure to the caller");
 
         int insertCall = source.indexOf("insertHistoryEntry(userId, timestamp)");
         int memoryAppend = source.indexOf("this.history.add(new VoucherHistoryEntry(this.id, userId, timestamp))");
 
         assertTrue(insertCall > -1, "claimForUser must persist the history row");
-        assertTrue(memoryAppend > insertCall,
-                "in-memory history must only be updated after the database insert succeeds");
+        assertTrue(
+                memoryAppend > insertCall, "in-memory history must only be updated after the database insert succeeds");
     }
 
     @Test
     void catalogRewardsOnlyAfterVoucherClaimSucceeds() throws Exception {
         String source = catalogManagerSource();
 
-        int claim = source.indexOf("Voucher.ClaimResult claimResult = voucher.claimForUser");
-        int claimedGuard = source.indexOf("case CLAIMED", claim);
+        int claim = source.indexOf("Voucher.ClaimResultclaimResult=voucher.claimForUser");
+        int claimedGuard = source.indexOf("caseCLAIMED", claim);
         int pointsGrant = source.indexOf("client.getHabbo().givePoints", claim);
         int creditsGrant = source.indexOf("client.getHabbo().giveCredits", claim);
 

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/users/WalletMutationContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/users/WalletMutationContractTest.java
@@ -1,11 +1,10 @@
 package com.eu.habbo.habbohotel.users;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class WalletMutationContractTest {
     @Test
@@ -20,16 +19,18 @@ class WalletMutationContractTest {
         int currencyLock = info.indexOf("synchronized (this.currencyLock)", tryCurrency);
         int currencyMath = info.indexOf("WalletBalanceMath.checkedBalance(current, amount)", currencyLock);
 
-        assertTrue(creditLock > tryCredits && creditMath > creditLock,
+        assertTrue(
+                creditLock > tryCredits && creditMath > creditLock,
                 "credit read-modify-write must be checked while holding the wallet lock");
-        assertTrue(currencyLock > tryCurrency && currencyMath > currencyLock,
+        assertTrue(
+                currencyLock > tryCurrency && currencyMath > currencyLock,
                 "currency read-modify-write must be checked while holding the wallet lock");
     }
 
     @Test
     void paidCustomBadgeDebitIsAtomicAndCreateIsSerializedPerUser() throws Exception {
-        String badge = Files.readString(Path.of(
-                "src/main/java/com/eu/habbo/habbohotel/users/custombadge/CustomBadgeManager.java"));
+        String badge = Files.readString(
+                Path.of("src/main/java/com/eu/habbo/habbohotel/users/custombadge/CustomBadgeManager.java"));
 
         int create = badge.indexOf("public CustomBadge create(");
         int userLock = badge.indexOf("synchronized (userLock)", create);
@@ -46,15 +47,17 @@ class WalletMutationContractTest {
     @Test
     void debitPluginsCannotSilentlyReduceTheAmountCharged() throws Exception {
         String habbo = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/users/Habbo.java"));
-        String marketplace = Files.readString(Path.of(
-                "src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlace.java"));
+        String marketplace = Files.readString(
+                        Path.of("src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlace.java"))
+                .replaceAll("\\s+", "");
 
-        assertTrue(habbo.contains("event.credits != -credits"),
+        assertTrue(
+                habbo.contains("event.credits != -credits"),
                 "a successful exact credit debit must remove the requested amount");
-        assertTrue(habbo.contains("event.type != type || event.points != -points"),
+        assertTrue(
+                habbo.contains("event.type != type || event.points != -points"),
                 "a successful exact points debit must preserve currency type and amount");
-        assertTrue(marketplace.contains("event.credits != -price"));
-        assertTrue(marketplace.contains(
-                "event.type != MARKETPLACE_CURRENCY || event.points != -price"));
+        assertTrue(marketplace.contains("event.credits!=-price"));
+        assertTrue(marketplace.contains("event.type!=MARKETPLACE_CURRENCY||event.points!=-price"));
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/plugin/ConfigurationBindingBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/plugin/ConfigurationBindingBehaviorTest.java
@@ -1,0 +1,56 @@
+package com.eu.habbo.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.habbohotel.rooms.RoomManager;
+import com.eu.habbo.plugin.events.emulator.EmulatorConfigUpdatedEvent;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ConfigurationBindingBehaviorTest {
+
+    private ConfigurationManager originalConfig;
+    private boolean originalShowPublicRooms;
+
+    @TempDir
+    Path tempDirectory;
+
+    @BeforeEach
+    void installConfiguration() throws Exception {
+        Field field = Emulator.class.getDeclaredField("config");
+        field.setAccessible(true);
+        this.originalConfig = (ConfigurationManager) field.get(null);
+        this.originalShowPublicRooms = RoomManager.SHOW_PUBLIC_IN_POPULAR_TAB;
+
+        Path config = this.tempDirectory.resolve("config.ini");
+        Files.writeString(
+                config,
+                "discount.additional.thresholds=invalid\n"
+                        + "hotel.navigator.populartab.publics=true\n");
+        field.set(null, new ConfigurationManager(config.toString()));
+    }
+
+    @AfterEach
+    void restoreConfiguration() throws Exception {
+        Field field = Emulator.class.getDeclaredField("config");
+        field.setAccessible(true);
+        field.set(null, this.originalConfig);
+        RoomManager.SHOW_PUBLIC_IN_POPULAR_TAB = this.originalShowPublicRooms;
+    }
+
+    @Test
+    void malformedValueDoesNotPreventLaterKeysFromApplying() {
+        assertDoesNotThrow(
+                () -> PluginManager.globalOnConfigurationUpdated(
+                        new EmulatorConfigUpdatedEvent()));
+        assertTrue(RoomManager.SHOW_PUBLIC_IN_POPULAR_TAB);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/plugin/ConfigurationBindingBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/plugin/ConfigurationBindingBehaviorTest.java
@@ -1,12 +1,14 @@
 package com.eu.habbo.plugin;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.core.ConfigurationManager;
-import com.eu.habbo.habbohotel.rooms.RoomManager;
-import com.eu.habbo.plugin.events.emulator.EmulatorConfigUpdatedEvent;
+import com.eu.habbo.habbohotel.catalog.TargetOffer;
+import com.eu.habbo.messages.incoming.hotelview.HotelViewRequestLTDAvailabilityEvent;
+import com.eu.habbo.messages.outgoing.catalog.DiscountComposer;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -18,7 +20,17 @@ import org.junit.jupiter.api.io.TempDir;
 class ConfigurationBindingBehaviorTest {
 
     private ConfigurationManager originalConfig;
-    private boolean originalShowPublicRooms;
+    private int originalMaximumItems;
+    private int originalBatchSize;
+    private int originalFreeItems;
+    private int originalMinimumBonus;
+    private int[] originalDiscountThresholds;
+    private boolean originalLtdEnabled;
+    private int originalLtdTimestamp;
+    private int originalLtdItemId;
+    private int originalLtdPageId;
+    private String originalLtdItemName;
+    private int originalTargetOffer;
 
     @TempDir
     Path tempDirectory;
@@ -28,13 +40,24 @@ class ConfigurationBindingBehaviorTest {
         Field field = Emulator.class.getDeclaredField("config");
         field.setAccessible(true);
         this.originalConfig = (ConfigurationManager) field.get(null);
-        this.originalShowPublicRooms = RoomManager.SHOW_PUBLIC_IN_POPULAR_TAB;
+        this.originalMaximumItems = DiscountComposer.MAXIMUM_ALLOWED_ITEMS;
+        this.originalBatchSize = DiscountComposer.DISCOUNT_BATCH_SIZE;
+        this.originalFreeItems = DiscountComposer.DISCOUNT_AMOUNT_PER_BATCH;
+        this.originalMinimumBonus = DiscountComposer.MINIMUM_DISCOUNTS_FOR_BONUS;
+        this.originalDiscountThresholds = DiscountComposer.ADDITIONAL_DISCOUNT_THRESHOLDS;
+        this.originalLtdEnabled = HotelViewRequestLTDAvailabilityEvent.ENABLED;
+        this.originalLtdTimestamp = HotelViewRequestLTDAvailabilityEvent.TIMESTAMP;
+        this.originalLtdItemId = HotelViewRequestLTDAvailabilityEvent.ITEM_ID;
+        this.originalLtdPageId = HotelViewRequestLTDAvailabilityEvent.PAGE_ID;
+        this.originalLtdItemName = HotelViewRequestLTDAvailabilityEvent.ITEM_NAME;
+        this.originalTargetOffer = TargetOffer.ACTIVE_TARGET_OFFER_ID;
 
         Path config = this.tempDirectory.resolve("config.ini");
         Files.writeString(
                 config,
                 "discount.additional.thresholds=invalid\n"
-                        + "hotel.navigator.populartab.publics=true\n");
+                        + "hotel.view.ltdcountdown.itemname=test\n"
+                        + "hotel.targetoffer.id=214\n");
         field.set(null, new ConfigurationManager(config.toString()));
     }
 
@@ -43,14 +66,23 @@ class ConfigurationBindingBehaviorTest {
         Field field = Emulator.class.getDeclaredField("config");
         field.setAccessible(true);
         field.set(null, this.originalConfig);
-        RoomManager.SHOW_PUBLIC_IN_POPULAR_TAB = this.originalShowPublicRooms;
+        DiscountComposer.MAXIMUM_ALLOWED_ITEMS = this.originalMaximumItems;
+        DiscountComposer.DISCOUNT_BATCH_SIZE = this.originalBatchSize;
+        DiscountComposer.DISCOUNT_AMOUNT_PER_BATCH = this.originalFreeItems;
+        DiscountComposer.MINIMUM_DISCOUNTS_FOR_BONUS = this.originalMinimumBonus;
+        DiscountComposer.ADDITIONAL_DISCOUNT_THRESHOLDS = this.originalDiscountThresholds;
+        HotelViewRequestLTDAvailabilityEvent.ENABLED = this.originalLtdEnabled;
+        HotelViewRequestLTDAvailabilityEvent.TIMESTAMP = this.originalLtdTimestamp;
+        HotelViewRequestLTDAvailabilityEvent.ITEM_ID = this.originalLtdItemId;
+        HotelViewRequestLTDAvailabilityEvent.PAGE_ID = this.originalLtdPageId;
+        HotelViewRequestLTDAvailabilityEvent.ITEM_NAME = this.originalLtdItemName;
+        TargetOffer.ACTIVE_TARGET_OFFER_ID = this.originalTargetOffer;
     }
 
     @Test
     void malformedValueDoesNotPreventLaterKeysFromApplying() {
-        assertDoesNotThrow(
-                () -> PluginManager.globalOnConfigurationUpdated(
-                        new EmulatorConfigUpdatedEvent()));
-        assertTrue(RoomManager.SHOW_PUBLIC_IN_POPULAR_TAB);
+        assertDoesNotThrow(() -> new CatalogConfigurationBinder(Emulator.getConfig(), false).bindDiscountsAndOffers());
+        assertEquals(214, TargetOffer.ACTIVE_TARGET_OFFER_ID);
+        assertSame(this.originalDiscountThresholds, DiscountComposer.ADDITIONAL_DISCOUNT_THRESHOLDS);
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/plugin/ConfigurationPublicationContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/plugin/ConfigurationPublicationContractTest.java
@@ -1,0 +1,47 @@
+package com.eu.habbo.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.eu.habbo.habbohotel.bots.Bot;
+import com.eu.habbo.habbohotel.catalog.CatalogManager;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomChatMessage;
+import com.eu.habbo.habbohotel.rooms.RoomLayout;
+import com.eu.habbo.habbohotel.rooms.RoomManager;
+import com.eu.habbo.habbohotel.users.HabboManager;
+import com.eu.habbo.habbohotel.wired.core.WiredEngine;
+import com.eu.habbo.messages.PacketManager;
+import com.eu.habbo.messages.outgoing.catalog.DiscountComposer;
+import com.eu.habbo.messages.outgoing.catalog.GiftConfigurationComposer;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ConfigurationPublicationContractTest {
+
+    @Test
+    void crossThreadConfigurationTargetsAreVolatile() throws Exception {
+        List<Field> fields = List.of(
+                Room.class.getField("HABBO_CHAT_DELAY"),
+                RoomChatMessage.class.getField("BANNED_BUBBLES"),
+                RoomLayout.class.getField("MAXIMUM_STEP_HEIGHT"),
+                RoomManager.class.getField("SHOW_PUBLIC_IN_POPULAR_TAB"),
+                WiredEngine.class.getField("MAX_RECURSION_DEPTH"),
+                PacketManager.class.getField("DEBUG_SHOW_PACKETS"),
+                CatalogManager.class.getField("PURCHASE_COOLDOWN"),
+                HabboManager.class.getField("WELCOME_MESSAGE"),
+                DiscountComposer.class.getField("ADDITIONAL_DISCOUNT_THRESHOLDS"),
+                GiftConfigurationComposer.class.getField("BOX_TYPES"),
+                Bot.class.getField("PLACEMENT_MESSAGES"));
+
+        for (Field field : fields) {
+            assertTrue(
+                    Modifier.isVolatile(field.getModifiers()),
+                    () -> field.getDeclaringClass().getSimpleName()
+                            + "."
+                            + field.getName()
+                            + " must publish reloads through a volatile field");
+        }
+    }
+}

--- a/config example/config.ini.example
+++ b/config example/config.ini.example
@@ -42,8 +42,8 @@ db.pool.connection_timeout_ms = 10000
 db.pool.idle_timeout_ms       = 600000
 db.pool.max_lifetime_ms       = 1800000
 db.pool.validation_timeout_ms = 5000
-# set db.pool.leak_detection_ms to 0 to disable
-db.pool.leak_detection_ms     = 20000 set to 0 to disable
+# Set to 0 to disable leak detection.
+db.pool.leak_detection_ms     = 20000
 
 enc.enabled=false
 enc.e=3
@@ -68,7 +68,7 @@ nitro.secure.master_key=change-me-to-a-long-random-secret
 login.remember.enabled=true
 login.remember.duration.days=30
 # Optional: set a persistent remember-me JWT secret here, otherwise one is generated and stored in emulator_settings.
-login.remember.jwt.secret=hange-me-to-a-long-random-secret
+login.remember.jwt.secret=change-me-to-a-long-random-secret
 # Lifetime for SSO tickets minted by Polaris's built-in password/remember endpoints.
 login.sso.ticket.ttl.seconds=60
 

--- a/docs/configuration-ownership.md
+++ b/docs/configuration-ownership.md
@@ -1,0 +1,17 @@
+# Configuration ownership
+
+Polaris loads startup-file or environment values first. Once the database is
+ready, `emulator_settings` and `wired_emulator_settings` overlay those values.
+Unknown keys remain valid because plugins may own configuration outside the
+first-party registry.
+
+Runtime changes made through `ConfigurationManager.update` are marked dirty and
+saved during shutdown. Values that were only loaded are not written back.
+This means an operator or administration tool may update a different database
+setting while Polaris is running without shutdown silently restoring the old
+in-memory value. If the same key is changed through the runtime API, that
+explicit runtime change is authoritative and is saved.
+
+Subsystem binders support live reload for database-backed hotel settings. Each
+key applies independently; malformed values retain the prior value and do not
+prevent later settings from applying.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1,0 +1,61 @@
+# Polaris startup configuration reference
+
+Unknown keys remain allowed for plugins. Database-backed hotel settings are documented separately from this startup-file registry.
+
+| Key | Type | Default | Environment | Restart | Live reload | Description |
+| --- | --- | --- | --- | --- | --- | --- |
+| `client.release.allowed` | string | `` | — | yes | no | Polaris startup setting. |
+| `crypto.ws.enabled` | boolean | `false` | — | yes | no | WebSocket listener setting. |
+| `db.database` | string | `` | `DB_DATABASE` | yes | no | Database startup setting. |
+| `db.hostname` | string | `` | `DB_HOSTNAME` | yes | no | Database startup setting. |
+| `db.integrity.audit.max_duration_seconds` | integer | `0` | — | yes | no | Startup integrity-audit setting. |
+| `db.integrity.audit.mode` | string | `warn` | — | yes | no | Startup integrity-audit setting. |
+| `db.integrity.audit.query_timeout_seconds` | integer | `0` | — | yes | no | Startup integrity-audit setting. |
+| `db.integrity.audit.sample_limit` | integer | `0` | — | yes | no | Startup integrity-audit setting. |
+| `db.migrate.on_startup` | boolean | `false` | `DB_MIGRATE_ON_STARTUP` | yes | no | Database startup setting. |
+| `db.migrations.backup.directory` | string | `` | — | yes | no | Migration backup setting. |
+| `db.migrations.backup.enabled` | boolean | `false` | — | yes | no | Migration backup setting. |
+| `db.migrations.backup.executable` | string | `` | — | yes | no | Migration backup setting. |
+| `db.migrations.backup.keep` | integer | `0` | — | yes | no | Migration backup setting. |
+| `db.migrations.backup.timeout_seconds` | integer | `0` | — | yes | no | Migration backup setting. |
+| `db.params` | string | `` | `DB_PARAMS` | yes | no | Database startup setting. |
+| `db.password` | string | `` | `DB_PASSWORD` | yes | no | Database startup setting. |
+| `db.pool.connection_timeout_ms` | long | `0` | — | yes | no | Database connection-pool setting. |
+| `db.pool.idle_timeout_ms` | long | `0` | — | yes | no | Database connection-pool setting. |
+| `db.pool.leak_detection_ms` | long | `0` | — | yes | no | Database connection-pool setting. |
+| `db.pool.max_lifetime_ms` | long | `0` | — | yes | no | Database connection-pool setting. |
+| `db.pool.maxsize` | integer | `0` | — | yes | no | Database connection-pool setting. |
+| `db.pool.minsize` | integer | `0` | — | yes | no | Database connection-pool setting. |
+| `db.pool.validation_timeout_ms` | long | `0` | — | yes | no | Database connection-pool setting. |
+| `db.port` | integer | `0` | `DB_PORT` | yes | no | Database startup setting. |
+| `db.slow_query.enabled` | boolean | `false` | — | yes | no | Sanitized slow-query diagnostic setting. |
+| `db.slow_query.max_sql_length` | integer | `0` | — | yes | no | Sanitized slow-query diagnostic setting. |
+| `db.slow_query.threshold_ms` | integer | `0` | — | yes | no | Sanitized slow-query diagnostic setting. |
+| `db.username` | string | `` | `DB_USERNAME` | yes | no | Database startup setting. |
+| `e2e.enabled` | boolean | `false` | — | yes | no | Polaris startup setting. |
+| `enc.d` | string | `` | — | yes | no | Legacy transport encryption setting. |
+| `enc.e` | string | `` | — | yes | no | Legacy transport encryption setting. |
+| `enc.enabled` | boolean | `false` | — | yes | no | Legacy transport encryption setting. |
+| `enc.n` | string | `` | — | yes | no | Legacy transport encryption setting. |
+| `game.host` | string | `` | `EMU_HOST` | yes | no | Game listener setting. |
+| `game.port` | integer | `0` | `EMU_PORT` | yes | no | Game listener setting. |
+| `habbo.console.style` | string | `` | — | yes | no | Polaris startup setting. |
+| `login.news.limit` | integer | `0` | — | yes | no | Built-in login endpoint setting. |
+| `login.remember.duration.days` | integer | `0` | — | yes | no | Built-in login endpoint setting. |
+| `login.remember.enabled` | boolean | `false` | — | yes | no | Built-in login endpoint setting. |
+| `login.remember.jwt.secret` | string | `` | — | yes | no | Built-in login endpoint setting. |
+| `login.sso.ticket.ttl.seconds` | integer | `0` | — | yes | no | Built-in login endpoint setting. |
+| `nitro.secure.api.enabled` | boolean | `false` | — | yes | no | Nitro secure-asset runtime setting. |
+| `nitro.secure.assets.enabled` | boolean | `false` | — | yes | no | Nitro secure-asset runtime setting. |
+| `nitro.secure.config.root` | string | `` | — | yes | no | Nitro secure-asset runtime setting. |
+| `nitro.secure.gamedata.root` | string | `` | — | yes | no | Nitro secure-asset runtime setting. |
+| `nitro.secure.master_key` | string | `` | — | yes | no | Nitro secure-asset runtime setting. |
+| `nitro.secure.session_ttl_sec` | integer | `0` | — | yes | no | Nitro secure-asset runtime setting. |
+| `rcon.allowed` | string | `` | `RCON_ALLOWED` | yes | no | RCON listener setting. |
+| `rcon.host` | string | `` | `RCON_HOST` | yes | no | RCON listener setting. |
+| `rcon.port` | integer | `0` | `RCON_PORT` | yes | no | RCON listener setting. |
+| `session.reconnect.grace.seconds` | integer | `0` | — | yes | no | Polaris startup setting. |
+| `ws.enabled` | boolean | `false` | — | yes | no | WebSocket listener setting. |
+| `ws.host` | string | `` | — | yes | no | WebSocket listener setting. |
+| `ws.port` | integer | `0` | — | yes | no | WebSocket listener setting. |
+| `ws.whitelist` | string | `` | — | yes | no | WebSocket listener setting. |


### PR DESCRIPTION
Splits hotel setting reloads into room, wired, network, and catalog binders with per-key failure isolation and safe cross-thread publication. Adds typed startup key metadata and generated configuration documentation, keeps room-layout coordinate narrowing explicit, fixes the shipped example values, and limits shutdown persistence to settings changed through the runtime API.

Manual testing:
- Set `commands.cmd_chatcolor.banned_numbers` to an invalid value and `hotel.navigator.populartab.publics` to `true`, reload settings, and confirm public rooms update while the prior chat-bubble list remains active.
- Change one setting through the runtime administration path, edit a different `emulator_settings` row directly, shut down cleanly, and confirm only the runtime-changed key is written back.