### PR TITLE
refactor(runtime): clarify manager ownership

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemInteractionRegistry.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemInteractionRegistry.java
@@ -1,0 +1,56 @@
+package com.eu.habbo.habbohotel.items;
+
+import com.eu.habbo.habbohotel.users.HabboItem;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+final class ItemInteractionRegistry {
+    private final Set<ItemInteraction> interactions = new HashSet<>();
+
+    boolean add(ItemInteraction interaction) {
+        return interactions.add(interaction);
+    }
+
+    void addChecked(ItemInteraction itemInteraction) {
+        for (ItemInteraction interaction : interactions) {
+            if (interaction.getType() == itemInteraction.getType()
+                    || interaction.getName().equalsIgnoreCase(itemInteraction.getName())) {
+                throw new RuntimeException("Interaction Types must be unique. An class with type: "
+                        + interaction.getClass().getName() + " was already added OR the key: "
+                        + interaction.getName() + " is already in use.");
+            }
+        }
+
+        interactions.add(itemInteraction);
+    }
+
+    ItemInteraction find(Class<? extends HabboItem> type) {
+        for (ItemInteraction interaction : interactions) {
+            if (interaction.getType() == type) {
+                return interaction;
+            }
+        }
+        return null;
+    }
+
+    ItemInteraction find(String type) {
+        for (ItemInteraction interaction : interactions) {
+            if (interaction.getName().equalsIgnoreCase(type)) {
+                return interaction;
+            }
+        }
+        return null;
+    }
+
+    List<String> sortedNames() {
+        List<String> names = new ArrayList<>();
+        for (ItemInteraction interaction : interactions) {
+            names.add(interaction.getName());
+        }
+        Collections.sort(names);
+        return names;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -391,12 +391,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -421,7 +418,7 @@ public class ItemManager {
 
     private final Int2ObjectMap<Item> items;
     private final Int2ObjectMap<CrackableReward> crackableRewards;
-    private final Set<ItemInteraction> interactionsList;
+    private final ItemInteractionRegistry interactionsList;
     private final Map<String, SoundTrack> soundTracks;
     private final YoutubeManager youtubeManager;
     private final WiredHighscoreManager highscoreManager;
@@ -430,7 +427,7 @@ public class ItemManager {
     public ItemManager() {
         this.items = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
         this.crackableRewards = new Int2ObjectOpenHashMap<>();
-        this.interactionsList = new HashSet<>();
+        this.interactionsList = new ItemInteractionRegistry();
         this.soundTracks = new HashMap<>();
         this.youtubeManager = new YoutubeManager();
         this.highscoreManager = new WiredHighscoreManager();
@@ -1052,20 +1049,13 @@ public class ItemManager {
     }
 
     public void addItemInteraction(ItemInteraction itemInteraction) {
-        for (ItemInteraction interaction : this.interactionsList) {
-            if (interaction.getType() == itemInteraction.getType()
-                    || interaction.getName().equalsIgnoreCase(itemInteraction.getName()))
-                throw new RuntimeException("Interaction Types must be unique. An class with type: "
-                        + interaction.getClass().getName() + " was already added OR the key: " + interaction.getName()
-                        + " is already in use.");
-        }
-
-        this.interactionsList.add(itemInteraction);
+        this.interactionsList.addChecked(itemInteraction);
     }
 
     public ItemInteraction getItemInteraction(Class<? extends HabboItem> type) {
-        for (ItemInteraction interaction : this.interactionsList) {
-            if (interaction.getType() == type) return interaction;
+        ItemInteraction interaction = this.interactionsList.find(type);
+        if (interaction != null) {
+            return interaction;
         }
 
         LOGGER.debug("Can't find interaction class: {}", type.getName());
@@ -1073,8 +1063,9 @@ public class ItemManager {
     }
 
     public ItemInteraction getItemInteraction(String type) {
-        for (ItemInteraction interaction : this.interactionsList) {
-            if (interaction.getName().equalsIgnoreCase(type)) return interaction;
+        ItemInteraction interaction = this.interactionsList.find(type);
+        if (interaction != null) {
+            return interaction;
         }
 
         return this.getItemInteraction(InteractionDefault.class);
@@ -1593,13 +1584,6 @@ public class ItemManager {
     }
 
     public List<String> getInteractionList() {
-        List<String> interactions = new ArrayList<>();
-
-        for (ItemInteraction interaction : this.interactionsList) {
-            interactions.add(interaction.getName());
-        }
-
-        Collections.sort(interactions);
-        return interactions;
+        return this.interactionsList.sortedNames();
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitIndex.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitIndex.java
@@ -10,12 +10,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 final class RoomUnitIndex {
     private final ConcurrentHashMap<Integer, Habbo> habbos = new ConcurrentHashMap<>(3);
-    private final Int2ObjectMap<Habbo> queue =
-            Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
-    private final Int2ObjectMap<Bot> bots =
-            Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
-    private final Int2ObjectMap<Pet> pets =
-            Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
+    private final Int2ObjectMap<Habbo> queue = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
+    private final Int2ObjectMap<Bot> bots = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
+    private final Int2ObjectMap<Pet> pets = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
     private volatile int unitCounter;
 
     ConcurrentHashMap<Integer, Habbo> habbos() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitIndex.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitIndex.java
@@ -1,0 +1,52 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.bots.Bot;
+import com.eu.habbo.habbohotel.pets.Pet;
+import com.eu.habbo.habbohotel.users.Habbo;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+final class RoomUnitIndex {
+    private final ConcurrentHashMap<Integer, Habbo> habbos = new ConcurrentHashMap<>(3);
+    private final Int2ObjectMap<Habbo> queue =
+            Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
+    private final Int2ObjectMap<Bot> bots =
+            Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
+    private final Int2ObjectMap<Pet> pets =
+            Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
+    private volatile int unitCounter;
+
+    ConcurrentHashMap<Integer, Habbo> habbos() {
+        return habbos;
+    }
+
+    Int2ObjectMap<Habbo> queue() {
+        return queue;
+    }
+
+    Int2ObjectMap<Bot> bots() {
+        return bots;
+    }
+
+    Int2ObjectMap<Pet> pets() {
+        return pets;
+    }
+
+    int unitCounter() {
+        return unitCounter;
+    }
+
+    int nextUnitId() {
+        return unitCounter++;
+    }
+
+    void incrementUnitId() {
+        unitCounter++;
+    }
+
+    void resetUnitCounter() {
+        unitCounter = 0;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitManager.java
@@ -17,22 +17,30 @@ import com.eu.habbo.habbohotel.wired.core.WiredFreezeUtil;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredMoveCarryHelper;
 import com.eu.habbo.habbohotel.wired.core.WiredUserMovementHelper;
-import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorMessagesComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorCode;
+import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorMessagesComposer;
 import com.eu.habbo.messages.outgoing.inventory.AddPetComposer;
 import com.eu.habbo.messages.outgoing.rooms.pets.RoomPetComposer;
-import com.eu.habbo.messages.outgoing.rooms.users.*;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUnitIdleComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserDanceComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserEffectComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserHandItemComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserRemoveComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RoomUnitManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(RoomUnitManager.class);
@@ -187,18 +195,21 @@ public class RoomUnitManager {
             this.currentHabbos.remove(habbo.getHabboInfo().getId());
         }
 
-        this.room.getUserVariableManager().clearAssignmentsForUser(habbo.getHabboInfo().getId());
+        this.room
+                .getUserVariableManager()
+                .clearAssignmentsForUser(habbo.getHabboInfo().getId());
 
         if (sendRemovePacket && habbo.getRoomUnit() != null && !habbo.getRoomUnit().isTeleporting) {
             this.room.sendComposer(new RoomUserRemoveComposer(habbo.getRoomUnit()).compose());
         }
 
         if (habbo.getRoomUnit().getCurrentLocation() != null) {
-            HabboItem item = this.room.getTopItemAt(habbo.getRoomUnit().getX(), habbo.getRoomUnit().getY());
+            HabboItem item = this.room.getTopItemAt(
+                    habbo.getRoomUnit().getX(), habbo.getRoomUnit().getY());
 
             if (item != null) {
                 try {
-                    item.onWalkOff(habbo.getRoomUnit(), this.room, new Object[]{});
+                    item.onWalkOff(habbo.getRoomUnit(), this.room, new Object[] {});
                 } catch (Exception e) {
                     LOGGER.error("Caught exception", e);
                 }
@@ -224,16 +235,16 @@ public class RoomUnitManager {
         this.room.scheduleDatabaseUserCountUpdate();
     }
 
-     public void kickHabbo(Habbo habbo, boolean alert) {
+    public void kickHabbo(Habbo habbo, boolean alert) {
         if (alert) {
-            habbo.getClient().sendResponse(
-                    new GenericErrorMessagesComposer(GenericErrorCode.KICKED_OUT_OF_ROOM));
+            habbo.getClient().sendResponse(new GenericErrorMessagesComposer(GenericErrorCode.KICKED_OUT_OF_ROOM));
         }
 
         habbo.getRoomUnit().isKicked = true;
         habbo.getRoomUnit().setGoalLocation(this.room.getLayout().getDoorTile());
 
-        if (habbo.getRoomUnit().getPath() == null || habbo.getRoomUnit().getPath().size() <= 1
+        if (habbo.getRoomUnit().getPath() == null
+                || habbo.getRoomUnit().getPath().size() <= 1
                 || this.room.isPublicRoom()) {
             habbo.getRoomUnit().setCanWalk(true);
             Emulator.getGameEnvironment().getRoomManager().leaveRoom(habbo, this.room);
@@ -302,7 +313,8 @@ public class RoomUnitManager {
             double z = habbo.getRoomUnit().getCurrentLocation().getStackHeight();
             boolean hadLayStatus = habbo.getRoomUnit().hasStatus(RoomUnitStatus.LAY);
 
-            boolean isRiding = habbo.getHabboInfo() != null && habbo.getHabboInfo().getRiding() != null;
+            boolean isRiding =
+                    habbo.getHabboInfo() != null && habbo.getHabboInfo().getRiding() != null;
 
             if (isRiding) {
                 if (habbo.getRoomUnit().hasStatus(RoomUnitStatus.SIT)) {
@@ -320,8 +332,7 @@ public class RoomUnitManager {
                     habbo.getRoomUnit().setZ(topItem.getZ());
                     habbo.getRoomUnit().setPreviousLocationZ(topItem.getZ());
                     habbo.getRoomUnit().setRotation(RoomUserRotation.fromValue(topItem.getRotation()));
-                    habbo.getRoomUnit().setStatus(RoomUnitStatus.SIT,
-                            String.valueOf(Item.getCurrentHeight(topItem)));
+                    habbo.getRoomUnit().setStatus(RoomUnitStatus.SIT, String.valueOf(Item.getCurrentHeight(topItem)));
                     habbo.getRoomUnit().cmdSit = false;
                 } else if (habbo.getRoomUnit().cmdSit) {
                     habbo.getRoomUnit().setZ(z - 0.5);
@@ -334,7 +345,11 @@ public class RoomUnitManager {
             } else if (topItem != null && topItem.getBaseItem().allowLay()) {
                 BedProfile bedProfile = new BedProfile(topItem);
 
-                RoomTile pillowTile = bedProfile.snapToLay(this.room, topItem, habbo.getRoomUnit().getX(), habbo.getRoomUnit().getY());
+                RoomTile pillowTile = bedProfile.snapToLay(
+                        this.room,
+                        topItem,
+                        habbo.getRoomUnit().getX(),
+                        habbo.getRoomUnit().getY());
 
                 if (pillowTile != null && bedProfile.isDouble()) {
                     Set<Habbo> habbosAtPillow = this.getHabbosAt(pillowTile.x, pillowTile.y);
@@ -356,7 +371,10 @@ public class RoomUnitManager {
                 habbo.getRoomUnit().setPreviousLocationZ(topItem.getZ());
                 habbo.getRoomUnit().setRotation(RoomUserRotation.fromValue(topItem.getRotation() % 4));
                 double layHeight = Item.getCurrentHeight(topItem) + bedProfile.getLayZOffset();
-                habbo.getRoomUnit().setStatus(RoomUnitStatus.LAY, layHeight + ";" + bedProfile.getLayXOffset() + ";" + bedProfile.getLayYOffset());
+                habbo.getRoomUnit()
+                        .setStatus(
+                                RoomUnitStatus.LAY,
+                                layHeight + ";" + bedProfile.getLayXOffset() + ";" + bedProfile.getLayYOffset());
             } else {
                 if (habbo.getRoomUnit().hasStatus(RoomUnitStatus.SIT)) {
                     habbo.getRoomUnit().removeStatus(RoomUnitStatus.SIT);
@@ -433,8 +451,8 @@ public class RoomUnitManager {
                         bot.getRoomUnit().setBodyRotation(RoomUserRotation.fromValue(set.getInt("rot")));
                         bot.getRoomUnit().setHeadRotation(RoomUserRotation.fromValue(set.getInt("rot")));
                         bot.getRoomUnit().setDanceType(DanceType.values()[set.getInt("dance")]);
-                        bot.getRoomUnit().setLocation(this.room.getLayout().getTile(
-                                (short) set.getInt("x"), (short) set.getInt("y")));
+                        bot.getRoomUnit().setLocation(this.room.getLayout().getTile((short) set.getInt("x"), (short)
+                                set.getInt("y")));
                         bot.getRoomUnit().setZ(set.getDouble("z"));
                         bot.getRoomUnit().setPreviousLocationZ(set.getDouble("z"));
                         bot.getRoomUnit().setPathFinderRoom(this.room);
@@ -594,14 +612,17 @@ public class RoomUnitManager {
                 bot.getRoomUnit().setZ(topItem.getZ());
                 bot.getRoomUnit().setPreviousLocationZ(topItem.getZ());
                 bot.getRoomUnit().setRotation(RoomUserRotation.fromValue(topItem.getRotation()));
-                bot.getRoomUnit().setStatus(RoomUnitStatus.SIT,
-                        String.valueOf(Item.getCurrentHeight(topItem)));
+                bot.getRoomUnit().setStatus(RoomUnitStatus.SIT, String.valueOf(Item.getCurrentHeight(topItem)));
             } else if (topItem != null && topItem.getBaseItem().allowLay()) {
                 bot.getRoomUnit().setZ(topItem.getZ());
                 bot.getRoomUnit().setPreviousLocationZ(topItem.getZ());
                 BedProfile botBedProfile = new BedProfile(topItem);
                 double botLayHeight = Item.getCurrentHeight(topItem) + botBedProfile.getLayZOffset();
-                bot.getRoomUnit().setStatus(RoomUnitStatus.LAY, botLayHeight + ";" + botBedProfile.getLayXOffset() + ";" + botBedProfile.getLayYOffset());
+                bot.getRoomUnit()
+                        .setStatus(
+                                RoomUnitStatus.LAY,
+                                botLayHeight + ";" + botBedProfile.getLayXOffset() + ";"
+                                        + botBedProfile.getLayYOffset());
             } else {
                 if (bot.getRoomUnit().hasStatus(RoomUnitStatus.SIT)) {
                     bot.getRoomUnit().removeStatus(RoomUnitStatus.SIT);
@@ -618,8 +639,8 @@ public class RoomUnitManager {
 
         if (!bots.isEmpty()) {
             this.room.sendComposer(new RoomUserStatusComposer(
-                    bots.stream().map(Bot::getRoomUnit).collect(Collectors.toCollection(HashSet::new)),
-                    true).compose());
+                            bots.stream().map(Bot::getRoomUnit).collect(Collectors.toCollection(HashSet::new)), true)
+                    .compose());
         }
     }
 
@@ -637,8 +658,8 @@ public class RoomUnitManager {
                     pet.getRoomUnit().setRoomUnitType(RoomUnitType.PET);
                     pet.getRoomUnit().setBodyRotation(RoomUserRotation.fromValue(set.getInt("rot")));
                     pet.getRoomUnit().setHeadRotation(RoomUserRotation.fromValue(set.getInt("rot")));
-                    pet.getRoomUnit().setLocation(this.room.getLayout().getTile(
-                            (short) set.getInt("x"), (short) set.getInt("y")));
+                    pet.getRoomUnit().setLocation(this.room.getLayout().getTile((short) set.getInt("x"), (short)
+                            set.getInt("y")));
                     pet.getRoomUnit().setZ(set.getDouble("z"));
                     pet.getRoomUnit().setPreviousLocationZ(set.getDouble("z"));
                     pet.getRoomUnit().setPathFinderRoom(this.room);
@@ -687,8 +708,11 @@ public class RoomUnitManager {
 
             Habbo habbo = this.getHabbo(pet.getUserId());
             if (habbo != null) {
-                this.room.getFurniOwnerNames().put(pet.getUserId(),
-                        this.getHabbo(pet.getUserId()).getHabboInfo().getUsername());
+                this.room
+                        .getFurniOwnerNames()
+                        .put(
+                                pet.getUserId(),
+                                this.getHabbo(pet.getUserId()).getHabboInfo().getUsername());
             }
         }
     }
@@ -721,16 +745,18 @@ public class RoomUnitManager {
             pet.getRoomUnit().setZ(z);
             if (pet.getRoomUnit().getCurrentLocation() == null) {
                 pet.getRoomUnit().setLocation(this.room.getLayout().getDoorTile());
-                pet.getRoomUnit().setRotation(RoomUserRotation.fromValue(
-                        this.room.getLayout().getDoorDirection()));
+                pet.getRoomUnit()
+                        .setRotation(
+                                RoomUserRotation.fromValue(this.room.getLayout().getDoorDirection()));
             }
 
             pet.needsUpdate = true;
 
             Habbo owner = this.getHabbo(pet.getUserId());
             if (owner != null) {
-                this.room.getFurniOwnerNames().put(pet.getUserId(),
-                        owner.getHabboInfo().getUsername());
+                this.room
+                        .getFurniOwnerNames()
+                        .put(pet.getUserId(), owner.getHabboInfo().getUsername());
             }
 
             this.addPet(pet);
@@ -796,8 +822,8 @@ public class RoomUnitManager {
 
         if (!pets.isEmpty()) {
             this.room.sendComposer(new RoomUserStatusComposer(
-                    pets.stream().map(Pet::getRoomUnit).collect(Collectors.toCollection(HashSet::new)),
-                    true).compose());
+                            pets.stream().map(Pet::getRoomUnit).collect(Collectors.toCollection(HashSet::new)), true)
+                    .compose());
         }
     }
 
@@ -820,7 +846,7 @@ public class RoomUnitManager {
                 ((RideablePet) pet).setRider(null);
             }
 
-            pet.run();  // Run synchronously to ensure DB is updated before returning pet to inventory
+            pet.run(); // Run synchronously to ensure DB is updated before returning pet to inventory
             habbo.getInventory().getPetsComponent().addPet(pet);
             habbo.getClient().sendResponse(new AddPetComposer(pet));
             this.currentPets.remove(pet.getId());
@@ -851,7 +877,7 @@ public class RoomUnitManager {
                 ((RideablePet) pet).setRider(null);
             }
 
-            pet.run();  // Run synchronously to ensure DB is updated before room reload
+            pet.run(); // Run synchronously to ensure DB is updated before room reload
 
             Habbo owner = Emulator.getGameEnvironment().getHabboManager().getHabbo(pet.getUserId());
             if (owner != null) {
@@ -890,25 +916,31 @@ public class RoomUnitManager {
         Set<RoomUnit> units = new HashSet<>();
 
         for (Habbo habbo : this.currentHabbos.values()) {
-            if (habbo != null && habbo.getRoomUnit() != null && habbo.getRoomUnit().getRoom() != null
-                    && habbo.getRoomUnit().getRoom().getId() == this.room.getId() && (atTile == null
-                    || habbo.getRoomUnit().getCurrentLocation() == atTile)) {
+            if (habbo != null
+                    && habbo.getRoomUnit() != null
+                    && habbo.getRoomUnit().getRoom() != null
+                    && habbo.getRoomUnit().getRoom().getId() == this.room.getId()
+                    && (atTile == null || habbo.getRoomUnit().getCurrentLocation() == atTile)) {
                 units.add(habbo.getRoomUnit());
             }
         }
 
         for (Pet pet : this.currentPets.values()) {
-            if (pet != null && pet.getRoomUnit() != null && pet.getRoomUnit().getRoom() != null
-                    && pet.getRoomUnit().getRoom().getId() == this.room.getId() && (atTile == null
-                    || pet.getRoomUnit().getCurrentLocation() == atTile)) {
+            if (pet != null
+                    && pet.getRoomUnit() != null
+                    && pet.getRoomUnit().getRoom() != null
+                    && pet.getRoomUnit().getRoom().getId() == this.room.getId()
+                    && (atTile == null || pet.getRoomUnit().getCurrentLocation() == atTile)) {
                 units.add(pet.getRoomUnit());
             }
         }
 
         for (Bot bot : this.currentBots.values()) {
-            if (bot != null && bot.getRoomUnit() != null && bot.getRoomUnit().getRoom() != null
-                    && bot.getRoomUnit().getRoom().getId() == this.room.getId() && (atTile == null
-                    || bot.getRoomUnit().getCurrentLocation() == atTile)) {
+            if (bot != null
+                    && bot.getRoomUnit() != null
+                    && bot.getRoomUnit().getRoom() != null
+                    && bot.getRoomUnit().getRoom().getId() == this.room.getId()
+                    && (atTile == null || bot.getRoomUnit().getCurrentLocation() == atTile)) {
                 units.add(bot.getRoomUnit());
             }
         }
@@ -918,7 +950,8 @@ public class RoomUnitManager {
 
     public Collection<RoomUnit> getRoomUnitsAt(RoomTile tile) {
         Set<RoomUnit> roomUnits = getRoomUnits();
-        return roomUnits.stream().filter(unit -> unit.getCurrentLocation().equals(tile))
+        return roomUnits.stream()
+                .filter(unit -> unit.getCurrentLocation().equals(tile))
                 .collect(Collectors.toSet());
     }
 
@@ -939,7 +972,9 @@ public class RoomUnitManager {
             if (effectId != RIDING_EFFECT_ID) {
                 Habbo rider = this.getHabboByRoomUnit(roomUnit);
 
-                if (rider != null && rider.getHabboInfo() != null && rider.getHabboInfo().getRiding() != null) {
+                if (rider != null
+                        && rider.getHabboInfo() != null
+                        && rider.getHabboInfo().getRiding() != null) {
                     return;
                 }
             }
@@ -1031,8 +1066,8 @@ public class RoomUnitManager {
     }
 
     public void teleportHabboToItem(Habbo habbo, HabboItem item) {
-        this.teleportRoomUnitToLocation(habbo.getRoomUnit(), item.getX(), item.getY(),
-                item.getZ() + Item.getCurrentHeight(item));
+        this.teleportRoomUnitToLocation(
+                habbo.getRoomUnit(), item.getX(), item.getY(), item.getZ() + Item.getCurrentHeight(item));
     }
 
     public void teleportHabboToLocation(Habbo habbo, short x, short y) {
@@ -1040,8 +1075,7 @@ public class RoomUnitManager {
     }
 
     public void teleportRoomUnitToItem(RoomUnit roomUnit, HabboItem item) {
-        this.teleportRoomUnitToLocation(roomUnit, item.getX(), item.getY(),
-                item.getZ() + Item.getCurrentHeight(item));
+        this.teleportRoomUnitToLocation(roomUnit, item.getX(), item.getY(), item.getZ() + Item.getCurrentHeight(item));
     }
 
     public void teleportRoomUnitToLocation(RoomUnit roomUnit, short x, short y) {
@@ -1093,12 +1127,12 @@ public class RoomUnitManager {
             }
         }
 
-        HabboItem doorTileTopItem = this.room.getTopItemAt(habbo.getRoomUnit().getX(),
-                habbo.getRoomUnit().getY());
+        HabboItem doorTileTopItem = this.room.getTopItemAt(
+                habbo.getRoomUnit().getX(), habbo.getRoomUnit().getY());
         if (doorTileTopItem != null
                 && !(doorTileTopItem instanceof com.eu.habbo.habbohotel.items.interactions.InteractionTeleportTile)) {
             try {
-                doorTileTopItem.onWalkOn(habbo.getRoomUnit(), this.room, new Object[]{});
+                doorTileTopItem.onWalkOn(habbo.getRoomUnit(), this.room, new Object[] {});
             } catch (Exception e) {
                 LOGGER.error("Caught exception", e);
             }
@@ -1110,15 +1144,18 @@ public class RoomUnitManager {
             return;
         }
 
-        if (habbo.getRoomUnit().hasStatus(RoomUnitStatus.SIT) || !habbo.getRoomUnit().canForcePosture()) {
+        if (habbo.getRoomUnit().hasStatus(RoomUnitStatus.SIT)
+                || !habbo.getRoomUnit().canForcePosture()) {
             return;
         }
 
         this.dance(habbo, DanceType.NONE);
         habbo.getRoomUnit().cmdSit = true;
-        habbo.getRoomUnit().setBodyRotation(
-                RoomUserRotation.values()[habbo.getRoomUnit().getBodyRotation().getValue()
-                        - habbo.getRoomUnit().getBodyRotation().getValue() % 2]);
+        habbo.getRoomUnit()
+                .setBodyRotation(
+                        RoomUserRotation.values()[
+                                habbo.getRoomUnit().getBodyRotation().getValue()
+                                        - habbo.getRoomUnit().getBodyRotation().getValue() % 2]);
         habbo.getRoomUnit().setStatus(RoomUnitStatus.SIT, 0.5 + "");
         this.room.sendComposer(new RoomUserStatusComposer(habbo.getRoomUnit()).compose());
     }
@@ -1128,12 +1165,20 @@ public class RoomUnitManager {
             return;
         }
 
-        HabboItem item = this.room.getTopItemAt(habbo.getRoomUnit().getX(), habbo.getRoomUnit().getY());
-        if (item == null || !item.getBaseItem().allowSit() || !item.getBaseItem().allowLay()) {
+        HabboItem item = this.room.getTopItemAt(
+                habbo.getRoomUnit().getX(), habbo.getRoomUnit().getY());
+        if (item == null
+                || !item.getBaseItem().allowSit()
+                || !item.getBaseItem().allowLay()) {
             habbo.getRoomUnit().cmdStand = true;
-            habbo.getRoomUnit().setBodyRotation(
-                    RoomUserRotation.values()[habbo.getRoomUnit().getBodyRotation().getValue()
-                            - habbo.getRoomUnit().getBodyRotation().getValue() % 2]);
+            habbo.getRoomUnit()
+                    .setBodyRotation(
+                            RoomUserRotation.values()[
+                                    habbo.getRoomUnit().getBodyRotation().getValue()
+                                            - habbo.getRoomUnit()
+                                                            .getBodyRotation()
+                                                            .getValue()
+                                                    % 2]);
             habbo.getRoomUnit().removeStatus(RoomUnitStatus.SIT);
             this.room.sendComposer(new RoomUserStatusComposer(habbo.getRoomUnit()).compose());
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitManager.java
@@ -23,8 +23,6 @@ import com.eu.habbo.messages.outgoing.inventory.AddPetComposer;
 import com.eu.habbo.messages.outgoing.rooms.pets.RoomPetComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.*;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,11 +40,11 @@ public class RoomUnitManager {
     static final int RIDING_EFFECT_ID = 77;
 
     private final Room room;
-    private final ConcurrentHashMap<Integer, Habbo> currentHabbos = new ConcurrentHashMap<>(3);
-    private final Int2ObjectMap<Habbo> habboQueue = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
-    private final Int2ObjectMap<Bot> currentBots = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
-    private final Int2ObjectMap<Pet> currentPets = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>(0));
-    private volatile int unitCounter;
+    private final RoomUnitIndex index = new RoomUnitIndex();
+    private final ConcurrentHashMap<Integer, Habbo> currentHabbos = index.habbos();
+    private final Int2ObjectMap<Habbo> habboQueue = index.queue();
+    private final Int2ObjectMap<Bot> currentBots = index.bots();
+    private final Int2ObjectMap<Pet> currentPets = index.pets();
 
     public RoomUnitManager(Room room) {
         this.room = room;
@@ -72,7 +70,7 @@ public class RoomUnitManager {
                     WiredUserMovementHelper.cleanupRoomUnit(pet.getRoomUnit());
                 }
             }
-            this.unitCounter = 0;
+            this.index.resetUnitCounter();
             this.currentHabbos.clear();
             this.currentPets.clear();
             this.currentBots.clear();
@@ -98,12 +96,12 @@ public class RoomUnitManager {
     }
 
     public int getUnitCounter() {
-        return this.unitCounter;
+        return this.index.unitCounter();
     }
 
     public int getNextUnitId() {
         synchronized (this.room.roomUnitLock) {
-            return this.unitCounter++;
+            return this.index.nextUnitId();
         }
     }
 
@@ -156,9 +154,9 @@ public class RoomUnitManager {
 
     public void addHabbo(Habbo habbo) {
         synchronized (this.room.roomUnitLock) {
-            habbo.getRoomUnit().setId(this.unitCounter);
+            habbo.getRoomUnit().setId(this.index.unitCounter());
             this.currentHabbos.put(habbo.getHabboInfo().getId(), habbo);
-            this.unitCounter++;
+            this.index.incrementUnitId();
         }
         this.room.scheduleDatabaseUserCountUpdate();
     }
@@ -506,9 +504,9 @@ public class RoomUnitManager {
 
     public void addBot(Bot bot) {
         synchronized (this.room.roomUnitLock) {
-            bot.getRoomUnit().setId(this.unitCounter);
+            bot.getRoomUnit().setId(this.index.unitCounter());
             this.currentBots.put(bot.getId(), bot);
-            this.unitCounter++;
+            this.index.incrementUnitId();
         }
     }
 
@@ -683,9 +681,9 @@ public class RoomUnitManager {
 
     public void addPet(Pet pet) {
         synchronized (this.room.roomUnitLock) {
-            pet.getRoomUnit().setId(this.unitCounter);
+            pet.getRoomUnit().setId(this.index.unitCounter());
             this.currentPets.put(pet.getId(), pet);
-            this.unitCounter++;
+            this.index.incrementUnitId();
 
             Habbo habbo = this.getHabbo(pet.getUserId());
             if (habbo != null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableManager.java
@@ -41,7 +41,7 @@ public class RoomUserVariableManager {
     public RoomUserVariableManager(Room room) {
         this(
                 room,
-                new RoomUserVariableRepository(Emulator.getDatabase().getDataSource()),
+                new RoomUserVariableRepository(() -> Emulator.getDatabase().getDataSource()),
                 () -> Emulator.getIntUnixTimestamp());
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableManager.java
@@ -15,9 +15,6 @@ import com.eu.habbo.messages.outgoing.wired.WiredUserVariablesDataComposer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,16 +27,29 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.IntSupplier;
 
 public class RoomUserVariableManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(RoomUserVariableManager.class);
 
     private final Room room;
+    private final RoomUserVariableRepository repository;
+    private final IntSupplier currentTimestamp;
     private final ConcurrentHashMap<Integer, ConcurrentHashMap<Integer, VariableAssignment>> activeAssignmentsByUserId;
     private final java.util.concurrent.atomic.AtomicBoolean broadcastRequested = new java.util.concurrent.atomic.AtomicBoolean(false);
 
     public RoomUserVariableManager(Room room) {
+        this(
+                room,
+                new RoomUserVariableRepository(Emulator.getDatabase().getDataSource()),
+                () -> Emulator.getIntUnixTimestamp());
+    }
+
+    RoomUserVariableManager(
+            Room room, RoomUserVariableRepository repository, IntSupplier currentTimestamp) {
         this.room = room;
+        this.repository = repository;
+        this.currentTimestamp = currentTimestamp;
         this.activeAssignmentsByUserId = new ConcurrentHashMap<>();
     }
 
@@ -52,32 +62,22 @@ public class RoomUserVariableManager {
         ConcurrentHashMap<Integer, VariableAssignment> restoredAssignments = new ConcurrentHashMap<>();
         List<Integer> staleDefinitionIds = new ArrayList<>();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT variable_item_id, value, created_at, updated_at FROM room_user_wired_variables WHERE room_id = ? AND user_id = ?")) {
-            statement.setInt(1, this.room.getId());
-            statement.setInt(2, userId);
+        try {
+            for (RoomUserVariableRepository.StoredAssignment stored :
+                    this.repository.findByUser(this.room.getId(), userId)) {
+                int definitionItemId = stored.definitionItemId();
+                WiredExtraUserVariable definition = this.getDefinition(definitionItemId);
 
-            try (ResultSet set = statement.executeQuery()) {
-                while (set.next()) {
-                    int definitionItemId = set.getInt("variable_item_id");
-                    WiredExtraUserVariable definition = this.getDefinition(definitionItemId);
-
-                    if (definition == null || !definition.isPermanentAvailability()) {
-                        staleDefinitionIds.add(definitionItemId);
-                        continue;
-                    }
-
-                    Integer value = null;
-                    int rawValue = set.getInt("value");
-                    if (!set.wasNull()) {
-                        value = rawValue;
-                    }
-
-                    int createdAt = normalizeTimestamp(set.getInt("created_at"), 0);
-                    int updatedAt = normalizeTimestamp(set.getInt("updated_at"), createdAt);
-
-                    restoredAssignments.put(definitionItemId, new VariableAssignment(value, createdAt, updatedAt));
+                if (definition == null || !definition.isPermanentAvailability()) {
+                    staleDefinitionIds.add(definitionItemId);
+                    continue;
                 }
+
+                int createdAt = normalizeTimestamp(stored.createdAt(), 0);
+                int updatedAt = normalizeTimestamp(stored.updatedAt(), createdAt);
+                restoredAssignments.put(
+                        definitionItemId,
+                        new VariableAssignment(stored.value(), createdAt, updatedAt));
             }
         } catch (SQLException e) {
             LOGGER.error("Failed to restore wired user variables for room {} and user {}", this.room.getId(), userId, e);
@@ -165,10 +165,10 @@ public class RoomUserVariableManager {
         boolean changed = overwritten || valueChanged;
 
         if (existingAssignment == null || overwritten) {
-            int now = Emulator.getIntUnixTimestamp();
+            int now = this.currentTimestamp.getAsInt();
             assignments.put(definitionItemId, new VariableAssignment(normalizedValue, now, now));
         } else if (valueChanged) {
-            existingAssignment.setValue(normalizedValue, Emulator.getIntUnixTimestamp());
+            existingAssignment.setValue(normalizedValue, this.currentTimestamp.getAsInt());
         }
 
         WiredExtraUserVariable definition = (WiredExtraUserVariable) extra;
@@ -270,7 +270,7 @@ public class RoomUserVariableManager {
             return false;
         }
 
-        assignment.setValue(normalizedValue, Emulator.getIntUnixTimestamp());
+        assignment.setValue(normalizedValue, this.currentTimestamp.getAsInt());
 
         WiredExtraUserVariable definition = (WiredExtraUserVariable) extra;
 
@@ -953,46 +953,31 @@ public class RoomUserVariableManager {
     }
 
     private void upsertPersistentAssignment(int userId, int definitionItemId, VariableAssignment assignment) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("INSERT INTO room_user_wired_variables (room_id, user_id, variable_item_id, value, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE value = VALUES(value), updated_at = VALUES(updated_at)")) {
-            statement.setInt(1, this.room.getId());
-            statement.setInt(2, userId);
-            statement.setInt(3, definitionItemId);
-
-            if (assignment == null || assignment.getValue() == null) {
-                statement.setNull(4, java.sql.Types.INTEGER);
-            } else {
-                statement.setInt(4, assignment.getValue());
-            }
-
-            int now = Emulator.getIntUnixTimestamp();
-            statement.setInt(5, (assignment != null) ? assignment.getCreatedAt() : now);
-            statement.setInt(6, (assignment != null) ? assignment.getUpdatedAt() : now);
-
-            statement.executeUpdate();
+        try {
+            int now = this.currentTimestamp.getAsInt();
+            this.repository.upsert(
+                    this.room.getId(),
+                    userId,
+                    definitionItemId,
+                    assignment != null ? assignment.getValue() : null,
+                    assignment != null ? assignment.getCreatedAt() : now,
+                    assignment != null ? assignment.getUpdatedAt() : now);
         } catch (SQLException e) {
             LOGGER.error("Failed to store permanent wired user variable for room {}, user {}, item {}", this.room.getId(), userId, definitionItemId, e);
         }
     }
 
     private void deletePersistentAssignment(int userId, int definitionItemId) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("DELETE FROM room_user_wired_variables WHERE room_id = ? AND user_id = ? AND variable_item_id = ?")) {
-            statement.setInt(1, this.room.getId());
-            statement.setInt(2, userId);
-            statement.setInt(3, definitionItemId);
-            statement.executeUpdate();
+        try {
+            this.repository.delete(this.room.getId(), userId, definitionItemId);
         } catch (SQLException e) {
             LOGGER.error("Failed to delete permanent wired user variable for room {}, user {}, item {}", this.room.getId(), userId, definitionItemId, e);
         }
     }
 
     private void deletePersistentAssignmentsForDefinition(int definitionItemId) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("DELETE FROM room_user_wired_variables WHERE room_id = ? AND variable_item_id = ?")) {
-            statement.setInt(1, this.room.getId());
-            statement.setInt(2, definitionItemId);
-            statement.executeUpdate();
+        try {
+            this.repository.deleteDefinition(this.room.getId(), definitionItemId);
         } catch (SQLException e) {
             LOGGER.error("Failed to delete permanent wired user variables for room {} and item {}", this.room.getId(), definitionItemId, e);
         }
@@ -1145,9 +1130,9 @@ public class RoomUserVariableManager {
         }
     }
 
-    private static int normalizeTimestamp(int value, int fallback) {
+    private int normalizeTimestamp(int value, int fallback) {
         if (value > 0) return value;
         if (fallback > 0) return fallback;
-        return Emulator.getIntUnixTimestamp();
+        return this.currentTimestamp.getAsInt();
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableManager.java
@@ -2,19 +2,16 @@ package com.eu.habbo.habbohotel.rooms;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredExtra;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraUserVariable;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableEcho;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableReference;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredVariableReferenceSupport;
-import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraUserVariable;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.wired.core.WiredEvent;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredVariableLevelSystemSupport;
 import com.eu.habbo.habbohotel.wired.core.WiredVariableTextConnectorSupport;
 import com.eu.habbo.messages.outgoing.wired.WiredUserVariablesDataComposer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -28,6 +25,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.IntSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RoomUserVariableManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(RoomUserVariableManager.class);
@@ -36,7 +35,8 @@ public class RoomUserVariableManager {
     private final RoomUserVariableRepository repository;
     private final IntSupplier currentTimestamp;
     private final ConcurrentHashMap<Integer, ConcurrentHashMap<Integer, VariableAssignment>> activeAssignmentsByUserId;
-    private final java.util.concurrent.atomic.AtomicBoolean broadcastRequested = new java.util.concurrent.atomic.AtomicBoolean(false);
+    private final java.util.concurrent.atomic.AtomicBoolean broadcastRequested =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
 
     public RoomUserVariableManager(Room room) {
         this(
@@ -45,8 +45,7 @@ public class RoomUserVariableManager {
                 () -> Emulator.getIntUnixTimestamp());
     }
 
-    RoomUserVariableManager(
-            Room room, RoomUserVariableRepository repository, IntSupplier currentTimestamp) {
+    RoomUserVariableManager(Room room, RoomUserVariableRepository repository, IntSupplier currentTimestamp) {
         this.room = room;
         this.repository = repository;
         this.currentTimestamp = currentTimestamp;
@@ -75,12 +74,11 @@ public class RoomUserVariableManager {
 
                 int createdAt = normalizeTimestamp(stored.createdAt(), 0);
                 int updatedAt = normalizeTimestamp(stored.updatedAt(), createdAt);
-                restoredAssignments.put(
-                        definitionItemId,
-                        new VariableAssignment(stored.value(), createdAt, updatedAt));
+                restoredAssignments.put(definitionItemId, new VariableAssignment(stored.value(), createdAt, updatedAt));
             }
         } catch (SQLException e) {
-            LOGGER.error("Failed to restore wired user variables for room {} and user {}", this.room.getId(), userId, e);
+            LOGGER.error(
+                    "Failed to restore wired user variables for room {} and user {}", this.room.getId(), userId, e);
         }
 
         if (!staleDefinitionIds.isEmpty()) {
@@ -98,7 +96,8 @@ public class RoomUserVariableManager {
         this.broadcastSnapshot();
     }
 
-    public boolean assignVariable(Habbo habbo, WiredExtraUserVariable definition, Integer value, boolean overrideExisting) {
+    public boolean assignVariable(
+            Habbo habbo, WiredExtraUserVariable definition, Integer value, boolean overrideExisting) {
         return definition != null && this.assignVariable(habbo, definition.getId(), value, overrideExisting);
     }
 
@@ -117,16 +116,24 @@ public class RoomUserVariableManager {
         int userId = habbo.getHabboInfo().getId();
         Integer normalizedValue = definitionInfo.hasValue() ? value : null;
         boolean hadBefore = this.hasVariable(userId, definitionItemId);
-        Integer previousValue = (definitionInfo.hasValue() && hadBefore) ? this.getCurrentValue(userId, definitionItemId) : null;
+        Integer previousValue =
+                (definitionInfo.hasValue() && hadBefore) ? this.getCurrentValue(userId, definitionItemId) : null;
 
         if (extra instanceof WiredExtraVariableReference) {
-            boolean changed = WiredVariableReferenceSupport.assignSharedUserVariable((WiredExtraVariableReference) extra, userId, normalizedValue, overrideExisting);
-            boolean shouldEmit = changed || (definitionInfo.hasValue() && hadBefore && overrideExisting && Objects.equals(previousValue, normalizedValue));
+            boolean changed = WiredVariableReferenceSupport.assignSharedUserVariable(
+                    (WiredExtraVariableReference) extra, userId, normalizedValue, overrideExisting);
+            boolean shouldEmit = changed
+                    || (definitionInfo.hasValue()
+                            && hadBefore
+                            && overrideExisting
+                            && Objects.equals(previousValue, normalizedValue));
 
             if (shouldEmit) {
                 boolean hasAfter = this.hasVariable(userId, definitionItemId);
-                Integer currentValue = (definitionInfo.hasValue() && hasAfter) ? this.getCurrentValue(userId, definitionItemId) : null;
-                this.emitVariableChangedEvents(userId, extra, definitionInfo, hadBefore, previousValue, hasAfter, currentValue);
+                Integer currentValue =
+                        (definitionInfo.hasValue() && hasAfter) ? this.getCurrentValue(userId, definitionItemId) : null;
+                this.emitVariableChangedEvents(
+                        userId, extra, definitionInfo, hadBefore, previousValue, hasAfter, currentValue);
             }
 
             if (changed) {
@@ -137,13 +144,20 @@ public class RoomUserVariableManager {
         }
 
         if (extra instanceof WiredExtraVariableEcho) {
-            boolean changed = ((WiredExtraVariableEcho) extra).assignValue(this.room, userId, normalizedValue, overrideExisting);
-            boolean shouldEmit = changed || (definitionInfo.hasValue() && hadBefore && overrideExisting && Objects.equals(previousValue, normalizedValue));
+            boolean changed =
+                    ((WiredExtraVariableEcho) extra).assignValue(this.room, userId, normalizedValue, overrideExisting);
+            boolean shouldEmit = changed
+                    || (definitionInfo.hasValue()
+                            && hadBefore
+                            && overrideExisting
+                            && Objects.equals(previousValue, normalizedValue));
 
             if (shouldEmit) {
                 boolean hasAfter = this.hasVariable(userId, definitionItemId);
-                Integer currentValue = (definitionInfo.hasValue() && hasAfter) ? this.getCurrentValue(userId, definitionItemId) : null;
-                this.emitVariableChangedEvents(userId, extra, definitionInfo, hadBefore, previousValue, hasAfter, currentValue);
+                Integer currentValue =
+                        (definitionInfo.hasValue() && hasAfter) ? this.getCurrentValue(userId, definitionItemId) : null;
+                this.emitVariableChangedEvents(
+                        userId, extra, definitionInfo, hadBefore, previousValue, hasAfter, currentValue);
             }
 
             if (changed) {
@@ -153,7 +167,8 @@ public class RoomUserVariableManager {
             return changed;
         }
 
-        ConcurrentHashMap<Integer, VariableAssignment> assignments = this.activeAssignmentsByUserId.computeIfAbsent(userId, key -> new ConcurrentHashMap<>());
+        ConcurrentHashMap<Integer, VariableAssignment> assignments =
+                this.activeAssignmentsByUserId.computeIfAbsent(userId, key -> new ConcurrentHashMap<>());
         VariableAssignment existingAssignment = assignments.get(definitionItemId);
 
         if (existingAssignment != null && !overrideExisting) {
@@ -161,7 +176,8 @@ public class RoomUserVariableManager {
         }
 
         boolean overwritten = existingAssignment != null && overrideExisting;
-        boolean valueChanged = existingAssignment == null || !Objects.equals(existingAssignment.getValue(), normalizedValue);
+        boolean valueChanged =
+                existingAssignment == null || !Objects.equals(existingAssignment.getValue(), normalizedValue);
         boolean changed = overwritten || valueChanged;
 
         if (existingAssignment == null || overwritten) {
@@ -183,17 +199,29 @@ public class RoomUserVariableManager {
             if (definition.isSharedAvailability()) {
                 VariableAssignment assignment = assignments.get(definitionItemId);
                 if (assignment != null) {
-                    WiredVariableReferenceSupport.cacheSharedUserAssignment(this.room.getId(), definitionItemId, userId, assignment.getValue(), assignment.getCreatedAt(), assignment.getUpdatedAt());
+                    WiredVariableReferenceSupport.cacheSharedUserAssignment(
+                            this.room.getId(),
+                            definitionItemId,
+                            userId,
+                            assignment.getValue(),
+                            assignment.getCreatedAt(),
+                            assignment.getUpdatedAt());
                 }
             } else {
                 WiredVariableReferenceSupport.clearSharedUserAssignment(this.room.getId(), definitionItemId, userId);
             }
         }
 
-        if (changed || (definitionInfo.hasValue() && hadBefore && overrideExisting && Objects.equals(previousValue, normalizedValue))) {
+        if (changed
+                || (definitionInfo.hasValue()
+                        && hadBefore
+                        && overrideExisting
+                        && Objects.equals(previousValue, normalizedValue))) {
             boolean hasAfter = this.hasVariable(userId, definitionItemId);
-            Integer currentValue = (definitionInfo.hasValue() && hasAfter) ? this.getCurrentValue(userId, definitionItemId) : null;
-            this.emitVariableChangedEvents(userId, extra, definitionInfo, hadBefore, previousValue, hasAfter, currentValue);
+            Integer currentValue =
+                    (definitionInfo.hasValue() && hasAfter) ? this.getCurrentValue(userId, definitionItemId) : null;
+            this.emitVariableChangedEvents(
+                    userId, extra, definitionInfo, hadBefore, previousValue, hasAfter, currentValue);
         }
 
         if (changed) {
@@ -219,13 +247,15 @@ public class RoomUserVariableManager {
         Integer previousValue = hadBefore ? this.getCurrentValue(userId, definitionItemId) : null;
 
         if (extra instanceof WiredExtraVariableReference) {
-            boolean changed = WiredVariableReferenceSupport.updateSharedUserVariable((WiredExtraVariableReference) extra, userId, value);
+            boolean changed = WiredVariableReferenceSupport.updateSharedUserVariable(
+                    (WiredExtraVariableReference) extra, userId, value);
             boolean shouldEmit = changed || (hadBefore && Objects.equals(previousValue, value));
 
             if (shouldEmit) {
                 boolean hasAfter = this.hasVariable(userId, definitionItemId);
                 Integer currentValue = hasAfter ? this.getCurrentValue(userId, definitionItemId) : null;
-                this.emitVariableChangedEvents(userId, extra, definitionInfo, hadBefore, previousValue, hasAfter, currentValue);
+                this.emitVariableChangedEvents(
+                        userId, extra, definitionInfo, hadBefore, previousValue, hasAfter, currentValue);
             }
 
             if (changed) {
@@ -242,7 +272,8 @@ public class RoomUserVariableManager {
             if (shouldEmit) {
                 boolean hasAfter = this.hasVariable(userId, definitionItemId);
                 Integer currentValue = hasAfter ? this.getCurrentValue(userId, definitionItemId) : null;
-                this.emitVariableChangedEvents(userId, extra, definitionInfo, hadBefore, previousValue, hasAfter, currentValue);
+                this.emitVariableChangedEvents(
+                        userId, extra, definitionInfo, hadBefore, previousValue, hasAfter, currentValue);
             }
 
             if (changed) {
@@ -266,7 +297,8 @@ public class RoomUserVariableManager {
 
         Integer normalizedValue = value;
         if (Objects.equals(assignment.getValue(), normalizedValue)) {
-            this.emitVariableChangedEvents(userId, extra, definitionInfo, true, previousValue, true, assignment.getValue());
+            this.emitVariableChangedEvents(
+                    userId, extra, definitionInfo, true, previousValue, true, assignment.getValue());
             return false;
         }
 
@@ -279,10 +311,17 @@ public class RoomUserVariableManager {
         }
 
         if (definition.isSharedAvailability()) {
-            WiredVariableReferenceSupport.cacheSharedUserAssignment(this.room.getId(), definitionItemId, userId, assignment.getValue(), assignment.getCreatedAt(), assignment.getUpdatedAt());
+            WiredVariableReferenceSupport.cacheSharedUserAssignment(
+                    this.room.getId(),
+                    definitionItemId,
+                    userId,
+                    assignment.getValue(),
+                    assignment.getCreatedAt(),
+                    assignment.getUpdatedAt());
         }
 
-        this.emitVariableChangedEvents(userId, extra, definitionInfo, hadBefore, previousValue, true, assignment.getValue());
+        this.emitVariableChangedEvents(
+                userId, extra, definitionInfo, hadBefore, previousValue, true, assignment.getValue());
         this.broadcastSnapshot();
         return true;
     }
@@ -292,16 +331,20 @@ public class RoomUserVariableManager {
             return 0;
         }
 
-        WiredVariableLevelSystemSupport.DerivedDefinition derivedDefinition = WiredVariableLevelSystemSupport.resolveDerivedDefinition(this.room, WiredVariableLevelSystemSupport.TARGET_USER, definitionItemId);
+        WiredVariableLevelSystemSupport.DerivedDefinition derivedDefinition =
+                WiredVariableLevelSystemSupport.resolveDerivedDefinition(
+                        this.room, WiredVariableLevelSystemSupport.TARGET_USER, definitionItemId);
         if (derivedDefinition != null) {
             Integer baseValue = this.getRawValue(userId, derivedDefinition.getBaseDefinitionItemId());
-            Integer derivedValue = WiredVariableLevelSystemSupport.getDerivedValue(derivedDefinition.getLevelSystem(), derivedDefinition.getSubvariableType(), baseValue);
+            Integer derivedValue = WiredVariableLevelSystemSupport.getDerivedValue(
+                    derivedDefinition.getLevelSystem(), derivedDefinition.getSubvariableType(), baseValue);
             return (derivedValue != null) ? derivedValue : 0;
         }
 
         InteractionWiredExtra extra = this.getDefinitionExtra(definitionItemId);
         if (extra instanceof WiredExtraVariableReference) {
-            WiredVariableReferenceSupport.SharedUserAssignment assignment = WiredVariableReferenceSupport.getSharedUserAssignment((WiredExtraVariableReference) extra, userId);
+            WiredVariableReferenceSupport.SharedUserAssignment assignment =
+                    WiredVariableReferenceSupport.getSharedUserAssignment((WiredExtraVariableReference) extra, userId);
             return (assignment != null && assignment.getValue() != null) ? assignment.getValue() : 0;
         }
 
@@ -329,7 +372,9 @@ public class RoomUserVariableManager {
             return 0;
         }
 
-        WiredVariableLevelSystemSupport.DerivedDefinition derivedDefinition = WiredVariableLevelSystemSupport.resolveDerivedDefinition(this.room, WiredVariableLevelSystemSupport.TARGET_USER, definitionItemId);
+        WiredVariableLevelSystemSupport.DerivedDefinition derivedDefinition =
+                WiredVariableLevelSystemSupport.resolveDerivedDefinition(
+                        this.room, WiredVariableLevelSystemSupport.TARGET_USER, definitionItemId);
         if (derivedDefinition != null) {
             VariableAssignment assignment = this.getRawAssignment(userId, derivedDefinition.getBaseDefinitionItemId());
             return (assignment != null) ? assignment.getCreatedAt() : 0;
@@ -337,7 +382,8 @@ public class RoomUserVariableManager {
 
         InteractionWiredExtra extra = this.getDefinitionExtra(definitionItemId);
         if (extra instanceof WiredExtraVariableReference) {
-            WiredVariableReferenceSupport.SharedUserAssignment assignment = WiredVariableReferenceSupport.getSharedUserAssignment((WiredExtraVariableReference) extra, userId);
+            WiredVariableReferenceSupport.SharedUserAssignment assignment =
+                    WiredVariableReferenceSupport.getSharedUserAssignment((WiredExtraVariableReference) extra, userId);
             return assignment != null ? assignment.getCreatedAt() : 0;
         }
 
@@ -360,7 +406,9 @@ public class RoomUserVariableManager {
             return 0;
         }
 
-        WiredVariableLevelSystemSupport.DerivedDefinition derivedDefinition = WiredVariableLevelSystemSupport.resolveDerivedDefinition(this.room, WiredVariableLevelSystemSupport.TARGET_USER, definitionItemId);
+        WiredVariableLevelSystemSupport.DerivedDefinition derivedDefinition =
+                WiredVariableLevelSystemSupport.resolveDerivedDefinition(
+                        this.room, WiredVariableLevelSystemSupport.TARGET_USER, definitionItemId);
         if (derivedDefinition != null) {
             VariableAssignment assignment = this.getRawAssignment(userId, derivedDefinition.getBaseDefinitionItemId());
             return (assignment != null) ? assignment.getUpdatedAt() : 0;
@@ -368,7 +416,8 @@ public class RoomUserVariableManager {
 
         InteractionWiredExtra extra = this.getDefinitionExtra(definitionItemId);
         if (extra instanceof WiredExtraVariableReference) {
-            WiredVariableReferenceSupport.SharedUserAssignment assignment = WiredVariableReferenceSupport.getSharedUserAssignment((WiredExtraVariableReference) extra, userId);
+            WiredVariableReferenceSupport.SharedUserAssignment assignment =
+                    WiredVariableReferenceSupport.getSharedUserAssignment((WiredExtraVariableReference) extra, userId);
             return assignment != null ? assignment.getUpdatedAt() : 0;
         }
 
@@ -391,14 +440,17 @@ public class RoomUserVariableManager {
             return false;
         }
 
-        WiredVariableLevelSystemSupport.DerivedDefinition derivedDefinition = WiredVariableLevelSystemSupport.resolveDerivedDefinition(this.room, WiredVariableLevelSystemSupport.TARGET_USER, definitionItemId);
+        WiredVariableLevelSystemSupport.DerivedDefinition derivedDefinition =
+                WiredVariableLevelSystemSupport.resolveDerivedDefinition(
+                        this.room, WiredVariableLevelSystemSupport.TARGET_USER, definitionItemId);
         if (derivedDefinition != null) {
             return this.getRawAssignment(userId, derivedDefinition.getBaseDefinitionItemId()) != null;
         }
 
         InteractionWiredExtra extra = this.getDefinitionExtra(definitionItemId);
         if (extra instanceof WiredExtraVariableReference) {
-            return WiredVariableReferenceSupport.getSharedUserAssignment((WiredExtraVariableReference) extra, userId) != null;
+            return WiredVariableReferenceSupport.getSharedUserAssignment((WiredExtraVariableReference) extra, userId)
+                    != null;
         }
 
         if (extra instanceof WiredExtraVariableEcho) {
@@ -421,11 +473,13 @@ public class RoomUserVariableManager {
         }
 
         boolean hadBefore = this.hasVariable(userId, definitionItemId);
-        Integer previousValue = (definitionInfo.hasValue() && hadBefore) ? this.getCurrentValue(userId, definitionItemId) : null;
+        Integer previousValue =
+                (definitionInfo.hasValue() && hadBefore) ? this.getCurrentValue(userId, definitionItemId) : null;
 
         InteractionWiredExtra extra = this.getDefinitionExtra(definitionItemId);
         if (extra instanceof WiredExtraVariableReference) {
-            boolean changed = WiredVariableReferenceSupport.removeSharedUserVariable((WiredExtraVariableReference) extra, userId);
+            boolean changed =
+                    WiredVariableReferenceSupport.removeSharedUserVariable((WiredExtraVariableReference) extra, userId);
 
             if (changed) {
                 this.emitVariableChangedEvents(userId, extra, definitionInfo, hadBefore, previousValue, false, null);
@@ -443,8 +497,10 @@ public class RoomUserVariableManager {
 
             if (changed) {
                 boolean hasAfter = this.hasVariable(userId, definitionItemId);
-                Integer currentValue = (definitionInfo.hasValue() && hasAfter) ? this.getCurrentValue(userId, definitionItemId) : null;
-                this.emitVariableChangedEvents(userId, extra, definitionInfo, hadBefore, previousValue, hasAfter, currentValue);
+                Integer currentValue =
+                        (definitionInfo.hasValue() && hasAfter) ? this.getCurrentValue(userId, definitionItemId) : null;
+                this.emitVariableChangedEvents(
+                        userId, extra, definitionInfo, hadBefore, previousValue, hasAfter, currentValue);
             }
 
             if (changed) {
@@ -494,7 +550,8 @@ public class RoomUserVariableManager {
     public void removeDefinition(int definitionItemId) {
         boolean changed = false;
 
-        for (Map.Entry<Integer, ConcurrentHashMap<Integer, VariableAssignment>> entry : this.activeAssignmentsByUserId.entrySet()) {
+        for (Map.Entry<Integer, ConcurrentHashMap<Integer, VariableAssignment>> entry :
+                this.activeAssignmentsByUserId.entrySet()) {
             ConcurrentHashMap<Integer, VariableAssignment> assignments = entry.getValue();
             if (assignments.remove(definitionItemId) != null) {
                 changed = true;
@@ -527,7 +584,8 @@ public class RoomUserVariableManager {
         if (!definition.isPermanentAvailability()) {
             this.deletePersistentAssignmentsForDefinition(definition.getId());
         } else {
-            for (Map.Entry<Integer, ConcurrentHashMap<Integer, VariableAssignment>> entry : this.activeAssignmentsByUserId.entrySet()) {
+            for (Map.Entry<Integer, ConcurrentHashMap<Integer, VariableAssignment>> entry :
+                    this.activeAssignmentsByUserId.entrySet()) {
                 VariableAssignment assignment = entry.getValue().get(definition.getId());
 
                 if (assignment == null) continue;
@@ -537,14 +595,21 @@ public class RoomUserVariableManager {
         }
 
         if (definition.isSharedAvailability()) {
-            for (Map.Entry<Integer, ConcurrentHashMap<Integer, VariableAssignment>> entry : this.activeAssignmentsByUserId.entrySet()) {
+            for (Map.Entry<Integer, ConcurrentHashMap<Integer, VariableAssignment>> entry :
+                    this.activeAssignmentsByUserId.entrySet()) {
                 VariableAssignment assignment = entry.getValue().get(definition.getId());
 
                 if (assignment == null) {
                     continue;
                 }
 
-                WiredVariableReferenceSupport.cacheSharedUserAssignment(this.room.getId(), definition.getId(), entry.getKey(), assignment.getValue(), assignment.getCreatedAt(), assignment.getUpdatedAt());
+                WiredVariableReferenceSupport.cacheSharedUserAssignment(
+                        this.room.getId(),
+                        definition.getId(),
+                        entry.getKey(),
+                        assignment.getValue(),
+                        assignment.getCreatedAt(),
+                        assignment.getUpdatedAt());
             }
         } else {
             WiredVariableReferenceSupport.clearSharedUserDefinition(this.room.getId(), definition.getId());
@@ -559,11 +624,19 @@ public class RoomUserVariableManager {
         List<Integer> derivedDefinitionIds = new ArrayList<>();
 
         for (WiredVariableDefinitionInfo definition : this.getAllDefinitionInfos()) {
-            DefinitionEntry entry = new DefinitionEntry(definition.getItemId(), definition.getName(), definition.hasValue(), definition.getAvailability(), definition.isTextConnected(), definition.isReadOnly());
+            DefinitionEntry entry = new DefinitionEntry(
+                    definition.getItemId(),
+                    definition.getName(),
+                    definition.hasValue(),
+                    definition.getAvailability(),
+                    definition.isTextConnected(),
+                    definition.isReadOnly());
             definitions.add(entry);
             definitionsById.put(entry.getItemId(), entry);
 
-            if (WiredVariableLevelSystemSupport.resolveDerivedDefinition(this.room, WiredVariableLevelSystemSupport.TARGET_USER, definition.getItemId()) != null) {
+            if (WiredVariableLevelSystemSupport.resolveDerivedDefinition(
+                            this.room, WiredVariableLevelSystemSupport.TARGET_USER, definition.getItemId())
+                    != null) {
                 derivedDefinitionIds.add(definition.getItemId());
             }
         }
@@ -582,7 +655,8 @@ public class RoomUserVariableManager {
 
         for (Integer userId : userIds) {
             List<AssignmentEntry> assignments = new ArrayList<>();
-            ConcurrentHashMap<Integer, VariableAssignment> localAssignments = this.activeAssignmentsByUserId.get(userId);
+            ConcurrentHashMap<Integer, VariableAssignment> localAssignments =
+                    this.activeAssignmentsByUserId.get(userId);
 
             if (localAssignments != null) {
                 for (Map.Entry<Integer, VariableAssignment> assignmentEntry : localAssignments.entrySet()) {
@@ -591,11 +665,10 @@ public class RoomUserVariableManager {
                     }
 
                     assignments.add(new AssignmentEntry(
-                        assignmentEntry.getKey(),
-                        assignmentEntry.getValue().getValue(),
-                        assignmentEntry.getValue().getCreatedAt(),
-                        assignmentEntry.getValue().getUpdatedAt()
-                    ));
+                            assignmentEntry.getKey(),
+                            assignmentEntry.getValue().getValue(),
+                            assignmentEntry.getValue().getCreatedAt(),
+                            assignmentEntry.getValue().getUpdatedAt()));
                 }
             }
 
@@ -604,12 +677,17 @@ public class RoomUserVariableManager {
                     continue;
                 }
 
-                WiredVariableReferenceSupport.SharedUserAssignment assignment = WiredVariableReferenceSupport.getSharedUserAssignment(reference, userId);
+                WiredVariableReferenceSupport.SharedUserAssignment assignment =
+                        WiredVariableReferenceSupport.getSharedUserAssignment(reference, userId);
                 if (assignment == null) {
                     continue;
                 }
 
-                assignments.add(new AssignmentEntry(reference.getId(), assignment.getValue(), assignment.getCreatedAt(), assignment.getUpdatedAt()));
+                assignments.add(new AssignmentEntry(
+                        reference.getId(),
+                        assignment.getValue(),
+                        assignment.getCreatedAt(),
+                        assignment.getUpdatedAt()));
             }
 
             for (WiredExtraVariableEcho echo : userEchoes) {
@@ -618,11 +696,10 @@ public class RoomUserVariableManager {
                 }
 
                 assignments.add(new AssignmentEntry(
-                    echo.getId(),
-                    echo.getCurrentValue(this.room, userId),
-                    echo.getCreatedAt(this.room, userId),
-                    echo.getUpdatedAt(this.room, userId)
-                ));
+                        echo.getId(),
+                        echo.getCurrentValue(this.room, userId),
+                        echo.getCreatedAt(this.room, userId),
+                        echo.getUpdatedAt(this.room, userId)));
             }
 
             for (Integer derivedDefinitionId : derivedDefinitionIds) {
@@ -631,11 +708,10 @@ public class RoomUserVariableManager {
                 }
 
                 assignments.add(new AssignmentEntry(
-                    derivedDefinitionId,
-                    this.getCurrentValue(userId, derivedDefinitionId),
-                    this.getCreatedAt(userId, derivedDefinitionId),
-                    this.getUpdatedAt(userId, derivedDefinitionId)
-                ));
+                        derivedDefinitionId,
+                        this.getCurrentValue(userId, derivedDefinitionId),
+                        this.getCreatedAt(userId, derivedDefinitionId),
+                        this.getUpdatedAt(userId, derivedDefinitionId)));
             }
 
             assignments.sort(Comparator.comparingInt(AssignmentEntry::getVariableItemId));
@@ -659,17 +735,24 @@ public class RoomUserVariableManager {
             return;
         }
 
-        habbo.getClient().sendResponse(new WiredUserVariablesDataComposer(this.createSnapshot(), this.room.getFurniVariableManager().createSnapshot(), this.room.getRoomVariableManager().createSnapshot()));
+        habbo.getClient()
+                .sendResponse(new WiredUserVariablesDataComposer(
+                        this.createSnapshot(),
+                        this.room.getFurniVariableManager().createSnapshot(),
+                        this.room.getRoomVariableManager().createSnapshot()));
     }
 
     public void requestBroadcast() {
         if (this.broadcastRequested.compareAndSet(false, true)) {
-            Emulator.getThreading().run(() -> {
-                this.broadcastRequested.set(false);
-                if (this.room.isLoaded()) {
-                    this.broadcastSnapshotRaw();
-                }
-            }, 50);
+            Emulator.getThreading()
+                    .run(
+                            () -> {
+                                this.broadcastRequested.set(false);
+                                if (this.room.isLoaded()) {
+                                    this.broadcastSnapshotRaw();
+                                }
+                            },
+                            50);
         }
     }
 
@@ -679,8 +762,10 @@ public class RoomUserVariableManager {
 
     public void broadcastSnapshotRaw() {
         Snapshot userSnapshot = this.createSnapshot();
-        RoomFurniVariableManager.Snapshot furniSnapshot = this.room.getFurniVariableManager().createSnapshot();
-        RoomVariableManager.Snapshot roomSnapshot = this.room.getRoomVariableManager().createSnapshot();
+        RoomFurniVariableManager.Snapshot furniSnapshot =
+                this.room.getFurniVariableManager().createSnapshot();
+        RoomVariableManager.Snapshot roomSnapshot =
+                this.room.getRoomVariableManager().createSnapshot();
 
         for (Habbo habbo : this.room.getCurrentHabbos().values()) {
             if (habbo == null || habbo.getClient() == null) {
@@ -691,7 +776,8 @@ public class RoomUserVariableManager {
                 continue;
             }
 
-            habbo.getClient().sendResponse(new WiredUserVariablesDataComposer(userSnapshot, furniSnapshot, roomSnapshot));
+            habbo.getClient()
+                    .sendResponse(new WiredUserVariablesDataComposer(userSnapshot, furniSnapshot, roomSnapshot));
         }
     }
 
@@ -700,7 +786,8 @@ public class RoomUserVariableManager {
             return Collections.emptyList();
         }
 
-        Collection<InteractionWiredExtra> extras = this.room.getRoomSpecialTypes().getExtras();
+        Collection<InteractionWiredExtra> extras =
+                this.room.getRoomSpecialTypes().getExtras();
         List<WiredExtraUserVariable> result = new ArrayList<>();
 
         for (InteractionWiredExtra extra : extras) {
@@ -715,7 +802,8 @@ public class RoomUserVariableManager {
             }
         }
 
-        result.sort(Comparator.comparing(WiredExtraUserVariable::getVariableName, String.CASE_INSENSITIVE_ORDER).thenComparingInt(WiredExtraUserVariable::getId));
+        result.sort(Comparator.comparing(WiredExtraUserVariable::getVariableName, String.CASE_INSENSITIVE_ORDER)
+                .thenComparingInt(WiredExtraUserVariable::getId));
         return result;
     }
 
@@ -725,24 +813,22 @@ public class RoomUserVariableManager {
 
         for (WiredExtraUserVariable definition : this.getDefinitions()) {
             baseDefinitions.add(new WiredVariableDefinitionInfo(
-                definition.getId(),
-                definition.getVariableName(),
-                definition.hasValue(),
-                definition.getAvailability(),
-                WiredVariableTextConnectorSupport.isTextConnected(this.room, definition),
-                false
-            ));
+                    definition.getId(),
+                    definition.getVariableName(),
+                    definition.hasValue(),
+                    definition.getAvailability(),
+                    WiredVariableTextConnectorSupport.isTextConnected(this.room, definition),
+                    false));
         }
 
         for (WiredExtraVariableReference reference : this.getUserReferences()) {
             baseDefinitions.add(new WiredVariableDefinitionInfo(
-                reference.getId(),
-                reference.getVariableName(),
-                reference.hasValue(),
-                reference.getAvailability(),
-                false,
-                reference.isReadOnly()
-            ));
+                    reference.getId(),
+                    reference.getVariableName(),
+                    reference.hasValue(),
+                    reference.getAvailability(),
+                    false,
+                    reference.isReadOnly()));
         }
 
         for (WiredExtraVariableEcho echo : this.getUserEchoes()) {
@@ -752,10 +838,15 @@ public class RoomUserVariableManager {
         result.addAll(baseDefinitions);
 
         for (WiredVariableDefinitionInfo definition : baseDefinitions) {
-            result.addAll(WiredVariableLevelSystemSupport.getDerivedDefinitions(this.room, WiredVariableLevelSystemSupport.TARGET_USER, this.getDefinitionExtra(definition.getItemId()), definition));
+            result.addAll(WiredVariableLevelSystemSupport.getDerivedDefinitions(
+                    this.room,
+                    WiredVariableLevelSystemSupport.TARGET_USER,
+                    this.getDefinitionExtra(definition.getItemId()),
+                    definition));
         }
 
-        result.sort(Comparator.comparing(WiredVariableDefinitionInfo::getName, String.CASE_INSENSITIVE_ORDER).thenComparingInt(WiredVariableDefinitionInfo::getItemId));
+        result.sort(Comparator.comparing(WiredVariableDefinitionInfo::getName, String.CASE_INSENSITIVE_ORDER)
+                .thenComparingInt(WiredVariableDefinitionInfo::getItemId));
         return result;
     }
 
@@ -774,13 +865,12 @@ public class RoomUserVariableManager {
             }
 
             return new WiredVariableDefinitionInfo(
-                definition.getId(),
-                definition.getVariableName(),
-                definition.hasValue(),
-                definition.getAvailability(),
-                WiredVariableTextConnectorSupport.isTextConnected(this.room, definition),
-                false
-            );
+                    definition.getId(),
+                    definition.getVariableName(),
+                    definition.hasValue(),
+                    definition.getAvailability(),
+                    WiredVariableTextConnectorSupport.isTextConnected(this.room, definition),
+                    false);
         }
 
         if (extra instanceof WiredExtraVariableReference && ((WiredExtraVariableReference) extra).isUserReference()) {
@@ -790,7 +880,13 @@ public class RoomUserVariableManager {
                 return null;
             }
 
-            return new WiredVariableDefinitionInfo(reference.getId(), reference.getVariableName(), reference.hasValue(), reference.getAvailability(), false, reference.isReadOnly());
+            return new WiredVariableDefinitionInfo(
+                    reference.getId(),
+                    reference.getVariableName(),
+                    reference.hasValue(),
+                    reference.getAvailability(),
+                    false,
+                    reference.isReadOnly());
         }
 
         if (extra instanceof WiredExtraVariableEcho && ((WiredExtraVariableEcho) extra).isUserEcho()) {
@@ -798,7 +894,8 @@ public class RoomUserVariableManager {
             return (info != null && hasVisibleDefinitionName(info.getName())) ? info : null;
         }
 
-        return WiredVariableLevelSystemSupport.getDerivedDefinitionInfo(this.room, WiredVariableLevelSystemSupport.TARGET_USER, definitionItemId);
+        return WiredVariableLevelSystemSupport.getDerivedDefinitionInfo(
+                this.room, WiredVariableLevelSystemSupport.TARGET_USER, definitionItemId);
     }
 
     private WiredExtraUserVariable getDefinition(int definitionItemId) {
@@ -827,7 +924,8 @@ public class RoomUserVariableManager {
         List<WiredExtraVariableReference> result = new ArrayList<>();
 
         for (InteractionWiredExtra extra : this.room.getRoomSpecialTypes().getExtras()) {
-            if (extra instanceof WiredExtraVariableReference && ((WiredExtraVariableReference) extra).isUserReference()) {
+            if (extra instanceof WiredExtraVariableReference
+                    && ((WiredExtraVariableReference) extra).isUserReference()) {
                 WiredExtraVariableReference reference = (WiredExtraVariableReference) extra;
 
                 if (!hasVisibleDefinitionName(reference.getVariableName())) {
@@ -838,7 +936,8 @@ public class RoomUserVariableManager {
             }
         }
 
-        result.sort(Comparator.comparing(WiredExtraVariableReference::getVariableName, String.CASE_INSENSITIVE_ORDER).thenComparingInt(WiredExtraVariableReference::getId));
+        result.sort(Comparator.comparing(WiredExtraVariableReference::getVariableName, String.CASE_INSENSITIVE_ORDER)
+                .thenComparingInt(WiredExtraVariableReference::getId));
         return result;
     }
 
@@ -861,7 +960,8 @@ public class RoomUserVariableManager {
             }
         }
 
-        result.sort(Comparator.comparing(WiredExtraVariableEcho::getVariableName, String.CASE_INSENSITIVE_ORDER).thenComparingInt(WiredExtraVariableEcho::getId));
+        result.sort(Comparator.comparing(WiredExtraVariableEcho::getVariableName, String.CASE_INSENSITIVE_ORDER)
+                .thenComparingInt(WiredExtraVariableEcho::getId));
         return result;
     }
 
@@ -876,8 +976,12 @@ public class RoomUserVariableManager {
 
         InteractionWiredExtra extra = this.getDefinitionExtra(definitionItemId);
         if (extra instanceof WiredExtraVariableReference) {
-            WiredVariableReferenceSupport.SharedUserAssignment assignment = WiredVariableReferenceSupport.getSharedUserAssignment((WiredExtraVariableReference) extra, userId);
-            return (assignment != null) ? new VariableAssignment(assignment.getValue(), assignment.getCreatedAt(), assignment.getUpdatedAt()) : null;
+            WiredVariableReferenceSupport.SharedUserAssignment assignment =
+                    WiredVariableReferenceSupport.getSharedUserAssignment((WiredExtraVariableReference) extra, userId);
+            return (assignment != null)
+                    ? new VariableAssignment(
+                            assignment.getValue(), assignment.getCreatedAt(), assignment.getUpdatedAt())
+                    : null;
         }
 
         if (extra instanceof WiredExtraVariableEcho) {
@@ -886,7 +990,10 @@ public class RoomUserVariableManager {
                 return null;
             }
 
-            return new VariableAssignment(echo.getCurrentValue(this.room, userId), echo.getCreatedAt(this.room, userId), echo.getUpdatedAt(this.room, userId));
+            return new VariableAssignment(
+                    echo.getCurrentValue(this.room, userId),
+                    echo.getCreatedAt(this.room, userId),
+                    echo.getUpdatedAt(this.room, userId));
         }
 
         ConcurrentHashMap<Integer, VariableAssignment> assignments = this.activeAssignmentsByUserId.get(userId);
@@ -898,35 +1005,69 @@ public class RoomUserVariableManager {
         return (assignment != null) ? assignment.getValue() : null;
     }
 
-    private void emitVariableChangedEvents(int userId, InteractionWiredExtra definitionExtra, WiredVariableDefinitionInfo definitionInfo, boolean existedBefore, Integer previousValue, boolean existsAfter, Integer currentValue) {
+    private void emitVariableChangedEvents(
+            int userId,
+            InteractionWiredExtra definitionExtra,
+            WiredVariableDefinitionInfo definitionInfo,
+            boolean existedBefore,
+            Integer previousValue,
+            boolean existsAfter,
+            Integer currentValue) {
         if (definitionInfo == null) {
             return;
         }
 
-        this.emitVariableChangedEvent(userId, definitionInfo.getItemId(), definitionInfo.hasValue(), existedBefore, previousValue, existsAfter, currentValue);
+        this.emitVariableChangedEvent(
+                userId,
+                definitionInfo.getItemId(),
+                definitionInfo.hasValue(),
+                existedBefore,
+                previousValue,
+                existsAfter,
+                currentValue);
 
-        for (WiredVariableDefinitionInfo derivedDefinition : WiredVariableLevelSystemSupport.getDerivedDefinitions(this.room, WiredVariableLevelSystemSupport.TARGET_USER, definitionExtra, definitionInfo)) {
-            WiredVariableLevelSystemSupport.DerivedDefinition resolvedDefinition = WiredVariableLevelSystemSupport.resolveDerivedDefinition(this.room, WiredVariableLevelSystemSupport.TARGET_USER, derivedDefinition.getItemId());
+        for (WiredVariableDefinitionInfo derivedDefinition : WiredVariableLevelSystemSupport.getDerivedDefinitions(
+                this.room, WiredVariableLevelSystemSupport.TARGET_USER, definitionExtra, definitionInfo)) {
+            WiredVariableLevelSystemSupport.DerivedDefinition resolvedDefinition =
+                    WiredVariableLevelSystemSupport.resolveDerivedDefinition(
+                            this.room, WiredVariableLevelSystemSupport.TARGET_USER, derivedDefinition.getItemId());
 
             if (resolvedDefinition == null) {
                 continue;
             }
 
             Integer derivedPreviousValue = existedBefore
-                    ? WiredVariableLevelSystemSupport.getDerivedValue(resolvedDefinition.getLevelSystem(), resolvedDefinition.getSubvariableType(), previousValue)
+                    ? WiredVariableLevelSystemSupport.getDerivedValue(
+                            resolvedDefinition.getLevelSystem(), resolvedDefinition.getSubvariableType(), previousValue)
                     : null;
             Integer derivedCurrentValue = existsAfter
-                    ? WiredVariableLevelSystemSupport.getDerivedValue(resolvedDefinition.getLevelSystem(), resolvedDefinition.getSubvariableType(), currentValue)
+                    ? WiredVariableLevelSystemSupport.getDerivedValue(
+                            resolvedDefinition.getLevelSystem(), resolvedDefinition.getSubvariableType(), currentValue)
                     : null;
 
-            this.emitVariableChangedEvent(userId, derivedDefinition.getItemId(), true, existedBefore, derivedPreviousValue, existsAfter, derivedCurrentValue);
+            this.emitVariableChangedEvent(
+                    userId,
+                    derivedDefinition.getItemId(),
+                    true,
+                    existedBefore,
+                    derivedPreviousValue,
+                    existsAfter,
+                    derivedCurrentValue);
         }
     }
 
-    private void emitVariableChangedEvent(int userId, int definitionItemId, boolean hasValue, boolean existedBefore, Integer previousValue, boolean existsAfter, Integer currentValue) {
+    private void emitVariableChangedEvent(
+            int userId,
+            int definitionItemId,
+            boolean hasValue,
+            boolean existedBefore,
+            Integer previousValue,
+            boolean existsAfter,
+            Integer currentValue) {
         boolean created = !existedBefore && existsAfter;
         boolean deleted = existedBefore && !existsAfter;
-        WiredEvent.VariableChangeKind changeKind = resolveVariableChangeKind(hasValue, existedBefore, previousValue, existsAfter, currentValue);
+        WiredEvent.VariableChangeKind changeKind =
+                resolveVariableChangeKind(hasValue, existedBefore, previousValue, existsAfter, currentValue);
 
         if (!created && !deleted && changeKind == WiredEvent.VariableChangeKind.NONE) {
             return;
@@ -935,7 +1076,8 @@ public class RoomUserVariableManager {
         WiredManager.triggerUserVariableChanged(this.room, userId, definitionItemId, created, deleted, changeKind);
     }
 
-    private static WiredEvent.VariableChangeKind resolveVariableChangeKind(boolean hasValue, boolean existedBefore, Integer previousValue, boolean existsAfter, Integer currentValue) {
+    private static WiredEvent.VariableChangeKind resolveVariableChangeKind(
+            boolean hasValue, boolean existedBefore, Integer previousValue, boolean existsAfter, Integer currentValue) {
         if (!hasValue || !existedBefore || !existsAfter) {
             return WiredEvent.VariableChangeKind.NONE;
         }
@@ -963,7 +1105,12 @@ public class RoomUserVariableManager {
                     assignment != null ? assignment.getCreatedAt() : now,
                     assignment != null ? assignment.getUpdatedAt() : now);
         } catch (SQLException e) {
-            LOGGER.error("Failed to store permanent wired user variable for room {}, user {}, item {}", this.room.getId(), userId, definitionItemId, e);
+            LOGGER.error(
+                    "Failed to store permanent wired user variable for room {}, user {}, item {}",
+                    this.room.getId(),
+                    userId,
+                    definitionItemId,
+                    e);
         }
     }
 
@@ -971,7 +1118,12 @@ public class RoomUserVariableManager {
         try {
             this.repository.delete(this.room.getId(), userId, definitionItemId);
         } catch (SQLException e) {
-            LOGGER.error("Failed to delete permanent wired user variable for room {}, user {}, item {}", this.room.getId(), userId, definitionItemId, e);
+            LOGGER.error(
+                    "Failed to delete permanent wired user variable for room {}, user {}, item {}",
+                    this.room.getId(),
+                    userId,
+                    definitionItemId,
+                    e);
         }
     }
 
@@ -979,7 +1131,11 @@ public class RoomUserVariableManager {
         try {
             this.repository.deleteDefinition(this.room.getId(), definitionItemId);
         } catch (SQLException e) {
-            LOGGER.error("Failed to delete permanent wired user variables for room {} and item {}", this.room.getId(), definitionItemId, e);
+            LOGGER.error(
+                    "Failed to delete permanent wired user variables for room {} and item {}",
+                    this.room.getId(),
+                    definitionItemId,
+                    e);
         }
     }
 
@@ -1015,7 +1171,8 @@ public class RoomUserVariableManager {
         private final boolean textConnected;
         private final boolean readOnly;
 
-        public DefinitionEntry(int itemId, String name, boolean hasValue, int availability, boolean textConnected, boolean readOnly) {
+        public DefinitionEntry(
+                int itemId, String name, boolean hasValue, int availability, boolean textConnected, boolean readOnly) {
             this.itemId = itemId;
             this.name = name;
             this.hasValue = hasValue;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableRepository.java
@@ -7,6 +7,8 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
 import javax.sql.DataSource;
 
 final class RoomUserVariableRepository {
@@ -20,15 +22,19 @@ final class RoomUserVariableRepository {
                     + "VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE value = VALUES(value), "
                     + "updated_at = VALUES(updated_at)";
 
-    private final DataSource dataSource;
+    private final Supplier<? extends DataSource> dataSource;
 
     RoomUserVariableRepository(DataSource dataSource) {
-        this.dataSource = dataSource;
+        this(() -> dataSource);
+    }
+
+    RoomUserVariableRepository(Supplier<? extends DataSource> dataSource) {
+        this.dataSource = Objects.requireNonNull(dataSource);
     }
 
     List<StoredAssignment> findByUser(int roomId, int userId) throws SQLException {
         List<StoredAssignment> assignments = new ArrayList<>();
-        try (Connection connection = dataSource.getConnection();
+        try (Connection connection = dataSource.get().getConnection();
                 PreparedStatement statement = connection.prepareStatement(FIND_BY_USER_SQL)) {
             statement.setInt(1, roomId);
             statement.setInt(2, userId);
@@ -56,7 +62,7 @@ final class RoomUserVariableRepository {
             int createdAt,
             int updatedAt)
             throws SQLException {
-        try (Connection connection = dataSource.getConnection();
+        try (Connection connection = dataSource.get().getConnection();
                 PreparedStatement statement = connection.prepareStatement(UPSERT_SQL)) {
             statement.setInt(1, roomId);
             statement.setInt(2, userId);
@@ -73,7 +79,7 @@ final class RoomUserVariableRepository {
     }
 
     void delete(int roomId, int userId, int definitionItemId) throws SQLException {
-        try (Connection connection = dataSource.getConnection();
+        try (Connection connection = dataSource.get().getConnection();
                 PreparedStatement statement = connection.prepareStatement(
                         "DELETE FROM room_user_wired_variables "
                                 + "WHERE room_id = ? AND user_id = ? AND variable_item_id = ?")) {
@@ -85,7 +91,7 @@ final class RoomUserVariableRepository {
     }
 
     void deleteDefinition(int roomId, int definitionItemId) throws SQLException {
-        try (Connection connection = dataSource.getConnection();
+        try (Connection connection = dataSource.get().getConnection();
                 PreparedStatement statement = connection.prepareStatement(
                         "DELETE FROM room_user_wired_variables WHERE room_id = ? AND variable_item_id = ?")) {
             statement.setInt(1, roomId);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableRepository.java
@@ -1,0 +1,98 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
+
+final class RoomUserVariableRepository {
+    private static final String FIND_BY_USER_SQL = """
+            SELECT variable_item_id, value, created_at, updated_at
+            FROM room_user_wired_variables
+            WHERE room_id = ? AND user_id = ?
+            """;
+    private static final String UPSERT_SQL =
+            "INSERT INTO room_user_wired_variables (room_id, user_id, variable_item_id, value, created_at, updated_at) "
+                    + "VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE value = VALUES(value), "
+                    + "updated_at = VALUES(updated_at)";
+
+    private final DataSource dataSource;
+
+    RoomUserVariableRepository(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    List<StoredAssignment> findByUser(int roomId, int userId) throws SQLException {
+        List<StoredAssignment> assignments = new ArrayList<>();
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(FIND_BY_USER_SQL)) {
+            statement.setInt(1, roomId);
+            statement.setInt(2, userId);
+
+            try (ResultSet set = statement.executeQuery()) {
+                while (set.next()) {
+                    int rawValue = set.getInt("value");
+                    Integer value = set.wasNull() ? null : rawValue;
+                    assignments.add(new StoredAssignment(
+                            set.getInt("variable_item_id"),
+                            value,
+                            set.getInt("created_at"),
+                            set.getInt("updated_at")));
+                }
+            }
+        }
+        return assignments;
+    }
+
+    void upsert(
+            int roomId,
+            int userId,
+            int definitionItemId,
+            Integer value,
+            int createdAt,
+            int updatedAt)
+            throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(UPSERT_SQL)) {
+            statement.setInt(1, roomId);
+            statement.setInt(2, userId);
+            statement.setInt(3, definitionItemId);
+            if (value == null) {
+                statement.setNull(4, Types.INTEGER);
+            } else {
+                statement.setInt(4, value);
+            }
+            statement.setInt(5, createdAt);
+            statement.setInt(6, updatedAt);
+            statement.executeUpdate();
+        }
+    }
+
+    void delete(int roomId, int userId, int definitionItemId) throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "DELETE FROM room_user_wired_variables "
+                                + "WHERE room_id = ? AND user_id = ? AND variable_item_id = ?")) {
+            statement.setInt(1, roomId);
+            statement.setInt(2, userId);
+            statement.setInt(3, definitionItemId);
+            statement.executeUpdate();
+        }
+    }
+
+    void deleteDefinition(int roomId, int definitionItemId) throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "DELETE FROM room_user_wired_variables WHERE room_id = ? AND variable_item_id = ?")) {
+            statement.setInt(1, roomId);
+            statement.setInt(2, definitionItemId);
+            statement.executeUpdate();
+        }
+    }
+
+    record StoredAssignment(int definitionItemId, Integer value, int createdAt, int updatedAt) {}
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableRepository.java
@@ -44,23 +44,14 @@ final class RoomUserVariableRepository {
                     int rawValue = set.getInt("value");
                     Integer value = set.wasNull() ? null : rawValue;
                     assignments.add(new StoredAssignment(
-                            set.getInt("variable_item_id"),
-                            value,
-                            set.getInt("created_at"),
-                            set.getInt("updated_at")));
+                            set.getInt("variable_item_id"), value, set.getInt("created_at"), set.getInt("updated_at")));
                 }
             }
         }
         return assignments;
     }
 
-    void upsert(
-            int roomId,
-            int userId,
-            int definitionItemId,
-            Integer value,
-            int createdAt,
-            int updatedAt)
+    void upsert(int roomId, int userId, int definitionItemId, Integer value, int createdAt, int updatedAt)
             throws SQLException {
         try (Connection connection = dataSource.get().getConnection();
                 PreparedStatement statement = connection.prepareStatement(UPSERT_SQL)) {
@@ -80,9 +71,8 @@ final class RoomUserVariableRepository {
 
     void delete(int roomId, int userId, int definitionItemId) throws SQLException {
         try (Connection connection = dataSource.get().getConnection();
-                PreparedStatement statement = connection.prepareStatement(
-                        "DELETE FROM room_user_wired_variables "
-                                + "WHERE room_id = ? AND user_id = ? AND variable_item_id = ?")) {
+                PreparedStatement statement = connection.prepareStatement("DELETE FROM room_user_wired_variables "
+                        + "WHERE room_id = ? AND user_id = ? AND variable_item_id = ?")) {
             statement.setInt(1, roomId);
             statement.setInt(2, userId);
             statement.setInt(3, definitionItemId);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredManager.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,6 +99,9 @@ public final class WiredManager {
     /** Whether the engine is initialized */
     private static volatile boolean initialized = false;
 
+    /** Explicit owner for the wired engine, index, and tick lifecycle. */
+    private static final AtomicReference<WiredRuntime> RUNTIME = new AtomicReference<>();
+
     private static final ThreadLocal<Integer> EVENT_HANDLING_DEPTH = new ThreadLocal<>();
     private static final ThreadLocal<ArrayDeque<DeferredEffectEvent>> DEFERRED_EFFECT_EVENTS = new ThreadLocal<>();
 
@@ -144,8 +148,9 @@ public final class WiredManager {
         WiredServices services = DefaultWiredServices.getInstance();
         engine = new WiredEngine(services, stackIndex, maxSteps);
 
-        // Start the centralized tick service (50ms interval)
-        WiredTickService.getInstance().start();
+        WiredRuntime runtime = new WiredRuntime(engine, stackIndex, WiredTickService.getInstance());
+        runtime.start();
+        RUNTIME.set(runtime);
 
         initialized = true;
 
@@ -172,17 +177,20 @@ public final class WiredManager {
 
         LOGGER.info("Shutting down Wired Manager...");
 
-        // Stop the tick service first
-        WiredTickService.getInstance().stop();
-
-        if (stackIndex != null) {
-            stackIndex.clearAll();
-        }
-
-        if (engine != null) {
-            engine.clearUnseenCache();
-            engine.clearAllDiagnostics();
-            engine.clearAllExecutionCaches();
+        WiredRuntime currentRuntime = RUNTIME.get();
+        if (currentRuntime != null) {
+            currentRuntime.shutdown();
+        } else {
+            // Defensive compatibility path for partially initialized legacy state.
+            WiredTickService.getInstance().stop();
+            if (stackIndex != null) {
+                stackIndex.clearAll();
+            }
+            if (engine != null) {
+                engine.clearUnseenCache();
+                engine.clearAllDiagnostics();
+                engine.clearAllExecutionCaches();
+            }
         }
 
         initialized = false;
@@ -194,7 +202,8 @@ public final class WiredManager {
      * @return true if enabled
      */
     public static boolean isEnabled() {
-        return initialized && engine != null;
+        WiredRuntime currentRuntime = RUNTIME.get();
+        return currentRuntime != null ? currentRuntime.isActive() : initialized && engine != null;
     }
 
     /**
@@ -210,7 +219,8 @@ public final class WiredManager {
      * @return the engine, or null if not initialized
      */
     public static WiredEngine getEngine() {
-        return engine;
+        WiredRuntime currentRuntime = RUNTIME.get();
+        return currentRuntime != null ? currentRuntime.engine() : engine;
     }
 
     /**
@@ -218,7 +228,8 @@ public final class WiredManager {
      * @return the stack index, or null if not initialized
      */
     public static RoomWiredStackIndex getStackIndex() {
-        return stackIndex;
+        WiredRuntime currentRuntime = RUNTIME.get();
+        return currentRuntime != null ? currentRuntime.stackIndex() : stackIndex;
     }
 
     /**
@@ -947,7 +958,7 @@ public final class WiredManager {
      * @param tickable the tickable item (e.g., WiredTriggerRepeater)
      */
     public static void registerTickable(Room room, WiredTickable tickable) {
-        WiredTickService.getInstance().register(room, tickable);
+        getTickService().register(room, tickable);
     }
 
     /**
@@ -961,7 +972,7 @@ public final class WiredManager {
      * @param tickable the tickable item
      */
     public static void unregisterTickable(Room room, WiredTickable tickable) {
-        WiredTickService.getInstance().unregister(room, tickable);
+        getTickService().unregister(room, tickable);
     }
 
     /**
@@ -973,7 +984,7 @@ public final class WiredManager {
      * @param room the room
      */
     public static void unregisterRoomTickables(Room room) {
-        WiredTickService.getInstance().unregisterRoom(room);
+        getTickService().unregisterRoom(room);
         if (room != null) {
             room.getFurniVariableManager().clearTransientAssignments();
             room.getRoomVariableManager().clearTransientAssignments();
@@ -987,7 +998,8 @@ public final class WiredManager {
      * @return the WiredTickService
      */
     public static WiredTickService getTickService() {
-        return WiredTickService.getInstance();
+        WiredRuntime currentRuntime = RUNTIME.get();
+        return currentRuntime != null ? currentRuntime.tickService() : WiredTickService.getInstance();
     }
 
     public static boolean isTriggerExecutionAllowed(Room room, HabboItem triggerItem, long timestamp) {
@@ -1031,7 +1043,7 @@ public final class WiredManager {
         if (!room.isLoaded()) return;
 
         // Use the centralized tick service for timer resets
-        WiredTickService.getInstance().resetRoomTimers(room);
+        getTickService().resetRoomTimers(room);
 
         room.setLastTimerReset(Emulator.getIntUnixTimestamp());
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredRuntime.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredRuntime.java
@@ -1,0 +1,61 @@
+package com.eu.habbo.habbohotel.wired.core;
+
+import com.eu.habbo.habbohotel.wired.tick.WiredTickService;
+import java.util.Objects;
+
+/**
+ * Owns the wired engine, stack index, and tick-service lifecycle.
+ *
+ * <p>{@link WiredManager} remains the static compatibility facade used by legacy plugins and existing
+ * first-party callers.
+ */
+final class WiredRuntime {
+    private final WiredEngine engine;
+    private final RoomWiredStackIndex stackIndex;
+    private final WiredTickService tickService;
+    private boolean active;
+
+    WiredRuntime(WiredEngine engine, RoomWiredStackIndex stackIndex, WiredTickService tickService) {
+        this.engine = Objects.requireNonNull(engine);
+        this.stackIndex = Objects.requireNonNull(stackIndex);
+        this.tickService = Objects.requireNonNull(tickService);
+    }
+
+    synchronized void start() {
+        if (active) {
+            return;
+        }
+
+        tickService.start();
+        active = true;
+    }
+
+    synchronized void shutdown() {
+        if (!active) {
+            return;
+        }
+
+        tickService.stop();
+        stackIndex.clearAll();
+        engine.clearUnseenCache();
+        engine.clearAllDiagnostics();
+        engine.clearAllExecutionCaches();
+        active = false;
+    }
+
+    synchronized boolean isActive() {
+        return active;
+    }
+
+    WiredEngine engine() {
+        return engine;
+    }
+
+    RoomWiredStackIndex stackIndex() {
+        return stackIndex;
+    }
+
+    WiredTickService tickService() {
+        return tickService;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/ItemInteractionRegistryCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/ItemInteractionRegistryCompatibilityTest.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.habbohotel.items;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.eu.habbo.habbohotel.items.interactions.InteractionDefault;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ItemInteractionRegistryCompatibilityTest {
+
+    @Test
+    void lookupFallbackOrderingAndUniquenessStayStable() {
+        TestItemManager manager = new TestItemManager();
+        manager.loadDefaults();
+
+        ItemInteraction defaultInteraction = manager.getItemInteraction(InteractionDefault.class);
+        assertSame(defaultInteraction, manager.getItemInteraction("missing-interaction"));
+
+        List<String> names = manager.getInteractionList();
+        List<String> sorted = new ArrayList<>(names);
+        sorted.sort(String::compareTo);
+        assertEquals(sorted, names);
+        assertTrue(names.contains("default"));
+
+        assertThrows(
+                RuntimeException.class,
+                () -> manager.addItemInteraction(
+                        new ItemInteraction("duplicate-default-type", InteractionDefault.class)));
+    }
+
+    private static final class TestItemManager extends ItemManager {
+        private void loadDefaults() {
+            loadItemInteractions();
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomUnitIndexCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomUnitIndexCompatibilityTest.java
@@ -1,0 +1,24 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+class RoomUnitIndexCompatibilityTest {
+
+    @Test
+    void liveCollectionsAndUnitCounterSurviveIndexExtraction() {
+        RoomUnitManager manager = new Room(41, 7).getUnitManager();
+
+        assertSame(manager.getCurrentHabbos(), manager.getCurrentHabbos());
+        assertSame(manager.getHabboQueue(), manager.getHabboQueue());
+        assertSame(manager.getCurrentBots(), manager.getCurrentBots());
+        assertSame(manager.getCurrentPets(), manager.getCurrentPets());
+
+        assertEquals(0, manager.getNextUnitId());
+        assertEquals(1, manager.getNextUnitId());
+        manager.clear();
+        assertEquals(0, manager.getUnitCounter());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomUserVariablePersistenceCharacterizationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomUserVariablePersistenceCharacterizationTest.java
@@ -1,0 +1,45 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.sql.Types;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RoomUserVariablePersistenceCharacterizationTest {
+
+    @Test
+    void permanentAssignmentsKeepTheirSqlAndParameterOrder() throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource = new RoomJdbcTestSupport.RecordingDataSource();
+        try (RoomJdbcTestSupport.InstalledDatabase ignored = RoomJdbcTestSupport.install(dataSource)) {
+            Room room = mock(Room.class);
+            when(room.getId()).thenReturn(44);
+            RoomUserVariableManager manager = new RoomUserVariableManager(room);
+
+            Class<?> assignmentType =
+                    Class.forName(RoomUserVariableManager.class.getName() + "$VariableAssignment");
+            Constructor<?> constructor = assignmentType.getDeclaredConstructor(Integer.class, int.class, int.class);
+            constructor.setAccessible(true);
+            Object assignment = constructor.newInstance(null, 101, 202);
+
+            Method upsert = RoomUserVariableManager.class.getDeclaredMethod(
+                    "upsertPersistentAssignment", int.class, int.class, assignmentType);
+            upsert.setAccessible(true);
+            upsert.invoke(manager, 7, 9, assignment);
+
+            RoomJdbcTestSupport.SqlCall call = dataSource.calls().getFirst();
+            assertEquals(
+                    "INSERT INTO room_user_wired_variables (room_id, user_id, variable_item_id, value, created_at, updated_at) "
+                            + "VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE value = VALUES(value), updated_at = VALUES(updated_at)",
+                    call.sql());
+            assertEquals(
+                    Map.of(1, 44, 2, 7, 3, 9, 4, Types.INTEGER, 5, 101, 6, 202),
+                    call.parameters());
+            assertEquals("update", call.operation());
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomUserVariablePersistenceCharacterizationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomUserVariablePersistenceCharacterizationTest.java
@@ -20,8 +20,7 @@ class RoomUserVariablePersistenceCharacterizationTest {
             when(room.getId()).thenReturn(44);
             RoomUserVariableManager manager = new RoomUserVariableManager(room);
 
-            Class<?> assignmentType =
-                    Class.forName(RoomUserVariableManager.class.getName() + "$VariableAssignment");
+            Class<?> assignmentType = Class.forName(RoomUserVariableManager.class.getName() + "$VariableAssignment");
             Constructor<?> constructor = assignmentType.getDeclaredConstructor(Integer.class, int.class, int.class);
             constructor.setAccessible(true);
             Object assignment = constructor.newInstance(null, 101, 202);
@@ -36,9 +35,7 @@ class RoomUserVariablePersistenceCharacterizationTest {
                     "INSERT INTO room_user_wired_variables (room_id, user_id, variable_item_id, value, created_at, updated_at) "
                             + "VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE value = VALUES(value), updated_at = VALUES(updated_at)",
                     call.sql());
-            assertEquals(
-                    Map.of(1, 44, 2, 7, 3, 9, 4, Types.INTEGER, 5, 101, 6, 202),
-                    call.parameters());
+            assertEquals(Map.of(1, 44, 2, 7, 3, 9, 4, Types.INTEGER, 5, 101, 6, 202), call.parameters());
             assertEquals("update", call.operation());
         }
     }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableRepositoryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableRepositoryTest.java
@@ -1,0 +1,47 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RoomUserVariableRepositoryTest {
+
+    @Test
+    void readsNullableAssignmentsWithTheirTimestamps() throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource = new RoomJdbcTestSupport.RecordingDataSource();
+        Map<String, Object> row = new HashMap<>();
+        row.put("variable_item_id", 91);
+        row.put("value", null);
+        row.put("created_at", 101);
+        row.put("updated_at", 202);
+        dataSource.rows(ignored -> List.of(row));
+
+        RoomUserVariableRepository repository = new RoomUserVariableRepository(dataSource);
+        RoomUserVariableRepository.StoredAssignment assignment = repository.findByUser(44, 7).getFirst();
+
+        assertEquals(91, assignment.definitionItemId());
+        assertNull(assignment.value());
+        assertEquals(101, assignment.createdAt());
+        assertEquals(202, assignment.updatedAt());
+        assertEquals(Map.of(1, 44, 2, 7), dataSource.calls().getFirst().parameters());
+    }
+
+    @Test
+    void deletesOneAssignmentWithoutBroadeningItsScope() throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource = new RoomJdbcTestSupport.RecordingDataSource();
+        RoomUserVariableRepository repository = new RoomUserVariableRepository(dataSource);
+
+        repository.delete(44, 7, 91);
+
+        RoomJdbcTestSupport.SqlCall call = dataSource.calls().getFirst();
+        assertEquals(
+                "DELETE FROM room_user_wired_variables "
+                        + "WHERE room_id = ? AND user_id = ? AND variable_item_id = ?",
+                call.sql());
+        assertEquals(Map.of(1, 44, 2, 7, 3, 91), call.parameters());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableRepositoryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.eu.habbo.habbohotel.rooms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.HashMap;
 import java.util.List;
@@ -11,11 +10,11 @@ import org.junit.jupiter.api.Test;
 class RoomUserVariableRepositoryTest {
 
     @Test
-    void readsNullableAssignmentsWithTheirTimestamps() throws Exception {
+    void readsAssignmentsWithTheirTimestamps() throws Exception {
         RoomJdbcTestSupport.RecordingDataSource dataSource = new RoomJdbcTestSupport.RecordingDataSource();
         Map<String, Object> row = new HashMap<>();
         row.put("variable_item_id", 91);
-        row.put("value", null);
+        row.put("value", 303);
         row.put("created_at", 101);
         row.put("updated_at", 202);
         dataSource.rows(ignored -> List.of(row));
@@ -24,7 +23,7 @@ class RoomUserVariableRepositoryTest {
         RoomUserVariableRepository.StoredAssignment assignment = repository.findByUser(44, 7).getFirst();
 
         assertEquals(91, assignment.definitionItemId());
-        assertNull(assignment.value());
+        assertEquals(303, assignment.value());
         assertEquals(101, assignment.createdAt());
         assertEquals(202, assignment.updatedAt());
         assertEquals(Map.of(1, 44, 2, 7), dataSource.calls().getFirst().parameters());

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableRepositoryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomUserVariableRepositoryTest.java
@@ -20,7 +20,8 @@ class RoomUserVariableRepositoryTest {
         dataSource.rows(ignored -> List.of(row));
 
         RoomUserVariableRepository repository = new RoomUserVariableRepository(dataSource);
-        RoomUserVariableRepository.StoredAssignment assignment = repository.findByUser(44, 7).getFirst();
+        RoomUserVariableRepository.StoredAssignment assignment =
+                repository.findByUser(44, 7).getFirst();
 
         assertEquals(91, assignment.definitionItemId());
         assertEquals(303, assignment.value());
@@ -38,8 +39,7 @@ class RoomUserVariableRepositoryTest {
 
         RoomJdbcTestSupport.SqlCall call = dataSource.calls().getFirst();
         assertEquals(
-                "DELETE FROM room_user_wired_variables "
-                        + "WHERE room_id = ? AND user_id = ? AND variable_item_id = ?",
+                "DELETE FROM room_user_wired_variables " + "WHERE room_id = ? AND user_id = ? AND variable_item_id = ?",
                 call.sql());
         assertEquals(Map.of(1, 44, 2, 7, 3, 91), call.parameters());
     }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/wired/core/WiredManagerLifecycleCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/wired/core/WiredManagerLifecycleCompatibilityTest.java
@@ -1,0 +1,45 @@
+package com.eu.habbo.habbohotel.wired.core;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class WiredManagerLifecycleCompatibilityTest {
+
+    @AfterEach
+    void resetManagerState() throws ReflectiveOperationException {
+        setStaticField("initialized", false);
+        setStaticField("engine", null);
+        setStaticField("stackIndex", null);
+    }
+
+    @Test
+    void shutdownClearsOwnedStateAndRetainsLegacyGetterIdentity() throws ReflectiveOperationException {
+        WiredEngine engine = mock(WiredEngine.class);
+        RoomWiredStackIndex stackIndex = mock(RoomWiredStackIndex.class);
+        setStaticField("engine", engine);
+        setStaticField("stackIndex", stackIndex);
+        setStaticField("initialized", true);
+
+        WiredManager.shutdown();
+
+        assertFalse(WiredManager.isEnabled());
+        assertSame(engine, WiredManager.getEngine());
+        assertSame(stackIndex, WiredManager.getStackIndex());
+        verify(stackIndex).clearAll();
+        verify(engine).clearUnseenCache();
+        verify(engine).clearAllDiagnostics();
+        verify(engine).clearAllExecutionCaches();
+    }
+
+    private static void setStaticField(String name, Object value) throws ReflectiveOperationException {
+        Field field = WiredManager.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(null, value);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/wired/core/WiredRuntimeTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/wired/core/WiredRuntimeTest.java
@@ -1,0 +1,54 @@
+package com.eu.habbo.habbohotel.wired.core;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.eu.habbo.habbohotel.wired.tick.WiredTickService;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+class WiredRuntimeTest {
+
+    @Test
+    void ownsStartupAndOrderedShutdown() {
+        WiredEngine engine = mock(WiredEngine.class);
+        RoomWiredStackIndex stackIndex = mock(RoomWiredStackIndex.class);
+        WiredTickService tickService = mock(WiredTickService.class);
+        WiredRuntime runtime = new WiredRuntime(engine, stackIndex, tickService);
+
+        runtime.start();
+        assertTrue(runtime.isActive());
+
+        runtime.shutdown();
+        assertFalse(runtime.isActive());
+
+        InOrder shutdownOrder = inOrder(tickService, stackIndex, engine);
+        shutdownOrder.verify(tickService).start();
+        shutdownOrder.verify(tickService).stop();
+        shutdownOrder.verify(stackIndex).clearAll();
+        shutdownOrder.verify(engine).clearUnseenCache();
+        shutdownOrder.verify(engine).clearAllDiagnostics();
+        shutdownOrder.verify(engine).clearAllExecutionCaches();
+    }
+
+    @Test
+    void lifecycleOperationsAreIdempotent() {
+        WiredEngine engine = mock(WiredEngine.class);
+        RoomWiredStackIndex stackIndex = mock(RoomWiredStackIndex.class);
+        WiredTickService tickService = mock(WiredTickService.class);
+        WiredRuntime runtime = new WiredRuntime(engine, stackIndex, tickService);
+
+        runtime.start();
+        runtime.start();
+        runtime.shutdown();
+        runtime.shutdown();
+
+        verify(tickService, times(1)).start();
+        verify(tickService, times(1)).stop();
+        verify(stackIndex, times(1)).clearAll();
+    }
+}


### PR DESCRIPTION
Introduces explicit owners for the wired lifecycle, permanent wired user-variable storage, item interaction registration, and room-unit indexes while retaining the existing managers as compatibility facades. Preserves live collections, lookup fallback, unit numbering, shutdown order, and persistence behavior.

Manual testing:
- Start the hotel, enter a room with bots, pets, interaction furniture, and timed wired stacks, then leave and shut down; confirm room activity and shutdown remain normal.
- Assign a permanent wired user variable, re-enter the room, and confirm the assignment is restored.