### PR TITLE
fix(runtime): make shared state updates atomic

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/VisitorBot.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/VisitorBot.java
@@ -26,7 +26,11 @@ public class VisitorBot extends Bot {
     }
 
     public static void initialise() {
-        DATE_FORMAT = new SimpleDateFormat(Emulator.getConfig().getValue("bots.visitor.dateformat"));
+        initialise(Emulator.getConfig().getValue("bots.visitor.dateformat"));
+    }
+
+    static void initialise(String pattern) {
+        DATE_FORMAT = new SimpleDateFormat(pattern);
     }
 
     @Override
@@ -42,7 +46,7 @@ public class VisitorBot extends Bot {
                     list.append("\r");
                     list.append(visit.roomName).append(" ");
                     list.append(Emulator.getTexts().getValue("generic.time.at")).append(" ");
-                    list.append(DATE_FORMAT.format(new Date((visit.timestamp * 1000L))));
+                    list.append(formatTimestamp(visit.timestamp));
                 }
 
                 visitMessage = visitMessage.replace("%list%", list.toString());
@@ -66,6 +70,10 @@ public class VisitorBot extends Bot {
                 }
             }
         }
+    }
+
+    static String formatTimestamp(int timestamp) {
+        return DATE_FORMAT.format(new Date(timestamp * 1000L));
     }
 
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/VisitorBot.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/VisitorBot.java
@@ -7,13 +7,14 @@ import com.eu.habbo.habbohotel.users.Habbo;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.Set;
 
 public class VisitorBot extends Bot {
-    private static SimpleDateFormat DATE_FORMAT;
+    private static DateTimeFormatter DATE_FORMAT;
     private boolean showedLog = false;
     private Set<ModToolRoomVisit> visits = new HashSet<>(3);
 
@@ -30,7 +31,7 @@ public class VisitorBot extends Bot {
     }
 
     static void initialise(String pattern) {
-        DATE_FORMAT = new SimpleDateFormat(pattern);
+        DATE_FORMAT = DateTimeFormatter.ofPattern(pattern).withZone(ZoneId.systemDefault());
     }
 
     @Override
@@ -73,7 +74,7 @@ public class VisitorBot extends Bot {
     }
 
     static String formatTimestamp(int timestamp) {
-        return DATE_FORMAT.format(new Date(timestamp * 1000L));
+        return DATE_FORMAT.format(Instant.ofEpochSecond(timestamp));
     }
 
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/VisitorBot.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/VisitorBot.java
@@ -4,7 +4,6 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.modtool.ModToolRoomVisit;
 import com.eu.habbo.habbohotel.rooms.RoomChatMessage;
 import com.eu.habbo.habbohotel.users.Habbo;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
@@ -40,7 +39,8 @@ public class VisitorBot extends Bot {
             if (message.getMessage().equalsIgnoreCase(Emulator.getTexts().getValue("generic.yes"))) {
                 this.showedLog = true;
 
-                String visitMessage = Emulator.getTexts().getValue("bots.visitor.list").replace("%count%", this.visits.size() + "");
+                String visitMessage =
+                        Emulator.getTexts().getValue("bots.visitor.list").replace("%count%", this.visits.size() + "");
 
                 StringBuilder list = new StringBuilder();
                 for (ModToolRoomVisit visit : this.visits) {
@@ -62,12 +62,23 @@ public class VisitorBot extends Bot {
     public void onUserEnter(Habbo habbo) {
         if (!this.showedLog) {
             if (habbo.getHabboInfo().getCurrentRoom() != null) {
-                this.visits = Emulator.getGameEnvironment().getModToolManager().getVisitsForRoom(habbo.getHabboInfo().getCurrentRoom(), 10, true, habbo.getHabboInfo().getLastOnline(), Emulator.getIntUnixTimestamp(), habbo.getHabboInfo().getCurrentRoom().getOwnerName());
+                this.visits = Emulator.getGameEnvironment()
+                        .getModToolManager()
+                        .getVisitsForRoom(
+                                habbo.getHabboInfo().getCurrentRoom(),
+                                10,
+                                true,
+                                habbo.getHabboInfo().getLastOnline(),
+                                Emulator.getIntUnixTimestamp(),
+                                habbo.getHabboInfo().getCurrentRoom().getOwnerName());
 
                 if (this.visits.isEmpty()) {
                     this.talk(Emulator.getTexts().getValue("bots.visitor.no_visits"));
                 } else {
-                    this.talk(Emulator.getTexts().getValue("bots.visitor.visits").replace("%count%", this.visits.size() + "").replace("%positive%", Emulator.getTexts().getValue("generic.yes")));
+                    this.talk(Emulator.getTexts()
+                            .getValue("bots.visitor.visits")
+                            .replace("%count%", this.visits.size() + "")
+                            .replace("%positive%", Emulator.getTexts().getValue("generic.yes")));
                 }
             }
         }
@@ -76,5 +87,4 @@ public class VisitorBot extends Bot {
     static String formatTimestamp(int timestamp) {
         return DATE_FORMAT.format(Instant.ofEpochSecond(timestamp));
     }
-
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
@@ -11,6 +11,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.OptionalInt;
 
 public class CatalogLimitedConfiguration implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogLimitedConfiguration.class);
@@ -23,11 +24,25 @@ public class CatalogLimitedConfiguration implements Runnable {
     private int soldOutFromPageId = 0;
 
     public CatalogLimitedConfiguration(int itemId, LinkedList<Integer> availableNumbers, int totalSet) {
+        this(
+                itemId,
+                availableNumbers,
+                totalSet,
+                Emulator.getConfig().getBoolean("catalog.ltd.random", true)
+        );
+    }
+
+    CatalogLimitedConfiguration(
+            int itemId,
+            LinkedList<Integer> availableNumbers,
+            int totalSet,
+            boolean randomize
+    ) {
         this.itemId = itemId;
         this.totalSet = totalSet;
         this.limitedNumbers = availableNumbers;
 
-        if (Emulator.getConfig().getBoolean("catalog.ltd.random", true)) {
+        if (randomize) {
             Collections.shuffle(this.limitedNumbers);
         } else {
             Collections.reverse(this.limitedNumbers);
@@ -37,6 +52,12 @@ public class CatalogLimitedConfiguration implements Runnable {
     public int getNumber() {
         synchronized (this.limitedNumbers) {
             return this.limitedNumbers.pop();
+        }
+    }
+
+    OptionalInt pollNumber() {
+        synchronized (this.limitedNumbers) {
+            return OptionalInt.of(this.limitedNumbers.pop());
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
@@ -57,7 +57,8 @@ public class CatalogLimitedConfiguration implements Runnable {
 
     OptionalInt pollNumber() {
         synchronized (this.limitedNumbers) {
-            return OptionalInt.of(this.limitedNumbers.pop());
+            Integer number = this.limitedNumbers.pollFirst();
+            return number == null ? OptionalInt.empty() : OptionalInt.of(number);
         }
     }
 
@@ -163,7 +164,9 @@ public class CatalogLimitedConfiguration implements Runnable {
     }
 
     public int available() {
-        return this.limitedNumbers.size();
+        synchronized (this.limitedNumbers) {
+            return this.limitedNumbers.size();
+        }
     }
 
     public int getTotalSet() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
@@ -3,15 +3,14 @@ package com.eu.habbo.habbohotel.catalog;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.OptionalInt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CatalogLimitedConfiguration implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogLimitedConfiguration.class);
@@ -24,20 +23,10 @@ public class CatalogLimitedConfiguration implements Runnable {
     private int soldOutFromPageId = 0;
 
     public CatalogLimitedConfiguration(int itemId, LinkedList<Integer> availableNumbers, int totalSet) {
-        this(
-                itemId,
-                availableNumbers,
-                totalSet,
-                Emulator.getConfig().getBoolean("catalog.ltd.random", true)
-        );
+        this(itemId, availableNumbers, totalSet, Emulator.getConfig().getBoolean("catalog.ltd.random", true));
     }
 
-    CatalogLimitedConfiguration(
-            int itemId,
-            LinkedList<Integer> availableNumbers,
-            int totalSet,
-            boolean randomize
-    ) {
+    CatalogLimitedConfiguration(int itemId, LinkedList<Integer> availableNumbers, int totalSet, boolean randomize) {
         this.itemId = itemId;
         this.totalSet = totalSet;
         this.limitedNumbers = availableNumbers;
@@ -73,9 +62,12 @@ public class CatalogLimitedConfiguration implements Runnable {
             if (!this.limitedNumbers.contains(number)) this.limitedNumbers.push(number);
 
             if (this.soldOutFromPageId > 0) {
-                CatalogItem catalogItem = Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(this.itemId);
+                CatalogItem catalogItem =
+                        Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(this.itemId);
                 if (catalogItem != null) {
-                    Emulator.getGameEnvironment().getCatalogManager().moveCatalogItem(catalogItem, this.soldOutFromPageId);
+                    Emulator.getGameEnvironment()
+                            .getCatalogManager()
+                            .moveCatalogItem(catalogItem, this.soldOutFromPageId);
                 }
                 this.soldOutFromPageId = 0;
             }
@@ -84,7 +76,8 @@ public class CatalogLimitedConfiguration implements Runnable {
             // the DB row matches the returned-to-pool in-memory state. A no-op when
             // the row is still unsold (user_id = 0).
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                 PreparedStatement statement = connection.prepareStatement("UPDATE catalog_items_limited SET user_id = 0, timestamp = 0, item_id = 0 WHERE catalog_item_id = ? AND number = ? LIMIT 1")) {
+                    PreparedStatement statement = connection.prepareStatement(
+                            "UPDATE catalog_items_limited SET user_id = 0, timestamp = 0, item_id = 0 WHERE catalog_item_id = ? AND number = ? LIMIT 1")) {
                 statement.setInt(1, catalogItemId);
                 statement.setInt(2, number);
                 statement.execute();
@@ -106,7 +99,8 @@ public class CatalogLimitedConfiguration implements Runnable {
     }
 
     public void limitedSold(Connection connection, int catalogItemId, Habbo habbo, HabboItem item) throws SQLException {
-        try (PreparedStatement statement = connection.prepareStatement("UPDATE catalog_items_limited SET user_id = ?, timestamp = ?, item_id = ? WHERE catalog_item_id = ? AND number = ? AND user_id = 0 LIMIT 1")) {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "UPDATE catalog_items_limited SET user_id = ?, timestamp = ?, item_id = ? WHERE catalog_item_id = ? AND number = ? AND user_id = 0 LIMIT 1")) {
             statement.setInt(1, habbo.getHabboInfo().getId());
             statement.setInt(2, Emulator.getIntUnixTimestamp());
             statement.setInt(3, item.getId());
@@ -127,11 +121,13 @@ public class CatalogLimitedConfiguration implements Runnable {
     public void markSoldOutIfEmpty() {
         synchronized (this.limitedNumbers) {
             if (this.limitedNumbers.isEmpty()) {
-                CatalogItem catalogItem = Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(this.itemId);
+                CatalogItem catalogItem =
+                        Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(this.itemId);
                 if (catalogItem != null) {
                     this.soldOutFromPageId = catalogItem.getPageId();
-                    Emulator.getGameEnvironment().getCatalogManager().moveCatalogItem(
-                            catalogItem, Emulator.getConfig().getInt("catalog.ltd.page.soldout"));
+                    Emulator.getGameEnvironment()
+                            .getCatalogManager()
+                            .moveCatalogItem(catalogItem, Emulator.getConfig().getInt("catalog.ltd.page.soldout"));
                 }
             }
         }
@@ -139,7 +135,9 @@ public class CatalogLimitedConfiguration implements Runnable {
 
     public void generateNumbers(int starting, int amount) {
         synchronized (this.limitedNumbers) {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO catalog_items_limited (catalog_item_id, number) VALUES (?, ?)")) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    PreparedStatement statement = connection.prepareStatement(
+                            "INSERT INTO catalog_items_limited (catalog_item_id, number) VALUES (?, ?)")) {
                 statement.setInt(1, this.itemId);
 
                 for (int i = starting; i <= amount; i++) {
@@ -179,7 +177,9 @@ public class CatalogLimitedConfiguration implements Runnable {
 
     @Override
     public void run() {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE catalog_items SET limited_stack = ?, limited_sells = ? WHERE id = ?")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "UPDATE catalog_items SET limited_stack = ?, limited_sells = ? WHERE id = ?")) {
             statement.setInt(1, this.totalSet);
             statement.setInt(2, this.totalSet - this.available());
             statement.setInt(3, this.itemId);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -530,7 +530,7 @@ public class CatalogManager {
     }
 
     private synchronized void loadCatalogFeaturedPages() {
-        this.catalogFeaturedPages.clear();
+        Int2ObjectMap<CatalogFeaturedPage> loadedFeaturedPages = new Int2ObjectOpenHashMap<>();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
                 Statement statement = connection.createStatement();
@@ -552,6 +552,8 @@ public class CatalogManager {
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
         }
+
+        this.replaceFeaturedPages(loadedFeaturedPages);
     }
 
     private synchronized void loadCatalogItems() {
@@ -680,8 +682,7 @@ public class CatalogManager {
     }
 
     private void loadTargetOffers() {
-        synchronized (this.targetOffers) {
-            this.targetOffers.clear();
+        Map<Integer, TargetOffer> loadedTargetOffers = new HashMap<>();
 
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
                     PreparedStatement statement = connection.prepareStatement(
@@ -692,10 +693,12 @@ public class CatalogManager {
                         this.targetOffers.put(set.getInt("id"), new TargetOffer(set));
                     }
                 }
-            } catch (SQLException e) {
-                LOGGER.error("Caught SQL exception", e);
             }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
         }
+
+        replaceContents(this.targetOffers, loadedTargetOffers);
     }
 
     private void loadVouchers() {
@@ -723,23 +726,54 @@ public class CatalogManager {
                 while (set.next()) {
                     Item item = Emulator.getGameEnvironment().getItemManager().getItem(set.getInt("item_id"));
 
-                    if (item != null) {
-                        if (this.prizes.get(set.getInt("rarity")) == null) {
-                            this.prizes.put(set.getInt("rarity"), new HashSet<>());
-                        }
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM recycler_prizes")) {
+            while (set.next()) {
+                Item item = Emulator.getGameEnvironment().getItemManager().getItem(set.getInt("item_id"));
 
-                        this.prizes.get(set.getInt("rarity")).add(item);
-                    } else {
-                        LOGGER.error("Cannot load item with ID: {} as recycler reward!", set.getInt("item_id"));
+                if (item != null) {
+                    if (loadedPrizes.get(set.getInt("rarity")) == null) {
+                        loadedPrizes.put(set.getInt("rarity"), new HashSet<>());
                     }
+
+                    loadedPrizes.get(set.getInt("rarity")).add(item);
+                } else {
+                    LOGGER.error("Cannot load item with ID: {} as recycler reward!", set.getInt("item_id"));
                 }
-            } catch (SQLException e) {
-                LOGGER.error("Caught SQL exception", e);
             }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
         }
+
+        replaceContents(this.prizes, loadedPrizes);
     }
 
     public void loadGiftWrappers() {
+        Map<Integer, Integer> loadedGiftWrappers = new HashMap<>();
+        Map<Integer, Integer> loadedGiftFurnis = new HashMap<>();
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM gift_wrappers ORDER BY sprite_id DESC")) {
+            while (set.next()) {
+                switch (set.getString("type")) {
+                    case "wrapper":
+                        loadedGiftWrappers.put(set.getInt("sprite_id"), set.getInt("item_id"));
+                        break;
+
+                    case "gift":
+                        loadedGiftFurnis.put(set.getInt("sprite_id"), set.getInt("item_id"));
+                        break;
+                }
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+
+        this.replaceGiftWrapping(loadedGiftWrappers, loadedGiftFurnis);
+    }
+
+    void replaceGiftWrapping(
+            Map<Integer, Integer> loadedGiftWrappers,
+            Map<Integer, Integer> loadedGiftFurnis
+    ) {
         synchronized (this.giftWrappers) {
             synchronized (this.giftFurnis) {
                 this.giftWrappers.clear();
@@ -768,8 +802,7 @@ public class CatalogManager {
     }
 
     private void loadClothing() {
-        synchronized (this.clothing) {
-            this.clothing.clear();
+        Map<Integer, ClothItem> loadedClothing = new HashMap<>();
 
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
                     Statement statement = connection.createStatement();
@@ -780,13 +813,19 @@ public class CatalogManager {
             } catch (SQLException e) {
                 LOGGER.error("Caught SQL exception", e);
             }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
         }
+
+        replaceContents(this.clothing, loadedClothing);
     }
 
     public ClothItem getClothing(String name) {
-        for (ClothItem item : this.clothing.values()) {
-            if (item.name.equalsIgnoreCase(name)) {
-                return item;
+        synchronized (this.clothing) {
+            for (ClothItem item : this.clothing.values()) {
+                if (item.name.equalsIgnoreCase(name)) {
+                    return item;
+                }
             }
         }
 
@@ -1008,6 +1047,7 @@ public class CatalogManager {
             LOGGER.error("No rewards specified for rarity level {}", level);
         }
 
+        LOGGER.error("No rewards specified for rarity level {}", level);
         return null;
     }
 
@@ -2415,7 +2455,23 @@ public class CatalogManager {
     }
 
     public TargetOffer getTargetOffer(int offerId) {
-        return this.targetOffers.get(offerId);
+        synchronized (this.targetOffers) {
+            return this.targetOffers.get(offerId);
+        }
+    }
+
+    void replaceFeaturedPages(Int2ObjectMap<CatalogFeaturedPage> loadedFeaturedPages) {
+        synchronized (this.catalogFeaturedPages) {
+            this.catalogFeaturedPages.clear();
+            this.catalogFeaturedPages.putAll(loadedFeaturedPages);
+        }
+    }
+
+    static <K, V> void replaceContents(Map<K, V> target, Map<K, V> loaded) {
+        synchronized (target) {
+            target.clear();
+            target.putAll(loaded);
+        }
     }
 
     private int calculateDiscountedPrice(int originalPrice, int amount, CatalogItem item) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -118,8 +118,7 @@ public class CatalogManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogManager.class);
 
-    public record GiftWrappingSnapshot(
-            Map<Integer, Integer> wrappers, Map<Integer, Integer> furniture) {}
+    public record GiftWrappingSnapshot(Map<Integer, Integer> wrappers, Map<Integer, Integer> furniture) {}
 
     public static final Map<String, Class<? extends CatalogPage>> pageDefinitions =
             new HashMap<String, Class<? extends CatalogPage>>(CatalogPageLayouts.values().length) {
@@ -689,8 +688,8 @@ public class CatalogManager {
         Map<Integer, TargetOffer> loadedTargetOffers = new HashMap<>();
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                PreparedStatement statement = connection.prepareStatement(
-                        "SELECT * FROM catalog_target_offers WHERE end_timestamp > ?")) {
+                PreparedStatement statement =
+                        connection.prepareStatement("SELECT * FROM catalog_target_offers WHERE end_timestamp > ?")) {
             statement.setInt(1, Emulator.getIntUnixTimestamp());
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
@@ -769,8 +768,7 @@ public class CatalogManager {
         this.replaceGiftWrapping(loadedGiftWrappers, loadedGiftFurnis);
     }
 
-    void replaceGiftWrapping(
-            Map<Integer, Integer> loadedGiftWrappers, Map<Integer, Integer> loadedGiftFurnis) {
+    void replaceGiftWrapping(Map<Integer, Integer> loadedGiftWrappers, Map<Integer, Integer> loadedGiftFurnis) {
         synchronized (this.giftWrappers) {
             synchronized (this.giftFurnis) {
                 this.giftWrappers.clear();
@@ -978,8 +976,7 @@ public class CatalogManager {
     public GiftWrappingSnapshot getGiftWrappingSnapshot() {
         synchronized (this.giftWrappers) {
             synchronized (this.giftFurnis) {
-                return new GiftWrappingSnapshot(
-                        new HashMap<>(this.giftWrappers), new HashMap<>(this.giftFurnis));
+                return new GiftWrappingSnapshot(new HashMap<>(this.giftWrappers), new HashMap<>(this.giftFurnis));
             }
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -108,6 +108,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -116,6 +117,9 @@ import org.slf4j.LoggerFactory;
 public class CatalogManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogManager.class);
+
+    public record GiftWrappingSnapshot(
+            Map<Integer, Integer> wrappers, Map<Integer, Integer> furniture) {}
 
     public static final Map<String, Class<? extends CatalogPage>> pageDefinitions =
             new HashMap<String, Class<? extends CatalogPage>>(CatalogPageLayouts.values().length) {
@@ -536,7 +540,7 @@ public class CatalogManager {
                 Statement statement = connection.createStatement();
                 ResultSet set = statement.executeQuery("SELECT * FROM catalog_featured_pages ORDER BY slot_id ASC")) {
             while (set.next()) {
-                this.catalogFeaturedPages.put(
+                loadedFeaturedPages.put(
                         set.getInt("slot_id"),
                         new CatalogFeaturedPage(
                                 set.getInt("slot_id"),
@@ -684,14 +688,13 @@ public class CatalogManager {
     private void loadTargetOffers() {
         Map<Integer, TargetOffer> loadedTargetOffers = new HashMap<>();
 
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                    PreparedStatement statement = connection.prepareStatement(
-                            "SELECT * FROM catalog_target_offers WHERE end_timestamp > ?")) {
-                statement.setInt(1, Emulator.getIntUnixTimestamp());
-                try (ResultSet set = statement.executeQuery()) {
-                    while (set.next()) {
-                        this.targetOffers.put(set.getInt("id"), new TargetOffer(set));
-                    }
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT * FROM catalog_target_offers WHERE end_timestamp > ?")) {
+            statement.setInt(1, Emulator.getIntUnixTimestamp());
+            try (ResultSet set = statement.executeQuery()) {
+                while (set.next()) {
+                    loadedTargetOffers.put(set.getInt("id"), new TargetOffer(set));
                 }
             }
         } catch (SQLException e) {
@@ -718,24 +721,18 @@ public class CatalogManager {
     }
 
     public void loadRecycler() {
-        synchronized (this.prizes) {
-            this.prizes.clear();
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                    Statement statement = connection.createStatement();
-                    ResultSet set = statement.executeQuery("SELECT * FROM recycler_prizes")) {
-                while (set.next()) {
-                    Item item = Emulator.getGameEnvironment().getItemManager().getItem(set.getInt("item_id"));
+        Map<Integer, Set<Item>> loadedPrizes = new HashMap<>();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM recycler_prizes")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM recycler_prizes")) {
             while (set.next()) {
                 Item item = Emulator.getGameEnvironment().getItemManager().getItem(set.getInt("item_id"));
 
                 if (item != null) {
-                    if (loadedPrizes.get(set.getInt("rarity")) == null) {
-                        loadedPrizes.put(set.getInt("rarity"), new HashSet<>());
-                    }
-
-                    loadedPrizes.get(set.getInt("rarity")).add(item);
+                    loadedPrizes
+                            .computeIfAbsent(set.getInt("rarity"), ignored -> new HashSet<>())
+                            .add(item);
                 } else {
                     LOGGER.error("Cannot load item with ID: {} as recycler reward!", set.getInt("item_id"));
                 }
@@ -751,7 +748,9 @@ public class CatalogManager {
         Map<Integer, Integer> loadedGiftWrappers = new HashMap<>();
         Map<Integer, Integer> loadedGiftFurnis = new HashMap<>();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM gift_wrappers ORDER BY sprite_id DESC")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM gift_wrappers ORDER BY sprite_id DESC")) {
             while (set.next()) {
                 switch (set.getString("type")) {
                     case "wrapper":
@@ -771,32 +770,13 @@ public class CatalogManager {
     }
 
     void replaceGiftWrapping(
-            Map<Integer, Integer> loadedGiftWrappers,
-            Map<Integer, Integer> loadedGiftFurnis
-    ) {
+            Map<Integer, Integer> loadedGiftWrappers, Map<Integer, Integer> loadedGiftFurnis) {
         synchronized (this.giftWrappers) {
             synchronized (this.giftFurnis) {
                 this.giftWrappers.clear();
                 this.giftFurnis.clear();
-
-                try (Connection connection =
-                                Emulator.getDatabase().getDataSource().getConnection();
-                        Statement statement = connection.createStatement();
-                        ResultSet set = statement.executeQuery("SELECT * FROM gift_wrappers ORDER BY sprite_id DESC")) {
-                    while (set.next()) {
-                        switch (set.getString("type")) {
-                            case "wrapper":
-                                this.giftWrappers.put(set.getInt("sprite_id"), set.getInt("item_id"));
-                                break;
-
-                            case "gift":
-                                this.giftFurnis.put(set.getInt("sprite_id"), set.getInt("item_id"));
-                                break;
-                        }
-                    }
-                } catch (SQLException e) {
-                    LOGGER.error("Caught SQL exception", e);
-                }
+                this.giftWrappers.putAll(loadedGiftWrappers);
+                this.giftFurnis.putAll(loadedGiftFurnis);
             }
         }
     }
@@ -804,14 +784,11 @@ public class CatalogManager {
     private void loadClothing() {
         Map<Integer, ClothItem> loadedClothing = new HashMap<>();
 
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                    Statement statement = connection.createStatement();
-                    ResultSet set = statement.executeQuery("SELECT * FROM catalog_clothing")) {
-                while (set.next()) {
-                    this.clothing.put(set.getInt("id"), new ClothItem(set));
-                }
-            } catch (SQLException e) {
-                LOGGER.error("Caught SQL exception", e);
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet set = statement.executeQuery("SELECT * FROM catalog_clothing")) {
+            while (set.next()) {
+                loadedClothing.put(set.getInt("id"), new ClothItem(set));
             }
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
@@ -992,6 +969,43 @@ public class CatalogManager {
         return this.catalogFeaturedPages;
     }
 
+    public List<CatalogFeaturedPage> getCatalogFeaturedPagesSnapshot() {
+        synchronized (this.catalogFeaturedPages) {
+            return new ArrayList<>(this.catalogFeaturedPages.values());
+        }
+    }
+
+    public GiftWrappingSnapshot getGiftWrappingSnapshot() {
+        synchronized (this.giftWrappers) {
+            synchronized (this.giftFurnis) {
+                return new GiftWrappingSnapshot(
+                        new HashMap<>(this.giftWrappers), new HashMap<>(this.giftFurnis));
+            }
+        }
+    }
+
+    public Map<Integer, Set<Item>> getRecyclerPrizesSnapshot() {
+        synchronized (this.prizes) {
+            Map<Integer, Set<Item>> snapshot = new HashMap<>();
+            for (Map.Entry<Integer, Set<Item>> entry : this.prizes.entrySet()) {
+                snapshot.put(entry.getKey(), new HashSet<>(entry.getValue()));
+            }
+            return snapshot;
+        }
+    }
+
+    public Map<Integer, ClothItem> getClothingSnapshot() {
+        synchronized (this.clothing) {
+            return new HashMap<>(this.clothing);
+        }
+    }
+
+    public Map<Integer, TargetOffer> getTargetOffersSnapshot() {
+        synchronized (this.targetOffers) {
+            return new HashMap<>(this.targetOffers);
+        }
+    }
+
     public CatalogItem getClubItem(int itemId) {
         synchronized (this.clubItems) {
             for (CatalogItem item : this.clubItems) {
@@ -1039,12 +1053,11 @@ public class CatalogManager {
             level = 2;
         }
 
-        if (this.prizes.containsKey(level) && !this.prizes.get(level).isEmpty()) {
-            return (Item) this.prizes.get(level)
-                    .toArray()[
-                    Emulator.getRandom().nextInt(this.prizes.get(level).size())];
-        } else {
-            LOGGER.error("No rewards specified for rarity level {}", level);
+        synchronized (this.prizes) {
+            Set<Item> levelPrizes = this.prizes.get(level);
+            if (levelPrizes != null && !levelPrizes.isEmpty()) {
+                return (Item) levelPrizes.toArray()[Emulator.getRandom().nextInt(levelPrizes.size())];
+            }
         }
 
         LOGGER.error("No rewards specified for rarity level {}", level);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -1283,7 +1283,14 @@ public class CatalogManager {
                 if (totalCredits > habbo.getHabboInfo().getCredits()) return;
                 if (totalPoints > habbo.getHabboInfo().getCurrencyAmount(item.getPointsType())) return;
 
-                if (limitedConfiguration != null) limitedNumber = limitedConfiguration.getNumber();
+                if (limitedConfiguration != null) {
+                    OptionalInt limitedNumberReservation = limitedConfiguration.pollNumber();
+                    if (limitedNumberReservation.isEmpty()) {
+                        habbo.getClient().sendResponse(new AlertLimitedSoldOutComposer());
+                        return;
+                    }
+                    limitedNumber = limitedNumberReservation.getAsInt();
+                }
 
                 if (this.isAtomicEntitlementPurchase(item)) {
                     this.purchaseEntitlementsAtomically(item, habbo, amount, free, totalCredits, totalPoints);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -276,6 +276,10 @@ public class CatalogManager {
     private volatile byte[] rareValuesPayloadCache;
 
     public CatalogManager() {
+        this(true);
+    }
+
+    CatalogManager(boolean initialize) {
         long millis = System.currentTimeMillis();
         this.catalogPages = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
         this.buildersClubCatalogPages = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
@@ -293,11 +297,13 @@ public class CatalogManager {
         this.limitedNumbers = new HashMap<>();
         this.furnitureValues = new Int2ObjectOpenHashMap<>();
 
-        this.initialize();
-
-        this.ecotronItem = Emulator.getGameEnvironment().getItemManager().getItem("ecotron_box");
-
-        LOGGER.info("Catalog Manager -> Loaded! ({} MS)", System.currentTimeMillis() - millis);
+        if (initialize) {
+            this.initialize();
+            this.ecotronItem = Emulator.getGameEnvironment().getItemManager().getItem("ecotron_box");
+            LOGGER.info("Catalog Manager -> Loaded! ({} MS)", System.currentTimeMillis() - millis);
+        } else {
+            this.ecotronItem = null;
+        }
     }
 
     public synchronized void initialize() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/layouts/FrontPageFeaturedLayout.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/layouts/FrontPageFeaturedLayout.java
@@ -7,6 +7,7 @@ import com.eu.habbo.messages.ServerMessage;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 
 public class FrontPageFeaturedLayout extends CatalogPage {
     public FrontPageFeaturedLayout(ResultSet set) throws SQLException {
@@ -36,9 +37,11 @@ public class FrontPageFeaturedLayout extends CatalogPage {
 
     public void serializeExtra(ServerMessage message) {
 
-        message.appendInt(Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPages().size());
+        List<CatalogFeaturedPage> featuredPages = Emulator.getGameEnvironment().getCatalogManager()
+                .getCatalogFeaturedPagesSnapshot();
+        message.appendInt(featuredPages.size());
 
-        for (CatalogFeaturedPage page : Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPages().values()) {
+        for (CatalogFeaturedPage page : featuredPages) {
             page.serialize(message);
         }
         message.appendInt(1); //Position

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/layouts/FrontPageFeaturedLayout.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/layouts/FrontPageFeaturedLayout.java
@@ -4,7 +4,6 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.catalog.CatalogFeaturedPage;
 import com.eu.habbo.habbohotel.catalog.CatalogPage;
 import com.eu.habbo.messages.ServerMessage;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
@@ -37,20 +36,20 @@ public class FrontPageFeaturedLayout extends CatalogPage {
 
     public void serializeExtra(ServerMessage message) {
 
-        List<CatalogFeaturedPage> featuredPages = Emulator.getGameEnvironment().getCatalogManager()
-                .getCatalogFeaturedPagesSnapshot();
+        List<CatalogFeaturedPage> featuredPages =
+                Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPagesSnapshot();
         message.appendInt(featuredPages.size());
 
         for (CatalogFeaturedPage page : featuredPages) {
             page.serialize(message);
         }
-        message.appendInt(1); //Position
+        message.appendInt(1); // Position
         message.appendString("NUOVO: Affare Stanza di Rilassamento");
         message.appendString("catalogue/feature_cata_vert_oly16bundle4.png");
-        message.appendInt(0); //Type
-        //0 : String //Page Name
-        //1 : Int //Page ID
-        //2 : String //Productdata
+        message.appendInt(0); // Type
+        // 0 : String //Page Name
+        // 1 : Int //Page ID
+        // 2 : String //Productdata
         message.appendString("");
         message.appendInt(-1);
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/GiftCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/GiftCommand.java
@@ -64,7 +64,11 @@ public class GiftCommand extends Command {
 
             HabboItem item = Emulator.getGameEnvironment().getItemManager().createItem(0, baseItem, 0, 0, "");
 
-            Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem((Integer) Emulator.getGameEnvironment().getCatalogManager().giftFurnis.values().toArray()[Emulator.getRandom().nextInt(Emulator.getGameEnvironment().getCatalogManager().giftFurnis.size())]);
+            Map<Integer, Integer> giftFurniture = Emulator.getGameEnvironment().getCatalogManager()
+                    .getGiftWrappingSnapshot().furniture();
+            Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem(
+                    (Integer) giftFurniture.values().toArray()[Emulator.getRandom().nextInt(giftFurniture.size())]
+            );
 
             String extraData = "1\t" + item.getId();
             extraData += "\t0\t0\t0\t" + finalMessage + "\t0\t0";

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/GiftCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/GiftCommand.java
@@ -11,7 +11,6 @@ import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,26 +28,46 @@ public class GiftCommand extends Command {
             try {
                 itemId = Integer.parseInt(params[2]);
             } catch (Exception e) {
-                gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_gift.not_a_number"), RoomChatMessageBubbles.ALERT);
+                gameClient
+                        .getHabbo()
+                        .whisper(
+                                Emulator.getTexts().getValue("commands.error.cmd_gift.not_a_number"),
+                                RoomChatMessageBubbles.ALERT);
                 return true;
             }
 
             if (itemId <= 0) {
-                gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_gift.not_a_number"), RoomChatMessageBubbles.ALERT);
+                gameClient
+                        .getHabbo()
+                        .whisper(
+                                Emulator.getTexts().getValue("commands.error.cmd_gift.not_a_number"),
+                                RoomChatMessageBubbles.ALERT);
                 return true;
             }
 
             Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(itemId);
 
             if (baseItem == null) {
-                gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_gift.not_found").replace("%itemid%", itemId + ""), RoomChatMessageBubbles.ALERT);
+                gameClient
+                        .getHabbo()
+                        .whisper(
+                                Emulator.getTexts()
+                                        .getValue("commands.error.cmd_gift.not_found")
+                                        .replace("%itemid%", itemId + ""),
+                                RoomChatMessageBubbles.ALERT);
                 return true;
             }
 
             HabboInfo habboInfo = HabboManager.getOfflineHabboInfo(username);
 
             if (habboInfo == null) {
-                gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_gift.user_not_found").replace("%username%", username), RoomChatMessageBubbles.ALERT);
+                gameClient
+                        .getHabbo()
+                        .whisper(
+                                Emulator.getTexts()
+                                        .getValue("commands.error.cmd_gift.user_not_found")
+                                        .replace("%username%", username),
+                                RoomChatMessageBubbles.ALERT);
                 return true;
             }
 
@@ -64,18 +83,26 @@ public class GiftCommand extends Command {
 
             HabboItem item = Emulator.getGameEnvironment().getItemManager().createItem(0, baseItem, 0, 0, "");
 
-            Map<Integer, Integer> giftFurniture = Emulator.getGameEnvironment().getCatalogManager()
-                    .getGiftWrappingSnapshot().furniture();
-            Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem(
-                    (Integer) giftFurniture.values().toArray()[Emulator.getRandom().nextInt(giftFurniture.size())]
-            );
+            Map<Integer, Integer> giftFurniture = Emulator.getGameEnvironment()
+                    .getCatalogManager()
+                    .getGiftWrappingSnapshot()
+                    .furniture();
+            Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem((Integer)
+                    giftFurniture.values().toArray()[Emulator.getRandom().nextInt(giftFurniture.size())]);
 
             String extraData = "1\t" + item.getId();
             extraData += "\t0\t0\t0\t" + finalMessage + "\t0\t0";
 
             Emulator.getGameEnvironment().getItemManager().createGift(username, giftItem, extraData, 0, 0);
 
-            gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.succes.cmd_gift").replace("%username%", username).replace("%itemname%", item.getBaseItem().getName()), RoomChatMessageBubbles.ALERT);
+            gameClient
+                    .getHabbo()
+                    .whisper(
+                            Emulator.getTexts()
+                                    .getValue("commands.succes.cmd_gift")
+                                    .replace("%username%", username)
+                                    .replace("%itemname%", item.getBaseItem().getName()),
+                            RoomChatMessageBubbles.ALERT);
 
             Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(habboInfo.getId());
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/MassGiftCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/MassGiftCommand.java
@@ -58,6 +58,8 @@ public class MassGiftCommand extends Command {
             keys.put("image", "${image.library.url}notifications/gift.gif");
             keys.put("message", Emulator.getTexts().getValue("generic.gift.received.anonymous"));
             ServerMessage giftNotificiationMessage = new BubbleAlertComposer(BubbleAlertKeys.RECEIVED_BADGE.key, keys).compose();
+            Map<Integer, Integer> giftFurniture = Emulator.getGameEnvironment().getCatalogManager()
+                    .getGiftWrappingSnapshot().furniture();
 
             Emulator.getThreading().run(() -> {
                 for (Map.Entry<Integer, Habbo> set : Emulator.getGameEnvironment().getHabboManager().getOnlineHabbos().entrySet()) {
@@ -65,7 +67,9 @@ public class MassGiftCommand extends Command {
 
                     HabboItem item = Emulator.getGameEnvironment().getItemManager().createItem(0, baseItem, 0, 0, "");
 
-                    Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem((Integer) Emulator.getGameEnvironment().getCatalogManager().giftFurnis.values().toArray()[Emulator.getRandom().nextInt(Emulator.getGameEnvironment().getCatalogManager().giftFurnis.size())]);
+                    Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem(
+                            (Integer) giftFurniture.values().toArray()[Emulator.getRandom().nextInt(giftFurniture.size())]
+                    );
 
                     String extraData = "1\t" + item.getId();
                     extraData += "\t0\t0\t0\t" + finalMessage + "\t0\t0";

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/MassGiftCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/MassGiftCommand.java
@@ -10,13 +10,14 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
-
 import java.util.HashMap;
 import java.util.Map;
 
 public class MassGiftCommand extends Command {
     public MassGiftCommand() {
-        super("cmd_massgift", Emulator.getTexts().getValue("commands.keys.cmd_massgift").split(";"));
+        super(
+                "cmd_massgift",
+                Emulator.getTexts().getValue("commands.keys.cmd_massgift").split(";"));
     }
 
     @Override
@@ -27,19 +28,33 @@ public class MassGiftCommand extends Command {
             try {
                 itemId = Integer.parseInt(params[1]);
             } catch (Exception e) {
-                gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_gift.not_a_number"), RoomChatMessageBubbles.ALERT);
+                gameClient
+                        .getHabbo()
+                        .whisper(
+                                Emulator.getTexts().getValue("commands.error.cmd_gift.not_a_number"),
+                                RoomChatMessageBubbles.ALERT);
                 return true;
             }
 
             if (itemId <= 0) {
-                gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_gift.not_a_number"), RoomChatMessageBubbles.ALERT);
+                gameClient
+                        .getHabbo()
+                        .whisper(
+                                Emulator.getTexts().getValue("commands.error.cmd_gift.not_a_number"),
+                                RoomChatMessageBubbles.ALERT);
                 return true;
             }
 
             final Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(itemId);
 
             if (baseItem == null) {
-                gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_gift.not_found").replace("%itemid%", itemId + ""), RoomChatMessageBubbles.ALERT);
+                gameClient
+                        .getHabbo()
+                        .whisper(
+                                Emulator.getTexts()
+                                        .getValue("commands.error.cmd_gift.not_found")
+                                        .replace("%itemid%", itemId + ""),
+                                RoomChatMessageBubbles.ALERT);
                 return true;
             }
 
@@ -57,30 +72,39 @@ public class MassGiftCommand extends Command {
             keys.put("display", "BUBBLE");
             keys.put("image", "${image.library.url}notifications/gift.gif");
             keys.put("message", Emulator.getTexts().getValue("generic.gift.received.anonymous"));
-            ServerMessage giftNotificiationMessage = new BubbleAlertComposer(BubbleAlertKeys.RECEIVED_BADGE.key, keys).compose();
-            Map<Integer, Integer> giftFurniture = Emulator.getGameEnvironment().getCatalogManager()
-                    .getGiftWrappingSnapshot().furniture();
+            ServerMessage giftNotificiationMessage =
+                    new BubbleAlertComposer(BubbleAlertKeys.RECEIVED_BADGE.key, keys).compose();
+            Map<Integer, Integer> giftFurniture = Emulator.getGameEnvironment()
+                    .getCatalogManager()
+                    .getGiftWrappingSnapshot()
+                    .furniture();
 
             Emulator.getThreading().run(() -> {
-                for (Map.Entry<Integer, Habbo> set : Emulator.getGameEnvironment().getHabboManager().getOnlineHabbos().entrySet()) {
+                for (Map.Entry<Integer, Habbo> set : Emulator.getGameEnvironment()
+                        .getHabboManager()
+                        .getOnlineHabbos()
+                        .entrySet()) {
                     Habbo habbo = set.getValue();
 
-                    HabboItem item = Emulator.getGameEnvironment().getItemManager().createItem(0, baseItem, 0, 0, "");
+                    HabboItem item =
+                            Emulator.getGameEnvironment().getItemManager().createItem(0, baseItem, 0, 0, "");
 
-                    Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem(
-                            (Integer) giftFurniture.values().toArray()[Emulator.getRandom().nextInt(giftFurniture.size())]
-                    );
+                    Item giftItem = Emulator.getGameEnvironment()
+                            .getItemManager()
+                            .getItem((Integer) giftFurniture.values()
+                                    .toArray()[Emulator.getRandom().nextInt(giftFurniture.size())]);
 
                     String extraData = "1\t" + item.getId();
                     extraData += "\t0\t0\t0\t" + finalMessage + "\t0\t0";
 
-                    Emulator.getGameEnvironment().getItemManager().createGift(habbo.getHabboInfo().getUsername(), giftItem, extraData, 0, 0);
+                    Emulator.getGameEnvironment()
+                            .getItemManager()
+                            .createGift(habbo.getHabboInfo().getUsername(), giftItem, extraData, 0, 0);
 
                     habbo.getClient().sendResponse(new InventoryRefreshComposer());
                     habbo.getClient().sendResponse(giftNotificiationMessage);
                 }
             });
-
 
             return true;
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/PromoteTargetOfferCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/PromoteTargetOfferCommand.java
@@ -27,7 +27,8 @@ public class PromoteTargetOfferCommand extends Command {
         String offerKey = params[1];
 
         if (offerKey.equalsIgnoreCase(Emulator.getTexts().getValue("commands.cmd_promote_offer.info"))) {
-            Map<Integer, TargetOffer> targetOffers = Emulator.getGameEnvironment().getCatalogManager().targetOffers;
+            Map<Integer, TargetOffer> targetOffers = Emulator.getGameEnvironment().getCatalogManager()
+                    .getTargetOffersSnapshot();
             String[] textConfig = Emulator.getTexts().getValue("commands.cmd_promote_offer.list").replace("%amount%", targetOffers.size() + "").split("<br>");
 
             String entryConfig = Emulator.getTexts().getValue("commands.cmd_promote_offer.list.entry");

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/PromoteTargetOfferCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/PromoteTargetOfferCommand.java
@@ -6,7 +6,6 @@ import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.catalog.TargetedOfferComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.MessagesForYouComposer;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -14,7 +13,9 @@ import java.util.Map;
 public class PromoteTargetOfferCommand extends Command {
 
     public PromoteTargetOfferCommand() {
-        super("cmd_promote_offer", Emulator.getTexts().getValue("commands.keys.cmd_promote_offer").split(";"));
+        super(
+                "cmd_promote_offer",
+                Emulator.getTexts().getValue("commands.keys.cmd_promote_offer").split(";"));
     }
 
     @Override
@@ -27,9 +28,12 @@ public class PromoteTargetOfferCommand extends Command {
         String offerKey = params[1];
 
         if (offerKey.equalsIgnoreCase(Emulator.getTexts().getValue("commands.cmd_promote_offer.info"))) {
-            Map<Integer, TargetOffer> targetOffers = Emulator.getGameEnvironment().getCatalogManager()
-                    .getTargetOffersSnapshot();
-            String[] textConfig = Emulator.getTexts().getValue("commands.cmd_promote_offer.list").replace("%amount%", targetOffers.size() + "").split("<br>");
+            Map<Integer, TargetOffer> targetOffers =
+                    Emulator.getGameEnvironment().getCatalogManager().getTargetOffersSnapshot();
+            String[] textConfig = Emulator.getTexts()
+                    .getValue("commands.cmd_promote_offer.list")
+                    .replace("%amount%", targetOffers.size() + "")
+                    .split("<br>");
 
             String entryConfig = Emulator.getTexts().getValue("commands.cmd_promote_offer.list.entry");
             List<String> message = new ArrayList<>();
@@ -37,7 +41,10 @@ public class PromoteTargetOfferCommand extends Command {
             for (String pair : textConfig) {
                 if (pair.contains("%list%")) {
                     for (TargetOffer offer : targetOffers.values()) {
-                        message.add(entryConfig.replace("%id%", offer.getId() + "").replace("%title%", offer.getTitle()).replace("%description%", offer.getDescription().substring(0, 25)));
+                        message.add(entryConfig
+                                .replace("%id%", offer.getId() + "")
+                                .replace("%title%", offer.getTitle())
+                                .replace("%description%", offer.getDescription().substring(0, 25)));
                     }
                 } else {
                     message.add(pair);
@@ -53,18 +60,29 @@ public class PromoteTargetOfferCommand extends Command {
             }
 
             if (offerId > 0) {
-                TargetOffer offer = Emulator.getGameEnvironment().getCatalogManager().getTargetOffer(offerId);
+                TargetOffer offer =
+                        Emulator.getGameEnvironment().getCatalogManager().getTargetOffer(offerId);
 
                 if (offer != null) {
                     TargetOffer.ACTIVE_TARGET_OFFER_ID = offer.getId();
-                    gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.succes.cmd_promote_offer").replace("%id%", offerKey).replace("%title%", offer.getTitle()));
+                    gameClient
+                            .getHabbo()
+                            .whisper(Emulator.getTexts()
+                                    .getValue("commands.succes.cmd_promote_offer")
+                                    .replace("%id%", offerKey)
+                                    .replace("%title%", offer.getTitle()));
 
-                    for (Habbo habbo : Emulator.getGameEnvironment().getHabboManager().getOnlineHabbos().values()) {
+                    for (Habbo habbo : Emulator.getGameEnvironment()
+                            .getHabboManager()
+                            .getOnlineHabbos()
+                            .values()) {
                         habbo.getClient().sendResponse(new TargetedOfferComposer(habbo, offer));
                     }
                 }
             } else {
-                gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_promote_offer.not_found"));
+                gameClient
+                        .getHabbo()
+                        .whisper(Emulator.getTexts().getValue("commands.error.cmd_promote_offer.not_found"));
                 return true;
             }
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/RoomGiftCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/RoomGiftCommand.java
@@ -9,6 +9,8 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.wired.WiredRewardAlertComposer;
 
+import java.util.Map;
+
 public class RoomGiftCommand extends Command {
     public RoomGiftCommand() {
         super("cmd_roomgift", Emulator.getTexts().getValue("commands.keys.cmd_roomgift").split(";"));
@@ -47,11 +49,15 @@ public class RoomGiftCommand extends Command {
             }
 
             final String finalMessage = message.toString();
+            Map<Integer, Integer> giftFurniture = Emulator.getGameEnvironment().getCatalogManager()
+                    .getGiftWrappingSnapshot().furniture();
 
             for (Habbo habbo : gameClient.getHabbo().getHabboInfo().getCurrentRoom().getHabbos()) {
                 HabboItem item = Emulator.getGameEnvironment().getItemManager().createItem(0, baseItem, 0, 0, "");
 
-                Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem((Integer) Emulator.getGameEnvironment().getCatalogManager().giftFurnis.values().toArray()[Emulator.getRandom().nextInt(Emulator.getGameEnvironment().getCatalogManager().giftFurnis.size())]);
+                Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem(
+                        (Integer) giftFurniture.values().toArray()[Emulator.getRandom().nextInt(giftFurniture.size())]
+                );
 
                 String extraData = "1\t" + item.getId();
                 extraData += "\t0\t0\t0\t" + finalMessage + "\t0\t0";

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/RoomGiftCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/RoomGiftCommand.java
@@ -8,12 +8,13 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.wired.WiredRewardAlertComposer;
-
 import java.util.Map;
 
 public class RoomGiftCommand extends Command {
     public RoomGiftCommand() {
-        super("cmd_roomgift", Emulator.getTexts().getValue("commands.keys.cmd_roomgift").split(";"));
+        super(
+                "cmd_roomgift",
+                Emulator.getTexts().getValue("commands.keys.cmd_roomgift").split(";"));
     }
 
     @Override
@@ -24,19 +25,33 @@ public class RoomGiftCommand extends Command {
             try {
                 itemId = Integer.parseInt(params[1]);
             } catch (Exception e) {
-                gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_gift.not_a_number"), RoomChatMessageBubbles.ALERT);
+                gameClient
+                        .getHabbo()
+                        .whisper(
+                                Emulator.getTexts().getValue("commands.error.cmd_gift.not_a_number"),
+                                RoomChatMessageBubbles.ALERT);
                 return true;
             }
 
             if (itemId <= 0) {
-                gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_gift.not_a_number"), RoomChatMessageBubbles.ALERT);
+                gameClient
+                        .getHabbo()
+                        .whisper(
+                                Emulator.getTexts().getValue("commands.error.cmd_gift.not_a_number"),
+                                RoomChatMessageBubbles.ALERT);
                 return true;
             }
 
             final Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(itemId);
 
             if (baseItem == null) {
-                gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_gift.not_found").replace("%itemid%", itemId + ""), RoomChatMessageBubbles.ALERT);
+                gameClient
+                        .getHabbo()
+                        .whisper(
+                                Emulator.getTexts()
+                                        .getValue("commands.error.cmd_gift.not_found")
+                                        .replace("%itemid%", itemId + ""),
+                                RoomChatMessageBubbles.ALERT);
                 return true;
             }
 
@@ -49,24 +64,29 @@ public class RoomGiftCommand extends Command {
             }
 
             final String finalMessage = message.toString();
-            Map<Integer, Integer> giftFurniture = Emulator.getGameEnvironment().getCatalogManager()
-                    .getGiftWrappingSnapshot().furniture();
+            Map<Integer, Integer> giftFurniture = Emulator.getGameEnvironment()
+                    .getCatalogManager()
+                    .getGiftWrappingSnapshot()
+                    .furniture();
 
-            for (Habbo habbo : gameClient.getHabbo().getHabboInfo().getCurrentRoom().getHabbos()) {
+            for (Habbo habbo :
+                    gameClient.getHabbo().getHabboInfo().getCurrentRoom().getHabbos()) {
                 HabboItem item = Emulator.getGameEnvironment().getItemManager().createItem(0, baseItem, 0, 0, "");
 
-                Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem(
-                        (Integer) giftFurniture.values().toArray()[Emulator.getRandom().nextInt(giftFurniture.size())]
-                );
+                Item giftItem = Emulator.getGameEnvironment().getItemManager().getItem((Integer)
+                        giftFurniture.values().toArray()[Emulator.getRandom().nextInt(giftFurniture.size())]);
 
                 String extraData = "1\t" + item.getId();
                 extraData += "\t0\t0\t0\t" + finalMessage + "\t0\t0";
 
-                Emulator.getGameEnvironment().getItemManager().createGift(habbo.getHabboInfo().getUsername(), giftItem, extraData, 0, 0);
+                Emulator.getGameEnvironment()
+                        .getItemManager()
+                        .createGift(habbo.getHabboInfo().getUsername(), giftItem, extraData, 0, 0);
 
                 habbo.getClient().sendResponse(new InventoryRefreshComposer());
 
-                habbo.getClient().sendResponse(new WiredRewardAlertComposer(WiredRewardAlertComposer.REWARD_RECEIVED_ITEM));
+                habbo.getClient()
+                        .sendResponse(new WiredRewardAlertComposer(WiredRewardAlertComposer.REWARD_RECEIVED_ITEM));
             }
 
             return true;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolBan.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolBan.java
@@ -9,9 +9,14 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 public class ModToolBan implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(ModToolBan.class);
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
 
     public static SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
     public int userId;
@@ -85,6 +90,6 @@ public class ModToolBan implements Runnable {
     }
 
     static String formatTimestamp(int timestamp) {
-        return dateFormat.format(timestamp * 1000L);
+        return TIMESTAMP_FORMATTER.format(Instant.ofEpochSecond(timestamp));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolBan.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolBan.java
@@ -77,10 +77,14 @@ public class ModToolBan implements Runnable {
                 "Type: " + this.type.getType() + "\r" +
                 "Reason: " + "<i>" + this.reason + "</i>" + "\r" +
                 "Moderator Id: " + this.staffId + "\r" +
-                "Date: " + dateFormat.format(this.timestamp * 1000L) + "\r" +
-                "Expire Date: " + dateFormat.format(this.expireDate * 1000L) + "\r" +
+                "Date: " + formatTimestamp(this.timestamp) + "\r" +
+                "Expire Date: " + formatTimestamp(this.expireDate) + "\r" +
                 "IP: " + this.ip + "\r" +
                 "MachineID: " + this.machineId + "\r" +
                 "Topic: " + this.cfhTopic;
+    }
+
+    static String formatTimestamp(int timestamp) {
+        return dateFormat.format(timestamp * 1000L);
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolBan.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/modtool/ModToolBan.java
@@ -1,9 +1,6 @@
 package com.eu.habbo.habbohotel.modtool;
 
 import com.eu.habbo.Emulator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -12,6 +9,8 @@ import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ModToolBan implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(ModToolBan.class);
@@ -44,7 +43,15 @@ public class ModToolBan implements Runnable {
         this.needsInsert = false;
     }
 
-    public ModToolBan(int userId, String ip, String machineId, int staffId, int expireDate, String reason, ModToolBanType type, int cfhTopic) {
+    public ModToolBan(
+            int userId,
+            String ip,
+            String machineId,
+            int staffId,
+            int expireDate,
+            String reason,
+            ModToolBanType type,
+            int cfhTopic) {
         this.userId = userId;
         this.staffId = staffId;
         this.timestamp = Emulator.getIntUnixTimestamp();
@@ -60,7 +67,9 @@ public class ModToolBan implements Runnable {
     @Override
     public void run() {
         if (this.needsInsert) {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO bans (user_id, ip, machine_id, user_staff_id, timestamp, ban_expire, ban_reason, type, cfh_topic) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    PreparedStatement statement = connection.prepareStatement(
+                            "INSERT INTO bans (user_id, ip, machine_id, user_staff_id, timestamp, ban_expire, ban_reason, type, cfh_topic) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
                 statement.setInt(1, this.userId);
                 statement.setString(2, this.ip);
                 statement.setString(3, this.machineId);
@@ -78,15 +87,15 @@ public class ModToolBan implements Runnable {
     }
 
     public String listInfo() {
-        return "Banned User Id: " + this.userId + "\r" +
-                "Type: " + this.type.getType() + "\r" +
-                "Reason: " + "<i>" + this.reason + "</i>" + "\r" +
-                "Moderator Id: " + this.staffId + "\r" +
-                "Date: " + formatTimestamp(this.timestamp) + "\r" +
-                "Expire Date: " + formatTimestamp(this.expireDate) + "\r" +
-                "IP: " + this.ip + "\r" +
-                "MachineID: " + this.machineId + "\r" +
-                "Topic: " + this.cfhTopic;
+        return "Banned User Id: " + this.userId + "\r" + "Type: "
+                + this.type.getType() + "\r" + "Reason: "
+                + "<i>" + this.reason + "</i>" + "\r" + "Moderator Id: "
+                + this.staffId + "\r" + "Date: "
+                + formatTimestamp(this.timestamp) + "\r" + "Expire Date: "
+                + formatTimestamp(this.expireDate) + "\r" + "IP: "
+                + this.ip + "\r" + "MachineID: "
+                + this.machineId + "\r" + "Topic: "
+                + this.cfhTopic;
     }
 
     static String formatTimestamp(int timestamp) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java
@@ -51,7 +51,7 @@ public class RoomRollerManager {
         Set<Integer> rollerFurniIds = new HashSet<>();
         Set<Integer> rolledUnitIds = new HashSet<>();
 
-        for (InteractionRoller roller : this.room.getRoomSpecialTypes().getRollers().values()) {
+        for (InteractionRoller roller : this.room.getRoomSpecialTypes().rollerSnapshot().values()) {
             processRoller(roller, messages, rollerFurniIds, rolledUnitIds, updatedUnit);
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java
@@ -15,13 +15,12 @@ import com.eu.habbo.messages.outgoing.rooms.users.RoomUnitOnRollerComposer;
 import com.eu.habbo.plugin.Event;
 import com.eu.habbo.plugin.events.furniture.FurnitureRolledEvent;
 import com.eu.habbo.plugin.events.users.UserRolledEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Manages roller mechanics within a room.
@@ -51,7 +50,8 @@ public class RoomRollerManager {
         Set<Integer> rollerFurniIds = new HashSet<>();
         Set<Integer> rolledUnitIds = new HashSet<>();
 
-        for (InteractionRoller roller : this.room.getRoomSpecialTypes().rollerSnapshot().values()) {
+        for (InteractionRoller roller :
+                this.room.getRoomSpecialTypes().rollerSnapshot().values()) {
             processRoller(roller, messages, rollerFurniIds, rolledUnitIds, updatedUnit);
         }
 
@@ -71,9 +71,12 @@ public class RoomRollerManager {
     /**
      * Processes a single roller and its contents.
      */
-    private void processRoller(InteractionRoller roller, Set<MessageComposer> messages,
-                               Set<Integer> rollerFurniIds, Set<Integer> rolledUnitIds,
-                               Set<RoomUnit> updatedUnit) {
+    private void processRoller(
+            InteractionRoller roller,
+            Set<MessageComposer> messages,
+            Set<Integer> rollerFurniIds,
+            Set<Integer> rolledUnitIds,
+            Set<RoomUnit> updatedUnit) {
 
         HabboItem newRoller = null;
         RoomLayout layout = this.room.getLayout();
@@ -95,7 +98,8 @@ public class RoomRollerManager {
             return;
         }
 
-        RoomTile tileInFront = layout.getTileInFront(layout.getTile(roller.getX(), roller.getY()), roller.getRotation());
+        RoomTile tileInFront =
+                layout.getTileInFront(layout.getTile(roller.getX(), roller.getY()), roller.getRotation());
 
         //   - Rot 2 (East) / Rot 4 (South): skip only when going uphill
         //   - Rot 0 (North) / Rot 6 (West): skip only when going downhill
@@ -139,9 +143,10 @@ public class RoomRollerManager {
             return;
         }
 
-        if (!tileInFront.getAllowStack() && !(tileInFront.isWalkable()
-                || tileInFront.state == RoomTileState.SIT
-                || tileInFront.state == RoomTileState.LAY)) {
+        if (!tileInFront.getAllowStack()
+                && !(tileInFront.isWalkable()
+                        || tileInFront.state == RoomTileState.SIT
+                        || tileInFront.state == RoomTileState.LAY)) {
             return;
         }
 
@@ -155,8 +160,7 @@ public class RoomRollerManager {
 
         List<HabboItem> toRemove = new ArrayList<>();
         for (HabboItem item : itemsOnRoller) {
-            if (item.getX() != roller.getX() || item.getY() != roller.getY()
-                    || rollerFurniIds.contains(item.getId())) {
+            if (item.getX() != roller.getX() || item.getY() != roller.getY() || rollerFurniIds.contains(item.getId())) {
                 toRemove.add(item);
             }
         }
@@ -168,8 +172,8 @@ public class RoomRollerManager {
         boolean stackContainsRoller = false;
 
         for (HabboItem item : itemsNewTile) {
-            if (!(item.getBaseItem().allowWalk() || item.getBaseItem().allowSit()) && !(
-                    item instanceof InteractionGate && item.getExtradata().equals("1"))) {
+            if (!(item.getBaseItem().allowWalk() || item.getBaseItem().allowSit())
+                    && !(item instanceof InteractionGate && item.getExtradata().equals("1"))) {
                 allowUsers = false;
             }
             if (item instanceof InteractionRoller) {
@@ -178,7 +182,8 @@ public class RoomRollerManager {
 
                 double rollerRelativeZ = roller.getZ() - rollerTile.z;
                 double newRollerRelativeZ = item.getZ() - tileInFront.z;
-                if ((Math.abs(rollerRelativeZ - newRollerRelativeZ) > 0.1 || (itemsNewTile.size() > 1 && item != topItem))
+                if ((Math.abs(rollerRelativeZ - newRollerRelativeZ) > 0.1
+                                || (itemsNewTile.size() > 1 && item != topItem))
                         && !InteractionRoller.NO_RULES) {
                     allowUsers = false;
                     allowFurniture = false;
@@ -210,9 +215,19 @@ public class RoomRollerManager {
 
         // Process units on roller
         if (allowUsers) {
-            processUnitsOnRoller(roller, rollerTile, tileInFront, topItem,
-                    itemsOnRoller, itemsNewTile, stackContainsRoller, allowFurniture,
-                    zOffset, messages, rolledUnitIds, updatedUnit);
+            processUnitsOnRoller(
+                    roller,
+                    rollerTile,
+                    tileInFront,
+                    topItem,
+                    itemsOnRoller,
+                    itemsNewTile,
+                    stackContainsRoller,
+                    allowFurniture,
+                    zOffset,
+                    messages,
+                    rolledUnitIds,
+                    updatedUnit);
         }
 
         // Send unit messages
@@ -225,8 +240,8 @@ public class RoomRollerManager {
 
         // Process furniture on roller
         if (allowFurniture || !stackContainsRoller || InteractionRoller.NO_RULES) {
-            processFurnitureOnRoller(roller, itemsOnRoller, newRoller, topItem,
-                    tileInFront, zOffset, messages, rollerFurniIds);
+            processFurnitureOnRoller(
+                    roller, itemsOnRoller, newRoller, topItem, tileInFront, zOffset, messages, rollerFurniIds);
         }
 
         // Send furniture messages
@@ -241,13 +256,19 @@ public class RoomRollerManager {
     /**
      * Processes units (Habbos, Pets) on a roller.
      */
-    private void processUnitsOnRoller(InteractionRoller roller, RoomTile rollerTile,
-                                      RoomTile tileInFront, HabboItem topItem,
-                                      Set<HabboItem> itemsOnRoller,
-                                      Set<HabboItem> itemsNewTile,
-                                      boolean stackContainsRoller, boolean allowFurniture,
-                                      double zOffset, Set<MessageComposer> messages,
-                                      Set<Integer> rolledUnitIds, Set<RoomUnit> updatedUnit) {
+    private void processUnitsOnRoller(
+            InteractionRoller roller,
+            RoomTile rollerTile,
+            RoomTile tileInFront,
+            HabboItem topItem,
+            Set<HabboItem> itemsOnRoller,
+            Set<HabboItem> itemsNewTile,
+            boolean stackContainsRoller,
+            boolean allowFurniture,
+            double zOffset,
+            Set<MessageComposer> messages,
+            Set<Integer> rolledUnitIds,
+            Set<RoomUnit> updatedUnit) {
 
         Event roomUserRolledEvent = null;
 
@@ -322,8 +343,13 @@ public class RoomRollerManager {
 
                         // Compose and send pet roller message first
                         RoomUnitOnRollerComposer petRollerComposer = new RoomUnitOnRollerComposer(
-                                ridingUnit, roller, ridingUnit.getCurrentLocation(), petOldZ,
-                                tileInFront, petNewZ, this.room);
+                                ridingUnit,
+                                roller,
+                                ridingUnit.getCurrentLocation(),
+                                petOldZ,
+                                tileInFront,
+                                petNewZ,
+                                this.room);
                         messages.add(petRollerComposer);
 
                         // Update newZ for the rider (1 unit above pet)
@@ -337,8 +363,8 @@ public class RoomRollerManager {
             rolledUnitIds.add(unit.getId());
             updatedUnit.remove(unit);
 
-            messages.add(new RoomUnitOnRollerComposer(unit, roller, unit.getCurrentLocation(),
-                    unit.getZ(), tileInFront, newZ, this.room));
+            messages.add(new RoomUnitOnRollerComposer(
+                    unit, roller, unit.getCurrentLocation(), unit.getZ(), tileInFront, newZ, this.room));
 
             if (itemsOnRoller.isEmpty()) {
                 HabboItem item = this.room.getTopItemAt(tileInFront.x, tileInFront.y);
@@ -346,15 +372,20 @@ public class RoomRollerManager {
                 if (item != null && itemsNewTile.contains(item) && !itemsOnRoller.contains(item)) {
                     final RoomUnit finalUnit = unit;
                     final RoomTile finalRollerTile = rollerTile;
-                    Emulator.getThreading().run(() -> {
-                        if (finalUnit.getGoal() == finalRollerTile) {
-                            try {
-                                item.onWalkOn(finalUnit, this.room, new Object[]{finalRollerTile, tileInFront});
-                            } catch (Exception e) {
-                                LOGGER.error("Caught exception", e);
-                            }
-                        }
-                    }, RoomQueueSpeedControlSupport.getEffectiveRollerIntervalMs(this.room));
+                    Emulator.getThreading()
+                            .run(
+                                    () -> {
+                                        if (finalUnit.getGoal() == finalRollerTile) {
+                                            try {
+                                                item.onWalkOn(
+                                                        finalUnit, this.room, new Object[] {finalRollerTile, tileInFront
+                                                        });
+                                            } catch (Exception e) {
+                                                LOGGER.error("Caught exception", e);
+                                            }
+                                        }
+                                    },
+                                    RoomQueueSpeedControlSupport.getEffectiveRollerIntervalMs(this.room));
                 }
             }
 
@@ -367,10 +398,15 @@ public class RoomRollerManager {
     /**
      * Processes furniture items on a roller.
      */
-    private void processFurnitureOnRoller(InteractionRoller roller, Set<HabboItem> itemsOnRoller,
-                                          HabboItem newRoller, HabboItem topItem, RoomTile tileInFront,
-                                          double zOffset, Set<MessageComposer> messages,
-                                          Set<Integer> rollerFurniIds) {
+    private void processFurnitureOnRoller(
+            InteractionRoller roller,
+            Set<HabboItem> itemsOnRoller,
+            HabboItem newRoller,
+            HabboItem topItem,
+            RoomTile tileInFront,
+            double zOffset,
+            Set<MessageComposer> messages,
+            Set<Integer> rollerFurniIds) {
 
         Event furnitureRolledEvent = null;
 
@@ -419,5 +455,4 @@ public class RoomRollerManager {
 
         return this.room.getLayout().getFloorAltitude(targetTile.x, targetTile.y);
     }
-
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypes.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypes.java
@@ -325,6 +325,12 @@ public class RoomSpecialTypes {
         return this.rollers;
     }
 
+    Map<Integer, InteractionRoller> rollerSnapshot() {
+        synchronized (this.rollers) {
+            return new HashMap<>(this.rollers);
+        }
+    }
+
 
     /**
      * Finds a wired trigger by its item ID.
@@ -1186,7 +1192,9 @@ public class RoomSpecialTypes {
         this.petFoods.clear();
         this.petToys.clear();
         this.petTrees.clear();
-        this.rollers.clear();
+        synchronized (this.rollers) {
+            this.rollers.clear();
+        }
 
         this.wiredTriggers.clear();
         this.wiredEffects.clear();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypes.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypes.java
@@ -4,7 +4,12 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.games.GameTeamColors;
 import com.eu.habbo.habbohotel.items.ICycleable;
 import com.eu.habbo.habbohotel.items.Item;
-import com.eu.habbo.habbohotel.items.interactions.*;
+import com.eu.habbo.habbohotel.items.interactions.InteractionRoller;
+import com.eu.habbo.habbohotel.items.interactions.InteractionTent;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredExtra;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.items.interactions.games.InteractionGameGate;
 import com.eu.habbo.habbohotel.items.interactions.games.InteractionGameScoreboard;
 import com.eu.habbo.habbohotel.items.interactions.games.InteractionGameTimer;
@@ -20,13 +25,12 @@ import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetDrink;
 import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetFood;
 import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetToy;
 import com.eu.habbo.habbohotel.items.interactions.pets.InteractionPetTree;
-import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectSendSignal;
+import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.WiredConditionType;
 import com.eu.habbo.habbohotel.wired.WiredEffectType;
 import com.eu.habbo.habbohotel.wired.WiredTriggerType;
-
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -57,7 +61,7 @@ public class RoomSpecialTypes {
     private final ConcurrentHashMap<WiredEffectType, Set<InteractionWiredEffect>> wiredEffects;
     private final ConcurrentHashMap<WiredConditionType, Set<InteractionWiredCondition>> wiredConditions;
     private final ConcurrentHashMap<Integer, InteractionWiredExtra> wiredExtras;
-    
+
     // Spatial index for O(1) coordinate-based lookups of wired components
     private final ConcurrentHashMap<Long, Set<InteractionWiredTrigger>> wiredTriggersByLocation;
     private final ConcurrentHashMap<Long, Set<InteractionWiredEffect>> wiredEffectsByLocation;
@@ -86,7 +90,7 @@ public class RoomSpecialTypes {
         this.wiredEffects = new ConcurrentHashMap<>();
         this.wiredConditions = new ConcurrentHashMap<>();
         this.wiredExtras = new ConcurrentHashMap<>();
-        
+
         // Initialize spatial indexes
         this.wiredTriggersByLocation = new ConcurrentHashMap<>();
         this.wiredEffectsByLocation = new ConcurrentHashMap<>();
@@ -101,7 +105,7 @@ public class RoomSpecialTypes {
         this.undefined = new HashMap<>(0);
         this.cycleTasks = ConcurrentHashMap.newKeySet();
     }
-    
+
     /**
      * Generates a unique key for spatial indexing based on x,y coordinates.
      * Uses bit shifting to combine two shorts into a single long for efficient lookups.
@@ -110,17 +114,18 @@ public class RoomSpecialTypes {
         return ((long) x << 32) | (y & 0xFFFFFFFFL);
     }
 
-
     public InteractionBattleBanzaiTeleporter getBanzaiTeleporter(int itemId) {
         return this.banzaiTeleporters.get(itemId);
     }
 
     public void addBanzaiTeleporter(InteractionBattleBanzaiTeleporter item) {
-        this.banzaiTeleporters.put(item.getId(), item); this.specialItemsById.put(item.getId(), item);
+        this.banzaiTeleporters.put(item.getId(), item);
+        this.specialItemsById.put(item.getId(), item);
     }
 
     public void removeBanzaiTeleporter(InteractionBattleBanzaiTeleporter item) {
-        this.banzaiTeleporters.remove(item.getId()); this.specialItemsById.remove(item.getId());
+        this.banzaiTeleporters.remove(item.getId());
+        this.specialItemsById.remove(item.getId());
     }
 
     public Set<InteractionBattleBanzaiTeleporter> getBanzaiTeleporters() {
@@ -132,7 +137,8 @@ public class RoomSpecialTypes {
         }
     }
 
-    public InteractionBattleBanzaiTeleporter getRandomTeleporter(Item baseItem, InteractionBattleBanzaiTeleporter exclude) {
+    public InteractionBattleBanzaiTeleporter getRandomTeleporter(
+            Item baseItem, InteractionBattleBanzaiTeleporter exclude) {
         List<InteractionBattleBanzaiTeleporter> teleporterList = new ArrayList<>();
         for (InteractionBattleBanzaiTeleporter teleporter : this.banzaiTeleporters.values()) {
             if (baseItem == null || teleporter.getBaseItem() == baseItem) {
@@ -149,7 +155,6 @@ public class RoomSpecialTypes {
 
         return null;
     }
-
 
     public InteractionNest getNest(int itemId) {
         synchronized (this.nests) {
@@ -180,7 +185,6 @@ public class RoomSpecialTypes {
         }
     }
 
-
     public InteractionPetDrink getPetDrink(int itemId) {
         synchronized (this.petDrinks) {
             return this.petDrinks.get(itemId);
@@ -209,7 +213,6 @@ public class RoomSpecialTypes {
             return petDrinks;
         }
     }
-
 
     public InteractionPetFood getPetFood(int itemId) {
         synchronized (this.petFoods) {
@@ -240,7 +243,6 @@ public class RoomSpecialTypes {
         }
     }
 
-
     public InteractionPetToy getPetToy(int itemId) {
         synchronized (this.petToys) {
             return this.petToys.get(itemId);
@@ -269,7 +271,6 @@ public class RoomSpecialTypes {
             return petToys;
         }
     }
-
 
     public InteractionPetTree getPetTree(int itemId) {
         synchronized (this.petTrees) {
@@ -300,7 +301,6 @@ public class RoomSpecialTypes {
         }
     }
 
-
     public InteractionRoller getRoller(int itemId) {
         synchronized (this.rollers) {
             return this.rollers.get(itemId);
@@ -330,7 +330,6 @@ public class RoomSpecialTypes {
             return new HashMap<>(this.rollers);
         }
     }
-
 
     /**
      * Finds a wired trigger by its item ID.
@@ -393,6 +392,7 @@ public class RoomSpecialTypes {
      * @param trigger The trigger to add
      */
     public static final int MAX_SIGNAL_SENDERS_PER_ROOM = 0;
+
     public static final int MAX_SIGNAL_RECEIVERS_PER_ROOM = 0;
     public static final int MAX_SENDERS_PER_RECEIVER = 0;
 
@@ -425,7 +425,8 @@ public class RoomSpecialTypes {
         return countSendersTargetingReceiver(receiverItemId, null);
     }
 
-    public int countSendersTargetingAnyReceiver(Collection<Integer> receiverItemIds, InteractionWiredEffect excludeSender) {
+    public int countSendersTargetingAnyReceiver(
+            Collection<Integer> receiverItemIds, InteractionWiredEffect excludeSender) {
         if (receiverItemIds == null || receiverItemIds.isEmpty()) {
             return 0;
         }
@@ -467,7 +468,9 @@ public class RoomSpecialTypes {
 
         Set<InteractionWiredTrigger> receivers = this.getTriggers(WiredTriggerType.RECEIVE_SIGNAL);
         for (InteractionWiredTrigger trigger : receivers) {
-            if (!(trigger instanceof com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerReceiveSignal receiver)) {
+            if (!(trigger
+                    instanceof
+                    com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerReceiveSignal receiver)) {
                 continue;
             }
 
@@ -516,11 +519,13 @@ public class RoomSpecialTypes {
 
     public void addTrigger(InteractionWiredTrigger trigger) {
         // Add to type-based index
-        this.wiredTriggers.computeIfAbsent(trigger.getType(), k -> ConcurrentHashMap.newKeySet())
+        this.wiredTriggers
+                .computeIfAbsent(trigger.getType(), k -> ConcurrentHashMap.newKeySet())
                 .add(trigger);
         // Add to spatial index
         long key = coordinateKey(trigger.getX(), trigger.getY());
-        this.wiredTriggersByLocation.computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet())
+        this.wiredTriggersByLocation
+                .computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet())
                 .add(trigger);
         this.specialItemsById.put(trigger.getId(), trigger);
     }
@@ -549,7 +554,7 @@ public class RoomSpecialTypes {
         }
         this.specialItemsById.remove(trigger.getId());
     }
-    
+
     /**
      * Updates the spatial index when a trigger is moved.
      * @param trigger The trigger that was moved
@@ -566,13 +571,13 @@ public class RoomSpecialTypes {
                 this.wiredTriggersByLocation.remove(oldKey);
             }
         }
-        
+
         // Add to new location
         long newKey = coordinateKey(trigger.getX(), trigger.getY());
-        this.wiredTriggersByLocation.computeIfAbsent(newKey, k -> ConcurrentHashMap.newKeySet())
+        this.wiredTriggersByLocation
+                .computeIfAbsent(newKey, k -> ConcurrentHashMap.newKeySet())
                 .add(trigger);
     }
-
 
     /**
      * Finds a wired effect by its item ID.
@@ -636,11 +641,13 @@ public class RoomSpecialTypes {
      */
     public void addEffect(InteractionWiredEffect effect) {
         // Add to type-based index
-        this.wiredEffects.computeIfAbsent(effect.getType(), k -> ConcurrentHashMap.newKeySet())
+        this.wiredEffects
+                .computeIfAbsent(effect.getType(), k -> ConcurrentHashMap.newKeySet())
                 .add(effect);
         // Add to spatial index
         long key = coordinateKey(effect.getX(), effect.getY());
-        this.wiredEffectsByLocation.computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet())
+        this.wiredEffectsByLocation
+                .computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet())
                 .add(effect);
         this.specialItemsById.put(effect.getId(), effect);
     }
@@ -669,7 +676,7 @@ public class RoomSpecialTypes {
         }
         this.specialItemsById.remove(effect.getId());
     }
-    
+
     /**
      * Updates the spatial index when an effect is moved.
      * @param effect The effect that was moved
@@ -686,13 +693,13 @@ public class RoomSpecialTypes {
                 this.wiredEffectsByLocation.remove(oldKey);
             }
         }
-        
+
         // Add to new location
         long newKey = coordinateKey(effect.getX(), effect.getY());
-        this.wiredEffectsByLocation.computeIfAbsent(newKey, k -> ConcurrentHashMap.newKeySet())
+        this.wiredEffectsByLocation
+                .computeIfAbsent(newKey, k -> ConcurrentHashMap.newKeySet())
                 .add(effect);
     }
-
 
     /**
      * Finds a wired condition by its item ID.
@@ -756,11 +763,13 @@ public class RoomSpecialTypes {
      */
     public void addCondition(InteractionWiredCondition condition) {
         // Add to type-based index
-        this.wiredConditions.computeIfAbsent(condition.getType(), k -> ConcurrentHashMap.newKeySet())
+        this.wiredConditions
+                .computeIfAbsent(condition.getType(), k -> ConcurrentHashMap.newKeySet())
                 .add(condition);
         // Add to spatial index
         long key = coordinateKey(condition.getX(), condition.getY());
-        this.wiredConditionsByLocation.computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet())
+        this.wiredConditionsByLocation
+                .computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet())
                 .add(condition);
         this.specialItemsById.put(condition.getId(), condition);
     }
@@ -789,7 +798,7 @@ public class RoomSpecialTypes {
         }
         this.specialItemsById.remove(condition.getId());
     }
-    
+
     /**
      * Updates the spatial index when a condition is moved.
      * @param condition The condition that was moved
@@ -806,13 +815,13 @@ public class RoomSpecialTypes {
                 this.wiredConditionsByLocation.remove(oldKey);
             }
         }
-        
+
         // Add to new location
         long newKey = coordinateKey(condition.getX(), condition.getY());
-        this.wiredConditionsByLocation.computeIfAbsent(newKey, k -> ConcurrentHashMap.newKeySet())
+        this.wiredConditionsByLocation
+                .computeIfAbsent(newKey, k -> ConcurrentHashMap.newKeySet())
                 .add(condition);
     }
-
 
     /**
      * Gets all wired extras in the room.
@@ -856,7 +865,8 @@ public class RoomSpecialTypes {
         this.wiredExtras.put(extra.getId(), extra);
         // Add to spatial index
         long key = coordinateKey(extra.getX(), extra.getY());
-        this.wiredExtrasByLocation.computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet())
+        this.wiredExtrasByLocation
+                .computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet())
                 .add(extra);
         this.specialItemsById.put(extra.getId(), extra);
     }
@@ -878,7 +888,7 @@ public class RoomSpecialTypes {
         }
         this.specialItemsById.remove(extra.getId());
     }
-    
+
     /**
      * Updates the spatial index when an extra is moved.
      * @param extra The extra that was moved
@@ -895,10 +905,11 @@ public class RoomSpecialTypes {
                 this.wiredExtrasByLocation.remove(oldKey);
             }
         }
-        
+
         // Add to new location
         long newKey = coordinateKey(extra.getX(), extra.getY());
-        this.wiredExtrasByLocation.computeIfAbsent(newKey, k -> ConcurrentHashMap.newKeySet())
+        this.wiredExtrasByLocation
+                .computeIfAbsent(newKey, k -> ConcurrentHashMap.newKeySet())
                 .add(extra);
     }
 
@@ -923,17 +934,18 @@ public class RoomSpecialTypes {
         return false;
     }
 
-
     public InteractionGameScoreboard getGameScorebord(int itemId) {
         return this.gameScoreboards.get(itemId);
     }
 
     public void addGameScoreboard(InteractionGameScoreboard scoreboard) {
-        this.gameScoreboards.put(scoreboard.getId(), scoreboard); this.specialItemsById.put(scoreboard.getId(), scoreboard);
+        this.gameScoreboards.put(scoreboard.getId(), scoreboard);
+        this.specialItemsById.put(scoreboard.getId(), scoreboard);
     }
 
     public void removeScoreboard(InteractionGameScoreboard scoreboard) {
-        this.gameScoreboards.remove(scoreboard.getId()); this.specialItemsById.remove(scoreboard.getId());
+        this.gameScoreboards.remove(scoreboard.getId());
+        this.specialItemsById.remove(scoreboard.getId());
     }
 
     public Map<Integer, InteractionFreezeScoreboard> getFreezeScoreboards() {
@@ -1023,17 +1035,18 @@ public class RoomSpecialTypes {
         }
     }
 
-
     public InteractionGameGate getGameGate(int itemId) {
         return this.gameGates.get(itemId);
     }
 
     public void addGameGate(InteractionGameGate gameGate) {
-        this.gameGates.put(gameGate.getId(), gameGate); this.specialItemsById.put(gameGate.getId(), gameGate);
+        this.gameGates.put(gameGate.getId(), gameGate);
+        this.specialItemsById.put(gameGate.getId(), gameGate);
     }
 
     public void removeGameGate(InteractionGameGate gameGate) {
-        this.gameGates.remove(gameGate.getId()); this.specialItemsById.remove(gameGate.getId());
+        this.gameGates.remove(gameGate.getId());
+        this.specialItemsById.remove(gameGate.getId());
     }
 
     public Map<Integer, InteractionFreezeGate> getFreezeGates() {
@@ -1064,17 +1077,18 @@ public class RoomSpecialTypes {
         }
     }
 
-
     public InteractionGameTimer getGameTimer(int itemId) {
         return this.gameTimers.get(itemId);
     }
 
     public void addGameTimer(InteractionGameTimer gameTimer) {
-        this.gameTimers.put(gameTimer.getId(), gameTimer); this.specialItemsById.put(gameTimer.getId(), gameTimer);
+        this.gameTimers.put(gameTimer.getId(), gameTimer);
+        this.specialItemsById.put(gameTimer.getId(), gameTimer);
     }
 
     public void removeGameTimer(InteractionGameTimer gameTimer) {
-        this.gameTimers.remove(gameTimer.getId()); this.specialItemsById.remove(gameTimer.getId());
+        this.gameTimers.remove(gameTimer.getId());
+        this.specialItemsById.remove(gameTimer.getId());
     }
 
     public Map<Integer, InteractionGameTimer> getGameTimers() {
@@ -1087,12 +1101,14 @@ public class RoomSpecialTypes {
 
     public InteractionFreezeExitTile getRandomFreezeExitTile() {
         synchronized (this.freezeExitTile) {
-            return (InteractionFreezeExitTile) this.freezeExitTile.values().toArray()[Emulator.getRandom().nextInt(this.freezeExitTile.size())];
+            return (InteractionFreezeExitTile)
+                    this.freezeExitTile.values().toArray()[Emulator.getRandom().nextInt(this.freezeExitTile.size())];
         }
     }
 
     public void addFreezeExitTile(InteractionFreezeExitTile freezeExitTile) {
-        this.freezeExitTile.put(freezeExitTile.getId(), freezeExitTile); this.specialItemsById.put(freezeExitTile.getId(), freezeExitTile);
+        this.freezeExitTile.put(freezeExitTile.getId(), freezeExitTile);
+        this.specialItemsById.put(freezeExitTile.getId(), freezeExitTile);
     }
 
     public Map<Integer, InteractionFreezeExitTile> getFreezeExitTiles() {
@@ -1100,7 +1116,8 @@ public class RoomSpecialTypes {
     }
 
     public void removeFreezeExitTile(InteractionFreezeExitTile freezeExitTile) {
-        this.freezeExitTile.remove(freezeExitTile.getId()); this.specialItemsById.remove(freezeExitTile.getId());
+        this.freezeExitTile.remove(freezeExitTile.getId());
+        this.specialItemsById.remove(freezeExitTile.getId());
     }
 
     public boolean hasFreezeExitTile() {
@@ -1123,7 +1140,7 @@ public class RoomSpecialTypes {
 
     public Set<HabboItem> getItemsOfType(Class<? extends HabboItem> type) {
         Set<HabboItem> items = new LinkedHashSet<>();
-        
+
         // Check pet trees collection for InteractionPetTree type
         if (type == InteractionPetTree.class) {
             synchronized (this.petTrees) {
@@ -1131,7 +1148,7 @@ public class RoomSpecialTypes {
             }
             return items;
         }
-        
+
         // Check pet toys collection for InteractionPetToy type
         if (type == InteractionPetToy.class) {
             synchronized (this.petToys) {
@@ -1139,11 +1156,10 @@ public class RoomSpecialTypes {
             }
             return items;
         }
-        
+
         synchronized (this.undefined) {
             for (HabboItem item : this.undefined.values()) {
-                if (item.getClass() == type)
-                    items.add(item);
+                if (item.getClass() == type) items.add(item);
             }
         }
 
@@ -1213,7 +1229,12 @@ public class RoomSpecialTypes {
 
     public Rectangle tentAt(RoomTile location) {
         for (HabboItem item : this.getItemsOfType(InteractionTent.class)) {
-            Rectangle rectangle = RoomLayout.getRectangle(item.getX(), item.getY(), item.getBaseItem().getWidth(), item.getBaseItem().getLength(), item.getRotation());
+            Rectangle rectangle = RoomLayout.getRectangle(
+                    item.getX(),
+                    item.getY(),
+                    item.getBaseItem().getWidth(),
+                    item.getBaseItem().getLength(),
+                    item.getRotation());
             if (RoomLayout.tileInSquare(rectangle, location)) {
                 return rectangle;
             }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -725,7 +725,7 @@ public class Habbo implements Runnable {
     public Set<Integer> getForbiddenClothing() {
         IntCollection clothingIDs = this.getInventory().getWardrobeComponent().getClothing();
 
-        return Emulator.getGameEnvironment().getCatalogManager().clothing.values().stream()
+        return Emulator.getGameEnvironment().getCatalogManager().getClothingSnapshot().values().stream()
                 .filter(c -> !clothingIDs.contains(c.id))
                 .map(c -> c.setId)
                 .flatMap(c -> Arrays.stream(c).boxed())

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -4,34 +4,64 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.GameEnvironment;
 import com.eu.habbo.habbohotel.achievements.AchievementManager;
 import com.eu.habbo.habbohotel.bots.Bot;
-import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.economy.EconomyLedger;
 import com.eu.habbo.habbohotel.economy.EconomyOperation;
 import com.eu.habbo.habbohotel.economy.EconomyOperationId;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.messenger.Messenger;
 import com.eu.habbo.habbohotel.pets.Pet;
-import com.eu.habbo.habbohotel.rooms.*;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomChatMessage;
+import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.rooms.RoomUnitType;
+import com.eu.habbo.habbohotel.rooms.RoomUserAction;
 import com.eu.habbo.habbohotel.users.inventory.BadgesComponent;
-import com.eu.habbo.messages.outgoing.generic.alerts.*;
-import com.eu.habbo.messages.outgoing.inventory.*;
+import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
+import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
+import com.eu.habbo.messages.outgoing.generic.alerts.GenericAlertComposer;
+import com.eu.habbo.messages.outgoing.generic.alerts.MessagesForYouComposer;
+import com.eu.habbo.messages.outgoing.generic.alerts.StaffAlertWithLinkComposer;
+import com.eu.habbo.messages.outgoing.inventory.AddBotComposer;
+import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
+import com.eu.habbo.messages.outgoing.inventory.AddPetComposer;
+import com.eu.habbo.messages.outgoing.inventory.InventoryBadgesComposer;
+import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
+import com.eu.habbo.messages.outgoing.inventory.RemoveBotComposer;
+import com.eu.habbo.messages.outgoing.inventory.RemoveHabboItemComposer;
+import com.eu.habbo.messages.outgoing.inventory.RemovePetComposer;
 import com.eu.habbo.messages.outgoing.rooms.FloodCounterComposer;
 import com.eu.habbo.messages.outgoing.rooms.ForwardToRoomComposer;
-import com.eu.habbo.messages.outgoing.rooms.users.*;
-import com.eu.habbo.messages.outgoing.users.*;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserActionComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserIgnoredComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserRespectComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserShoutComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserTalkComposer;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserWhisperComposer;
+import com.eu.habbo.messages.outgoing.users.AddUserBadgeComposer;
+import com.eu.habbo.messages.outgoing.users.MutedWhisperComposer;
+import com.eu.habbo.messages.outgoing.users.UserCreditsComposer;
+import com.eu.habbo.messages.outgoing.users.UserCurrencyComposer;
+import com.eu.habbo.messages.outgoing.users.UserPointsComposer;
 import com.eu.habbo.networking.gameserver.GameServerAttributes;
 import com.eu.habbo.plugin.events.users.UserCreditsEvent;
 import com.eu.habbo.plugin.events.users.UserDisconnectEvent;
 import com.eu.habbo.plugin.events.users.UserGetIPAddressEvent;
 import com.eu.habbo.plugin.events.users.UserPointsEvent;
 import it.unimi.dsi.fastutil.ints.IntCollection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.sql.ResultSet;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Habbo implements Runnable {
 
@@ -118,7 +148,6 @@ public class Habbo implements Runnable {
         this.client = client;
     }
 
-
     public boolean connect() {
         ConnectionSecurityResult security = this.checkConnectionSecurity();
         if (!security.allowed()) {
@@ -128,7 +157,11 @@ public class Habbo implements Runnable {
         this.isOnline(true);
         this.messenger.connectionChanged(this, true, false);
         Emulator.getGameEnvironment().getRoomManager().loadRoomsForHabbo(this);
-        LOGGER.info("{} logged in from IP {} using proxyserver {}", this.habboInfo.getUsername(), this.habboInfo.getIpLogin(), security.proxyInfo());
+        LOGGER.info(
+                "{} logged in from IP {} using proxyserver {}",
+                this.habboInfo.getUsername(),
+                this.habboInfo.getIpLogin(),
+                security.proxyInfo());
         LOGGER.info("{} client MachineId = {}", this.habboInfo.getUsername(), this.client.getMachineId());
         return true;
     }
@@ -157,7 +190,8 @@ public class Habbo implements Runnable {
         if (wsIp != null && !wsIp.isEmpty()) {
             ip = wsIp;
             proxyInfo = remoteIp(this.client.getChannel().remoteAddress());
-        } else if (!Emulator.getConfig().getBoolean("networking.tcp.proxy") && this.client.getChannel().remoteAddress() != null) {
+        } else if (!Emulator.getConfig().getBoolean("networking.tcp.proxy")
+                && this.client.getChannel().remoteAddress() != null) {
             ip = remoteIp(this.client.getChannel().remoteAddress());
             proxyInfo = "- no proxy server used";
         } else {
@@ -203,9 +237,7 @@ public class Habbo implements Runnable {
         return "";
     }
 
-    private record ConnectionSecurityResult(boolean allowed, String proxyInfo) {
-    }
-
+    private record ConnectionSecurityResult(boolean allowed, String proxyInfo) {}
 
     public void disconnect() {
         GameEnvironment environment = Emulator.getGameEnvironment();
@@ -216,42 +248,38 @@ public class Habbo implements Runnable {
         synchronized (this) {
             if (this.disconnected || this.disconnecting) {
                 if (!shuttingDown) {
-                    pluginManager.fireEvent(
-                            new UserDisconnectEvent(this));
+                    pluginManager.fireEvent(new UserDisconnectEvent(this));
                 }
                 return;
             }
 
-            persistenceRegistration =
-                    habboManager.beginDisconnectPersistence(
-                            this.habboInfo.getId());
+            persistenceRegistration = habboManager.beginDisconnectPersistence(this.habboInfo.getId());
             boolean cancelled;
             try {
                 cancelled = !shuttingDown
                         && pluginManager
-                        .fireEvent(new UserDisconnectEvent(this))
-                        .isCancelled();
+                                .fireEvent(new UserDisconnectEvent(this))
+                                .isCancelled();
             } catch (RuntimeException exception) {
-                habboManager.cancelDisconnectPersistence(
-                        persistenceRegistration);
+                habboManager.cancelDisconnectPersistence(persistenceRegistration);
                 throw exception;
             }
             if (cancelled) {
-                habboManager.cancelDisconnectPersistence(
-                        persistenceRegistration);
+                habboManager.cancelDisconnectPersistence(persistenceRegistration);
                 return;
             }
             this.disconnecting = true;
 
             try {
                 if (this.getHabboInfo().getCurrentRoom() != null) {
-                    environment.getRoomManager().leaveRoom(
-                            this,
-                            this.getHabboInfo().getCurrentRoom());
+                    environment
+                            .getRoomManager()
+                            .leaveRoom(this, this.getHabboInfo().getCurrentRoom());
                 }
                 if (this.getHabboInfo().getRoomQueueId() > 0) {
-                    Room room = environment.getRoomManager().getRoom(
-                            this.getHabboInfo().getRoomQueueId());
+                    Room room = environment
+                            .getRoomManager()
+                            .getRoom(this.getHabboInfo().getRoomQueueId());
 
                     if (room != null) {
                         room.removeFromQueue(this);
@@ -285,9 +313,7 @@ public class Habbo implements Runnable {
             }
         }
 
-        habboManager.submitDisconnectPersistence(
-                persistenceRegistration,
-                this::persistDisconnect);
+        habboManager.submitDisconnectPersistence(persistenceRegistration, this::persistDisconnect);
     }
 
     private void persistDisconnect() {
@@ -306,48 +332,50 @@ public class Habbo implements Runnable {
         }
     }
 
-
     public boolean hasPermission(String key) {
         return this.hasPermission(key, false);
     }
 
-
     public boolean hasPermission(String key, boolean hasRoomRights) {
         return Emulator.getGameEnvironment().getPermissionsManager().hasPermission(this, key, hasRoomRights);
     }
-
 
     public void giveCredits(int credits) {
         this.giveCredits(credits, "economy.api.credits");
     }
 
     public void giveCredits(int credits, String reason) {
-        this.giveCredits(credits, reason,
+        this.giveCredits(
+                credits,
+                reason,
                 EconomyOperationId.create("credits:" + this.getHabboInfo().getId()),
                 this.getHabboInfo().getId());
     }
 
     public void giveCredits(int credits, String reason, String operationId, Integer actorId) {
-        if (credits == 0)
-            return;
+        if (credits == 0) return;
 
         UserCreditsEvent event = new UserCreditsEvent(this, credits);
-        if (Emulator.getPluginManager().fireEvent(event).isCancelled())
-            return;
+        if (Emulator.getPluginManager().fireEvent(event).isCancelled()) return;
 
         try {
-            LedgerWalletMutation.execute(this, new EconomyOperation(
-                    operationId,
-                    this.getHabboInfo().getId(),
-                    actorId,
-                    event.credits > 0 ? "credit_grant" : "credit_debit",
-                    reason,
-                    EconomyLedger.CREDITS,
-                    event.credits,
-                    null,
-                    ""));
+            LedgerWalletMutation.execute(
+                    this,
+                    new EconomyOperation(
+                            operationId,
+                            this.getHabboInfo().getId(),
+                            actorId,
+                            event.credits > 0 ? "credit_grant" : "credit_debit",
+                            reason,
+                            EconomyLedger.CREDITS,
+                            event.credits,
+                            null,
+                            ""));
         } catch (Exception exception) {
-            LOGGER.error("Unable to apply audited credit mutation for user {}", this.getHabboInfo().getId(), exception);
+            LOGGER.error(
+                    "Unable to apply audited credit mutation for user {}",
+                    this.getHabboInfo().getId(),
+                    exception);
             return;
         }
 
@@ -362,11 +390,7 @@ public class Habbo implements Runnable {
                 this.getHabboInfo().getId());
     }
 
-    public boolean tryTakeCredits(
-            int credits,
-            String reason,
-            String operationId,
-            Integer actorId) {
+    public boolean tryTakeCredits(int credits, String reason, String operationId, Integer actorId) {
         if (credits <= 0) {
             return false;
         }
@@ -377,27 +401,31 @@ public class Habbo implements Runnable {
         }
 
         try {
-            LedgerWalletMutation.execute(this, new EconomyOperation(
-                    operationId,
-                    this.getHabboInfo().getId(),
-                    actorId,
-                    "credit_debit",
-                    reason,
-                    EconomyLedger.CREDITS,
-                    event.credits,
-                    null,
-                    ""));
+            LedgerWalletMutation.execute(
+                    this,
+                    new EconomyOperation(
+                            operationId,
+                            this.getHabboInfo().getId(),
+                            actorId,
+                            "credit_debit",
+                            reason,
+                            EconomyLedger.CREDITS,
+                            event.credits,
+                            null,
+                            ""));
         } catch (IllegalArgumentException exception) {
             return false;
         } catch (Exception exception) {
-            LOGGER.error("Unable to apply audited credit debit for user {}", this.getHabboInfo().getId(), exception);
+            LOGGER.error(
+                    "Unable to apply audited credit debit for user {}",
+                    this.getHabboInfo().getId(),
+                    exception);
             return false;
         }
 
         if (this.client != null) this.client.sendResponse(new UserCreditsComposer(this));
         return true;
     }
-
 
     public void givePixels(int pixels) {
         this.givePoints(0, pixels, "economy.api.pixels");
@@ -407,49 +435,54 @@ public class Habbo implements Runnable {
         this.givePoints(0, pixels, reason);
     }
 
-
     public void givePoints(int points) {
         this.givePoints(Emulator.getConfig().getInt("seasonal.primary.type"), points);
     }
-
 
     public void givePoints(int type, int points) {
         this.givePoints(type, points, "economy.api.currency");
     }
 
     public void givePoints(int type, int points, String reason) {
-        this.givePoints(type, points, reason,
+        this.givePoints(
+                type,
+                points,
+                reason,
                 EconomyOperationId.create("currency:" + this.getHabboInfo().getId() + ":" + type),
                 this.getHabboInfo().getId());
     }
 
     public void givePoints(int type, int points, String reason, String operationId, Integer actorId) {
-        if (points == 0)
-            return;
+        if (points == 0) return;
 
         UserPointsEvent event = new UserPointsEvent(this, points, type);
-        if (Emulator.getPluginManager().fireEvent(event).isCancelled())
-            return;
+        if (Emulator.getPluginManager().fireEvent(event).isCancelled()) return;
 
         try {
-            LedgerWalletMutation.execute(this, new EconomyOperation(
-                    operationId,
-                    this.getHabboInfo().getId(),
-                    actorId,
-                    event.points > 0 ? "currency_grant" : "currency_debit",
-                    reason,
-                    event.type,
-                    event.points,
-                    null,
-                    ""));
+            LedgerWalletMutation.execute(
+                    this,
+                    new EconomyOperation(
+                            operationId,
+                            this.getHabboInfo().getId(),
+                            actorId,
+                            event.points > 0 ? "currency_grant" : "currency_debit",
+                            reason,
+                            event.type,
+                            event.points,
+                            null,
+                            ""));
         } catch (Exception exception) {
-            LOGGER.error("Unable to apply audited currency mutation for user {}", this.getHabboInfo().getId(), exception);
+            LOGGER.error(
+                    "Unable to apply audited currency mutation for user {}",
+                    this.getHabboInfo().getId(),
+                    exception);
             return;
         }
         if (this.client != null) {
             if (event.type == 0) this.client.sendResponse(new UserCurrencyComposer(this));
-            else this.client.sendResponse(new UserPointsComposer(
-                    this.getHabboInfo().getCurrencyAmount(event.type), event.points, event.type));
+            else
+                this.client.sendResponse(new UserPointsComposer(
+                        this.getHabboInfo().getCurrencyAmount(event.type), event.points, event.type));
         }
     }
 
@@ -458,43 +491,42 @@ public class Habbo implements Runnable {
                 type,
                 points,
                 "economy.api.currency",
-                EconomyOperationId.create(
-                        "currency:" + this.getHabboInfo().getId() + ":" + type),
+                EconomyOperationId.create("currency:" + this.getHabboInfo().getId() + ":" + type),
                 this.getHabboInfo().getId());
     }
 
-    public boolean tryTakePoints(
-            int type,
-            int points,
-            String reason,
-            String operationId,
-            Integer actorId) {
+    public boolean tryTakePoints(int type, int points, String reason, String operationId, Integer actorId) {
         if (points <= 0) {
             return false;
         }
 
         UserPointsEvent event = new UserPointsEvent(this, -points, type);
         if (Emulator.getPluginManager().fireEvent(event).isCancelled()
-                || event.type != type || event.points != -points) {
+                || event.type != type
+                || event.points != -points) {
             return false;
         }
 
         try {
-            LedgerWalletMutation.execute(this, new EconomyOperation(
-                    operationId,
-                    this.getHabboInfo().getId(),
-                    actorId,
-                    "currency_debit",
-                    reason,
-                    event.type,
-                    event.points,
-                    null,
-                    ""));
+            LedgerWalletMutation.execute(
+                    this,
+                    new EconomyOperation(
+                            operationId,
+                            this.getHabboInfo().getId(),
+                            actorId,
+                            "currency_debit",
+                            reason,
+                            event.type,
+                            event.points,
+                            null,
+                            ""));
         } catch (IllegalArgumentException exception) {
             return false;
         } catch (Exception exception) {
-            LOGGER.error("Unable to apply audited currency debit for user {}",
-                    this.getHabboInfo().getId(), exception);
+            LOGGER.error(
+                    "Unable to apply audited currency debit for user {}",
+                    this.getHabboInfo().getId(),
+                    exception);
             return false;
         }
 
@@ -505,66 +537,62 @@ public class Habbo implements Runnable {
         return true;
     }
 
-
     public void whisper(String message) {
         this.whisper(message, this.habboStats.chatColor);
     }
 
-
     public void whisper(String message, RoomChatMessageBubbles bubble) {
         if (this.getRoomUnit().isInRoom()) {
-            this.client.sendResponse(new RoomUserWhisperComposer(new RoomChatMessage(message, this.getRoomUnit(), bubble)));
+            this.client.sendResponse(
+                    new RoomUserWhisperComposer(new RoomChatMessage(message, this.getRoomUnit(), bubble)));
         }
     }
-
 
     public void talk(String message) {
         this.talk(message, this.habboStats.chatColor);
     }
 
-
     public void talk(String message, RoomChatMessageBubbles bubble) {
         if (this.getRoomUnit().isInRoom()) {
-            this.getHabboInfo().getCurrentRoom().sendComposer(new RoomUserTalkComposer(new RoomChatMessage(message, this.getRoomUnit(), bubble)).compose());
+            this.getHabboInfo()
+                    .getCurrentRoom()
+                    .sendComposer(new RoomUserTalkComposer(new RoomChatMessage(message, this.getRoomUnit(), bubble))
+                            .compose());
         }
     }
-
 
     public void shout(String message) {
         this.shout(message, this.habboStats.chatColor);
     }
 
-
     public void shout(String message, RoomChatMessageBubbles bubble) {
         if (this.getRoomUnit().isInRoom()) {
-            this.getHabboInfo().getCurrentRoom().sendComposer(new RoomUserShoutComposer(new RoomChatMessage(message, this.getRoomUnit(), bubble)).compose());
+            this.getHabboInfo()
+                    .getCurrentRoom()
+                    .sendComposer(new RoomUserShoutComposer(new RoomChatMessage(message, this.getRoomUnit(), bubble))
+                            .compose());
         }
     }
 
-
     public void alert(String message) {
         if (Emulator.getConfig().getBoolean("hotel.alert.oldstyle")) {
-            this.client.sendResponse(new MessagesForYouComposer(new String[]{message}));
+            this.client.sendResponse(new MessagesForYouComposer(new String[] {message}));
         } else {
             this.client.sendResponse(new GenericAlertComposer(message));
         }
     }
 
-
     public void alert(String[] messages) {
         this.client.sendResponse(new MessagesForYouComposer(messages));
     }
-
 
     public void alertWithUrl(String message, String url) {
         this.client.sendResponse(new StaffAlertWithLinkComposer(message, url));
     }
 
-
     public void goToRoom(int id) {
         this.client.sendResponse(new ForwardToRoomComposer(id));
     }
-
 
     public void addFurniture(HabboItem item) {
         this.habboInventory.getItemsComponent().addItem(item);
@@ -572,31 +600,26 @@ public class Habbo implements Runnable {
         this.client.sendResponse(new InventoryRefreshComposer());
     }
 
-
     public void addFurniture(Collection<HabboItem> items) {
         this.habboInventory.getItemsComponent().addItems(items);
         this.client.sendResponse(new AddHabboItemComposer(items));
         this.client.sendResponse(new InventoryRefreshComposer());
     }
 
-
     public void removeFurniture(HabboItem item) {
         this.habboInventory.getItemsComponent().removeHabboItem(item);
         this.client.sendResponse(new RemoveHabboItemComposer(item.getId()));
     }
-
 
     public void addBot(Bot bot) {
         this.habboInventory.getBotsComponent().addBot(bot);
         this.client.sendResponse(new AddBotComposer(bot));
     }
 
-
     public void removeBot(Bot bot) {
         this.habboInventory.getBotsComponent().removeBot(bot);
         this.client.sendResponse(new RemoveBotComposer(bot));
     }
-
 
     public void deleteBot(Bot bot) {
         this.removeBot(bot);
@@ -604,18 +627,15 @@ public class Habbo implements Runnable {
         Emulator.getGameEnvironment().getBotManager().deleteBot(bot);
     }
 
-
     public void addPet(Pet pet) {
         this.habboInventory.getPetsComponent().addPet(pet);
         this.client.sendResponse(new AddPetComposer(pet));
     }
 
-
     public void removePet(Pet pet) {
         this.habboInventory.getPetsComponent().removePet(pet);
         this.client.sendResponse(new RemovePetComposer(pet));
     }
-
 
     public boolean addBadge(String code) {
         return this.addBadge(code, "");
@@ -626,7 +646,8 @@ public class Habbo implements Runnable {
             HabboBadge badge = BadgesComponent.createBadge(code, this);
             this.habboInventory.getBadgesComponent().addBadge(badge);
             this.client.sendResponse(new AddUserBadgeComposer(badge, senderName));
-            this.client.sendResponse(new AddHabboItemComposer(badge.getId(), AddHabboItemComposer.AddHabboItemCategory.BADGE));
+            this.client.sendResponse(
+                    new AddHabboItemComposer(badge.getId(), AddHabboItemComposer.AddHabboItemCategory.BADGE));
 
             Map<String, String> keys = new HashMap<>();
             keys.put("display", "BUBBLE");
@@ -639,7 +660,6 @@ public class Habbo implements Runnable {
 
         return false;
     }
-
 
     public void deleteBadge(HabboBadge badge) {
         if (badge != null) {
@@ -679,7 +699,6 @@ public class Habbo implements Runnable {
     public int noobStatus() {
 
         return 1;
-
     }
 
     public void clearCaches() {
@@ -705,17 +724,21 @@ public class Habbo implements Runnable {
         this.habboStats.ltdPurchaseLog = newLog;
     }
 
-
     public void respect(Habbo target) {
         if (target != null && target != this) {
             target.getHabboStats().respectPointsReceived++;
             this.getHabboStats().respectPointsGiven++;
             this.getHabboStats().respectPointsToGive--;
             this.getHabboInfo().getCurrentRoom().sendComposer(new RoomUserRespectComposer(target).compose());
-            this.getHabboInfo().getCurrentRoom().sendComposer(new RoomUserActionComposer(this.getRoomUnit(), RoomUserAction.THUMB_UP).compose());
+            this.getHabboInfo()
+                    .getCurrentRoom()
+                    .sendComposer(new RoomUserActionComposer(this.getRoomUnit(), RoomUserAction.THUMB_UP).compose());
 
-            AchievementManager.progressAchievement(this, Emulator.getGameEnvironment().getAchievementManager().getAchievement("RespectGiven"));
-            AchievementManager.progressAchievement(target, Emulator.getGameEnvironment().getAchievementManager().getAchievement("RespectEarned"));
+            AchievementManager.progressAchievement(
+                    this, Emulator.getGameEnvironment().getAchievementManager().getAchievement("RespectGiven"));
+            AchievementManager.progressAchievement(
+                    target,
+                    Emulator.getGameEnvironment().getAchievementManager().getAchievement("RespectEarned"));
 
             this.getHabboInfo().getCurrentRoom().unIdle(this);
             this.getHabboInfo().getCurrentRoom().dance(this.getRoomUnit(), DanceType.NONE);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
@@ -104,8 +104,12 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                     return;
                 }
 
-                if (!Emulator.getGameEnvironment().getCatalogManager().giftWrappers.containsKey(spriteId)
-                        && !Emulator.getGameEnvironment().getCatalogManager().giftFurnis.containsKey(spriteId)) {
+                CatalogManager.GiftWrappingSnapshot giftWrapping =
+                        Emulator.getGameEnvironment().getCatalogManager().getGiftWrappingSnapshot();
+                Map<Integer, Integer> giftWrappers = giftWrapping.wrappers();
+                Map<Integer, Integer> giftFurniture = giftWrapping.furniture();
+
+                if (!giftWrappers.containsKey(spriteId) && !giftFurniture.containsKey(spriteId)) {
                     LOGGER.debug("invalid spriteId for gift wrapper/furni -> {}", spriteId);
                     this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                     return;
@@ -117,10 +121,10 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                     return;
                 }
 
-                Integer iItemId = Emulator.getGameEnvironment().getCatalogManager().giftWrappers.get(spriteId);
+                Integer iItemId = giftWrappers.get(spriteId);
 
                 if (iItemId == null) {
-                    iItemId = Emulator.getGameEnvironment().getCatalogManager().giftFurnis.get(spriteId);
+                    iItemId = giftFurniture.get(spriteId);
                 }
 
                 if (iItemId == null) {
@@ -133,11 +137,12 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
 
                 if (giftItem == null) {
                     LOGGER.debug("direct giftItem null, trying random fallback. iItemId={}", iItemId);
-                    giftItem = Emulator.getGameEnvironment().getItemManager().getItem(
-                            (Integer) Emulator.getGameEnvironment().getCatalogManager().giftFurnis.values().toArray()[
-                                    Emulator.getRandom().nextInt(Emulator.getGameEnvironment().getCatalogManager().giftFurnis.size())
-                                    ]
-                    );
+                    Object[] giftFurnitureIds = giftFurniture.values().toArray();
+                    if (giftFurnitureIds.length > 0) {
+                        giftItem = Emulator.getGameEnvironment().getItemManager().getItem(
+                                (Integer) giftFurnitureIds[Emulator.getRandom().nextInt(giftFurnitureIds.length)]
+                        );
+                    }
 
                     if (giftItem == null) {
                         LOGGER.debug("fallback giftItem also null");
@@ -230,7 +235,7 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                     }
 
                     // Paid wrapping (giftWrappers) costs hotel.gifts.special.price; default furni wrap is free.
-                    boolean isPaidWrap = Emulator.getGameEnvironment().getCatalogManager().giftWrappers.containsKey(spriteId);
+                    boolean isPaidWrap = giftWrappers.containsKey(spriteId);
                     int wrapFee = isPaidWrap ? Emulator.getConfig().getInt("hotel.gifts.special.price", 0) : 0;
                     int totalCredits;
                     int totalPoints;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
@@ -2,11 +2,28 @@ package com.eu.habbo.messages.incoming.catalog;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.achievements.AchievementManager;
-import com.eu.habbo.habbohotel.catalog.*;
-import com.eu.habbo.habbohotel.catalog.layouts.*;
+import com.eu.habbo.habbohotel.catalog.CatalogItem;
+import com.eu.habbo.habbohotel.catalog.CatalogLimitedConfiguration;
+import com.eu.habbo.habbohotel.catalog.CatalogManager;
+import com.eu.habbo.habbohotel.catalog.CatalogPage;
+import com.eu.habbo.habbohotel.catalog.CatalogPageAccessPolicy;
+import com.eu.habbo.habbohotel.catalog.CatalogPaymentService;
+import com.eu.habbo.habbohotel.catalog.CatalogPurchaseMath;
+import com.eu.habbo.habbohotel.catalog.ClubOffer;
+import com.eu.habbo.habbohotel.catalog.layouts.BuildersClubAddonsLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.BuildersClubFrontPageLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.BuildersClubLoyaltyLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.ClubBuyLayout;
+import com.eu.habbo.habbohotel.catalog.layouts.VipBuyLayout;
 import com.eu.habbo.habbohotel.items.FurnitureType;
 import com.eu.habbo.habbohotel.items.Item;
-import com.eu.habbo.habbohotel.items.interactions.*;
+import com.eu.habbo.habbohotel.items.interactions.InteractionBadgeDisplay;
+import com.eu.habbo.habbohotel.items.interactions.InteractionGuildFurni;
+import com.eu.habbo.habbohotel.items.interactions.InteractionGuildGate;
+import com.eu.habbo.habbohotel.items.interactions.InteractionHopper;
+import com.eu.habbo.habbohotel.items.interactions.InteractionTeleport;
+import com.eu.habbo.habbohotel.items.interactions.InteractionTeleportTile;
+import com.eu.habbo.habbohotel.items.interactions.InteractionTrophy;
 import com.eu.habbo.habbohotel.modtool.ScripterManager;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.users.Habbo;
@@ -14,7 +31,12 @@ import com.eu.habbo.habbohotel.users.HabboBadge;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.users.subscriptions.Subscription;
 import com.eu.habbo.messages.incoming.MessageHandler;
-import com.eu.habbo.messages.outgoing.catalog.*;
+import com.eu.habbo.messages.outgoing.catalog.AlertLimitedSoldOutComposer;
+import com.eu.habbo.messages.outgoing.catalog.AlertPurchaseFailedComposer;
+import com.eu.habbo.messages.outgoing.catalog.AlertPurchaseUnavailableComposer;
+import com.eu.habbo.messages.outgoing.catalog.GiftConfigurationComposer;
+import com.eu.habbo.messages.outgoing.catalog.GiftReceiverNotFoundComposer;
+import com.eu.habbo.messages.outgoing.catalog.PurchaseOKComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.generic.alerts.GenericAlertComposer;
@@ -23,15 +45,18 @@ import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.users.UserClubComposer;
 import com.eu.habbo.threading.runnables.ShutdownEmulator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CatalogBuyItemAsGiftEvent extends MessageHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogBuyItemAsGiftEvent.class);
@@ -51,18 +76,22 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
 
     @Override
     public void handle() throws Exception {
-        if (Emulator.getIntUnixTimestamp() - this.client.getHabbo().getHabboStats().lastGiftTimestamp >= CatalogManager.PURCHASE_COOLDOWN) {
+        if (Emulator.getIntUnixTimestamp() - this.client.getHabbo().getHabboStats().lastGiftTimestamp
+                >= CatalogManager.PURCHASE_COOLDOWN) {
             if (ShutdownEmulator.timestamp > 0) {
                 LOGGER.debug("emulator closing");
-                this.client.sendResponse(new HotelWillCloseInMinutesComposer((ShutdownEmulator.timestamp - Emulator.getIntUnixTimestamp()) / 60));
-                this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                this.client.sendResponse(new HotelWillCloseInMinutesComposer(
+                        (ShutdownEmulator.timestamp - Emulator.getIntUnixTimestamp()) / 60));
+                this.client.sendResponse(
+                        new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                 return;
             }
 
             synchronized (this.client.getHabbo().getHabboStats()) {
                 if (this.client.getHabbo().getHabboStats().isPurchasingFurniture) {
                     LOGGER.debug("isPurchasingFurniture already true");
-                    this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                    this.client.sendResponse(
+                            new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                     return;
                 }
                 this.client.getHabbo().getHabboStats().isPurchasingFurniture = true;
@@ -84,20 +113,31 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                 int messageMax = Emulator.getConfig().getInt("hotel.gifts.length.max", 300);
                 String rawMessage = this.packet.readString();
                 if (rawMessage.length() > messageMax) rawMessage = rawMessage.substring(0, messageMax);
-                String message = Emulator.getGameEnvironment().getWordFilter().filter(rawMessage, this.client.getHabbo());
+                String message =
+                        Emulator.getGameEnvironment().getWordFilter().filter(rawMessage, this.client.getHabbo());
                 int spriteId = this.packet.readInt();
                 int color = this.packet.readInt();
                 int ribbonId = this.packet.readInt();
                 boolean showName = this.packet.readBoolean();
 
-                LOGGER.debug("Gift request: pageId={}, itemId={}, spriteId={}, color={}, ribbonId={}", pageId, itemId, spriteId, color, ribbonId);
+                LOGGER.debug(
+                        "Gift request: pageId={}, itemId={}, spriteId={}, color={}, ribbonId={}",
+                        pageId,
+                        itemId,
+                        spriteId,
+                        color,
+                        ribbonId);
 
                 int userId = 0;
 
-                CatalogPage clubGiftPage = Emulator.getGameEnvironment().getCatalogManager().catalogPages.get(pageId);
+                CatalogPage clubGiftPage = Emulator.getGameEnvironment()
+                        .getCatalogManager()
+                        .catalogPages
+                        .get(pageId);
                 if (this.isClubOfferPage(clubGiftPage)) {
                     if (!this.canAccessPage(clubGiftPage)) {
-                        this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                        this.client.sendResponse(
+                                new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                         return;
                     }
                     this.handleClubOfferGift(clubGiftPage, itemId, username);
@@ -111,13 +151,16 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
 
                 if (!giftWrappers.containsKey(spriteId) && !giftFurniture.containsKey(spriteId)) {
                     LOGGER.debug("invalid spriteId for gift wrapper/furni -> {}", spriteId);
-                    this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                    this.client.sendResponse(
+                            new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                     return;
                 }
 
-                if (!GiftConfigurationComposer.BOX_TYPES.contains(color) || !GiftConfigurationComposer.RIBBON_TYPES.contains(ribbonId)) {
+                if (!GiftConfigurationComposer.BOX_TYPES.contains(color)
+                        || !GiftConfigurationComposer.RIBBON_TYPES.contains(ribbonId)) {
                     LOGGER.debug("invalid color/ribbon -> color={}, ribbonId={}", color, ribbonId);
-                    this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                    this.client.sendResponse(
+                            new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                     return;
                 }
 
@@ -129,7 +172,8 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
 
                 if (iItemId == null) {
                     LOGGER.debug("iItemId null for spriteId={}", spriteId);
-                    this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                    this.client.sendResponse(
+                            new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                     return;
                 }
 
@@ -139,24 +183,29 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                     LOGGER.debug("direct giftItem null, trying random fallback. iItemId={}", iItemId);
                     Object[] giftFurnitureIds = giftFurniture.values().toArray();
                     if (giftFurnitureIds.length > 0) {
-                        giftItem = Emulator.getGameEnvironment().getItemManager().getItem(
-                                (Integer) giftFurnitureIds[Emulator.getRandom().nextInt(giftFurnitureIds.length)]
-                        );
+                        giftItem = Emulator.getGameEnvironment()
+                                .getItemManager()
+                                .getItem((Integer)
+                                        giftFurnitureIds[Emulator.getRandom().nextInt(giftFurnitureIds.length)]);
                     }
 
                     if (giftItem == null) {
                         LOGGER.debug("fallback giftItem also null");
-                        this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                        this.client.sendResponse(
+                                new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                         return;
                     }
                 }
 
-                try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
-                    Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(username);
+                try (Connection connection =
+                        Emulator.getDatabase().getDataSource().getConnection()) {
+                    Habbo habbo =
+                            Emulator.getGameEnvironment().getHabboManager().getHabbo(username);
 
                     if (habbo == null) {
                         LOGGER.debug("target user not online, checking DB -> {}", username);
-                        try (PreparedStatement statement = connection.prepareStatement("SELECT id FROM users WHERE username = ?")) {
+                        try (PreparedStatement statement =
+                                connection.prepareStatement("SELECT id FROM users WHERE username = ?")) {
                             statement.setString(1, username);
 
                             try (ResultSet set = statement.executeQuery()) {
@@ -177,17 +226,34 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                         return;
                     }
 
-                    CatalogPage page = Emulator.getGameEnvironment().getCatalogManager().catalogPages.get(pageId);
+                    CatalogPage page = Emulator.getGameEnvironment()
+                            .getCatalogManager()
+                            .catalogPages
+                            .get(pageId);
 
                     if (page == null) {
                         LOGGER.debug("page null -> {}", pageId);
-                        this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                        this.client.sendResponse(
+                                new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                         return;
                     }
 
-                    if (page.getRank() > this.client.getHabbo().getHabboInfo().getRank().getId() || !page.isEnabled() || !page.isVisible()) {
-                        LOGGER.debug("page access denied. pageRank={}, userRank={}, enabled={}, visible={}", page.getRank(), this.client.getHabbo().getHabboInfo().getRank().getId(), page.isEnabled(), page.isVisible());
-                        this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                    if (page.getRank()
+                                    > this.client
+                                            .getHabbo()
+                                            .getHabboInfo()
+                                            .getRank()
+                                            .getId()
+                            || !page.isEnabled()
+                            || !page.isVisible()) {
+                        LOGGER.debug(
+                                "page access denied. pageRank={}, userRank={}, enabled={}, visible={}",
+                                page.getRank(),
+                                this.client.getHabbo().getHabboInfo().getRank().getId(),
+                                page.isEnabled(),
+                                page.isVisible());
+                        this.client.sendResponse(
+                                new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                         return;
                     }
 
@@ -208,20 +274,27 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
 
                     if (item == null) {
                         LOGGER.debug("catalog item null -> {}", itemId);
-                        this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                        this.client.sendResponse(
+                                new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                         return;
                     }
 
-                    if (item.isClubOnly() && !this.client.getHabbo().getHabboStats().hasActiveClub()) {
+                    if (item.isClubOnly()
+                            && !this.client.getHabbo().getHabboStats().hasActiveClub()) {
                         LOGGER.debug("item requires club -> itemId={}", itemId);
-                        this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.REQUIRES_CLUB));
+                        this.client.sendResponse(
+                                new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.REQUIRES_CLUB));
                         return;
                     }
 
                     for (Item baseItem : item.getBaseItems()) {
                         if (!baseItem.allowGift()) {
-                            LOGGER.debug("base item not giftable -> baseItemId={}, name={}", baseItem.getId(), baseItem.getName());
-                            this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                            LOGGER.debug(
+                                    "base item not giftable -> baseItemId={}, name={}",
+                                    baseItem.getId(),
+                                    baseItem.getName());
+                            this.client.sendResponse(
+                                    new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                             return;
                         }
                     }
@@ -244,14 +317,21 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                         totalPoints = CatalogPurchaseMath.requireNonNegative(item.getPoints(), "gift points price");
                     } catch (IllegalArgumentException e) {
                         LOGGER.warn("Rejected invalid gift price for itemId={}", itemId);
-                        this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                        this.client.sendResponse(
+                                new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                         return;
                     }
 
                     if (totalCredits > this.client.getHabbo().getHabboInfo().getCredits()
-                            || totalPoints > this.client.getHabbo().getHabboInfo().getCurrencyAmount(item.getPointsType())) {
-                        LOGGER.debug("not enough currency. creditsNeeded={}, pointsNeeded={}, pointsType={}", totalCredits, totalPoints, item.getPointsType());
-                        this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                            || totalPoints
+                                    > this.client.getHabbo().getHabboInfo().getCurrencyAmount(item.getPointsType())) {
+                        LOGGER.debug(
+                                "not enough currency. creditsNeeded={}, pointsNeeded={}, pointsType={}",
+                                totalCredits,
+                                totalPoints,
+                                item.getPointsType());
+                        this.client.sendResponse(
+                                new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                         return;
                     }
 
@@ -260,7 +340,11 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                     int limitedNumber = 0;
 
                     if (item.isLimited()) {
-                        if (Emulator.getGameEnvironment().getCatalogManager().getLimitedConfig(item).available() == 0) {
+                        if (Emulator.getGameEnvironment()
+                                        .getCatalogManager()
+                                        .getLimitedConfig(item)
+                                        .available()
+                                == 0) {
                             LOGGER.debug("LTD available=0 -> itemId={}", itemId);
                             this.client.sendResponse(new AlertLimitedSoldOutComposer());
                             return;
@@ -270,30 +354,46 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                             int ltdLimit = Emulator.getConfig().getInt("hotel.purchase.ltd.limit.daily.total");
                             if (this.client.getHabbo().getHabboStats().totalLtds() >= ltdLimit) {
                                 LOGGER.debug("sender reached daily total LTD limit");
-                                this.client.getHabbo().alert(
-                                        Emulator.getTexts().getValue("error.catalog.buy.limited.daily.total")
-                                                .replace("%itemname%", item.getBaseItems().iterator().next().getDisplayName())
-                                                .replace("%limit%", ltdLimit + "")
-                                );
+                                this.client
+                                        .getHabbo()
+                                        .alert(Emulator.getTexts()
+                                                .getValue("error.catalog.buy.limited.daily.total")
+                                                .replace(
+                                                        "%itemname%",
+                                                        item.getBaseItems()
+                                                                .iterator()
+                                                                .next()
+                                                                .getDisplayName())
+                                                .replace("%limit%", ltdLimit + ""));
                                 return;
                             }
 
                             ltdLimit = Emulator.getConfig().getInt("hotel.purchase.ltd.limit.daily.item");
                             if (this.client.getHabbo().getHabboStats().totalLtds(item.getId()) >= ltdLimit) {
                                 LOGGER.debug("sender reached daily LTD item limit");
-                                this.client.getHabbo().alert(
-                                        Emulator.getTexts().getValue("error.catalog.buy.limited.daily.item")
-                                                .replace("%itemname%", item.getBaseItems().iterator().next().getDisplayName())
-                                                .replace("%limit%", ltdLimit + "")
-                                );
+                                this.client
+                                        .getHabbo()
+                                        .alert(Emulator.getTexts()
+                                                .getValue("error.catalog.buy.limited.daily.item")
+                                                .replace(
+                                                        "%itemname%",
+                                                        item.getBaseItems()
+                                                                .iterator()
+                                                                .next()
+                                                                .getDisplayName())
+                                                .replace("%limit%", ltdLimit + ""));
                                 return;
                             }
                         }
 
-                        limitedConfiguration = Emulator.getGameEnvironment().getCatalogManager().getLimitedConfig(item);
+                        limitedConfiguration = Emulator.getGameEnvironment()
+                                .getCatalogManager()
+                                .getLimitedConfig(item);
 
                         if (limitedConfiguration == null) {
-                            limitedConfiguration = Emulator.getGameEnvironment().getCatalogManager().createOrUpdateLimitedConfig(item);
+                            limitedConfiguration = Emulator.getGameEnvironment()
+                                    .getCatalogManager()
+                                    .createOrUpdateLimitedConfig(item);
                         }
 
                         limitedNumber = limitedConfiguration.getNumber();
@@ -311,7 +411,8 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                                 }
                             } else {
                                 int c = 0;
-                                try (PreparedStatement statement = connection.prepareStatement("SELECT COUNT(*) as c FROM users_badges WHERE user_id = ? AND badge_code LIKE ?")) {
+                                try (PreparedStatement statement = connection.prepareStatement(
+                                        "SELECT COUNT(*) as c FROM users_badges WHERE user_id = ? AND badge_code LIKE ?")) {
                                     statement.setInt(1, userId);
                                     statement.setString(2, baseItem.getName());
 
@@ -331,37 +432,47 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
 
                     if (badgeFound) {
                         LOGGER.debug("receiver already has badge");
-                        this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.ALREADY_HAVE_BADGE));
+                        this.client.sendResponse(
+                                new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.ALREADY_HAVE_BADGE));
                         return;
                     }
 
                     if (item.getAmount() > 1 || item.getBaseItems().size() > 1) {
-                        LOGGER.debug("unsupported multi amount/baseItems. amount={}, baseItems={}", item.getAmount(), item.getBaseItems().size());
-                        this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                        LOGGER.debug(
+                                "unsupported multi amount/baseItems. amount={}, baseItems={}",
+                                item.getAmount(),
+                                item.getBaseItems().size());
+                        this.client.sendResponse(
+                                new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
                         return;
                     }
 
                     // Reject unsupported shapes before creating recipient-owned rows.
                     for (Item baseItem : item.getBaseItems()) {
-                        if (baseItem == null || item.getItemAmount(baseItem.getId()) > 1
+                        if (baseItem == null
+                                || item.getItemAmount(baseItem.getId()) > 1
                                 || baseItem.getType() == FurnitureType.BADGE
                                 || Item.isBot(baseItem)
                                 || Item.isPet(baseItem)
                                 || baseItem.getName().contains("avatar_effect")
                                 || baseItem.getInteractionType().getType() == InteractionGuildFurni.class
                                 || baseItem.getInteractionType().getType() == InteractionGuildGate.class) {
-                            this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                            this.client.sendResponse(
+                                    new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                             return;
                         }
                     }
 
-                    int chargeCredits = this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS) ? 0 : totalCredits;
+                    int chargeCredits =
+                            this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS) ? 0 : totalCredits;
                     boolean hasInfinitePoints = item.getPointsType() == 0
                             ? this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_PIXELS)
                             : this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_POINTS);
                     int chargePoints = hasInfinitePoints ? 0 : totalPoints;
-                    if (!CatalogPaymentService.tryTake(this.client.getHabbo(), chargeCredits, item.getPointsType(), chargePoints)) {
-                        this.client.sendResponse(new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
+                    if (!CatalogPaymentService.tryTake(
+                            this.client.getHabbo(), chargeCredits, item.getPointsType(), chargePoints)) {
+                        this.client.sendResponse(
+                                new AlertPurchaseUnavailableComposer(AlertPurchaseUnavailableComposer.ILLEGAL));
                         return;
                     }
                     paidCredits = chargeCredits;
@@ -371,7 +482,9 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                     for (Item baseItem : item.getBaseItems()) {
                         if (item.getItemAmount(baseItem.getId()) > 1) {
                             LOGGER.debug("unsupported item amount > 1 for baseItemId={}", baseItem.getId());
-                            this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                            this.client.sendResponse(
+                                    new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR)
+                                            .compose());
                             return;
                         }
 
@@ -382,9 +495,12 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                                         if (habbo != null) {
                                             HabboBadge badge = new HabboBadge(0, baseItem.getName(), 0, habbo);
                                             Emulator.getThreading().run(badge);
-                                            habbo.getInventory().getBadgesComponent().addBadge(badge);
+                                            habbo.getInventory()
+                                                    .getBadgesComponent()
+                                                    .addBadge(badge);
                                         } else {
-                                            try (PreparedStatement statement = connection.prepareStatement("INSERT INTO users_badges (user_id, badge_code) VALUES (?, ?)")) {
+                                            try (PreparedStatement statement = connection.prepareStatement(
+                                                    "INSERT INTO users_badges (user_id, badge_code) VALUES (?, ?)")) {
                                                 statement.setInt(1, userId);
                                                 statement.setString(2, baseItem.getName());
                                                 statement.execute();
@@ -395,28 +511,45 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                                     }
                                 } else if (item.getName().startsWith("rentable_bot_")) {
                                     LOGGER.debug("rentable bot gifts not supported");
-                                    this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                                    this.client.sendResponse(
+                                            new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR)
+                                                    .compose());
                                     return;
                                 } else if (Item.isPet(baseItem)) {
                                     LOGGER.debug("pet gifts not supported");
-                                    this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR).compose());
+                                    this.client.sendResponse(
+                                            new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR)
+                                                    .compose());
                                     return;
                                 } else {
                                     if (baseItem.getInteractionType().getType() == InteractionTrophy.class
-                                            || baseItem.getInteractionType().getType() == InteractionBadgeDisplay.class) {
+                                            || baseItem.getInteractionType().getType()
+                                                    == InteractionBadgeDisplay.class) {
                                         if (baseItem.getInteractionType().getType() == InteractionBadgeDisplay.class
                                                 && habbo != null
-                                                && !habbo.getClient().getHabbo().getInventory().getBadgesComponent().hasBadge(extraData)) {
+                                                && !habbo.getClient()
+                                                        .getHabbo()
+                                                        .getInventory()
+                                                        .getBadgesComponent()
+                                                        .hasBadge(extraData)) {
                                             ScripterManager.scripterDetected(
                                                     habbo.getClient(),
-                                                    Emulator.getTexts().getValue("scripter.warning.catalog.badge_display")
-                                                            .replace("%username%", habbo.getClient().getHabbo().getHabboInfo().getUsername())
-                                                            .replace("%badge%", extraData)
-                                            );
+                                                    Emulator.getTexts()
+                                                            .getValue("scripter.warning.catalog.badge_display")
+                                                            .replace(
+                                                                    "%username%",
+                                                                    habbo.getClient()
+                                                                            .getHabbo()
+                                                                            .getHabboInfo()
+                                                                            .getUsername())
+                                                            .replace("%badge%", extraData));
                                             extraData = "UMAD";
                                         }
 
-                                        extraData = this.client.getHabbo().getHabboInfo().getUsername()
+                                        extraData = this.client
+                                                        .getHabbo()
+                                                        .getHabboInfo()
+                                                        .getUsername()
                                                 + (char) 9
                                                 + Calendar.getInstance().get(Calendar.DAY_OF_MONTH)
                                                 + "-"
@@ -428,46 +561,69 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                                     }
 
                                     if (baseItem.getInteractionType().getType() == InteractionTeleport.class
-                                            || baseItem.getInteractionType().getType() == InteractionTeleportTile.class) {
+                                            || baseItem.getInteractionType().getType()
+                                                    == InteractionTeleportTile.class) {
 
-                                        HabboItem teleportOne = Emulator.getGameEnvironment().getItemManager().createItem(userId, baseItem, limitedStack, limitedNumber, extraData);
-                                        HabboItem teleportTwo = Emulator.getGameEnvironment().getItemManager().createItem(userId, baseItem, limitedStack, limitedNumber, extraData);
+                                        HabboItem teleportOne = Emulator.getGameEnvironment()
+                                                .getItemManager()
+                                                .createItem(userId, baseItem, limitedStack, limitedNumber, extraData);
+                                        HabboItem teleportTwo = Emulator.getGameEnvironment()
+                                                .getItemManager()
+                                                .createItem(userId, baseItem, limitedStack, limitedNumber, extraData);
 
                                         if (teleportOne == null || teleportTwo == null) {
-                                            LOGGER.debug("teleport creation failed. baseItemId={}, teleportOneNull={}, teleportTwoNull={}", baseItem.getId(), teleportOne == null, teleportTwo == null);
-                                            this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                                            LOGGER.debug(
+                                                    "teleport creation failed. baseItemId={}, teleportOneNull={}, teleportTwoNull={}",
+                                                    baseItem.getId(),
+                                                    teleportOne == null,
+                                                    teleportTwo == null);
+                                            this.client.sendResponse(new AlertPurchaseFailedComposer(
+                                                    AlertPurchaseFailedComposer.SERVER_ERROR));
                                             return;
                                         }
 
-                                        Emulator.getGameEnvironment().getItemManager().insertTeleportPair(teleportOne.getId(), teleportTwo.getId());
+                                        Emulator.getGameEnvironment()
+                                                .getItemManager()
+                                                .insertTeleportPair(teleportOne.getId(), teleportTwo.getId());
                                         itemsList.add(teleportOne);
                                         itemsList.add(teleportTwo);
 
                                     } else if (baseItem.getInteractionType().getType() == InteractionHopper.class) {
-                                        HabboItem habboItem = Emulator.getGameEnvironment().getItemManager().createItem(userId, baseItem, limitedNumber, limitedNumber, extraData);
+                                        HabboItem habboItem = Emulator.getGameEnvironment()
+                                                .getItemManager()
+                                                .createItem(userId, baseItem, limitedNumber, limitedNumber, extraData);
 
                                         if (habboItem == null) {
                                             LOGGER.debug("hopper creation failed. baseItemId={}", baseItem.getId());
-                                            this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                                            this.client.sendResponse(new AlertPurchaseFailedComposer(
+                                                    AlertPurchaseFailedComposer.SERVER_ERROR));
                                             return;
                                         }
 
-                                        Emulator.getGameEnvironment().getItemManager().insertHopper(habboItem);
+                                        Emulator.getGameEnvironment()
+                                                .getItemManager()
+                                                .insertHopper(habboItem);
                                         itemsList.add(habboItem);
 
                                     } else if (baseItem.getInteractionType().getType() == InteractionGuildFurni.class
                                             || baseItem.getInteractionType().getType() == InteractionGuildGate.class) {
-                                        HabboItem createdItem = Emulator.getGameEnvironment().getItemManager().createItem(userId, baseItem, limitedStack, limitedNumber, extraData);
+                                        HabboItem createdItem = Emulator.getGameEnvironment()
+                                                .getItemManager()
+                                                .createItem(userId, baseItem, limitedStack, limitedNumber, extraData);
 
                                         if (createdItem == null) {
                                             LOGGER.debug("guild item creation failed. baseItemId={}", baseItem.getId());
-                                            this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                                            this.client.sendResponse(new AlertPurchaseFailedComposer(
+                                                    AlertPurchaseFailedComposer.SERVER_ERROR));
                                             return;
                                         }
 
                                         if (!(createdItem instanceof InteractionGuildFurni)) {
-                                            LOGGER.debug("created guild item has wrong class -> {}", createdItem.getClass().getName());
-                                            this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                                            LOGGER.debug(
+                                                    "created guild item has wrong class -> {}",
+                                                    createdItem.getClass().getName());
+                                            this.client.sendResponse(new AlertPurchaseFailedComposer(
+                                                    AlertPurchaseFailedComposer.SERVER_ERROR));
                                             return;
                                         }
 
@@ -480,19 +636,28 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                                             guildId = Integer.parseInt(extraData);
                                         } catch (Exception e) {
                                             LOGGER.error("Caught exception", e);
-                                            this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                                            this.client.sendResponse(new AlertPurchaseFailedComposer(
+                                                    AlertPurchaseFailedComposer.SERVER_ERROR));
                                             return;
                                         }
 
                                         Emulator.getThreading().run(habboItem);
-                                        Emulator.getGameEnvironment().getGuildManager().setGuild(habboItem, guildId);
+                                        Emulator.getGameEnvironment()
+                                                .getGuildManager()
+                                                .setGuild(habboItem, guildId);
                                         itemsList.add(habboItem);
                                     } else {
-                                        HabboItem habboItem = Emulator.getGameEnvironment().getItemManager().createItem(userId, baseItem, limitedStack, limitedNumber, extraData);
+                                        HabboItem habboItem = Emulator.getGameEnvironment()
+                                                .getItemManager()
+                                                .createItem(userId, baseItem, limitedStack, limitedNumber, extraData);
 
                                         if (habboItem == null) {
-                                            LOGGER.debug("normal item creation failed. baseItemId={}, baseItemName={}", baseItem.getId(), baseItem.getName());
-                                            this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                                            LOGGER.debug(
+                                                    "normal item creation failed. baseItemId={}, baseItemName={}",
+                                                    baseItem.getId(),
+                                                    baseItem.getName());
+                                            this.client.sendResponse(new AlertPurchaseFailedComposer(
+                                                    AlertPurchaseFailedComposer.SERVER_ERROR));
                                             return;
                                         }
 
@@ -501,8 +666,10 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                                 }
                             } else {
                                 LOGGER.debug("avatar_effect not supported");
-                                this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
-                                this.client.sendResponse(new GenericAlertComposer(Emulator.getTexts().getValue("error.catalog.buy.not_yet")));
+                                this.client.sendResponse(
+                                        new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                                this.client.sendResponse(new GenericAlertComposer(
+                                        Emulator.getTexts().getValue("error.catalog.buy.not_yet")));
                                 return;
                             }
                         }
@@ -510,7 +677,8 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
 
                     if (itemsList.isEmpty()) {
                         LOGGER.debug("itemsList empty before giftData");
-                        this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                        this.client.sendResponse(
+                                new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
                         return;
                     }
 
@@ -519,7 +687,8 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                     for (HabboItem i : itemsList) {
                         if (i == null) {
                             LOGGER.debug("null HabboItem detected inside itemsList");
-                            this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                            this.client.sendResponse(
+                                    new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
                             return;
                         }
 
@@ -538,11 +707,14 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                             .append("\t")
                             .append(this.client.getHabbo().getHabboInfo().getLook());
 
-                    HabboItem gift = Emulator.getGameEnvironment().getItemManager().createGift(username, giftItem, giftData.toString(), 0, 0);
+                    HabboItem gift = Emulator.getGameEnvironment()
+                            .getItemManager()
+                            .createGift(username, giftItem, giftData.toString(), 0, 0);
 
                     if (gift == null) {
                         LOGGER.debug("createGift returned null");
-                        this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                        this.client.sendResponse(
+                                new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
                         return;
                     }
                     createdGiftItems.add(gift);
@@ -560,13 +732,18 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                     if (this.client.getHabbo().getHabboInfo().getId() != userId) {
                         AchievementManager.progressAchievement(
                                 this.client.getHabbo(),
-                                Emulator.getGameEnvironment().getAchievementManager().getAchievement("GiftGiver")
-                        );
+                                Emulator.getGameEnvironment()
+                                        .getAchievementManager()
+                                        .getAchievement("GiftGiver"));
                     }
 
                     if (habbo != null) {
                         habbo.getClient().sendResponse(new AddHabboItemComposer(gift));
-                        habbo.getClient().getHabbo().getInventory().getItemsComponent().addItem(gift);
+                        habbo.getClient()
+                                .getHabbo()
+                                .getInventory()
+                                .getItemsComponent()
+                                .addItem(gift);
                         habbo.getClient().sendResponse(new InventoryRefreshComposer());
 
                         Map<String, String> keys = new HashMap<>();
@@ -575,21 +752,32 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                         keys.put("message", Emulator.getTexts().getValue("generic.gift.received.anonymous"));
 
                         if (showName) {
-                            keys.put("message", Emulator.getTexts().getValue("generic.gift.received")
-                                    .replace("%username%", this.client.getHabbo().getHabboInfo().getUsername()));
+                            keys.put(
+                                    "message",
+                                    Emulator.getTexts()
+                                            .getValue("generic.gift.received")
+                                            .replace(
+                                                    "%username%",
+                                                    this.client
+                                                            .getHabbo()
+                                                            .getHabboInfo()
+                                                            .getUsername()));
                         }
 
-                        habbo.getClient().sendResponse(new BubbleAlertComposer(BubbleAlertKeys.RECEIVED_BADGE.key, keys));
+                        habbo.getClient()
+                                .sendResponse(new BubbleAlertComposer(BubbleAlertKeys.RECEIVED_BADGE.key, keys));
                     }
 
                     if (this.client.getHabbo().getHabboInfo().getId() != userId) {
                         AchievementManager.progressAchievement(
                                 userId,
-                                Emulator.getGameEnvironment().getAchievementManager().getAchievement("GiftReceiver")
-                        );
+                                Emulator.getGameEnvironment()
+                                        .getAchievementManager()
+                                        .getAchievement("GiftReceiver"));
                     }
 
-                    // Gift fully delivered; commit cooldown and clear refund tracking so the catch block can't double-refund.
+                    // Gift fully delivered; commit cooldown and clear refund tracking so the catch block can't
+                    // double-refund.
                     this.client.getHabbo().getHabboStats().lastGiftTimestamp = Emulator.getIntUnixTimestamp();
                     if (item.isLimited()) {
                         this.client.getHabbo().getHabboStats().addLtdLog(item.getId(), Emulator.getIntUnixTimestamp());
@@ -607,10 +795,12 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
                 try {
                     if (!giftDelivered) {
                         for (HabboItem createdItem : createdGiftItems) {
-                            if (createdItem != null) Emulator.getGameEnvironment().getItemManager().deleteItem(createdItem);
+                            if (createdItem != null)
+                                Emulator.getGameEnvironment().getItemManager().deleteItem(createdItem);
                         }
                         if (paidCredits > 0 || paidPoints > 0) {
-                            CatalogPaymentService.refund(this.client.getHabbo(), paidCredits, paidPointsType, paidPoints);
+                            CatalogPaymentService.refund(
+                                    this.client.getHabbo(), paidCredits, paidPointsType, paidPoints);
                         }
                     }
                 } finally {
@@ -653,7 +843,8 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
     }
 
     private void handleClubOfferGift(CatalogPage page, int offerId, String username) {
-        ClubOffer offer = Emulator.getGameEnvironment().getCatalogManager().clubOffers.get(offerId);
+        ClubOffer offer =
+                Emulator.getGameEnvironment().getCatalogManager().clubOffers.get(offerId);
 
         if (offer == null || !offer.belongsToWindow(this.getClubOfferWindowId(page))) {
             this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
@@ -695,7 +886,8 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
             recipientId = recipient.getHabboInfo().getId();
         } else {
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                 PreparedStatement statement = connection.prepareStatement("SELECT id FROM users WHERE username = ?")) {
+                    PreparedStatement statement =
+                            connection.prepareStatement("SELECT id FROM users WHERE username = ?")) {
                 statement.setString(1, username);
                 try (ResultSet set = statement.executeQuery()) {
                     if (set.next()) recipientId = set.getInt(1);
@@ -715,7 +907,8 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
             return;
         }
 
-        String subscriptionType = offer.isBuildersClubSubscription() ? Subscription.BUILDERS_CLUB : Subscription.HABBO_CLUB;
+        String subscriptionType =
+                offer.isBuildersClubSubscription() ? Subscription.BUILDERS_CLUB : Subscription.HABBO_CLUB;
 
         int paidCredits = this.client.getHabbo().hasPermission(Permission.ACC_INFINITE_CREDITS) ? 0 : totalCredits;
         boolean hasInfinitePoints = offer.getPointsType() == 0
@@ -746,7 +939,10 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
         }
 
         if (recipient != null) {
-            recipient.getClient().sendResponse(new UserClubComposer(recipient, subscriptionType, UserClubComposer.RESPONSE_TYPE_NORMAL));
+            recipient
+                    .getClient()
+                    .sendResponse(
+                            new UserClubComposer(recipient, subscriptionType, UserClubComposer.RESPONSE_TYPE_NORMAL));
 
             String prefix = Emulator.getTexts().getValue("prereg.reward.you.received", "You have received:");
             String daysWord = Emulator.getTexts().getValue("generic.days", "days");
@@ -762,8 +958,7 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
         if (this.client.getHabbo().getHabboInfo().getId() != recipientId) {
             AchievementManager.progressAchievement(
                     this.client.getHabbo(),
-                    Emulator.getGameEnvironment().getAchievementManager().getAchievement("GiftGiver")
-            );
+                    Emulator.getGameEnvironment().getAchievementManager().getAchievement("GiftGiver"));
         }
 
         this.client.sendResponse(new PurchaseOKComposer(null));

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPageComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPageComposer.java
@@ -62,9 +62,11 @@ public class CatalogPageComposer extends MessageComposer {
     }
 
     public void serializeExtra(ServerMessage message) {
-        message.appendInt(Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPages().size());
+        List<CatalogFeaturedPage> featuredPages = Emulator.getGameEnvironment().getCatalogManager()
+                .getCatalogFeaturedPagesSnapshot();
+        message.appendInt(featuredPages.size());
 
-        for (CatalogFeaturedPage page : Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPages().values()) {
+        for (CatalogFeaturedPage page : featuredPages) {
             page.serialize(message);
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPageComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPageComposer.java
@@ -11,7 +11,6 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,21 +37,24 @@ public class CatalogPageComposer extends MessageComposer {
         this.page.serialize(this.response);
 
         if (this.page instanceof RecentPurchasesLayout) {
-            this.response.appendInt(this.habbo.getHabboStats().getRecentPurchases().size());
+            this.response.appendInt(
+                    this.habbo.getHabboStats().getRecentPurchases().size());
 
-            for (Map.Entry<Integer, CatalogItem> item : this.habbo.getHabboStats().getRecentPurchases().entrySet()) {
+            for (Map.Entry<Integer, CatalogItem> item :
+                    this.habbo.getHabboStats().getRecentPurchases().entrySet()) {
                 item.getValue().serialize(this.response);
             }
         } else {
             this.response.appendInt(this.page.getCatalogItems().size());
-            List<CatalogItem> items = new ArrayList<>(this.page.getCatalogItems().values());
+            List<CatalogItem> items =
+                    new ArrayList<>(this.page.getCatalogItems().values());
             Collections.sort(items);
             for (CatalogItem item : items) {
                 item.serialize(this.response);
             }
         }
         this.response.appendInt(this.offerId);
-        this.response.appendBoolean(false); //acceptSeasonCurrencyAsCredits
+        this.response.appendBoolean(false); // acceptSeasonCurrencyAsCredits
 
         if (this.page instanceof FrontPageFeaturedLayout || this.page instanceof FrontpageLayout) {
             this.serializeExtra(this.response);
@@ -62,8 +64,8 @@ public class CatalogPageComposer extends MessageComposer {
     }
 
     public void serializeExtra(ServerMessage message) {
-        List<CatalogFeaturedPage> featuredPages = Emulator.getGameEnvironment().getCatalogManager()
-                .getCatalogFeaturedPagesSnapshot();
+        List<CatalogFeaturedPage> featuredPages =
+                Emulator.getGameEnvironment().getCatalogManager().getCatalogFeaturedPagesSnapshot();
         message.appendInt(featuredPages.size());
 
         for (CatalogFeaturedPage page : featuredPages) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/GiftConfigurationComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/GiftConfigurationComposer.java
@@ -18,8 +18,7 @@ public class GiftConfigurationComposer extends MessageComposer {
         this.response.appendBoolean(true);
         this.response.appendInt(Emulator.getConfig().getInt("hotel.gifts.special.price", 2));
 
-        var giftWrapping =
-                Emulator.getGameEnvironment().getCatalogManager().getGiftWrappingSnapshot();
+        var giftWrapping = Emulator.getGameEnvironment().getCatalogManager().getGiftWrappingSnapshot();
 
         this.response.appendInt(giftWrapping.wrappers().size());
         for (Integer i : giftWrapping.wrappers().keySet()) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/GiftConfigurationComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/GiftConfigurationComposer.java
@@ -18,10 +18,11 @@ public class GiftConfigurationComposer extends MessageComposer {
         this.response.appendBoolean(true);
         this.response.appendInt(Emulator.getConfig().getInt("hotel.gifts.special.price", 2));
 
-        this.response.appendInt(
-                Emulator.getGameEnvironment().getCatalogManager().giftWrappers.size());
-        for (Integer i :
-                Emulator.getGameEnvironment().getCatalogManager().giftWrappers.keySet()) {
+        var giftWrapping =
+                Emulator.getGameEnvironment().getCatalogManager().getGiftWrappingSnapshot();
+
+        this.response.appendInt(giftWrapping.wrappers().size());
+        for (Integer i : giftWrapping.wrappers().keySet()) {
             this.response.appendInt(i);
         }
 
@@ -35,11 +36,9 @@ public class GiftConfigurationComposer extends MessageComposer {
             this.response.appendInt(type);
         }
 
-        this.response.appendInt(
-                Emulator.getGameEnvironment().getCatalogManager().giftFurnis.size());
+        this.response.appendInt(giftWrapping.furniture().size());
 
-        for (Map.Entry<Integer, Integer> set :
-                Emulator.getGameEnvironment().getCatalogManager().giftFurnis.entrySet()) {
+        for (Map.Entry<Integer, Integer> set : giftWrapping.furniture().entrySet()) {
             this.response.appendInt(set.getKey());
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/RecyclerLogicComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/RecyclerLogicComposer.java
@@ -13,8 +13,10 @@ public class RecyclerLogicComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.RecyclerLogicComposer);
-        this.response.appendInt(Emulator.getGameEnvironment().getCatalogManager().prizes.size());
-        for (Map.Entry<Integer, Set<Item>> map : Emulator.getGameEnvironment().getCatalogManager().prizes.entrySet()) {
+        Map<Integer, Set<Item>> prizes = Emulator.getGameEnvironment().getCatalogManager()
+                .getRecyclerPrizesSnapshot();
+        this.response.appendInt(prizes.size());
+        for (Map.Entry<Integer, Set<Item>> map : prizes.entrySet()) {
             this.response.appendInt(map.getKey());
             this.response.appendInt(Integer.valueOf(Emulator.getConfig().getValue("hotel.ecotron.rarity.chance." + map.getKey())));
             this.response.appendInt(map.getValue().size());

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/RecyclerLogicComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/RecyclerLogicComposer.java
@@ -5,7 +5,6 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-
 import java.util.Map;
 import java.util.Set;
 
@@ -13,12 +12,13 @@ public class RecyclerLogicComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.RecyclerLogicComposer);
-        Map<Integer, Set<Item>> prizes = Emulator.getGameEnvironment().getCatalogManager()
-                .getRecyclerPrizesSnapshot();
+        Map<Integer, Set<Item>> prizes =
+                Emulator.getGameEnvironment().getCatalogManager().getRecyclerPrizesSnapshot();
         this.response.appendInt(prizes.size());
         for (Map.Entry<Integer, Set<Item>> map : prizes.entrySet()) {
             this.response.appendInt(map.getKey());
-            this.response.appendInt(Integer.valueOf(Emulator.getConfig().getValue("hotel.ecotron.rarity.chance." + map.getKey())));
+            this.response.appendInt(
+                    Integer.valueOf(Emulator.getConfig().getValue("hotel.ecotron.rarity.chance." + map.getKey())));
             this.response.appendInt(map.getValue().size());
             for (Item item : map.getValue()) {
                 this.response.appendString(item.getName());

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolIssueChatlogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolIssueChatlogComposer.java
@@ -88,7 +88,7 @@ public class ModToolIssueChatlogComposer extends MessageComposer {
 
         this.response.appendShort(this.chatlog.size());
         for (ModToolChatLog chatLog : this.chatlog) {
-            this.response.appendString(format.format(chatLog.timestamp * 1000L));
+            this.response.appendString(formatTimestamp(chatLog.timestamp));
             this.response.appendInt(chatLog.habboId);
             this.response.appendString(chatLog.username);
             this.response.appendString(chatLog.message);
@@ -97,6 +97,10 @@ public class ModToolIssueChatlogComposer extends MessageComposer {
         //}
 
         return this.response;
+    }
+
+    static String formatTimestamp(int timestamp) {
+        return format.format(timestamp * 1000L);
     }
 
     public ModToolIssue getIssue() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolIssueChatlogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolIssueChatlogComposer.java
@@ -8,11 +8,16 @@ import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 
 public class ModToolIssueChatlogComposer extends MessageComposer {
     public static SimpleDateFormat format = new SimpleDateFormat("HH:mm");
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+            DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault());
     private final ModToolIssue issue;
     private final List<ModToolChatLog> chatlog;
     private final String roomName;
@@ -100,7 +105,7 @@ public class ModToolIssueChatlogComposer extends MessageComposer {
     }
 
     static String formatTimestamp(int timestamp) {
-        return format.format(timestamp * 1000L);
+        return TIMESTAMP_FORMATTER.format(Instant.ofEpochSecond(timestamp));
     }
 
     public ModToolIssue getIssue() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolIssueChatlogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolIssueChatlogComposer.java
@@ -1,12 +1,15 @@
 package com.eu.habbo.messages.outgoing.modtool;
 
 import com.eu.habbo.Emulator;
-import com.eu.habbo.habbohotel.modtool.*;
+import com.eu.habbo.habbohotel.modtool.ModToolChatLog;
+import com.eu.habbo.habbohotel.modtool.ModToolChatRecordDataContext;
+import com.eu.habbo.habbohotel.modtool.ModToolIssue;
+import com.eu.habbo.habbohotel.modtool.ModToolIssueChatlogType;
+import com.eu.habbo.habbohotel.modtool.ModToolTicketType;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -29,7 +32,8 @@ public class ModToolIssueChatlogComposer extends MessageComposer {
         this.roomName = roomName;
     }
 
-    public ModToolIssueChatlogComposer(ModToolIssue issue, List<ModToolChatLog> chatlog, String roomName, ModToolIssueChatlogType type) {
+    public ModToolIssueChatlogComposer(
+            ModToolIssue issue, List<ModToolChatLog> chatlog, String roomName, ModToolIssueChatlogType type) {
         this.issue = issue;
         this.chatlog = chatlog;
         this.roomName = roomName;
@@ -46,10 +50,9 @@ public class ModToolIssueChatlogComposer extends MessageComposer {
 
         Collections.sort(this.chatlog);
 
-        if (this.chatlog.isEmpty())
-            return null;
+        if (this.chatlog.isEmpty()) return null;
 
-        this.response.appendByte(this.type.getType()); //Report Type
+        this.response.appendByte(this.type.getType()); // Report Type
 
         if (this.issue.type == ModToolTicketType.IM) {
             this.response.appendShort(1);
@@ -78,7 +81,7 @@ public class ModToolIssueChatlogComposer extends MessageComposer {
             ModToolChatRecordDataContext.PHOTO_ID.append(this.response);
             this.response.appendString(this.issue.photoItem.getId() + "");
         } else {
-            this.response.appendShort(3); //Context Count
+            this.response.appendShort(3); // Context Count
 
             ModToolChatRecordDataContext.ROOM_NAME.append(this.response);
             this.response.appendString(this.roomName);
@@ -99,7 +102,7 @@ public class ModToolIssueChatlogComposer extends MessageComposer {
             this.response.appendString(chatLog.message);
             this.response.appendBoolean(chatLog.highlighted);
         }
-        //}
+        // }
 
         return this.response;
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserChatlogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserChatlogComposer.java
@@ -40,7 +40,7 @@ public class ModToolUserChatlogComposer extends MessageComposer {
 
             this.response.appendShort(visit.chat.size());
             for (ModToolChatLog chatLog : visit.chat) {
-                this.response.appendString(format.format(chatLog.timestamp * 1000L));
+                this.response.appendString(formatTimestamp(chatLog.timestamp));
                 this.response.appendInt(chatLog.habboId);
                 this.response.appendString(chatLog.username);
                 this.response.appendString(chatLog.message);
@@ -48,6 +48,10 @@ public class ModToolUserChatlogComposer extends MessageComposer {
             }
         }
         return this.response;
+    }
+
+    static String formatTimestamp(int timestamp) {
+        return format.format(timestamp * 1000L);
     }
 
     public ArrayList<ModToolRoomVisit> getSet() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserChatlogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserChatlogComposer.java
@@ -7,10 +7,15 @@ import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 
 public class ModToolUserChatlogComposer extends MessageComposer {
     public static SimpleDateFormat format = new SimpleDateFormat("HH:mm");
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+            DateTimeFormatter.ofPattern("HH:mm").withZone(ZoneId.systemDefault());
     private final ArrayList<ModToolRoomVisit> set;
     private final int userId;
     private final String username;
@@ -51,7 +56,7 @@ public class ModToolUserChatlogComposer extends MessageComposer {
     }
 
     static String formatTimestamp(int timestamp) {
-        return format.format(timestamp * 1000L);
+        return TIMESTAMP_FORMATTER.format(Instant.ofEpochSecond(timestamp));
     }
 
     public ArrayList<ModToolRoomVisit> getSet() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserChatlogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserChatlogComposer.java
@@ -5,7 +5,6 @@ import com.eu.habbo.habbohotel.modtool.ModToolRoomVisit;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.ZoneId;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserInfoComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserInfoComposer.java
@@ -11,14 +11,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.*;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Map;
 
 public class ModToolUserInfoComposer extends MessageComposer {
     private static final Logger LOGGER = LoggerFactory.getLogger(ModToolUserInfoComposer.class);
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+    private static final DateTimeFormatter DATE_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault());
 
     private final ResultSet set;
     private final boolean hideMail;
@@ -167,6 +169,6 @@ public class ModToolUserInfoComposer extends MessageComposer {
      */
     static String formatUnixTimestamp(int timestamp) {
         if (timestamp <= 0) return "";
-        return DATE_FORMAT.format(new Date(timestamp * 1000L));
+        return DATE_FORMAT.format(Instant.ofEpochSecond(timestamp));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserInfoComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserInfoComposer.java
@@ -165,7 +165,7 @@ public class ModToolUserInfoComposer extends MessageComposer {
      * is rendered as an empty string so the client falls back to its
      * empty-state placeholder.
      */
-    private static String formatUnixTimestamp(int timestamp) {
+    static String formatUnixTimestamp(int timestamp) {
         if (timestamp <= 0) return "";
         return DATE_FORMAT.format(new Date(timestamp * 1000L));
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserInfoComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserInfoComposer.java
@@ -7,15 +7,17 @@ import com.eu.habbo.habbohotel.modtool.ModToolSanctions;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ModToolUserInfoComposer extends MessageComposer {
     private static final Logger LOGGER = LoggerFactory.getLogger(ModToolUserInfoComposer.class);
@@ -55,27 +57,30 @@ public class ModToolUserInfoComposer extends MessageComposer {
             this.response.appendInt(totalBans); // Number of bans
             this.response.appendInt(this.set.getInt("tradelock_amount"));
             this.response.appendString(formatUnixTimestamp(tradeLockExpiryTimestamp)); // Trading lock expiry timestamp
-            this.response.appendString(formatUnixTimestamp(lastPurchaseTimestamp));   // Last Purchase Timestamp
-            this.response.appendInt(userId); //Personal Identification #
+            this.response.appendString(formatUnixTimestamp(lastPurchaseTimestamp)); // Last Purchase Timestamp
+            this.response.appendInt(userId); // Personal Identification #
             this.response.appendInt(identityRelatedBanCount); // Number of account bans on the same machine_id
             this.response.appendString(this.hideMail ? "" : this.set.getString("mail"));
-            this.response.appendString("Rank (" + this.set.getInt("rank_id") + "): " + this.set.getString("rank_name")); //user_class_txt
+            this.response.appendString(
+                    "Rank (" + this.set.getInt("rank_id") + "): " + this.set.getString("rank_name")); // user_class_txt
 
             ModToolSanctions modToolSanctions = Emulator.getGameEnvironment().getModToolSanctions();
 
             if (Emulator.getConfig().getBoolean("hotel.sanctions.enabled")) {
-                Map<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap = Emulator.getGameEnvironment().getModToolSanctions().getSanctions(this.set.getInt("user_id"));
-                ArrayList<ModToolSanctionItem> modToolSanctionItems = modToolSanctionItemsHashMap.get(this.set.getInt("user_id"));
+                Map<Integer, ArrayList<ModToolSanctionItem>> modToolSanctionItemsHashMap =
+                        Emulator.getGameEnvironment().getModToolSanctions().getSanctions(this.set.getInt("user_id"));
+                ArrayList<ModToolSanctionItem> modToolSanctionItems =
+                        modToolSanctionItemsHashMap.get(this.set.getInt("user_id"));
 
-                if (modToolSanctionItems != null && modToolSanctionItems.size() > 0) //has sanction
+                if (modToolSanctionItems != null && modToolSanctionItems.size() > 0) // has sanction
                 {
                     ModToolSanctionItem item = modToolSanctionItems.get(modToolSanctionItems.size() - 1);
-                    ModToolSanctionLevelItem modToolSanctionLevelItem = modToolSanctions.getSanctionLevelItem(item.sanctionLevel);
+                    ModToolSanctionLevelItem modToolSanctionLevelItem =
+                            modToolSanctions.getSanctionLevelItem(item.sanctionLevel);
 
                     this.response.appendString(modToolSanctions.getSanctionType(modToolSanctionLevelItem));
                     this.response.appendInt(31);
                 }
-
             }
 
             return this.response;
@@ -91,7 +96,8 @@ public class ModToolUserInfoComposer extends MessageComposer {
 
     private static int countBansForUser(int userId) {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT COUNT(*) AS amount FROM bans WHERE user_id = ?")) {
+                PreparedStatement statement =
+                        connection.prepareStatement("SELECT COUNT(*) AS amount FROM bans WHERE user_id = ?")) {
             statement.setInt(1, userId);
             try (ResultSet set = statement.executeQuery()) {
                 if (set.next()) return set.getInt("amount");
@@ -110,7 +116,8 @@ public class ModToolUserInfoComposer extends MessageComposer {
      */
     private static int fetchLastPurchaseTimestamp(int userId) {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT MAX(`timestamp`) AS ts FROM logs_shop_purchases WHERE user_id = ?")) {
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT MAX(`timestamp`) AS ts FROM logs_shop_purchases WHERE user_id = ?")) {
             statement.setInt(1, userId);
             try (ResultSet set = statement.executeQuery()) {
                 if (set.next()) return set.getInt("ts");
@@ -128,7 +135,8 @@ public class ModToolUserInfoComposer extends MessageComposer {
      */
     private static int fetchActiveTradeLockExpiry(int userId, int now) {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT MAX(trade_locked_until) AS expiry FROM sanctions WHERE habbo_id = ? AND trade_locked_until > ?")) {
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT MAX(trade_locked_until) AS expiry FROM sanctions WHERE habbo_id = ? AND trade_locked_until > ?")) {
             statement.setInt(1, userId);
             statement.setInt(2, now);
             try (ResultSet set = statement.executeQuery()) {
@@ -150,7 +158,8 @@ public class ModToolUserInfoComposer extends MessageComposer {
         if (machineId == null || machineId.isEmpty()) return 0;
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT COUNT(DISTINCT user_id) AS amount FROM bans WHERE machine_id = ? AND user_id != ?")) {
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT COUNT(DISTINCT user_id) AS amount FROM bans WHERE machine_id = ? AND user_id != ?")) {
             statement.setString(1, machineId);
             statement.setInt(2, userId);
             try (ResultSet set = statement.executeQuery()) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/UserClothesComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/UserClothesComposer.java
@@ -8,6 +8,7 @@ import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 public class UserClothesComposer extends MessageComposer {
     private static class ClothEntry {
@@ -25,8 +26,11 @@ public class UserClothesComposer extends MessageComposer {
     private final ArrayList<ClothEntry> clothEntries = new ArrayList<>();
 
     public UserClothesComposer(Habbo habbo) {
+        Map<Integer, ClothItem> clothing = Emulator.getGameEnvironment().getCatalogManager()
+                .getClothingSnapshot();
+
         for (int value : habbo.getInventory().getWardrobeComponent().getClothing()) {
-            ClothItem item = Emulator.getGameEnvironment().getCatalogManager().clothing.get(value);
+            ClothItem item = clothing.get(value);
 
             if (item != null) {
                 for (Integer j : item.setId) {
@@ -37,7 +41,7 @@ public class UserClothesComposer extends MessageComposer {
             }
         }
 
-        for (ClothItem item : Emulator.getGameEnvironment().getCatalogManager().clothing.values()) {
+        for (ClothItem item : clothing.values()) {
             if (item != null) {
                 this.clothEntries.add(new ClothEntry(item.name, item.setId));
             }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/UserClothesComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/UserClothesComposer.java
@@ -6,7 +6,6 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -26,8 +25,8 @@ public class UserClothesComposer extends MessageComposer {
     private final ArrayList<ClothEntry> clothEntries = new ArrayList<>();
 
     public UserClothesComposer(Habbo habbo) {
-        Map<Integer, ClothItem> clothing = Emulator.getGameEnvironment().getCatalogManager()
-                .getClothingSnapshot();
+        Map<Integer, ClothItem> clothing =
+                Emulator.getGameEnvironment().getCatalogManager().getClothingSnapshot();
 
         for (int value : habbo.getInventory().getWardrobeComponent().getClothing()) {
             ClothItem item = clothing.get(value);

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/SendGift.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/SendGift.java
@@ -10,6 +10,8 @@ import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.google.gson.Gson;
 import jakarta.validation.constraints.Positive;
 
+import java.util.Map;
+
 public class SendGift extends RCONMessage<SendGift.SendGiftJSON> {
     private static final int DEFAULT_MAX_MESSAGE_LENGTH = 300;
 
@@ -77,15 +79,17 @@ public class SendGift extends RCONMessage<SendGift.SendGiftJSON> {
     }
 
     private Item randomGiftItem() {
-        synchronized (Emulator.getGameEnvironment().getCatalogManager().giftFurnis) {
-            int size = Emulator.getGameEnvironment().getCatalogManager().giftFurnis.size();
-            if (size == 0) {
-                return null;
-            }
-
-            Object[] giftIds = Emulator.getGameEnvironment().getCatalogManager().giftFurnis.values().toArray();
-            return Emulator.getGameEnvironment().getItemManager().getItem((Integer) giftIds[Emulator.getRandom().nextInt(size)]);
+        Map<Integer, Integer> giftFurnis = Emulator.getGameEnvironment().getCatalogManager()
+                .getGiftWrappingSnapshot().furniture();
+        int size = giftFurnis.size();
+        if (size == 0) {
+            return null;
         }
+
+        Object[] giftIds = giftFurnis.values().toArray();
+        return Emulator.getGameEnvironment().getItemManager().getItem(
+                (Integer) giftIds[Emulator.getRandom().nextInt(size)]
+        );
     }
 
     static String sanitizeGiftMessage(String message) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/SendGift.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/SendGift.java
@@ -9,7 +9,6 @@ import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.google.gson.Gson;
 import jakarta.validation.constraints.Positive;
-
 import java.util.Map;
 
 public class SendGift extends RCONMessage<SendGift.SendGiftJSON> {
@@ -23,7 +22,9 @@ public class SendGift extends RCONMessage<SendGift.SendGiftJSON> {
     public void handle(Gson gson, SendGiftJSON json) {
         if (json.user_id <= 0) {
             this.status = RCONMessage.STATUS_ERROR;
-            this.message = Emulator.getTexts().getValue("commands.error.cmd_gift.user_not_found").replace("%username%", json.user_id + "");
+            this.message = Emulator.getTexts()
+                    .getValue("commands.error.cmd_gift.user_not_found")
+                    .replace("%username%", json.user_id + "");
             return;
         }
 
@@ -36,13 +37,17 @@ public class SendGift extends RCONMessage<SendGift.SendGiftJSON> {
         Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(json.itemid);
         if (baseItem == null) {
             this.status = RCONMessage.STATUS_ERROR;
-            this.message = Emulator.getTexts().getValue("commands.error.cmd_gift.not_found").replace("%itemid%", json.itemid + "");
+            this.message = Emulator.getTexts()
+                    .getValue("commands.error.cmd_gift.not_found")
+                    .replace("%itemid%", json.itemid + "");
             return;
         }
 
         if (!baseItem.allowGift()) {
             this.status = RCONMessage.STATUS_ERROR;
-            this.message = Emulator.getTexts().getValue("commands.error.cmd_gift.not_found").replace("%itemid%", json.itemid + "");
+            this.message = Emulator.getTexts()
+                    .getValue("commands.error.cmd_gift.not_found")
+                    .replace("%itemid%", json.itemid + "");
             return;
         }
 
@@ -50,7 +55,9 @@ public class SendGift extends RCONMessage<SendGift.SendGiftJSON> {
         HabboInfo habboInfo = habbo != null ? habbo.getHabboInfo() : HabboManager.getOfflineHabboInfo(json.user_id);
         if (habboInfo == null) {
             this.status = RCONMessage.HABBO_NOT_FOUND;
-            this.message = Emulator.getTexts().getValue("commands.error.cmd_gift.user_not_found").replace("%username%", json.user_id + "");
+            this.message = Emulator.getTexts()
+                    .getValue("commands.error.cmd_gift.user_not_found")
+                    .replace("%username%", json.user_id + "");
             return;
         }
 
@@ -65,13 +72,19 @@ public class SendGift extends RCONMessage<SendGift.SendGiftJSON> {
         String extraData = "1\t" + item.getId();
         extraData += "\t0\t0\t0\t" + sanitizeGiftMessage(json.message) + "\t0\t0";
 
-        if (Emulator.getGameEnvironment().getItemManager().createGift(habboInfo.getUsername(), giftItem, extraData, 0, 0) == null) {
+        if (Emulator.getGameEnvironment()
+                        .getItemManager()
+                        .createGift(habboInfo.getUsername(), giftItem, extraData, 0, 0)
+                == null) {
             this.status = RCONMessage.SYSTEM_ERROR;
             this.message = "failed to create gift";
             return;
         }
 
-        this.message = Emulator.getTexts().getValue("commands.succes.cmd_gift").replace("%username%", habboInfo.getUsername()).replace("%itemname%", item.getBaseItem().getName());
+        this.message = Emulator.getTexts()
+                .getValue("commands.succes.cmd_gift")
+                .replace("%username%", habboInfo.getUsername())
+                .replace("%itemname%", item.getBaseItem().getName());
 
         if (habbo != null) {
             habbo.getClient().sendResponse(new InventoryRefreshComposer());
@@ -79,17 +92,18 @@ public class SendGift extends RCONMessage<SendGift.SendGiftJSON> {
     }
 
     private Item randomGiftItem() {
-        Map<Integer, Integer> giftFurnis = Emulator.getGameEnvironment().getCatalogManager()
-                .getGiftWrappingSnapshot().furniture();
+        Map<Integer, Integer> giftFurnis = Emulator.getGameEnvironment()
+                .getCatalogManager()
+                .getGiftWrappingSnapshot()
+                .furniture();
         int size = giftFurnis.size();
         if (size == 0) {
             return null;
         }
 
         Object[] giftIds = giftFurnis.values().toArray();
-        return Emulator.getGameEnvironment().getItemManager().getItem(
-                (Integer) giftIds[Emulator.getRandom().nextInt(size)]
-        );
+        return Emulator.getGameEnvironment().getItemManager().getItem((Integer)
+                giftIds[Emulator.getRandom().nextInt(size)]);
     }
 
     static String sanitizeGiftMessage(String message) {
@@ -115,10 +129,8 @@ public class SendGift extends RCONMessage<SendGift.SendGiftJSON> {
         @Positive(message = "invalid user")
         public int user_id = -1;
 
-
         @Positive(message = "invalid item")
         public int itemid = -1;
-
 
         public String message = "";
     }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/bots/VisitorBotDateFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/bots/VisitorBotDateFormattingTest.java
@@ -3,6 +3,7 @@ package com.eu.habbo.habbohotel.bots;
 import org.junit.jupiter.api.Test;
 
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,5 +19,12 @@ class VisitorBotDateFormattingTest {
         assertEquals(
                 new SimpleDateFormat(pattern).format(new Date(timestamp * 1000L)),
                 VisitorBot.formatTimestamp(timestamp));
+    }
+
+    @Test
+    void visitorBotUsesAnImmutableFormatter() throws Exception {
+        assertEquals(
+                DateTimeFormatter.class,
+                VisitorBot.class.getDeclaredField("DATE_FORMAT").getType());
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/bots/VisitorBotDateFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/bots/VisitorBotDateFormattingTest.java
@@ -1,0 +1,22 @@
+package com.eu.habbo.habbohotel.bots;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class VisitorBotDateFormattingTest {
+
+    @Test
+    void preservesConfiguredTimestampPattern() {
+        int timestamp = 1_700_000_000;
+        String pattern = "yyyy-mm-dd HH:mm";
+        VisitorBot.initialise(pattern);
+
+        assertEquals(
+                new SimpleDateFormat(pattern).format(new Date(timestamp * 1000L)),
+                VisitorBot.formatTimestamp(timestamp));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/bots/VisitorBotDateFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/bots/VisitorBotDateFormattingTest.java
@@ -1,12 +1,11 @@
 package com.eu.habbo.habbohotel.bots;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.text.SimpleDateFormat;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 class VisitorBotDateFormattingTest {
 

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfigurationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfigurationTest.java
@@ -2,11 +2,21 @@ package com.eu.habbo.habbohotel.catalog;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.OptionalInt;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -32,10 +42,66 @@ class CatalogLimitedConfigurationTest {
         assertEquals(0, configuration.available());
     }
 
+    @Test
+    void internalPollingReportsEmptyStockWithoutThrowing() {
+        assertTrue(configurationWith().pollNumber().isEmpty());
+    }
+
+    @Test
+    void concurrentPollingReservesTheLastNumberOnce() throws Exception {
+        CatalogLimitedConfiguration configuration = configurationWith(17);
+        int buyers = 8;
+        CountDownLatch ready = new CountDownLatch(buyers);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(buyers);
+
+        try {
+            List<Future<OptionalInt>> reservations = new ArrayList<>();
+            for (int buyer = 0; buyer < buyers; buyer++) {
+                reservations.add(executor.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    return configuration.pollNumber();
+                }));
+            }
+
+            assertTrue(ready.await(2, TimeUnit.SECONDS));
+            start.countDown();
+
+            int reserved = 0;
+            for (Future<OptionalInt> reservation : reservations) {
+                if (reservation.get(2, TimeUnit.SECONDS).isPresent()) reserved++;
+            }
+
+            assertEquals(1, reserved);
+            assertEquals(0, configuration.available());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void purchasePathMapsAnEmptyReservationToSoldOut() throws Exception {
+        String manager = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"
+        ));
+        String configuration = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java"
+        ));
+
+        assertTrue(manager.contains("limitedConfiguration.pollNumber()"));
+        assertTrue(manager.contains("limitedNumberReservation.isEmpty()"));
+        assertFalse(manager.contains("limitedNumber = limitedConfiguration.getNumber()"));
+        assertTrue(configuration.contains("this.limitedNumbers.pollFirst()"));
+        assertTrue(configuration.contains(
+                "public int available() {\n        synchronized (this.limitedNumbers) {"
+        ));
+    }
+
     private static CatalogLimitedConfiguration configurationWith(Integer... numbers) {
         return new CatalogLimitedConfiguration(
                 1,
-                new LinkedList<>(java.util.List.of(numbers)),
+                new LinkedList<>(List.of(numbers)),
                 numbers.length,
                 false
         );

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfigurationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfigurationTest.java
@@ -1,0 +1,43 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedList;
+import java.util.NoSuchElementException;
+import java.util.OptionalInt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogLimitedConfigurationTest {
+
+    @Test
+    void publicNumberDrawingKeepsItsExistingLifoAndEmptyBehavior() {
+        CatalogLimitedConfiguration configuration = configurationWith(1, 2);
+
+        assertEquals(2, configuration.getNumber());
+        assertEquals(1, configuration.getNumber());
+        assertThrows(NoSuchElementException.class, configuration::getNumber);
+    }
+
+    @Test
+    void internalPollingReturnsAnAvailableNumber() {
+        CatalogLimitedConfiguration configuration = configurationWith(17);
+
+        OptionalInt number = configuration.pollNumber();
+
+        assertTrue(number.isPresent());
+        assertEquals(17, number.getAsInt());
+        assertEquals(0, configuration.available());
+    }
+
+    private static CatalogLimitedConfiguration configurationWith(Integer... numbers) {
+        return new CatalogLimitedConfiguration(
+                1,
+                new LinkedList<>(java.util.List.of(numbers)),
+                numbers.length,
+                false
+        );
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfigurationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfigurationTest.java
@@ -1,6 +1,9 @@
 package com.eu.habbo.habbohotel.catalog;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -14,11 +17,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class CatalogLimitedConfigurationTest {
 
@@ -82,28 +81,18 @@ class CatalogLimitedConfigurationTest {
 
     @Test
     void purchasePathMapsAnEmptyReservationToSoldOut() throws Exception {
-        String manager = Files.readString(Path.of(
-                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"
-        ));
-        String configuration = Files.readString(Path.of(
-                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java"
-        ));
+        String manager = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"));
+        String configuration = Files.readString(
+                Path.of("src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java"));
 
         assertTrue(manager.contains("limitedConfiguration.pollNumber()"));
         assertTrue(manager.contains("limitedNumberReservation.isEmpty()"));
         assertFalse(manager.contains("limitedNumber = limitedConfiguration.getNumber()"));
         assertTrue(configuration.contains("this.limitedNumbers.pollFirst()"));
-        assertTrue(configuration.contains(
-                "public int available() {\n        synchronized (this.limitedNumbers) {"
-        ));
+        assertTrue(configuration.contains("public int available() {\n        synchronized (this.limitedNumbers) {"));
     }
 
     private static CatalogLimitedConfiguration configurationWith(Integer... numbers) {
-        return new CatalogLimitedConfiguration(
-                1,
-                new LinkedList<>(List.of(numbers)),
-                numbers.length,
-                false
-        );
+        return new CatalogLimitedConfiguration(1, new LinkedList<>(List.of(numbers)), numbers.length, false);
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPublicCacheCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPublicCacheCompatibilityTest.java
@@ -1,0 +1,75 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.habbohotel.items.Item;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogPublicCacheCompatibilityTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void publicCatalogCachesRemainFinalMutableObjects() throws Exception {
+        Path configFile = this.tempDir.resolve("config.ini");
+        Files.writeString(configFile, "");
+        Field configField = Emulator.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        Object previousConfig = configField.get(null);
+        CatalogManager manager;
+        try {
+            configField.set(null, new ConfigurationManager(configFile.toString()));
+            manager = new CatalogManager(false);
+        } finally {
+            configField.set(null, previousConfig);
+        }
+
+        assertPublicFinalField("giftWrappers");
+        assertPublicFinalField("giftFurnis");
+        assertPublicFinalField("prizes");
+        assertPublicFinalField("targetOffers");
+        assertPublicFinalField("clothing");
+        assertPublicFinalField("catalogFeaturedPages");
+
+        Map<Integer, Integer> giftWrappers = manager.giftWrappers;
+        Map<Integer, Integer> giftFurnis = manager.giftFurnis;
+        Map<Integer, Set<Item>> prizes = manager.prizes;
+        Map<Integer, TargetOffer> targetOffers = manager.targetOffers;
+        Map<Integer, ClothItem> clothing = manager.clothing;
+
+        giftWrappers.put(1, 11);
+        giftFurnis.put(2, 22);
+        prizes.put(3, new java.util.HashSet<>());
+        targetOffers.put(4, null);
+        clothing.put(5, null);
+        manager.catalogFeaturedPages.put(6, null);
+
+        assertSame(giftWrappers, manager.giftWrappers);
+        assertSame(giftFurnis, manager.giftFurnis);
+        assertSame(prizes, manager.prizes);
+        assertSame(targetOffers, manager.targetOffers);
+        assertSame(clothing, manager.clothing);
+        assertEquals(11, manager.giftWrappers.get(1));
+        assertEquals(22, manager.giftFurnis.get(2));
+        assertTrue(manager.catalogFeaturedPages.containsKey(6));
+    }
+
+    private static void assertPublicFinalField(String name) throws Exception {
+        Field field = CatalogManager.class.getField(name);
+        assertTrue(Modifier.isPublic(field.getModifiers()));
+        assertTrue(Modifier.isFinal(field.getModifiers()));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPublicCacheCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPublicCacheCompatibilityTest.java
@@ -3,39 +3,33 @@ package com.eu.habbo.habbohotel.catalog;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.core.ConfigurationManager;
 import com.eu.habbo.habbohotel.items.Item;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CatalogPublicCacheCompatibilityTest {
 
-    @TempDir
-    Path tempDir;
-
     @Test
     void publicCatalogCachesRemainFinalMutableObjects() throws Exception {
-        Path configFile = this.tempDir.resolve("config.ini");
-        Files.writeString(configFile, "");
-        Field configField = Emulator.class.getDeclaredField("config");
-        configField.setAccessible(true);
-        Object previousConfig = configField.get(null);
-        CatalogManager manager;
-        try {
-            configField.set(null, new ConfigurationManager(configFile.toString()));
-            manager = new CatalogManager(false);
-        } finally {
-            configField.set(null, previousConfig);
-        }
+        CatalogManager manager = createManager();
 
         assertPublicFinalField("giftWrappers");
         assertPublicFinalField("giftFurnis");
@@ -67,9 +61,193 @@ class CatalogPublicCacheCompatibilityTest {
         assertTrue(manager.catalogFeaturedPages.containsKey(6));
     }
 
+    @Test
+    void firstPartyReadersUseSnapshotsAndReloadsReplaceContents() throws Exception {
+        String manager = source("habbohotel/catalog/CatalogManager.java");
+
+        assertTrue(manager.contains("GiftWrappingSnapshot getGiftWrappingSnapshot()"));
+        assertTrue(manager.contains("getRecyclerPrizesSnapshot()"));
+        assertTrue(manager.contains("getClothingSnapshot()"));
+        assertTrue(manager.contains("getTargetOffersSnapshot()"));
+        assertTrue(manager.contains("getCatalogFeaturedPagesSnapshot()"));
+        assertTrue(manager.contains("return this.catalogFeaturedPages;"),
+                "the legacy featured-page getter must remain live");
+
+        assertTrue(manager.contains("replaceContents(this.targetOffers, loadedTargetOffers);"));
+        assertTrue(manager.contains("replaceContents(this.prizes, loadedPrizes);"));
+        assertTrue(manager.contains("replaceContents(this.clothing, loadedClothing);"));
+        assertTrue(manager.contains("replaceGiftWrapping(loadedGiftWrappers, loadedGiftFurnis);"));
+        assertTrue(manager.contains("replaceFeaturedPages(loadedFeaturedPages);"));
+
+        assertNoDirectCacheRead("messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java",
+                ".giftWrappers", ".giftFurnis");
+        assertNoDirectCacheRead("messages/outgoing/catalog/GiftConfigurationComposer.java",
+                ".giftWrappers", ".giftFurnis");
+        assertNoDirectCacheRead("habbohotel/commands/GiftCommand.java", ".giftFurnis");
+        assertNoDirectCacheRead("habbohotel/commands/MassGiftCommand.java", ".giftFurnis");
+        assertNoDirectCacheRead("habbohotel/commands/RoomGiftCommand.java", ".giftFurnis");
+        assertNoDirectCacheRead("messages/rcon/SendGift.java", ".giftFurnis");
+        assertNoDirectCacheRead("messages/outgoing/catalog/RecyclerLogicComposer.java", ".prizes");
+        assertNoDirectCacheRead("messages/outgoing/users/UserClothesComposer.java", ".clothing");
+        assertNoDirectCacheRead("habbohotel/users/Habbo.java", ".clothing");
+        assertNoDirectCacheRead("habbohotel/commands/PromoteTargetOfferCommand.java", ".targetOffers");
+
+        assertFalse(source("messages/outgoing/catalog/CatalogPageComposer.java")
+                .contains("getCatalogFeaturedPages()"));
+        assertFalse(source("habbohotel/catalog/layouts/FrontPageFeaturedLayout.java")
+                .contains("getCatalogFeaturedPages()"));
+    }
+
+    @Test
+    void snapshotsAreIndependentAndCacheReplacementPreservesIdentity() throws Exception {
+        CatalogManager manager = createManager();
+        Map<Integer, Integer> giftWrappers = manager.giftWrappers;
+        Map<Integer, Integer> giftFurnis = manager.giftFurnis;
+        Map<Integer, Set<Item>> prizes = manager.prizes;
+        Map<Integer, TargetOffer> targetOffers = manager.targetOffers;
+        Map<Integer, ClothItem> clothing = manager.clothing;
+        var featuredPages = manager.catalogFeaturedPages;
+
+        manager.giftWrappers.put(1, 11);
+        manager.giftFurnis.put(2, 22);
+        manager.prizes.put(3, new HashSet<>());
+        manager.targetOffers.put(4, null);
+        manager.clothing.put(5, null);
+        manager.catalogFeaturedPages.put(6, null);
+
+        CatalogManager.GiftWrappingSnapshot giftSnapshot = manager.getGiftWrappingSnapshot();
+        giftSnapshot.wrappers().clear();
+        giftSnapshot.furniture().clear();
+        manager.getRecyclerPrizesSnapshot().get(3).add(null);
+        manager.getTargetOffersSnapshot().clear();
+        manager.getClothingSnapshot().clear();
+        manager.getCatalogFeaturedPagesSnapshot().clear();
+
+        assertEquals(11, manager.giftWrappers.get(1));
+        assertEquals(22, manager.giftFurnis.get(2));
+        assertFalse(manager.prizes.get(3).contains(null));
+        assertTrue(manager.targetOffers.containsKey(4));
+        assertTrue(manager.clothing.containsKey(5));
+        assertTrue(manager.catalogFeaturedPages.containsKey(6));
+
+        manager.replaceGiftWrapping(Map.of(7, 77), Map.of(8, 88));
+        CatalogManager.replaceContents(manager.prizes, Map.of(9, new HashSet<>()));
+        Map<Integer, TargetOffer> replacementOffers = new HashMap<>();
+        replacementOffers.put(10, null);
+        CatalogManager.replaceContents(manager.targetOffers, replacementOffers);
+        Map<Integer, ClothItem> replacementClothing = new HashMap<>();
+        replacementClothing.put(11, null);
+        CatalogManager.replaceContents(manager.clothing, replacementClothing);
+        var replacementFeaturedPages = new Int2ObjectOpenHashMap<CatalogFeaturedPage>();
+        replacementFeaturedPages.put(12, null);
+        manager.replaceFeaturedPages(replacementFeaturedPages);
+
+        assertSame(giftWrappers, manager.giftWrappers);
+        assertSame(giftFurnis, manager.giftFurnis);
+        assertSame(prizes, manager.prizes);
+        assertSame(targetOffers, manager.targetOffers);
+        assertSame(clothing, manager.clothing);
+        assertSame(featuredPages, manager.catalogFeaturedPages);
+        assertEquals(Map.of(7, 77), manager.giftWrappers);
+        assertEquals(Map.of(8, 88), manager.giftFurnis);
+        assertTrue(manager.prizes.containsKey(9));
+        assertTrue(manager.targetOffers.containsKey(10));
+        assertTrue(manager.clothing.containsKey(11));
+        assertTrue(manager.catalogFeaturedPages.containsKey(12));
+    }
+
+    @Test
+    void concurrentReloadReplacementAndSnapshotIterationRemainConsistent() throws Exception {
+        CatalogManager manager = createManager();
+        Map<Integer, Integer> giftWrappers = manager.giftWrappers;
+        Map<Integer, Integer> giftFurnis = manager.giftFurnis;
+        Map<Integer, Set<Item>> prizes = manager.prizes;
+        Map<Integer, TargetOffer> targetOffers = manager.targetOffers;
+        Map<Integer, ClothItem> clothing = manager.clothing;
+        var featuredPages = manager.catalogFeaturedPages;
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<?> reloads = executor.submit(() -> {
+                start.await();
+                for (int index = 0; index < 1_000; index++) {
+                    manager.replaceGiftWrapping(Map.of(index, index), Map.of(index, index));
+                    CatalogManager.replaceContents(manager.prizes, Map.of(index, new HashSet<>()));
+
+                    Map<Integer, TargetOffer> offers = new HashMap<>();
+                    offers.put(index, null);
+                    CatalogManager.replaceContents(manager.targetOffers, offers);
+
+                    Map<Integer, ClothItem> clothes = new HashMap<>();
+                    clothes.put(index, null);
+                    CatalogManager.replaceContents(manager.clothing, clothes);
+
+                    var featured = new Int2ObjectOpenHashMap<CatalogFeaturedPage>();
+                    featured.put(index, null);
+                    manager.replaceFeaturedPages(featured);
+                }
+                return null;
+            });
+            Future<?> readers = executor.submit(() -> {
+                start.await();
+                for (int index = 0; index < 1_000; index++) {
+                    CatalogManager.GiftWrappingSnapshot giftWrapping = manager.getGiftWrappingSnapshot();
+                    assertEquals(giftWrapping.wrappers().keySet(), giftWrapping.furniture().keySet());
+                    manager.getRecyclerPrizesSnapshot().values().forEach(Set::size);
+                    manager.getTargetOffersSnapshot().values().forEach(value -> {
+                    });
+                    manager.getClothingSnapshot().values().forEach(value -> {
+                    });
+                    manager.getCatalogFeaturedPagesSnapshot().forEach(value -> {
+                    });
+                }
+                return null;
+            });
+
+            start.countDown();
+            reloads.get(5, TimeUnit.SECONDS);
+            readers.get(5, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertSame(giftWrappers, manager.giftWrappers);
+        assertSame(giftFurnis, manager.giftFurnis);
+        assertSame(prizes, manager.prizes);
+        assertSame(targetOffers, manager.targetOffers);
+        assertSame(clothing, manager.clothing);
+        assertSame(featuredPages, manager.catalogFeaturedPages);
+    }
+
     private static void assertPublicFinalField(String name) throws Exception {
         Field field = CatalogManager.class.getField(name);
         assertTrue(Modifier.isPublic(field.getModifiers()));
         assertTrue(Modifier.isFinal(field.getModifiers()));
+    }
+
+    private static void assertNoDirectCacheRead(String relativePath, String... fragments) throws Exception {
+        String source = source(relativePath);
+        for (String fragment : fragments) {
+            assertFalse(source.contains(fragment), relativePath + " reads " + fragment + " directly");
+        }
+    }
+
+    private static String source(String relativePath) throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/" + relativePath));
+    }
+
+    private CatalogManager createManager() throws Exception {
+        Field configField = Emulator.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        Object previousConfig = configField.get(null);
+        try {
+            configField.set(null, new ConfigurationManager(
+                    Path.of("..", "config example", "config.ini.example").toString()
+            ));
+            return new CatalogManager(false);
+        } finally {
+            configField.set(null, previousConfig);
+        }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPublicCacheCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPublicCacheCompatibilityTest.java
@@ -1,11 +1,14 @@
 package com.eu.habbo.habbohotel.catalog;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.eu.habbo.Emulator;
 import com.eu.habbo.core.ConfigurationManager;
 import com.eu.habbo.habbohotel.items.Item;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import org.junit.jupiter.api.Test;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.file.Files;
@@ -19,11 +22,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class CatalogPublicCacheCompatibilityTest {
 
@@ -70,7 +69,8 @@ class CatalogPublicCacheCompatibilityTest {
         assertTrue(manager.contains("getClothingSnapshot()"));
         assertTrue(manager.contains("getTargetOffersSnapshot()"));
         assertTrue(manager.contains("getCatalogFeaturedPagesSnapshot()"));
-        assertTrue(manager.contains("return this.catalogFeaturedPages;"),
+        assertTrue(
+                manager.contains("return this.catalogFeaturedPages;"),
                 "the legacy featured-page getter must remain live");
 
         assertTrue(manager.contains("replaceContents(this.targetOffers, loadedTargetOffers);"));
@@ -79,10 +79,10 @@ class CatalogPublicCacheCompatibilityTest {
         assertTrue(manager.contains("replaceGiftWrapping(loadedGiftWrappers, loadedGiftFurnis);"));
         assertTrue(manager.contains("replaceFeaturedPages(loadedFeaturedPages);"));
 
-        assertNoDirectCacheRead("messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java",
-                ".giftWrappers", ".giftFurnis");
-        assertNoDirectCacheRead("messages/outgoing/catalog/GiftConfigurationComposer.java",
-                ".giftWrappers", ".giftFurnis");
+        assertNoDirectCacheRead(
+                "messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java", ".giftWrappers", ".giftFurnis");
+        assertNoDirectCacheRead(
+                "messages/outgoing/catalog/GiftConfigurationComposer.java", ".giftWrappers", ".giftFurnis");
         assertNoDirectCacheRead("habbohotel/commands/GiftCommand.java", ".giftFurnis");
         assertNoDirectCacheRead("habbohotel/commands/MassGiftCommand.java", ".giftFurnis");
         assertNoDirectCacheRead("habbohotel/commands/RoomGiftCommand.java", ".giftFurnis");
@@ -92,8 +92,7 @@ class CatalogPublicCacheCompatibilityTest {
         assertNoDirectCacheRead("habbohotel/users/Habbo.java", ".clothing");
         assertNoDirectCacheRead("habbohotel/commands/PromoteTargetOfferCommand.java", ".targetOffers");
 
-        assertFalse(source("messages/outgoing/catalog/CatalogPageComposer.java")
-                .contains("getCatalogFeaturedPages()"));
+        assertFalse(source("messages/outgoing/catalog/CatalogPageComposer.java").contains("getCatalogFeaturedPages()"));
         assertFalse(source("habbohotel/catalog/layouts/FrontPageFeaturedLayout.java")
                 .contains("getCatalogFeaturedPages()"));
     }
@@ -193,14 +192,13 @@ class CatalogPublicCacheCompatibilityTest {
                 start.await();
                 for (int index = 0; index < 1_000; index++) {
                     CatalogManager.GiftWrappingSnapshot giftWrapping = manager.getGiftWrappingSnapshot();
-                    assertEquals(giftWrapping.wrappers().keySet(), giftWrapping.furniture().keySet());
+                    assertEquals(
+                            giftWrapping.wrappers().keySet(),
+                            giftWrapping.furniture().keySet());
                     manager.getRecyclerPrizesSnapshot().values().forEach(Set::size);
-                    manager.getTargetOffersSnapshot().values().forEach(value -> {
-                    });
-                    manager.getClothingSnapshot().values().forEach(value -> {
-                    });
-                    manager.getCatalogFeaturedPagesSnapshot().forEach(value -> {
-                    });
+                    manager.getTargetOffersSnapshot().values().forEach(value -> {});
+                    manager.getClothingSnapshot().values().forEach(value -> {});
+                    manager.getCatalogFeaturedPagesSnapshot().forEach(value -> {});
                 }
                 return null;
             });
@@ -242,9 +240,10 @@ class CatalogPublicCacheCompatibilityTest {
         configField.setAccessible(true);
         Object previousConfig = configField.get(null);
         try {
-            configField.set(null, new ConfigurationManager(
-                    Path.of("..", "config example", "config.ini.example").toString()
-            ));
+            configField.set(
+                    null,
+                    new ConfigurationManager(Path.of("..", "config example", "config.ini.example")
+                            .toString()));
             return new CatalogManager(false);
         } finally {
             configField.set(null, previousConfig);

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseAtomicityContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseAtomicityContractTest.java
@@ -43,17 +43,18 @@ class CatalogPurchaseAtomicityContractTest {
 
     @Test
     void giftsDebitBeforeCreationAndCompensateOnFailure() throws Exception {
-        String gift = source("com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java");
+        String gift =
+                withoutWhitespace(source("com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java"));
 
         int debit = gift.indexOf(
-                "CatalogPaymentService.tryTake(this.client.getHabbo(), chargeCredits, item.getPointsType(), chargePoints)");
+                "CatalogPaymentService.tryTake(this.client.getHabbo(),chargeCredits,item.getPointsType(),chargePoints)");
         int create = gift.indexOf("getItemManager().createItem(userId", debit);
         assertTrue(
                 debit > -1 && create > debit, "gift payment must be reserved before recipient-owned rows are created");
-        assertTrue(gift.contains("if (!giftDelivered)"), "failed gift delivery must enter compensating cleanup");
+        assertTrue(gift.contains("if(!giftDelivered)"), "failed gift delivery must enter compensating cleanup");
         assertTrue(
                 gift.contains(
-                        "CatalogPaymentService.refund(this.client.getHabbo(), paidCredits, paidPointsType, paidPoints)"),
+                        "CatalogPaymentService.refund(this.client.getHabbo(),paidCredits,paidPointsType,paidPoints)"),
                 "failed gift delivery must restore the exact reserved payment");
     }
 

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
@@ -1,14 +1,13 @@
 package com.eu.habbo.habbohotel.economy;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class EconomyAuditCoverageContractTest {
     private static final Path SOURCES = Path.of("src/main/java");
@@ -17,7 +16,8 @@ class EconomyAuditCoverageContractTest {
     void durableWalletSqlIsCentralizedInLedgerSnapshotAndAccountBootstrap() throws Exception {
         Set<String> owners = new HashSet<>();
         try (var paths = Files.walk(SOURCES)) {
-            for (Path path : paths.filter(file -> file.toString().endsWith(".java")).toList()) {
+            for (Path path :
+                    paths.filter(file -> file.toString().endsWith(".java")).toList()) {
                 String source = Files.readString(path);
                 if (source.contains("UPDATE users SET credits")
                         || source.contains("INSERT INTO users_currency")
@@ -27,7 +27,9 @@ class EconomyAuditCoverageContractTest {
             }
         }
 
-        assertEquals(Set.of("EconomyLedger.java", "HabboInfo.java", "RegistrationSupport.java"), owners,
+        assertEquals(
+                Set.of("EconomyLedger.java", "HabboInfo.java", "RegistrationSupport.java"),
+                owners,
                 "new durable wallet mutations must use EconomyLedger; only snapshot persistence and account bootstrap bypass it");
     }
 
@@ -45,14 +47,14 @@ class EconomyAuditCoverageContractTest {
 
     @Test
     void genericOnlineAndAdministrativeGrantsUseExplicitAuditedReasons() throws Exception {
-        String habbo = Files.readString(SOURCES.resolve("com/eu/habbo/habbohotel/users/Habbo.java"));
-        String housekeepingCredits = Files.readString(SOURCES.resolve(
-                "com/eu/habbo/messages/incoming/housekeeping/HousekeepingGiveCreditsEvent.java"));
-        String housekeepingCurrency = Files.readString(SOURCES.resolve(
-                "com/eu/habbo/messages/incoming/housekeeping/HousekeepingGiveCurrencyEvent.java"));
+        String habbo = Files.readString(SOURCES.resolve("com/eu/habbo/habbohotel/users/Habbo.java"))
+                .replaceAll("\\s+", "");
+        String housekeepingCredits = Files.readString(
+                SOURCES.resolve("com/eu/habbo/messages/incoming/housekeeping/HousekeepingGiveCreditsEvent.java"));
+        String housekeepingCurrency = Files.readString(
+                SOURCES.resolve("com/eu/habbo/messages/incoming/housekeeping/HousekeepingGiveCurrencyEvent.java"));
 
-        assertTrue(habbo.contains(
-                "LedgerWalletMutation.execute(this, new EconomyOperation("));
+        assertTrue(habbo.contains("LedgerWalletMutation.execute(this,newEconomyOperation("));
         assertTrue(housekeepingCredits.contains("\"housekeeping.user.give_credits\""));
         assertTrue(housekeepingCurrency.contains("\"housekeeping.user.give_currency\""));
     }
@@ -61,7 +63,8 @@ class EconomyAuditCoverageContractTest {
     void firstPartyCodeDoesNotUseLegacyDirectWalletMutators() throws Exception {
         Set<String> callers = new HashSet<>();
         try (var paths = Files.walk(SOURCES)) {
-            for (Path path : paths.filter(file -> file.toString().endsWith(".java")).toList()) {
+            for (Path path :
+                    paths.filter(file -> file.toString().endsWith(".java")).toList()) {
                 if (path.getFileName().toString().equals("HabboInfo.java")) {
                     continue;
                 }
@@ -77,18 +80,22 @@ class EconomyAuditCoverageContractTest {
             }
         }
 
-        assertEquals(Set.of(), callers,
+        assertEquals(
+                Set.of(),
+                callers,
                 "first-party wallet changes must use explicit ledger operations or committed-balance publication");
     }
 
     @Test
     void catalogPaymentReservationsUseAuditedLedgerMutations() throws Exception {
-        String service = Files.readString(SOURCES.resolve(
-                "com/eu/habbo/habbohotel/catalog/CatalogPaymentService.java"));
+        String service =
+                Files.readString(SOURCES.resolve("com/eu/habbo/habbohotel/catalog/CatalogPaymentService.java"));
 
-        assertTrue(service.contains("EconomyLedger.executeBatch(operations)"),
+        assertTrue(
+                service.contains("EconomyLedger.executeBatch(operations)"),
                 "catalog payment reservations and refunds must be durable ledger operations");
-        assertTrue(service.contains("LedgerWalletMutation.applyCommitted("),
+        assertTrue(
+                service.contains("LedgerWalletMutation.applyCommitted("),
                 "online balances must publish the committed ledger result without a second snapshot save");
         assertTrue(!service.contains(".tryDebitCatalogPayment("));
         assertTrue(!service.contains(".refundCatalogPayment("));

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/modtool/ModToolBanDateFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/modtool/ModToolBanDateFormattingTest.java
@@ -27,4 +27,19 @@ class ModToolBanDateFormattingTest {
             ModToolBan.dateFormat = original;
         }
     }
+
+    @Test
+    void firstPartyBanFormattingDoesNotUseThePublicMutableFormatter() {
+        int timestamp = 1_700_000_000;
+        String expected = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+                .format(new Date(timestamp * 1000L));
+        SimpleDateFormat original = ModToolBan.dateFormat;
+        try {
+            ModToolBan.dateFormat = new SimpleDateFormat("ss");
+
+            assertEquals(expected, ModToolBan.formatTimestamp(timestamp));
+        } finally {
+            ModToolBan.dateFormat = original;
+        }
+    }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/modtool/ModToolBanDateFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/modtool/ModToolBanDateFormattingTest.java
@@ -1,0 +1,30 @@
+package com.eu.habbo.habbohotel.modtool;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ModToolBanDateFormattingTest {
+
+    @Test
+    void preservesBanTimestampTextAndPublicFieldMutability() {
+        int timestamp = 1_700_000_000;
+        String expected = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+                .format(new Date(timestamp * 1000L));
+
+        assertEquals(expected, ModToolBan.formatTimestamp(timestamp));
+
+        SimpleDateFormat original = ModToolBan.dateFormat;
+        try {
+            SimpleDateFormat replacement = new SimpleDateFormat("ss");
+            ModToolBan.dateFormat = replacement;
+            assertSame(replacement, ModToolBan.dateFormat);
+        } finally {
+            ModToolBan.dateFormat = original;
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/modtool/ModToolBanDateFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/modtool/ModToolBanDateFormattingTest.java
@@ -1,20 +1,18 @@
 package com.eu.habbo.habbohotel.modtool;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import org.junit.jupiter.api.Test;
 
 class ModToolBanDateFormattingTest {
 
     @Test
     void preservesBanTimestampTextAndPublicFieldMutability() {
         int timestamp = 1_700_000_000;
-        String expected = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
-                .format(new Date(timestamp * 1000L));
+        String expected = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(timestamp * 1000L));
 
         assertEquals(expected, ModToolBan.formatTimestamp(timestamp));
 
@@ -31,8 +29,7 @@ class ModToolBanDateFormattingTest {
     @Test
     void firstPartyBanFormattingDoesNotUseThePublicMutableFormatter() {
         int timestamp = 1_700_000_000;
-        String expected = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
-                .format(new Date(timestamp * 1000L));
+        String expected = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(timestamp * 1000L));
         SimpleDateFormat original = ModToolBan.dateFormat;
         try {
             ModToolBan.dateFormat = new SimpleDateFormat("ss");

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomRollerIterationContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomRollerIterationContractTest.java
@@ -1,0 +1,21 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoomRollerIterationContractTest {
+
+    @Test
+    void firstPartyCycleUsesTheLockedRollerSnapshot() throws Exception {
+        String source = Files.readString(
+                Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java"));
+
+        assertTrue(source.contains("rollerSnapshot().values()"));
+        assertFalse(source.contains("getRollers().values()"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomRollerIterationContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomRollerIterationContractTest.java
@@ -1,19 +1,17 @@
 package com.eu.habbo.habbohotel.rooms;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class RoomRollerIterationContractTest {
 
     @Test
     void firstPartyCycleUsesTheLockedRollerSnapshot() throws Exception {
-        String source = Files.readString(
-                Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java"));
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/RoomRollerManager.java"));
 
         assertTrue(source.contains("rollerSnapshot().values()"));
         assertFalse(source.contains("getRollers().values()"));

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypesRollerCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypesRollerCompatibilityTest.java
@@ -4,7 +4,14 @@ import com.eu.habbo.habbohotel.items.interactions.InteractionRoller;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -20,5 +27,32 @@ class RoomSpecialTypesRollerCompatibilityTest {
         assertSame(rollers, specialTypes.getRollers());
         assertTrue(specialTypes.getRollers().containsKey(17));
         rollers.remove(17);
+    }
+
+    @Test
+    void disposeUsesTheRollerMapMonitor() throws Exception {
+        RoomSpecialTypes specialTypes = new RoomSpecialTypes();
+        Map<Integer, InteractionRoller> rollers = specialTypes.getRollers();
+        CountDownLatch disposeAttempted = new CountDownLatch(1);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<?> dispose;
+
+        try {
+            synchronized (rollers) {
+                dispose = executor.submit(() -> {
+                    disposeAttempted.countDown();
+                    specialTypes.dispose();
+                });
+
+                assertTrue(disposeAttempted.await(2, TimeUnit.SECONDS));
+                assertThrows(TimeoutException.class,
+                        () -> dispose.get(100, TimeUnit.MILLISECONDS),
+                        "dispose must wait for first-party roller mutation to leave the shared monitor");
+            }
+
+            dispose.get(2, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypesRollerCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypesRollerCompatibilityTest.java
@@ -11,8 +11,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RoomSpecialTypesRollerCompatibilityTest {
@@ -27,6 +28,19 @@ class RoomSpecialTypesRollerCompatibilityTest {
         assertSame(rollers, specialTypes.getRollers());
         assertTrue(specialTypes.getRollers().containsKey(17));
         rollers.remove(17);
+    }
+
+    @Test
+    void internalSnapshotDoesNotChangeWithTheLiveMap() {
+        RoomSpecialTypes specialTypes = new RoomSpecialTypes();
+        Map<Integer, InteractionRoller> rollers = specialTypes.getRollers();
+        rollers.put(17, null);
+
+        Map<Integer, InteractionRoller> snapshot = specialTypes.rollerSnapshot();
+        rollers.remove(17);
+
+        assertTrue(snapshot.containsKey(17));
+        assertFalse(rollers.containsKey(17));
     }
 
     @Test

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypesRollerCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypesRollerCompatibilityTest.java
@@ -1,0 +1,24 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.items.interactions.InteractionRoller;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoomSpecialTypesRollerCompatibilityTest {
+
+    @Test
+    void publicRollerMapRemainsLiveStableAndMutable() {
+        RoomSpecialTypes specialTypes = new RoomSpecialTypes();
+        Map<Integer, InteractionRoller> rollers = specialTypes.getRollers();
+
+        rollers.put(17, null);
+
+        assertSame(rollers, specialTypes.getRollers());
+        assertTrue(specialTypes.getRollers().containsKey(17));
+        rollers.remove(17);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypesRollerCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomSpecialTypesRollerCompatibilityTest.java
@@ -1,8 +1,11 @@
 package com.eu.habbo.habbohotel.rooms;
 
-import com.eu.habbo.habbohotel.items.interactions.InteractionRoller;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.eu.habbo.habbohotel.items.interactions.InteractionRoller;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -10,11 +13,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class RoomSpecialTypesRollerCompatibilityTest {
 
@@ -59,7 +58,8 @@ class RoomSpecialTypesRollerCompatibilityTest {
                 });
 
                 assertTrue(disposeAttempted.await(2, TimeUnit.SECONDS));
-                assertThrows(TimeoutException.class,
+                assertThrows(
+                        TimeoutException.class,
                         () -> dispose.get(100, TimeUnit.MILLISECONDS),
                         "dispose must wait for first-party roller mutation to leave the shared monitor");
             }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/users/WalletMutationContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/users/WalletMutationContractTest.java
@@ -46,16 +46,17 @@ class WalletMutationContractTest {
 
     @Test
     void debitPluginsCannotSilentlyReduceTheAmountCharged() throws Exception {
-        String habbo = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/users/Habbo.java"));
+        String habbo = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/users/Habbo.java"))
+                .replaceAll("\\s+", "");
         String marketplace = Files.readString(
                         Path.of("src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlace.java"))
                 .replaceAll("\\s+", "");
 
         assertTrue(
-                habbo.contains("event.credits != -credits"),
+                habbo.contains("event.credits!=-credits"),
                 "a successful exact credit debit must remove the requested amount");
         assertTrue(
-                habbo.contains("event.type != type || event.points != -points"),
+                habbo.contains("event.type!=type||event.points!=-points"),
                 "a successful exact points debit must preserve currency type and amount");
         assertTrue(marketplace.contains("event.credits!=-price"));
         assertTrue(marketplace.contains("event.type!=MARKETPLACE_CURRENCY||event.points!=-price"));

--- a/Emulator/src/test/java/com/eu/habbo/messages/outgoing/modtool/ModToolTimestampFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/outgoing/modtool/ModToolTimestampFormattingTest.java
@@ -1,0 +1,48 @@
+package com.eu.habbo.messages.outgoing.modtool;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ModToolTimestampFormattingTest {
+    private static final int TIMESTAMP = 1_700_000_000;
+
+    @Test
+    void preservesChatlogAndUserInfoTimestampText() {
+        assertEquals(
+                format("HH:mm", TIMESTAMP),
+                ModToolUserChatlogComposer.formatTimestamp(TIMESTAMP));
+        assertEquals(
+                format("HH:mm", TIMESTAMP),
+                ModToolIssueChatlogComposer.formatTimestamp(TIMESTAMP));
+        assertEquals(
+                format("yyyy-MM-dd HH:mm", TIMESTAMP),
+                ModToolUserInfoComposer.formatUnixTimestamp(TIMESTAMP));
+        assertEquals("", ModToolUserInfoComposer.formatUnixTimestamp(0));
+    }
+
+    @Test
+    void publicChatlogFormattersRemainDirectlyWritable() {
+        SimpleDateFormat userFormatter = ModToolUserChatlogComposer.format;
+        SimpleDateFormat issueFormatter = ModToolIssueChatlogComposer.format;
+        try {
+            SimpleDateFormat replacement = new SimpleDateFormat("ss");
+            ModToolUserChatlogComposer.format = replacement;
+            ModToolIssueChatlogComposer.format = replacement;
+
+            assertSame(replacement, ModToolUserChatlogComposer.format);
+            assertSame(replacement, ModToolIssueChatlogComposer.format);
+        } finally {
+            ModToolUserChatlogComposer.format = userFormatter;
+            ModToolIssueChatlogComposer.format = issueFormatter;
+        }
+    }
+
+    private static String format(String pattern, int timestamp) {
+        return new SimpleDateFormat(pattern).format(new Date(timestamp * 1000L));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/outgoing/modtool/ModToolTimestampFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/outgoing/modtool/ModToolTimestampFormattingTest.java
@@ -3,6 +3,7 @@ package com.eu.habbo.messages.outgoing.modtool;
 import org.junit.jupiter.api.Test;
 
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,6 +41,30 @@ class ModToolTimestampFormattingTest {
             ModToolUserChatlogComposer.format = userFormatter;
             ModToolIssueChatlogComposer.format = issueFormatter;
         }
+    }
+
+    @Test
+    void firstPartyChatFormattingDoesNotUsePublicMutableFormatters() {
+        SimpleDateFormat userFormatter = ModToolUserChatlogComposer.format;
+        SimpleDateFormat issueFormatter = ModToolIssueChatlogComposer.format;
+        try {
+            ModToolUserChatlogComposer.format = new SimpleDateFormat("ss");
+            ModToolIssueChatlogComposer.format = new SimpleDateFormat("ss");
+            String expected = format("HH:mm", TIMESTAMP);
+
+            assertEquals(expected, ModToolUserChatlogComposer.formatTimestamp(TIMESTAMP));
+            assertEquals(expected, ModToolIssueChatlogComposer.formatTimestamp(TIMESTAMP));
+        } finally {
+            ModToolUserChatlogComposer.format = userFormatter;
+            ModToolIssueChatlogComposer.format = issueFormatter;
+        }
+    }
+
+    @Test
+    void userInfoUsesAnImmutableFormatter() throws Exception {
+        assertEquals(
+                DateTimeFormatter.class,
+                ModToolUserInfoComposer.class.getDeclaredField("DATE_FORMAT").getType());
     }
 
     private static String format(String pattern, int timestamp) {

--- a/Emulator/src/test/java/com/eu/habbo/messages/outgoing/modtool/ModToolTimestampFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/outgoing/modtool/ModToolTimestampFormattingTest.java
@@ -1,28 +1,21 @@
 package com.eu.habbo.messages.outgoing.modtool;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.text.SimpleDateFormat;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import org.junit.jupiter.api.Test;
 
 class ModToolTimestampFormattingTest {
     private static final int TIMESTAMP = 1_700_000_000;
 
     @Test
     void preservesChatlogAndUserInfoTimestampText() {
-        assertEquals(
-                format("HH:mm", TIMESTAMP),
-                ModToolUserChatlogComposer.formatTimestamp(TIMESTAMP));
-        assertEquals(
-                format("HH:mm", TIMESTAMP),
-                ModToolIssueChatlogComposer.formatTimestamp(TIMESTAMP));
-        assertEquals(
-                format("yyyy-MM-dd HH:mm", TIMESTAMP),
-                ModToolUserInfoComposer.formatUnixTimestamp(TIMESTAMP));
+        assertEquals(format("HH:mm", TIMESTAMP), ModToolUserChatlogComposer.formatTimestamp(TIMESTAMP));
+        assertEquals(format("HH:mm", TIMESTAMP), ModToolIssueChatlogComposer.formatTimestamp(TIMESTAMP));
+        assertEquals(format("yyyy-MM-dd HH:mm", TIMESTAMP), ModToolUserInfoComposer.formatUnixTimestamp(TIMESTAMP));
         assertEquals("", ModToolUserInfoComposer.formatUnixTimestamp(0));
     }
 


### PR DESCRIPTION
Hardens shared mutable state used by room rollers, catalog reloads, limited-stock purchases, and timestamp formatting. First-party readers use locked snapshots while legacy public maps remain live and stable, catalog reloads publish complete cache replacements, limited stock reservation is atomic, and first-party timestamp formatting no longer shares mutable formatter state.

Manual testing:
- Reload the catalog while users browse featured pages, gift items, open recycler rewards, and change clothing; confirm responses remain complete throughout the reload.
- Have two users buy the final limited item at the same time; confirm one purchase succeeds and the other receives the sold-out response without a server error or negative stock.
