### PR TITLE
fix(network): harden connection flow control

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/core/config/ConfigRegistry.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/config/ConfigRegistry.java
@@ -130,6 +130,13 @@ public final class ConfigRegistry {
                 "ws.port",
                 "session.reconnect.grace.seconds");
         keys.add(definition("runtime.threads", ConfigKey.ValueType.INTEGER, "8", true));
+        keys.add(definition("http.blocking.pool.size", ConfigKey.ValueType.INTEGER, "8", true));
+        keys.add(definition(
+                "io.netty.write_buffer.low_water_mark", ConfigKey.ValueType.INTEGER, "32768", true));
+        keys.add(definition(
+                "io.netty.write_buffer.high_water_mark", ConfigKey.ValueType.INTEGER, "65536", true));
+        keys.add(definition(
+                "io.netty.unwritable.timeout.seconds", ConfigKey.ValueType.INTEGER, "10", true));
         add(
                 keys,
                 ConfigKey.ValueType.LONG,
@@ -229,6 +236,12 @@ public final class ConfigRegistry {
         }
         if (name.startsWith("game.")) {
             return "Game listener setting.";
+        }
+        if (name.startsWith("http.blocking.")) {
+            return "Blocking HTTP worker setting.";
+        }
+        if (name.startsWith("io.netty.")) {
+            return "Netty channel flow-control setting.";
         }
         if (name.startsWith("ws.") || name.startsWith("crypto.ws.")) {
             return "WebSocket listener setting.";

--- a/Emulator/src/main/java/com/eu/habbo/core/config/ConfigRegistry.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/config/ConfigRegistry.java
@@ -131,12 +131,9 @@ public final class ConfigRegistry {
                 "session.reconnect.grace.seconds");
         keys.add(definition("runtime.threads", ConfigKey.ValueType.INTEGER, "8", true));
         keys.add(definition("http.blocking.pool.size", ConfigKey.ValueType.INTEGER, "8", true));
-        keys.add(definition(
-                "io.netty.write_buffer.low_water_mark", ConfigKey.ValueType.INTEGER, "32768", true));
-        keys.add(definition(
-                "io.netty.write_buffer.high_water_mark", ConfigKey.ValueType.INTEGER, "65536", true));
-        keys.add(definition(
-                "io.netty.unwritable.timeout.seconds", ConfigKey.ValueType.INTEGER, "10", true));
+        keys.add(definition("io.netty.write_buffer.low_water_mark", ConfigKey.ValueType.INTEGER, "32768", true));
+        keys.add(definition("io.netty.write_buffer.high_water_mark", ConfigKey.ValueType.INTEGER, "65536", true));
+        keys.add(definition("io.netty.unwritable.timeout.seconds", ConfigKey.ValueType.INTEGER, "10", true));
         add(
                 keys,
                 ConfigKey.ValueType.LONG,

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClientManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClientManager.java
@@ -121,6 +121,16 @@ public class GameClientManager {
 
 
     public Habbo getHabbo(int id) {
+        GameClient authenticatedClient = this.authenticatedClients.get(id);
+        if (authenticatedClient != null) {
+            Habbo authenticatedHabbo = authenticatedClient.getHabbo();
+            if (authenticatedHabbo != null
+                    && authenticatedHabbo.getHabboInfo() != null
+                    && authenticatedHabbo.getHabboInfo().getId() == id) {
+                return authenticatedHabbo;
+            }
+        }
+
         for (GameClient client : this.clients.values()) {
             if (client.getHabbo() == null)
                 continue;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClientManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClientManager.java
@@ -5,8 +5,11 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.networking.gameserver.GameServerAttributes;
-import io.netty.channel.*;
-
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -22,11 +25,9 @@ public class GameClientManager {
         this.authenticatedClients = new ConcurrentHashMap<>();
     }
 
-
     public ConcurrentMap<ChannelId, GameClient> getSessions() {
         return this.clients;
     }
-
 
     public boolean addClient(ChannelHandlerContext ctx) {
         GameClient client = new GameClient(ctx.channel());
@@ -42,7 +43,6 @@ public class GameClientManager {
 
         return this.clients.putIfAbsent(ctx.channel().id(), client) == null;
     }
-
 
     public void disposeClient(GameClient client) {
         if (client == null) {
@@ -73,7 +73,8 @@ public class GameClientManager {
 
         if (client != null) {
             if (client.getHabbo() != null && client.getHabbo().getHabboInfo() != null) {
-                this.releaseAuthenticatedSession(client.getHabbo().getHabboInfo().getId(), client);
+                this.releaseAuthenticatedSession(
+                        client.getHabbo().getHabboInfo().getId(), client);
             }
             client.dispose(allowSessionResume);
         }
@@ -104,21 +105,18 @@ public class GameClientManager {
         return this.authenticatedClients.containsKey(userId) ? 1 : 0;
     }
 
-
     public boolean containsHabbo(Integer id) {
         if (!this.clients.isEmpty()) {
             for (GameClient client : this.clients.values()) {
                 if (client.getHabbo() != null) {
                     if (client.getHabbo().getHabboInfo() != null) {
-                        if (client.getHabbo().getHabboInfo().getId() == id)
-                            return true;
+                        if (client.getHabbo().getHabboInfo().getId() == id) return true;
                     }
                 }
             }
         }
         return false;
     }
-
 
     public Habbo getHabbo(int id) {
         GameClient authenticatedClient = this.authenticatedClients.get(id);
@@ -132,29 +130,23 @@ public class GameClientManager {
         }
 
         for (GameClient client : this.clients.values()) {
-            if (client.getHabbo() == null)
-                continue;
+            if (client.getHabbo() == null) continue;
 
-            if (client.getHabbo().getHabboInfo().getId() == id)
-                return client.getHabbo();
+            if (client.getHabbo().getHabboInfo().getId() == id) return client.getHabbo();
         }
 
         return null;
     }
-
 
     public Habbo getHabbo(String username) {
         for (GameClient client : this.clients.values()) {
-            if (client.getHabbo() == null)
-                continue;
+            if (client.getHabbo() == null) continue;
 
-            if (client.getHabbo().getHabboInfo().getUsername().equalsIgnoreCase(username))
-                return client.getHabbo();
+            if (client.getHabbo().getHabboInfo().getUsername().equalsIgnoreCase(username)) return client.getHabbo();
         }
 
         return null;
     }
-
 
     public List<Habbo> getHabbosWithIP(String ip) {
         List<Habbo> habbos = new ArrayList<>();
@@ -169,7 +161,6 @@ public class GameClientManager {
 
         return habbos;
     }
-
 
     /**
      * Find an existing GameClient that authenticated with the given SSO ticket.
@@ -186,12 +177,13 @@ public class GameClientManager {
         return null;
     }
 
-
     public List<Habbo> getHabbosWithMachineId(String machineId) {
         List<Habbo> habbos = new ArrayList<>();
 
         for (GameClient client : this.clients.values()) {
-            if (client.getHabbo() != null && client.getHabbo().getHabboInfo() != null && client.getMachineId().equalsIgnoreCase(machineId)) {
+            if (client.getHabbo() != null
+                    && client.getHabbo().getHabboInfo() != null
+                    && client.getMachineId().equalsIgnoreCase(machineId)) {
                 habbos.add(client.getHabbo());
             }
         }
@@ -199,11 +191,9 @@ public class GameClientManager {
         return habbos;
     }
 
-
     public void sendBroadcastResponse(MessageComposer composer) {
         this.sendBroadcastResponse(composer.compose());
     }
-
 
     public void sendBroadcastResponse(ServerMessage message) {
         for (GameClient client : this.clients.values()) {
@@ -211,21 +201,17 @@ public class GameClientManager {
         }
     }
 
-
     public void sendBroadcastResponse(ServerMessage message, GameClient exclude) {
         for (GameClient client : this.clients.values()) {
-            if (client.equals(exclude))
-                continue;
+            if (client.equals(exclude)) continue;
 
             client.sendResponse(message);
         }
     }
 
-
     public void sendBroadcastResponse(ServerMessage message, String minPermission, GameClient exclude) {
         for (GameClient client : this.clients.values()) {
-            if (client.equals(exclude))
-                continue;
+            if (client.equals(exclude)) continue;
 
             if (client.getHabbo() != null) {
                 if (client.getHabbo().hasPermission(minPermission)) {
@@ -236,13 +222,16 @@ public class GameClientManager {
     }
 
     public void CFKeepAlive() {
-        Emulator.getThreading().run(() -> {
-            for (GameClient client : this.clients.values()) {
-                if (client != null && client.getChannel().isActive()) {
-                    client.sendKeepAlive();
-                }
-            }
-            CFKeepAlive();
-        }, 30000);
+        Emulator.getThreading()
+                .run(
+                        () -> {
+                            for (GameClient client : this.clients.values()) {
+                                if (client != null && client.getChannel().isActive()) {
+                                    client.sendKeepAlive();
+                                }
+                            }
+                            CFKeepAlive();
+                        },
+                        30000);
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/Server.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/Server.java
@@ -90,6 +90,43 @@ public abstract class Server {
         bootstrap.childOption(ChannelOption.SO_REUSEADDR, true);
         bootstrap.childOption(ChannelOption.RCVBUF_ALLOCATOR, new AdaptiveRecvByteBufAllocator(1024, 8192, 65536));
         bootstrap.childOption(ChannelOption.ALLOCATOR, allocator());
+        bootstrap.childOption(ChannelOption.WRITE_BUFFER_WATER_MARK, configuredWriteBufferWaterMark());
+    }
+
+    protected static WriteBufferWaterMark configuredWriteBufferWaterMark() {
+        int low = DEFAULT_WRITE_BUFFER_LOW_WATER_MARK;
+        int high = DEFAULT_WRITE_BUFFER_HIGH_WATER_MARK;
+        if (Emulator.getConfig() != null) {
+            low = Emulator.getConfig().getInt("io.netty.write_buffer.low_water_mark", low);
+            high = Emulator.getConfig().getInt("io.netty.write_buffer.high_water_mark", high);
+        }
+
+        if (low < 0 || high <= low) {
+            LOGGER.warn(
+                    "Invalid Netty write-buffer water marks low={} high={}; using defaults low={} high={}",
+                    low,
+                    high,
+                    DEFAULT_WRITE_BUFFER_LOW_WATER_MARK,
+                    DEFAULT_WRITE_BUFFER_HIGH_WATER_MARK);
+            low = DEFAULT_WRITE_BUFFER_LOW_WATER_MARK;
+            high = DEFAULT_WRITE_BUFFER_HIGH_WATER_MARK;
+        }
+        return new WriteBufferWaterMark(low, high);
+    }
+
+    protected static int configuredUnwritableTimeoutSeconds() {
+        int timeout = Emulator.getConfig() == null
+                ? DEFAULT_UNWRITABLE_TIMEOUT_SECONDS
+                : Emulator.getConfig()
+                        .getInt("io.netty.unwritable.timeout.seconds", DEFAULT_UNWRITABLE_TIMEOUT_SECONDS);
+        if (timeout <= 0) {
+            LOGGER.warn(
+                    "Invalid Netty unwritable timeout {}; using default {} seconds",
+                    timeout,
+                    DEFAULT_UNWRITABLE_TIMEOUT_SECONDS);
+            return DEFAULT_UNWRITABLE_TIMEOUT_SECONDS;
+        }
+        return timeout;
     }
 
     public void connect() {

--- a/Emulator/src/main/java/com/eu/habbo/networking/Server.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/Server.java
@@ -11,6 +11,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -21,6 +22,9 @@ import org.slf4j.LoggerFactory;
 public abstract class Server {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Server.class);
+    private static final int DEFAULT_WRITE_BUFFER_LOW_WATER_MARK = 32 * 1024;
+    private static final int DEFAULT_WRITE_BUFFER_HIGH_WATER_MARK = 64 * 1024;
+    private static final int DEFAULT_UNWRITABLE_TIMEOUT_SECONDS = 10;
 
     private static volatile ByteBufAllocator sharedAllocator;
 

--- a/Emulator/src/main/java/com/eu/habbo/networking/Server.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/Server.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.networking;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -40,10 +41,9 @@ public abstract class Server {
         if (sharedAllocator == null) {
             synchronized (Server.class) {
                 if (sharedAllocator == null) {
-                    boolean pooled = Emulator.getConfig() != null
-                            && "true"
-                                    .equalsIgnoreCase(
-                                            Emulator.getConfig().getValue("io.netty.allocator.pooled", "false"));
+                    ConfigurationManager configuration = configuration();
+                    boolean pooled = configuration != null
+                            && "true".equalsIgnoreCase(configuration.getValue("io.netty.allocator.pooled", "false"));
                     sharedAllocator = pooled ? new PooledByteBufAllocator(false) : new UnpooledByteBufAllocator(false);
                     LOGGER.info("Netty ByteBuf allocator: {}", pooled ? "pooled-heap" : "unpooled-heap");
                 }
@@ -96,9 +96,10 @@ public abstract class Server {
     protected static WriteBufferWaterMark configuredWriteBufferWaterMark() {
         int low = DEFAULT_WRITE_BUFFER_LOW_WATER_MARK;
         int high = DEFAULT_WRITE_BUFFER_HIGH_WATER_MARK;
-        if (Emulator.getConfig() != null) {
-            low = Emulator.getConfig().getInt("io.netty.write_buffer.low_water_mark", low);
-            high = Emulator.getConfig().getInt("io.netty.write_buffer.high_water_mark", high);
+        ConfigurationManager configuration = configuration();
+        if (configuration != null) {
+            low = configuration.getInt("io.netty.write_buffer.low_water_mark", low);
+            high = configuration.getInt("io.netty.write_buffer.high_water_mark", high);
         }
 
         if (low < 0 || high <= low) {
@@ -115,10 +116,10 @@ public abstract class Server {
     }
 
     protected static int configuredUnwritableTimeoutSeconds() {
-        int timeout = Emulator.getConfig() == null
+        ConfigurationManager configuration = configuration();
+        int timeout = configuration == null
                 ? DEFAULT_UNWRITABLE_TIMEOUT_SECONDS
-                : Emulator.getConfig()
-                        .getInt("io.netty.unwritable.timeout.seconds", DEFAULT_UNWRITABLE_TIMEOUT_SECONDS);
+                : configuration.getInt("io.netty.unwritable.timeout.seconds", DEFAULT_UNWRITABLE_TIMEOUT_SECONDS);
         if (timeout <= 0) {
             LOGGER.warn(
                     "Invalid Netty unwritable timeout {}; using default {} seconds",
@@ -127,6 +128,10 @@ public abstract class Server {
             return DEFAULT_UNWRITABLE_TIMEOUT_SECONDS;
         }
         return timeout;
+    }
+
+    private static ConfigurationManager configuration() {
+        return Emulator.getConfig();
     }
 
     public void connect() {

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BlockingHttpExecutionGroup.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BlockingHttpExecutionGroup.java
@@ -1,0 +1,45 @@
+package com.eu.habbo.networking.gameserver;
+
+import com.eu.habbo.Emulator;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.EventExecutorGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+final class BlockingHttpExecutionGroup {
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(BlockingHttpExecutionGroup.class);
+    private static final EventExecutorGroup GROUP = new DefaultEventExecutorGroup(
+            configuredThreads(),
+            new DefaultThreadFactory("BlockingHttp", true));
+
+    private BlockingHttpExecutionGroup() {
+    }
+
+    static EventExecutorGroup get() {
+        return GROUP;
+    }
+
+    static void shutdown() {
+        try {
+            GROUP.shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS)
+                    .syncUninterruptibly();
+        } catch (Exception e) {
+            LOGGER.warn("Blocking HTTP group shutdown interrupted", e);
+        }
+    }
+
+    static int configuredThreads() {
+        int fallback = 8;
+        if (Emulator.getConfig() == null) {
+            return fallback;
+        }
+
+        int configured = Emulator.getConfig().getInt(
+                "http.blocking.pool.size", fallback);
+        return configured > 0 ? configured : fallback;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BlockingHttpExecutionGroup.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BlockingHttpExecutionGroup.java
@@ -1,6 +1,5 @@
 package com.eu.habbo.networking.gameserver;
 
-import com.eu.habbo.Emulator;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.EventExecutorGroup;
@@ -10,30 +9,40 @@ import org.slf4j.LoggerFactory;
 
 final class BlockingHttpExecutionGroup {
     private static final Logger LOGGER = LoggerFactory.getLogger(BlockingHttpExecutionGroup.class);
-    private static final EventExecutorGroup GROUP =
-            new DefaultEventExecutorGroup(configuredThreads(), new DefaultThreadFactory("BlockingHttp", true));
+    private static final GroupHolder GROUP = new GroupHolder();
 
     private BlockingHttpExecutionGroup() {}
 
-    static EventExecutorGroup get() {
-        return GROUP;
+    static EventExecutorGroup get(int configuredThreads) {
+        return GROUP.get(configuredThreads);
     }
 
     static void shutdown() {
-        try {
-            GROUP.shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS).syncUninterruptibly();
-        } catch (Exception e) {
-            LOGGER.warn("Blocking HTTP group shutdown interrupted", e);
-        }
+        GROUP.shutdown();
     }
 
-    static int configuredThreads() {
-        int fallback = 8;
-        if (Emulator.getConfig() == null) {
-            return fallback;
+    private static final class GroupHolder {
+        private EventExecutorGroup group;
+
+        private synchronized EventExecutorGroup get(int configuredThreads) {
+            if (this.group == null || this.group.isShuttingDown() || this.group.isShutdown()) {
+                int threads = configuredThreads > 0 ? configuredThreads : 8;
+                this.group = new DefaultEventExecutorGroup(threads, new DefaultThreadFactory("BlockingHttp", true));
+            }
+            return this.group;
         }
 
-        int configured = Emulator.getConfig().getInt("http.blocking.pool.size", fallback);
-        return configured > 0 ? configured : fallback;
+        private synchronized void shutdown() {
+            if (this.group == null) {
+                return;
+            }
+            try {
+                this.group.shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS).syncUninterruptibly();
+            } catch (Exception e) {
+                LOGGER.warn("Blocking HTTP group shutdown interrupted", e);
+            } finally {
+                this.group = null;
+            }
+        }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BlockingHttpExecutionGroup.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BlockingHttpExecutionGroup.java
@@ -4,20 +4,16 @@ import com.eu.habbo.Emulator;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.EventExecutorGroup;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.TimeUnit;
-
 final class BlockingHttpExecutionGroup {
-    private static final Logger LOGGER =
-            LoggerFactory.getLogger(BlockingHttpExecutionGroup.class);
-    private static final EventExecutorGroup GROUP = new DefaultEventExecutorGroup(
-            configuredThreads(),
-            new DefaultThreadFactory("BlockingHttp", true));
+    private static final Logger LOGGER = LoggerFactory.getLogger(BlockingHttpExecutionGroup.class);
+    private static final EventExecutorGroup GROUP =
+            new DefaultEventExecutorGroup(configuredThreads(), new DefaultThreadFactory("BlockingHttp", true));
 
-    private BlockingHttpExecutionGroup() {
-    }
+    private BlockingHttpExecutionGroup() {}
 
     static EventExecutorGroup get() {
         return GROUP;
@@ -25,8 +21,7 @@ final class BlockingHttpExecutionGroup {
 
     static void shutdown() {
         try {
-            GROUP.shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS)
-                    .syncUninterruptibly();
+            GROUP.shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS).syncUninterruptibly();
         } catch (Exception e) {
             LOGGER.warn("Blocking HTTP group shutdown interrupted", e);
         }
@@ -38,8 +33,7 @@ final class BlockingHttpExecutionGroup {
             return fallback;
         }
 
-        int configured = Emulator.getConfig().getInt(
-                "http.blocking.pool.size", fallback);
+        int configured = Emulator.getConfig().getInt("http.blocking.pool.size", fallback);
         return configured > 0 ? configured : fallback;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
@@ -26,6 +26,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LoggingHandler;
 import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.networking.gameserver;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.gameclients.GameClientManager;
 import com.eu.habbo.messages.PacketManager;
@@ -44,8 +45,8 @@ public class GameServer extends Server {
                 "Game Server",
                 host,
                 port,
-                Emulator.getConfig().getInt("io.bossgroup.threads"),
-                Emulator.getConfig().getInt("io.workergroup.threads"));
+                configuration().getInt("io.bossgroup.threads"),
+                configuration().getInt("io.workergroup.threads"));
         this.packetManager = new PacketManager();
         this.gameClientManager = new GameClientManager();
     }
@@ -95,15 +96,15 @@ public class GameServer extends Server {
 
     private void initializeWebSocketServer() {
         this.webSocketListening = false;
-        if (!Emulator.getConfig().getBoolean("ws.enabled", false)) {
+        if (!configuration().getBoolean("ws.enabled", false)) {
             return;
         }
 
-        String wsHost = Emulator.getConfig().getValue("ws.host", "0.0.0.0");
-        int wsPort = Emulator.getConfig().getInt("ws.port", 2096);
+        String wsHost = configuration().getValue("ws.host", "0.0.0.0");
+        int wsPort = configuration().getInt("ws.port", 2096);
 
-        WebSocketChannelInitializer wsInitializer =
-                new WebSocketChannelInitializer(configuredUnwritableTimeoutSeconds());
+        WebSocketChannelInitializer wsInitializer = new WebSocketChannelInitializer(
+                configuredUnwritableTimeoutSeconds(), configuration().getInt("http.blocking.pool.size", 8));
 
         this.webSocketBootstrap = new ServerBootstrap();
         this.webSocketBootstrap.group(this.getBossGroup(), this.getWorkerGroup());
@@ -122,7 +123,7 @@ public class GameServer extends Server {
             wsFuture.channel().closeFuture().addListener(ignored -> this.webSocketListening = false);
             LOGGER.info("WebSocket server started on {}:{} (SSL: {})", wsHost, wsPort, wsInitializer.isSslEnabled());
 
-            if (com.eu.habbo.Emulator.getConfig().getBoolean("crypto.ws.signing.enabled", false)) {
+            if (configuration().getBoolean("crypto.ws.signing.enabled", false)) {
                 try {
                     com.eu.habbo.networking.gameserver.crypto.CryptoSigningKeyManager.get();
                     LOGGER.info(
@@ -133,6 +134,10 @@ public class GameServer extends Server {
                 }
             }
         }
+    }
+
+    private static ConfigurationManager configuration() {
+        return Emulator.getConfig();
     }
 
     public PacketManager getPacketManager() {

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
@@ -17,6 +17,7 @@ import com.eu.habbo.networking.gameserver.decoders.PacketDispatchMarker;
 import com.eu.habbo.networking.gameserver.encoders.GameServerMessageEncoder;
 import com.eu.habbo.networking.gameserver.encoders.GameServerMessageLogger;
 import com.eu.habbo.networking.gameserver.handlers.IdleTimeoutHandler;
+import com.eu.habbo.networking.gameserver.handlers.SustainedUnwritableHandler;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -56,6 +57,10 @@ public class GameServer extends Server {
             @Override
             public void initChannel(SocketChannel ch) throws Exception {
                 ch.pipeline().addLast("logger", new LoggingHandler());
+                ch.pipeline().addLast(
+                        "outboundBackpressure",
+                        new SustainedUnwritableHandler(
+                                configuredUnwritableTimeoutSeconds(), TimeUnit.SECONDS));
 
                 // Decoders.
                 ch.pipeline().addLast(new GamePolicyDecoder());
@@ -96,7 +101,8 @@ public class GameServer extends Server {
         String wsHost = Emulator.getConfig().getValue("ws.host", "0.0.0.0");
         int wsPort = Emulator.getConfig().getInt("ws.port", 2096);
 
-        WebSocketChannelInitializer wsInitializer = new WebSocketChannelInitializer();
+        WebSocketChannelInitializer wsInitializer =
+                new WebSocketChannelInitializer(configuredUnwritableTimeoutSeconds());
 
         this.webSocketBootstrap = new ServerBootstrap();
         this.webSocketBootstrap.group(this.getBossGroup(), this.getWorkerGroup());

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
@@ -158,6 +158,7 @@ public class GameServer extends Server {
             this.gameClientManager.forceDisposeClient(client);
         }
 
+        BlockingHttpExecutionGroup.shutdown();
         GamePacketExecutionGroup.shutdown();
 
         super.stop();

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
@@ -58,10 +58,10 @@ public class GameServer extends Server {
             @Override
             public void initChannel(SocketChannel ch) throws Exception {
                 ch.pipeline().addLast("logger", new LoggingHandler());
-                ch.pipeline().addLast(
-                        "outboundBackpressure",
-                        new SustainedUnwritableHandler(
-                                configuredUnwritableTimeoutSeconds(), TimeUnit.SECONDS));
+                ch.pipeline()
+                        .addLast(
+                                "outboundBackpressure",
+                                new SustainedUnwritableHandler(configuredUnwritableTimeoutSeconds(), TimeUnit.SECONDS));
 
                 // Decoders.
                 ch.pipeline().addLast(new GamePolicyDecoder());

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
@@ -13,6 +13,7 @@ import com.eu.habbo.networking.gameserver.decoders.*;
 import com.eu.habbo.networking.gameserver.encoders.GameServerMessageEncoder;
 import com.eu.habbo.networking.gameserver.encoders.GameServerMessageLogger;
 import com.eu.habbo.networking.gameserver.handlers.IdleTimeoutHandler;
+import com.eu.habbo.networking.gameserver.handlers.SustainedUnwritableHandler;
 import com.eu.habbo.networking.gameserver.handlers.WebSocketHttpHandler;
 import com.eu.habbo.networking.gameserver.stats.EmuStatsHttpHandler;
 import com.eu.habbo.networking.gameserver.ssl.SSLCertificateLoader;
@@ -30,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLEngine;
+import java.util.concurrent.TimeUnit;
 
 public class WebSocketChannelInitializer extends ChannelInitializer<SocketChannel> {
     private static final Logger LOGGER = LoggerFactory.getLogger(WebSocketChannelInitializer.class);
@@ -38,8 +40,17 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
     private final SslContext sslContext;
     private final boolean sslEnabled;
     private final WebSocketServerProtocolConfig wsConfig;
+    private final int unwritableTimeoutSeconds;
 
     public WebSocketChannelInitializer() {
+        this(10);
+    }
+
+    WebSocketChannelInitializer(int unwritableTimeoutSeconds) {
+        if (unwritableTimeoutSeconds <= 0) {
+            throw new IllegalArgumentException("unwritableTimeoutSeconds must be positive");
+        }
+        this.unwritableTimeoutSeconds = unwritableTimeoutSeconds;
         this.sslContext = SSLCertificateLoader.getContext();
         this.sslEnabled = this.sslContext != null;
         this.wsConfig = WebSocketServerProtocolConfig.newBuilder()
@@ -52,6 +63,10 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
     @Override
     protected void initChannel(SocketChannel ch) {
         ch.pipeline().addLast("logger", new LoggingHandler());
+        ch.pipeline().addLast(
+                "outboundBackpressure",
+                new SustainedUnwritableHandler(
+                        this.unwritableTimeoutSeconds, TimeUnit.SECONDS));
 
         if (this.sslEnabled) {
             SSLEngine engine = this.sslContext.newEngine(ch.alloc());

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
@@ -48,16 +48,22 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
     private final boolean sslEnabled;
     private final WebSocketServerProtocolConfig wsConfig;
     private final int unwritableTimeoutSeconds;
+    private final int blockingHttpThreads;
 
     public WebSocketChannelInitializer() {
-        this(10);
+        this(10, 8);
     }
 
     WebSocketChannelInitializer(int unwritableTimeoutSeconds) {
+        this(unwritableTimeoutSeconds, 8);
+    }
+
+    WebSocketChannelInitializer(int unwritableTimeoutSeconds, int blockingHttpThreads) {
         if (unwritableTimeoutSeconds <= 0) {
             throw new IllegalArgumentException("unwritableTimeoutSeconds must be positive");
         }
         this.unwritableTimeoutSeconds = unwritableTimeoutSeconds;
+        this.blockingHttpThreads = blockingHttpThreads;
         this.sslContext = SSLCertificateLoader.getContext();
         this.sslEnabled = this.sslContext != null;
         this.wsConfig = WebSocketServerProtocolConfig.newBuilder()
@@ -83,7 +89,7 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
         ch.pipeline().addLast("httpCodec", new HttpServerCodec());
         ch.pipeline().addLast("httpAggregator", new HttpObjectAggregator(MAX_FRAME_SIZE));
         ch.pipeline().addLast("wsHttpHandler", new WebSocketHttpHandler());
-        EventExecutorGroup blockingHttp = BlockingHttpExecutionGroup.get();
+        EventExecutorGroup blockingHttp = BlockingHttpExecutionGroup.get(this.blockingHttpThreads);
         ch.pipeline().addLast(blockingHttp, "nitroSecureAssetHandler", new NitroSecureAssetHandler());
         ch.pipeline().addLast("nitroSecureApiHandler", new NitroSecureApiHandler());
         ch.pipeline().addLast("authHttpHandler", new AuthHttpHandler());

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
@@ -21,6 +21,7 @@ import com.eu.habbo.networking.gameserver.encoders.GameServerMessageEncoder;
 import com.eu.habbo.networking.gameserver.encoders.GameServerMessageLogger;
 import com.eu.habbo.networking.gameserver.handlers.IdleTimeoutHandler;
 import com.eu.habbo.networking.gameserver.handlers.SustainedUnwritableHandler;
+import com.eu.habbo.networking.gameserver.handlers.WebSocketHttpCleanupHandler;
 import com.eu.habbo.networking.gameserver.handlers.WebSocketHttpHandler;
 import com.eu.habbo.networking.gameserver.ssl.SSLCertificateLoader;
 import com.eu.habbo.networking.gameserver.stats.EmuStatsHttpHandler;
@@ -97,6 +98,7 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
         ch.pipeline().addLast(blockingHttp, "badgeLeaderboardHttpHandler", new BadgeLeaderboardHttpHandler());
         ch.pipeline().addLast(blockingHttp, "emuStatsHttpHandler", new EmuStatsHttpHandler());
         ch.pipeline().addLast("wsProtocolHandler", new WebSocketServerProtocolHandler(this.wsConfig));
+        ch.pipeline().addLast("wsHttpCleanup", new WebSocketHttpCleanupHandler());
         ch.pipeline().addLast("wsFrameAggregator", new WebSocketFrameAggregator(MAX_FRAME_SIZE));
         ch.pipeline().addLast("wsCodec", new WebSocketCodec());
 

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
@@ -27,6 +27,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.util.concurrent.EventExecutorGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,12 +77,25 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
         ch.pipeline().addLast("httpCodec", new HttpServerCodec());
         ch.pipeline().addLast("httpAggregator", new HttpObjectAggregator(MAX_FRAME_SIZE));
         ch.pipeline().addLast("wsHttpHandler", new WebSocketHttpHandler());
-        ch.pipeline().addLast("nitroSecureAssetHandler", new NitroSecureAssetHandler());
+        EventExecutorGroup blockingHttp = BlockingHttpExecutionGroup.get();
+        ch.pipeline().addLast(
+                blockingHttp,
+                "nitroSecureAssetHandler",
+                new NitroSecureAssetHandler());
         ch.pipeline().addLast("nitroSecureApiHandler", new NitroSecureApiHandler());
         ch.pipeline().addLast("authHttpHandler", new AuthHttpHandler());
-        ch.pipeline().addLast("badgeHttpHandler", new BadgeHttpHandler());
-        ch.pipeline().addLast("badgeLeaderboardHttpHandler", new BadgeLeaderboardHttpHandler());
-        ch.pipeline().addLast("emuStatsHttpHandler", new EmuStatsHttpHandler());
+        ch.pipeline().addLast(
+                blockingHttp,
+                "badgeHttpHandler",
+                new BadgeHttpHandler());
+        ch.pipeline().addLast(
+                blockingHttp,
+                "badgeLeaderboardHttpHandler",
+                new BadgeLeaderboardHttpHandler());
+        ch.pipeline().addLast(
+                blockingHttp,
+                "emuStatsHttpHandler",
+                new EmuStatsHttpHandler());
         ch.pipeline().addLast("wsProtocolHandler", new WebSocketServerProtocolHandler(this.wsConfig));
         ch.pipeline().addLast("wsFrameAggregator", new WebSocketFrameAggregator(MAX_FRAME_SIZE));
         ch.pipeline().addLast("wsCodec", new WebSocketCodec());

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
@@ -5,18 +5,25 @@ import com.eu.habbo.messages.PacketManager;
 import com.eu.habbo.networking.gameserver.auth.AuthHttpHandler;
 import com.eu.habbo.networking.gameserver.auth.NitroSecureApiHandler;
 import com.eu.habbo.networking.gameserver.auth.NitroSecureAssetHandler;
-import com.eu.habbo.networking.gameserver.badges.BadgeLeaderboardHttpHandler;
 import com.eu.habbo.networking.gameserver.badges.BadgeHttpHandler;
+import com.eu.habbo.networking.gameserver.badges.BadgeLeaderboardHttpHandler;
 import com.eu.habbo.networking.gameserver.codec.WebSocketCodec;
 import com.eu.habbo.networking.gameserver.crypto.WsHandshakeHandler;
-import com.eu.habbo.networking.gameserver.decoders.*;
+import com.eu.habbo.networking.gameserver.decoders.GameByteDecoder;
+import com.eu.habbo.networking.gameserver.decoders.GameByteFrameDecoder;
+import com.eu.habbo.networking.gameserver.decoders.GameClientMessageLogger;
+import com.eu.habbo.networking.gameserver.decoders.GameMessageHandler;
+import com.eu.habbo.networking.gameserver.decoders.GameMessageRateLimit;
+import com.eu.habbo.networking.gameserver.decoders.GamePolicyDecoder;
+import com.eu.habbo.networking.gameserver.decoders.PacketDispatchLatencyHandler;
+import com.eu.habbo.networking.gameserver.decoders.PacketDispatchMarker;
 import com.eu.habbo.networking.gameserver.encoders.GameServerMessageEncoder;
 import com.eu.habbo.networking.gameserver.encoders.GameServerMessageLogger;
 import com.eu.habbo.networking.gameserver.handlers.IdleTimeoutHandler;
 import com.eu.habbo.networking.gameserver.handlers.SustainedUnwritableHandler;
 import com.eu.habbo.networking.gameserver.handlers.WebSocketHttpHandler;
-import com.eu.habbo.networking.gameserver.stats.EmuStatsHttpHandler;
 import com.eu.habbo.networking.gameserver.ssl.SSLCertificateLoader;
+import com.eu.habbo.networking.gameserver.stats.EmuStatsHttpHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpObjectAggregator;
@@ -28,11 +35,10 @@ import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.concurrent.EventExecutorGroup;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.net.ssl.SSLEngine;
-import java.util.concurrent.TimeUnit;
 
 public class WebSocketChannelInitializer extends ChannelInitializer<SocketChannel> {
     private static final Logger LOGGER = LoggerFactory.getLogger(WebSocketChannelInitializer.class);
@@ -64,10 +70,10 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
     @Override
     protected void initChannel(SocketChannel ch) {
         ch.pipeline().addLast("logger", new LoggingHandler());
-        ch.pipeline().addLast(
-                "outboundBackpressure",
-                new SustainedUnwritableHandler(
-                        this.unwritableTimeoutSeconds, TimeUnit.SECONDS));
+        ch.pipeline()
+                .addLast(
+                        "outboundBackpressure",
+                        new SustainedUnwritableHandler(this.unwritableTimeoutSeconds, TimeUnit.SECONDS));
 
         if (this.sslEnabled) {
             SSLEngine engine = this.sslContext.newEngine(ch.alloc());
@@ -78,24 +84,12 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
         ch.pipeline().addLast("httpAggregator", new HttpObjectAggregator(MAX_FRAME_SIZE));
         ch.pipeline().addLast("wsHttpHandler", new WebSocketHttpHandler());
         EventExecutorGroup blockingHttp = BlockingHttpExecutionGroup.get();
-        ch.pipeline().addLast(
-                blockingHttp,
-                "nitroSecureAssetHandler",
-                new NitroSecureAssetHandler());
+        ch.pipeline().addLast(blockingHttp, "nitroSecureAssetHandler", new NitroSecureAssetHandler());
         ch.pipeline().addLast("nitroSecureApiHandler", new NitroSecureApiHandler());
         ch.pipeline().addLast("authHttpHandler", new AuthHttpHandler());
-        ch.pipeline().addLast(
-                blockingHttp,
-                "badgeHttpHandler",
-                new BadgeHttpHandler());
-        ch.pipeline().addLast(
-                blockingHttp,
-                "badgeLeaderboardHttpHandler",
-                new BadgeLeaderboardHttpHandler());
-        ch.pipeline().addLast(
-                blockingHttp,
-                "emuStatsHttpHandler",
-                new EmuStatsHttpHandler());
+        ch.pipeline().addLast(blockingHttp, "badgeHttpHandler", new BadgeHttpHandler());
+        ch.pipeline().addLast(blockingHttp, "badgeLeaderboardHttpHandler", new BadgeLeaderboardHttpHandler());
+        ch.pipeline().addLast(blockingHttp, "emuStatsHttpHandler", new EmuStatsHttpHandler());
         ch.pipeline().addLast("wsProtocolHandler", new WebSocketServerProtocolHandler(this.wsConfig));
         ch.pipeline().addLast("wsFrameAggregator", new WebSocketFrameAggregator(MAX_FRAME_SIZE));
         ch.pipeline().addLast("wsCodec", new WebSocketCodec());
@@ -114,13 +108,9 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
 
         ch.pipeline().addLast("idleEventHandler", new IdleTimeoutHandler(30, 60));
         ch.pipeline().addLast(new GameMessageRateLimit());
-        ch.pipeline().addLast(
-                "packetDispatchMarker",
-                new PacketDispatchMarker());
-        ch.pipeline().addLast(
-                GamePacketExecutionGroup.get(),
-                "packetDispatchLatency",
-                new PacketDispatchLatencyHandler());
+        ch.pipeline().addLast("packetDispatchMarker", new PacketDispatchMarker());
+        ch.pipeline()
+                .addLast(GamePacketExecutionGroup.get(), "packetDispatchLatency", new PacketDispatchLatencyHandler());
         ch.pipeline().addLast(GamePacketExecutionGroup.get(), "gameMessageHandler", new GameMessageHandler());
         ch.pipeline().addLast("messageEncoder", new GameServerMessageEncoder());
 
@@ -132,5 +122,4 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
     public boolean isSslEnabled() {
         return this.sslEnabled;
     }
-
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodec.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodec.java
@@ -16,6 +16,11 @@ public class WebSocketCodec extends MessageToMessageCodec<WebSocketFrame, ByteBu
 
     @Override
     protected void decode(ChannelHandlerContext ctx, WebSocketFrame in, List<Object> out) {
+        if (!(in instanceof BinaryWebSocketFrame) || !in.isFinalFragment()) {
+            ctx.close();
+            return;
+        }
+
         out.add(in.content().retain());
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodec.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodec.java
@@ -5,7 +5,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageCodec;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
-
 import java.util.List;
 
 public class WebSocketCodec extends MessageToMessageCodec<WebSocketFrame, ByteBuf> {

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandler.java
@@ -1,0 +1,25 @@
+package com.eu.habbo.networking.gameserver.handlers;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+public final class SustainedUnwritableHandler extends ChannelInboundHandlerAdapter {
+
+    private final long timeoutNanos;
+
+    public SustainedUnwritableHandler(long timeout, TimeUnit unit) {
+        Objects.requireNonNull(unit, "unit");
+        if (timeout <= 0) {
+            throw new IllegalArgumentException("timeout must be positive");
+        }
+        this.timeoutNanos = unit.toNanos(timeout);
+    }
+
+    @Override
+    public void channelWritabilityChanged(ChannelHandlerContext context) {
+        context.fireChannelWritabilityChanged();
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandler.java
@@ -2,13 +2,20 @@ package com.eu.habbo.networking.gameserver.handlers;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 public final class SustainedUnwritableHandler extends ChannelInboundHandlerAdapter {
 
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(SustainedUnwritableHandler.class);
+
     private final long timeoutNanos;
+    private ScheduledFuture<?> closeFuture;
 
     public SustainedUnwritableHandler(long timeout, TimeUnit unit) {
         Objects.requireNonNull(unit, "unit");
@@ -20,6 +27,46 @@ public final class SustainedUnwritableHandler extends ChannelInboundHandlerAdapt
 
     @Override
     public void channelWritabilityChanged(ChannelHandlerContext context) {
+        if (context.channel().isWritable()) {
+            cancelClose();
+        } else if (this.closeFuture == null) {
+            this.closeFuture = context.executor().schedule(
+                    () -> closeIfStillUnwritable(context),
+                    this.timeoutNanos,
+                    TimeUnit.NANOSECONDS);
+        }
         context.fireChannelWritabilityChanged();
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext context) throws Exception {
+        cancelClose();
+        super.channelInactive(context);
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext context) {
+        cancelClose();
+    }
+
+    private void closeIfStillUnwritable(ChannelHandlerContext context) {
+        this.closeFuture = null;
+        if (!context.channel().isOpen() || context.channel().isWritable()) {
+            return;
+        }
+
+        LOGGER.warn(
+                "Disconnecting channel {} after {} ms of sustained unwritability; {} bytes must drain before writes resume",
+                context.channel().remoteAddress(),
+                TimeUnit.NANOSECONDS.toMillis(this.timeoutNanos),
+                context.channel().bytesBeforeWritable());
+        context.close();
+    }
+
+    private void cancelClose() {
+        if (this.closeFuture != null) {
+            this.closeFuture.cancel(false);
+            this.closeFuture = null;
+        }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandler.java
@@ -2,17 +2,15 @@ package com.eu.habbo.networking.gameserver.handlers;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Objects;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class SustainedUnwritableHandler extends ChannelInboundHandlerAdapter {
 
-    private static final Logger LOGGER =
-            LoggerFactory.getLogger(SustainedUnwritableHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SustainedUnwritableHandler.class);
 
     private final long timeoutNanos;
     private ScheduledFuture<?> closeFuture;
@@ -30,10 +28,8 @@ public final class SustainedUnwritableHandler extends ChannelInboundHandlerAdapt
         if (context.channel().isWritable()) {
             cancelClose();
         } else if (this.closeFuture == null) {
-            this.closeFuture = context.executor().schedule(
-                    () -> closeIfStillUnwritable(context),
-                    this.timeoutNanos,
-                    TimeUnit.NANOSECONDS);
+            this.closeFuture = context.executor()
+                    .schedule(() -> closeIfStillUnwritable(context), this.timeoutNanos, TimeUnit.NANOSECONDS);
         }
         context.fireChannelWritabilityChanged();
     }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/WebSocketHttpCleanupHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/WebSocketHttpCleanupHandler.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.networking.gameserver.handlers;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+
+/**
+ * Removes the HTTP-only request handlers once a channel has upgraded to
+ * WebSocket. They sit ahead of the WebSocket decoders and several are bound to
+ * the blocking HTTP executor, so leaving them in place hops every inbound game
+ * frame onto that executor for a no-op pass-through and lets a slow HTTP query
+ * on a shared worker delay game traffic.
+ */
+public class WebSocketHttpCleanupHandler extends ChannelInboundHandlerAdapter {
+    private static final String[] HTTP_ONLY_HANDLERS = {
+        "nitroSecureAssetHandler",
+        "nitroSecureApiHandler",
+        "authHttpHandler",
+        "badgeHttpHandler",
+        "badgeLeaderboardHttpHandler",
+        "emuStatsHttpHandler",
+    };
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
+            ChannelPipeline pipeline = ctx.pipeline();
+            for (String name : HTTP_ONLY_HANDLERS) {
+                if (pipeline.get(name) != null) {
+                    pipeline.remove(name);
+                }
+            }
+            ctx.fireUserEventTriggered(evt);
+            pipeline.remove(this);
+            return;
+        }
+        super.userEventTriggered(ctx, evt);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
@@ -6,7 +6,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.slf4j.Logger;
@@ -101,10 +101,7 @@ public class RCONServerHandler extends ChannelInboundHandlerAdapter {
     }
 
     static void writeAndClose(ChannelHandlerContext ctx, String response) {
-        ChannelFuture f = ctx.channel().write(responseBuffer(response), ctx.channel().voidPromise());
-        ctx.channel().flush();
-        ctx.flush();
-        f.channel().close();
+        ctx.writeAndFlush(responseBuffer(response)).addListener(ChannelFutureListener.CLOSE);
     }
 
     static ByteBuf responseBuffer(String response) {

--- a/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
@@ -100,10 +100,14 @@ public class RCONServerHandler extends ChannelInboundHandlerAdapter {
         return socketAddress == null ? "" : socketAddress.toString().replace("/", "");
     }
 
-    private static void writeAndClose(ChannelHandlerContext ctx, String response) {
-        ChannelFuture f = ctx.channel().write(Unpooled.copiedBuffer(response.getBytes(java.nio.charset.StandardCharsets.UTF_8)), ctx.channel().voidPromise());
+    static void writeAndClose(ChannelHandlerContext ctx, String response) {
+        ChannelFuture f = ctx.channel().write(responseBuffer(response), ctx.channel().voidPromise());
         ctx.channel().flush();
         ctx.flush();
         f.channel().close();
+    }
+
+    static ByteBuf responseBuffer(String response) {
+        return Unpooled.copiedBuffer(response.getBytes(java.nio.charset.StandardCharsets.UTF_8));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
@@ -1,6 +1,5 @@
 package com.eu.habbo.networking.rconserver;
 
-
 import com.eu.habbo.Emulator;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -9,11 +8,10 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RCONServerHandler extends ChannelInboundHandlerAdapter {
 
@@ -50,9 +48,10 @@ public class RCONServerHandler extends ChannelInboundHandlerAdapter {
             int readableBytes = data.readableBytes();
             int maxPayloadBytes = maxPayloadBytes();
             if (readableBytes > maxPayloadBytes) {
-                writeAndClose(ctx, RconResponse.error(
-                        com.eu.habbo.messages.rcon.RCONMessage.STATUS_ERROR,
-                        "payload too large").toJson(GSON));
+                writeAndClose(
+                        ctx,
+                        RconResponse.error(com.eu.habbo.messages.rcon.RCONMessage.STATUS_ERROR, "payload too large")
+                                .toJson(GSON));
                 LOGGER.warn("Rejected oversized RCON payload: {} bytes (max {})", readableBytes, maxPayloadBytes);
                 return;
             }
@@ -61,14 +60,14 @@ public class RCONServerHandler extends ChannelInboundHandlerAdapter {
             data.getBytes(0, d);
             String message = new String(d, java.nio.charset.StandardCharsets.UTF_8);
             Gson gson = GSON;
-            String response = RconResponse.error(
-                    com.eu.habbo.messages.rcon.RCONMessage.STATUS_ERROR,
-                    "invalid request").toJson(GSON);
+            String response = RconResponse.error(com.eu.habbo.messages.rcon.RCONMessage.STATUS_ERROR, "invalid request")
+                    .toJson(GSON);
             String key = "";
             try {
                 JsonObject object = gson.fromJson(message, JsonObject.class);
                 key = object.get("key").getAsString();
-                response = Emulator.getRconServer().handle(ctx, key, object.get("data").toString());
+                response = Emulator.getRconServer()
+                        .handle(ctx, key, object.get("data").toString());
             } catch (ArrayIndexOutOfBoundsException e) {
                 LOGGER.error("Unknown RCON Message: {}", key);
             } catch (Exception e) {

--- a/Emulator/src/test/java/com/eu/habbo/core/config/ConfigRegistryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/core/config/ConfigRegistryTest.java
@@ -52,6 +52,16 @@ class ConfigRegistryTest {
                 ConfigRegistry.standard().renderMarkdown());
     }
 
+    @Test
+    void networkWorkerAndBackpressureDefaultsAreTyped() {
+        String reference = ConfigRegistry.standard().renderMarkdown();
+
+        assertTrue(reference.contains("| `http.blocking.pool.size` | integer | `8` |"));
+        assertTrue(reference.contains("| `io.netty.write_buffer.low_water_mark` | integer | `32768` |"));
+        assertTrue(reference.contains("| `io.netty.write_buffer.high_water_mark` | integer | `65536` |"));
+        assertTrue(reference.contains("| `io.netty.unwritable.timeout.seconds` | integer | `10` |"));
+    }
+
     private static Set<String> keys(Path path) throws Exception {
         Set<String> keys = new HashSet<>();
         for (String line : Files.readAllLines(path)) {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientLookupTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientLookupTest.java
@@ -1,0 +1,53 @@
+package com.eu.habbo.habbohotel.gameclients;
+
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GameClientLookupTest {
+
+    @Test
+    void lookupFallsBackToRegisteredClientsAfterIndexRelease() {
+        GameClientManager manager = new GameClientManager();
+        GameClient client = clientFor(7);
+        Habbo habbo = client.getHabbo();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        manager.getSessions().put(channel.id(), client);
+        manager.claimAuthenticatedSession(7, client);
+        manager.releaseAuthenticatedSession(7, client);
+
+        assertSame(habbo, manager.getHabbo(7));
+
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void lookupFallsBackWhileTheIndexedClientHasNoHabbo() {
+        GameClientManager manager = new GameClientManager();
+        GameClient indexedClient = mock(GameClient.class);
+        GameClient teardownClient = clientFor(7);
+        Habbo habbo = teardownClient.getHabbo();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        manager.getSessions().put(channel.id(), teardownClient);
+        manager.claimAuthenticatedSession(7, indexedClient);
+
+        assertSame(habbo, manager.getHabbo(7));
+
+        channel.finishAndReleaseAll();
+    }
+
+    private static GameClient clientFor(int userId) {
+        HabboInfo info = mock(HabboInfo.class);
+        when(info.getId()).thenReturn(userId);
+        Habbo habbo = mock(Habbo.class);
+        when(habbo.getHabboInfo()).thenReturn(info);
+        GameClient client = mock(GameClient.class);
+        when(client.getHabbo()).thenReturn(habbo);
+        return client;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientLookupTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientLookupTest.java
@@ -12,6 +12,16 @@ import static org.mockito.Mockito.when;
 class GameClientLookupTest {
 
     @Test
+    void lookupUsesTheAuthenticatedClientIndex() {
+        GameClientManager manager = new GameClientManager();
+        GameClient client = clientFor(7);
+        Habbo habbo = client.getHabbo();
+        manager.claimAuthenticatedSession(7, client);
+
+        assertSame(habbo, manager.getHabbo(7));
+    }
+
+    @Test
     void lookupFallsBackToRegisteredClientsAfterIndexRelease() {
         GameClientManager manager = new GameClientManager();
         GameClient client = clientFor(7);

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientLookupTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/GameClientLookupTest.java
@@ -1,13 +1,13 @@
 package com.eu.habbo.habbohotel.gameclients;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboInfo;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class GameClientLookupTest {
 

--- a/Emulator/src/test/java/com/eu/habbo/networking/ServerOutboundBackpressureTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/ServerOutboundBackpressureTest.java
@@ -1,0 +1,37 @@
+package com.eu.habbo.networking;
+
+import io.netty.channel.ChannelOption;
+import io.netty.channel.WriteBufferWaterMark;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ServerOutboundBackpressureTest {
+
+    @Test
+    void configuresExplicitWriteBufferWaterMarks() throws Exception {
+        TestServer server = new TestServer();
+        try {
+            server.initializePipeline();
+
+            WriteBufferWaterMark waterMark = (WriteBufferWaterMark) server
+                    .getServerBootstrap()
+                    .config()
+                    .childOptions()
+                    .get(ChannelOption.WRITE_BUFFER_WATER_MARK);
+
+            assertNotNull(waterMark);
+            assertEquals(32 * 1024, waterMark.low());
+            assertEquals(64 * 1024, waterMark.high());
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static final class TestServer extends Server {
+        private TestServer() throws Exception {
+            super("Backpressure Test Server", "127.0.0.1", 0, 1, 1);
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/ServerOutboundBackpressureTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/ServerOutboundBackpressureTest.java
@@ -1,11 +1,11 @@
 package com.eu.habbo.networking;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import io.netty.channel.ChannelOption;
 import io.netty.channel.WriteBufferWaterMark;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class ServerOutboundBackpressureTest {
 
@@ -15,11 +15,8 @@ class ServerOutboundBackpressureTest {
         try {
             server.initializePipeline();
 
-            WriteBufferWaterMark waterMark = (WriteBufferWaterMark) server
-                    .getServerBootstrap()
-                    .config()
-                    .childOptions()
-                    .get(ChannelOption.WRITE_BUFFER_WATER_MARK);
+            WriteBufferWaterMark waterMark = (WriteBufferWaterMark)
+                    server.getServerBootstrap().config().childOptions().get(ChannelOption.WRITE_BUFFER_WATER_MARK);
 
             assertNotNull(waterMark);
             assertEquals(32 * 1024, waterMark.low());

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
@@ -1,0 +1,72 @@
+package com.eu.habbo.networking.gameserver;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.concurrent.EventExecutor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class WebSocketHttpOffloadTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void blockingHttpHandlersLeaveTheSocketEventLoopAndKeepChannelOrdering()
+            throws Exception {
+        Field configField = Emulator.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        Object previousConfig = configField.get(null);
+        Path configFile = this.temporaryDirectory.resolve("config.ini");
+        Files.writeString(
+                configFile,
+                "nitro.secure.master_key=test-key\n"
+                        + "nitro.secure.assets.enabled=true\n"
+                        + "crypto.ws.enabled=false\n");
+        configField.set(null, new ConfigurationManager(configFile.toString()));
+
+        EventLoopGroup eventLoops =
+                new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        NioSocketChannel channel = new NioSocketChannel();
+        try {
+            eventLoops.register(channel).syncUninterruptibly();
+            new WebSocketChannelInitializer().initChannel(channel);
+
+            EventExecutor socketExecutor = channel.eventLoop();
+            EventExecutor blockingExecutor =
+                    channel.pipeline().context("nitroSecureAssetHandler").executor();
+
+            assertNotSame(socketExecutor, blockingExecutor);
+            assertSame(
+                    blockingExecutor,
+                    channel.pipeline().context("badgeHttpHandler").executor());
+            assertSame(
+                    blockingExecutor,
+                    channel.pipeline().context("badgeLeaderboardHttpHandler").executor());
+            assertSame(
+                    blockingExecutor,
+                    channel.pipeline().context("emuStatsHttpHandler").executor());
+            assertSame(
+                    socketExecutor,
+                    channel.pipeline().context("wsHttpHandler").executor());
+            assertSame(
+                    socketExecutor,
+                    channel.pipeline().context("authHttpHandler").executor());
+        } finally {
+            channel.close().syncUninterruptibly();
+            eventLoops.shutdownGracefully().syncUninterruptibly();
+            configField.set(null, previousConfig);
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
@@ -93,17 +93,18 @@ class WebSocketHttpOffloadTest {
 
             channel.eventLoop()
                     .submit(() -> channel.pipeline()
-                            .fireUserEventTriggered(
-                                    new WebSocketServerProtocolHandler.HandshakeComplete(
-                                            "/", EmptyHttpHeaders.INSTANCE, null)))
+                            .fireUserEventTriggered(new WebSocketServerProtocolHandler.HandshakeComplete(
+                                    "/", EmptyHttpHeaders.INSTANCE, null)))
                     .syncUninterruptibly();
 
-            assertNull(channel.pipeline().context("nitroSecureAssetHandler"));
-            assertNull(channel.pipeline().context("nitroSecureApiHandler"));
-            assertNull(channel.pipeline().context("authHttpHandler"));
-            assertNull(channel.pipeline().context("badgeHttpHandler"));
-            assertNull(channel.pipeline().context("badgeLeaderboardHttpHandler"));
-            assertNull(channel.pipeline().context("emuStatsHttpHandler"));
+            // Handlers bound to the blocking HTTP executor are unlinked on that
+            // executor, so wait for the removals to settle.
+            awaitRemoved(channel, "nitroSecureAssetHandler");
+            awaitRemoved(channel, "nitroSecureApiHandler");
+            awaitRemoved(channel, "authHttpHandler");
+            awaitRemoved(channel, "badgeHttpHandler");
+            awaitRemoved(channel, "badgeLeaderboardHttpHandler");
+            awaitRemoved(channel, "emuStatsHttpHandler");
             assertNotNull(channel.pipeline().context("gameMessageHandler"));
         } finally {
             channel.close().syncUninterruptibly();
@@ -111,6 +112,17 @@ class WebSocketHttpOffloadTest {
             BlockingHttpExecutionGroup.shutdown();
             configField.set(null, previousConfig);
         }
+    }
+
+    private static void awaitRemoved(NioSocketChannel channel, String handlerName) throws InterruptedException {
+        long deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(2);
+        while (channel.pipeline().context(handlerName) != null) {
+            if (System.nanoTime() > deadline) {
+                break;
+            }
+            Thread.sleep(5);
+        }
+        assertNull(channel.pipeline().context(handlerName));
     }
 
     @Test

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
@@ -1,7 +1,9 @@
 package com.eu.habbo.networking.gameserver;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.eu.habbo.Emulator;
@@ -10,6 +12,8 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import io.netty.util.concurrent.EventExecutor;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
@@ -60,6 +64,47 @@ class WebSocketHttpOffloadTest {
             assertSame(
                     socketExecutor,
                     channel.pipeline().context("authHttpHandler").executor());
+        } finally {
+            channel.close().syncUninterruptibly();
+            eventLoops.shutdownGracefully().syncUninterruptibly();
+            BlockingHttpExecutionGroup.shutdown();
+            configField.set(null, previousConfig);
+        }
+    }
+
+    @Test
+    void httpHandlersAreRemovedAfterTheWebSocketUpgrade() throws Exception {
+        Field configField = Emulator.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        Object previousConfig = configField.get(null);
+        Path configFile = this.temporaryDirectory.resolve("config.ini");
+        Files.writeString(
+                configFile,
+                "nitro.secure.master_key=test-key\n"
+                        + "nitro.secure.assets.enabled=true\n"
+                        + "crypto.ws.enabled=false\n");
+        configField.set(null, new ConfigurationManager(configFile.toString()));
+
+        EventLoopGroup eventLoops = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        NioSocketChannel channel = new NioSocketChannel();
+        try {
+            eventLoops.register(channel).syncUninterruptibly();
+            new WebSocketChannelInitializer().initChannel(channel);
+
+            channel.eventLoop()
+                    .submit(() -> channel.pipeline()
+                            .fireUserEventTriggered(
+                                    new WebSocketServerProtocolHandler.HandshakeComplete(
+                                            "/", EmptyHttpHeaders.INSTANCE, null)))
+                    .syncUninterruptibly();
+
+            assertNull(channel.pipeline().context("nitroSecureAssetHandler"));
+            assertNull(channel.pipeline().context("nitroSecureApiHandler"));
+            assertNull(channel.pipeline().context("authHttpHandler"));
+            assertNull(channel.pipeline().context("badgeHttpHandler"));
+            assertNull(channel.pipeline().context("badgeLeaderboardHttpHandler"));
+            assertNull(channel.pipeline().context("emuStatsHttpHandler"));
+            assertNotNull(channel.pipeline().context("gameMessageHandler"));
         } finally {
             channel.close().syncUninterruptibly();
             eventLoops.shutdownGracefully().syncUninterruptibly();

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
@@ -1,5 +1,6 @@
 package com.eu.habbo.networking.gameserver;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -62,7 +63,22 @@ class WebSocketHttpOffloadTest {
         } finally {
             channel.close().syncUninterruptibly();
             eventLoops.shutdownGracefully().syncUninterruptibly();
+            BlockingHttpExecutionGroup.shutdown();
             configField.set(null, previousConfig);
+        }
+    }
+
+    @Test
+    void blockingHttpWorkerCountUsesTheConfiguredValue() {
+        BlockingHttpExecutionGroup.shutdown();
+        try {
+            int executors = 0;
+            for (EventExecutor ignored : BlockingHttpExecutionGroup.get(3)) {
+                executors++;
+            }
+            assertEquals(3, executors);
+        } finally {
+            BlockingHttpExecutionGroup.shutdown();
         }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
@@ -1,5 +1,8 @@
 package com.eu.habbo.networking.gameserver;
 
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 import com.eu.habbo.Emulator;
 import com.eu.habbo.core.ConfigurationManager;
 import io.netty.channel.EventLoopGroup;
@@ -7,15 +10,11 @@ import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.EventExecutor;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class WebSocketHttpOffloadTest {
 
@@ -23,8 +22,7 @@ class WebSocketHttpOffloadTest {
     Path temporaryDirectory;
 
     @Test
-    void blockingHttpHandlersLeaveTheSocketEventLoopAndKeepChannelOrdering()
-            throws Exception {
+    void blockingHttpHandlersLeaveTheSocketEventLoopAndKeepChannelOrdering() throws Exception {
         Field configField = Emulator.class.getDeclaredField("config");
         configField.setAccessible(true);
         Object previousConfig = configField.get(null);
@@ -36,8 +34,7 @@ class WebSocketHttpOffloadTest {
                         + "crypto.ws.enabled=false\n");
         configField.set(null, new ConfigurationManager(configFile.toString()));
 
-        EventLoopGroup eventLoops =
-                new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        EventLoopGroup eventLoops = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
         NioSocketChannel channel = new NioSocketChannel();
         try {
             eventLoops.register(channel).syncUninterruptibly();
@@ -58,8 +55,7 @@ class WebSocketHttpOffloadTest {
                     blockingExecutor,
                     channel.pipeline().context("emuStatsHttpHandler").executor());
             assertSame(
-                    socketExecutor,
-                    channel.pipeline().context("wsHttpHandler").executor());
+                    socketExecutor, channel.pipeline().context("wsHttpHandler").executor());
             assertSame(
                     socketExecutor,
                     channel.pipeline().context("authHttpHandler").executor());

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodecTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodecTest.java
@@ -1,0 +1,44 @@
+package com.eu.habbo.networking.gameserver.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class WebSocketCodecTest {
+
+    @Test
+    void binaryFramesExposeTheirExactPayload() {
+        EmbeddedChannel channel = new EmbeddedChannel(new WebSocketCodec());
+        channel.writeInbound(new BinaryWebSocketFrame(
+                Unpooled.copiedBuffer("game-packet", StandardCharsets.UTF_8)));
+
+        ByteBuf payload = channel.readInbound();
+        try {
+            assertEquals("game-packet", payload.toString(StandardCharsets.UTF_8));
+        } finally {
+            payload.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void outboundPayloadsRemainBinaryFrames() {
+        EmbeddedChannel channel = new EmbeddedChannel(new WebSocketCodec());
+        channel.writeOutbound(Unpooled.copiedBuffer("game-packet", StandardCharsets.UTF_8));
+
+        BinaryWebSocketFrame frame = assertInstanceOf(BinaryWebSocketFrame.class, channel.readOutbound());
+        try {
+            assertEquals("game-packet", frame.content().toString(StandardCharsets.UTF_8));
+        } finally {
+            frame.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodecTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodecTest.java
@@ -4,12 +4,22 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.ContinuationWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class WebSocketCodecTest {
 
@@ -38,6 +48,38 @@ class WebSocketCodecTest {
             assertEquals("game-packet", frame.content().toString(StandardCharsets.UTF_8));
         } finally {
             frame.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void nonBinaryFramesAreRejectedAtTheGameProtocolBoundary() {
+        List<Supplier<WebSocketFrame>> unexpectedFrames = List.of(
+                () -> new TextWebSocketFrame("text"),
+                () -> new ContinuationWebSocketFrame(
+                        Unpooled.copiedBuffer("continuation", StandardCharsets.UTF_8)),
+                PingWebSocketFrame::new,
+                PongWebSocketFrame::new,
+                CloseWebSocketFrame::new);
+
+        for (Supplier<WebSocketFrame> frameFactory : unexpectedFrames) {
+            assertRejected(frameFactory.get());
+        }
+    }
+
+    @Test
+    void unaggregatedBinaryFragmentsAreRejected() {
+        assertRejected(new BinaryWebSocketFrame(
+                false, 0, Unpooled.copiedBuffer("fragment", StandardCharsets.UTF_8)));
+    }
+
+    private static void assertRejected(WebSocketFrame frame) {
+        EmbeddedChannel channel = new EmbeddedChannel(new WebSocketCodec());
+        try {
+            assertFalse(channel.writeInbound(frame));
+            assertFalse(channel.isOpen());
+            assertNull(channel.readInbound());
+        } finally {
             channel.finishAndReleaseAll();
         }
     }

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodecTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/codec/WebSocketCodecTest.java
@@ -1,5 +1,10 @@
 package com.eu.habbo.networking.gameserver.codec;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -10,24 +15,17 @@ import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
-import org.junit.jupiter.api.Test;
-
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Supplier;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Test;
 
 class WebSocketCodecTest {
 
     @Test
     void binaryFramesExposeTheirExactPayload() {
         EmbeddedChannel channel = new EmbeddedChannel(new WebSocketCodec());
-        channel.writeInbound(new BinaryWebSocketFrame(
-                Unpooled.copiedBuffer("game-packet", StandardCharsets.UTF_8)));
+        channel.writeInbound(new BinaryWebSocketFrame(Unpooled.copiedBuffer("game-packet", StandardCharsets.UTF_8)));
 
         ByteBuf payload = channel.readInbound();
         try {
@@ -56,8 +54,7 @@ class WebSocketCodecTest {
     void nonBinaryFramesAreRejectedAtTheGameProtocolBoundary() {
         List<Supplier<WebSocketFrame>> unexpectedFrames = List.of(
                 () -> new TextWebSocketFrame("text"),
-                () -> new ContinuationWebSocketFrame(
-                        Unpooled.copiedBuffer("continuation", StandardCharsets.UTF_8)),
+                () -> new ContinuationWebSocketFrame(Unpooled.copiedBuffer("continuation", StandardCharsets.UTF_8)),
                 PingWebSocketFrame::new,
                 PongWebSocketFrame::new,
                 CloseWebSocketFrame::new);
@@ -69,8 +66,7 @@ class WebSocketCodecTest {
 
     @Test
     void unaggregatedBinaryFragmentsAreRejected() {
-        assertRejected(new BinaryWebSocketFrame(
-                false, 0, Unpooled.copiedBuffer("fragment", StandardCharsets.UTF_8)));
+        assertRejected(new BinaryWebSocketFrame(false, 0, Unpooled.copiedBuffer("fragment", StandardCharsets.UTF_8)));
     }
 
     private static void assertRejected(WebSocketFrame frame) {

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandlerTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandlerTest.java
@@ -1,0 +1,67 @@
+package com.eu.habbo.networking.gameserver.handlers;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SustainedUnwritableHandlerTest {
+
+    @Test
+    void closesAChannelThatRemainsUnwritableForTheWholeTimeout() {
+        EmbeddedChannel channel = channelWithTimeout(5);
+
+        setWritable(channel, false);
+        channel.advanceTimeBy(4, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+        assertTrue(channel.isOpen());
+
+        channel.advanceTimeBy(1, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+
+        assertFalse(channel.isOpen());
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void keepsAChannelOpenWhenWritabilityRecovers() {
+        EmbeddedChannel channel = channelWithTimeout(5);
+
+        setWritable(channel, false);
+        channel.advanceTimeBy(4, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+        setWritable(channel, true);
+        channel.advanceTimeBy(2, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+
+        assertTrue(channel.isOpen());
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void repeatedUnwritableEventsDoNotExtendTheOriginalDeadline() {
+        EmbeddedChannel channel = channelWithTimeout(5);
+
+        setWritable(channel, false);
+        channel.advanceTimeBy(4, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+        channel.pipeline().fireChannelWritabilityChanged();
+        channel.advanceTimeBy(1, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+
+        assertFalse(channel.isOpen());
+        channel.finishAndReleaseAll();
+    }
+
+    private static EmbeddedChannel channelWithTimeout(long seconds) {
+        return new EmbeddedChannel(new SustainedUnwritableHandler(seconds, TimeUnit.SECONDS));
+    }
+
+    private static void setWritable(EmbeddedChannel channel, boolean writable) {
+        channel.unsafe().outboundBuffer().setUserDefinedWritability(1, writable);
+        channel.runPendingTasks();
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandlerTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandlerTest.java
@@ -56,6 +56,24 @@ class SustainedUnwritableHandlerTest {
         channel.finishAndReleaseAll();
     }
 
+    @Test
+    void repeatedRecoveryCyclesDoNotLeaveAStaleCloseTask() {
+        EmbeddedChannel channel = channelWithTimeout(5);
+
+        for (int cycle = 0; cycle < 1_000; cycle++) {
+            setWritable(channel, false);
+            channel.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+            channel.runScheduledPendingTasks();
+            setWritable(channel, true);
+        }
+
+        channel.advanceTimeBy(5, TimeUnit.SECONDS);
+        channel.runScheduledPendingTasks();
+
+        assertTrue(channel.isOpen());
+        channel.finishAndReleaseAll();
+    }
+
     private static EmbeddedChannel channelWithTimeout(long seconds) {
         return new EmbeddedChannel(new SustainedUnwritableHandler(seconds, TimeUnit.SECONDS));
     }

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandlerTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/handlers/SustainedUnwritableHandlerTest.java
@@ -1,12 +1,11 @@
 package com.eu.habbo.networking.gameserver.handlers;
 
-import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.TimeUnit;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
 
 class SustainedUnwritableHandlerTest {
 

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerWriteTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerWriteTest.java
@@ -1,11 +1,22 @@
 package com.eu.habbo.networking.rconserver;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class RCONServerHandlerWriteTest {
 
@@ -17,5 +28,32 @@ class RCONServerHandlerWriteTest {
         } finally {
             response.release();
         }
+    }
+
+    @Test
+    void connectionClosesOnlyAfterTheResponseWriteCompletes() {
+        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+        Channel channel = mock(Channel.class);
+        ChannelPromise voidPromise = mock(ChannelPromise.class);
+        ChannelFuture legacyFuture = mock(ChannelFuture.class);
+        ChannelFuture responseFuture = mock(ChannelFuture.class);
+        when(context.channel()).thenReturn(channel);
+        when(channel.voidPromise()).thenReturn(voidPromise);
+        when(channel.write(any(ByteBuf.class), eq(voidPromise))).thenAnswer(invocation -> {
+            ((ByteBuf) invocation.getArgument(0)).release();
+            return legacyFuture;
+        });
+        when(legacyFuture.channel()).thenReturn(channel);
+        when(context.writeAndFlush(any(ByteBuf.class))).thenAnswer(invocation -> {
+            ((ByteBuf) invocation.getArgument(0)).release();
+            return responseFuture;
+        });
+
+        RCONServerHandler.writeAndClose(context, "{\"status\":1}");
+
+        verify(context).writeAndFlush(any(ByteBuf.class));
+        verify(responseFuture).addListener(ChannelFutureListener.CLOSE);
+        verify(channel, never()).voidPromise();
+        verify(channel, never()).close();
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerWriteTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerWriteTest.java
@@ -1,22 +1,18 @@
 package com.eu.habbo.networking.rconserver;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RCONServerHandlerWriteTest {
 
@@ -32,28 +28,37 @@ class RCONServerHandlerWriteTest {
 
     @Test
     void connectionClosesOnlyAfterTheResponseWriteCompletes() {
-        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
-        Channel channel = mock(Channel.class);
-        ChannelPromise voidPromise = mock(ChannelPromise.class);
-        ChannelFuture legacyFuture = mock(ChannelFuture.class);
-        ChannelFuture responseFuture = mock(ChannelFuture.class);
-        when(context.channel()).thenReturn(channel);
-        when(channel.voidPromise()).thenReturn(voidPromise);
-        when(channel.write(any(ByteBuf.class), eq(voidPromise))).thenAnswer(invocation -> {
-            ((ByteBuf) invocation.getArgument(0)).release();
-            return legacyFuture;
-        });
-        when(legacyFuture.channel()).thenReturn(channel);
-        when(context.writeAndFlush(any(ByteBuf.class))).thenAnswer(invocation -> {
-            ((ByteBuf) invocation.getArgument(0)).release();
-            return responseFuture;
-        });
+        DelayedWriteHandler delayedWrite = new DelayedWriteHandler();
+        ContextMarker marker = new ContextMarker();
+        EmbeddedChannel channel = new EmbeddedChannel(delayedWrite, marker);
 
-        RCONServerHandler.writeAndClose(context, "{\"status\":1}");
+        RCONServerHandler.writeAndClose(
+                channel.pipeline().context(marker), "{\"status\":1}");
 
-        verify(context).writeAndFlush(any(ByteBuf.class));
-        verify(responseFuture).addListener(ChannelFutureListener.CLOSE);
-        verify(channel, never()).voidPromise();
-        verify(channel, never()).close();
+        assertNotNull(delayedWrite.promise);
+        assertTrue(channel.isOpen());
+        assertEquals("{\"status\":1}",
+                delayedWrite.message.toString(StandardCharsets.UTF_8));
+
+        delayedWrite.promise.setSuccess();
+        channel.runPendingTasks();
+
+        assertFalse(channel.isOpen());
+        delayedWrite.message.release();
+        channel.finishAndReleaseAll();
+    }
+
+    private static final class ContextMarker extends io.netty.channel.ChannelInboundHandlerAdapter {
+    }
+
+    private static final class DelayedWriteHandler extends ChannelOutboundHandlerAdapter {
+        private ByteBuf message;
+        private ChannelPromise promise;
+
+        @Override
+        public void write(ChannelHandlerContext context, Object message, ChannelPromise promise) {
+            this.message = (ByteBuf) message;
+            this.promise = promise;
+        }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerWriteTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerWriteTest.java
@@ -1,0 +1,21 @@
+package com.eu.habbo.networking.rconserver;
+
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RCONServerHandlerWriteTest {
+
+    @Test
+    void responseUsesItsExactUtf8Bytes() {
+        ByteBuf response = RCONServerHandler.responseBuffer("{\"message\":\"på gensyn\"}");
+        try {
+            assertEquals("{\"message\":\"på gensyn\"}", response.toString(StandardCharsets.UTF_8));
+        } finally {
+            response.release();
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerWriteTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerWriteTest.java
@@ -1,18 +1,17 @@
 package com.eu.habbo.networking.rconserver;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.jupiter.api.Test;
-
 import java.nio.charset.StandardCharsets;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class RCONServerHandlerWriteTest {
 
@@ -32,13 +31,11 @@ class RCONServerHandlerWriteTest {
         ContextMarker marker = new ContextMarker();
         EmbeddedChannel channel = new EmbeddedChannel(delayedWrite, marker);
 
-        RCONServerHandler.writeAndClose(
-                channel.pipeline().context(marker), "{\"status\":1}");
+        RCONServerHandler.writeAndClose(channel.pipeline().context(marker), "{\"status\":1}");
 
         assertNotNull(delayedWrite.promise);
         assertTrue(channel.isOpen());
-        assertEquals("{\"status\":1}",
-                delayedWrite.message.toString(StandardCharsets.UTF_8));
+        assertEquals("{\"status\":1}", delayedWrite.message.toString(StandardCharsets.UTF_8));
 
         delayedWrite.promise.setSuccess();
         channel.runPendingTasks();
@@ -48,8 +45,7 @@ class RCONServerHandlerWriteTest {
         channel.finishAndReleaseAll();
     }
 
-    private static final class ContextMarker extends io.netty.channel.ChannelInboundHandlerAdapter {
-    }
+    private static final class ContextMarker extends io.netty.channel.ChannelInboundHandlerAdapter {}
 
     private static final class DelayedWriteHandler extends ChannelOutboundHandlerAdapter {
         private ByteBuf message;

--- a/config example/config.ini.example
+++ b/config example/config.ini.example
@@ -79,6 +79,9 @@ login.news.limit=5
 ## io.packet.handler.threads=24 #Game packet-handler pool size; runs game handlers OFF the Netty I/O loop. Default max(16, 2 x CPU cores).
 ## auth.http.pool.size=16 #Dedicated worker pool for the /api/auth/* HTTP endpoints (BCrypt/JDBC/Turnstile/SMTP run off the event loop). Default 16.
 ## io.netty.allocator.pooled=false #Set true to opt into Netty's pooled ByteBuf allocator. Default false (unpooled-heap).
+## io.netty.write_buffer.low_water_mark=32768 #Mark a channel writable again after queued outbound bytes drain below this value.
+## io.netty.write_buffer.high_water_mark=65536 #Mark a channel unwritable after queued outbound bytes exceed this value.
+## io.netty.unwritable.timeout.seconds=10 #Disconnect a channel that remains unwritable for this long.
 
 #Structured slow-query diagnostics. SQL literals and bound values are never logged.
 db.slow_query.enabled=true

--- a/config example/config.ini.example
+++ b/config example/config.ini.example
@@ -78,6 +78,7 @@ login.news.limit=5
 #Performance / concurrency (optional — sensible defaults apply if unset; adjust in the Database).
 ## io.packet.handler.threads=24 #Game packet-handler pool size; runs game handlers OFF the Netty I/O loop. Default max(16, 2 x CPU cores).
 ## auth.http.pool.size=16 #Dedicated worker pool for the /api/auth/* HTTP endpoints (BCrypt/JDBC/Turnstile/SMTP run off the event loop). Default 16.
+## http.blocking.pool.size=8 #Dedicated workers for blocking badge, asset, leaderboard, and emulator-stats endpoints. Default 8.
 ## io.netty.allocator.pooled=false #Set true to opt into Netty's pooled ByteBuf allocator. Default false (unpooled-heap).
 ## io.netty.write_buffer.low_water_mark=32768 #Mark a channel writable again after queued outbound bytes drain below this value.
 ## io.netty.write_buffer.high_water_mark=65536 #Mark a channel unwritable after queued outbound bytes exceed this value.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -40,6 +40,10 @@ Unknown keys remain allowed for plugins. Database-backed hotel settings are docu
 | `game.host` | string | `` | `EMU_HOST` | yes | no | Game listener setting. |
 | `game.port` | integer | `0` | `EMU_PORT` | yes | no | Game listener setting. |
 | `habbo.console.style` | string | `` | — | yes | no | Polaris startup setting. |
+| `http.blocking.pool.size` | integer | `8` | — | yes | no | Blocking HTTP worker setting. |
+| `io.netty.unwritable.timeout.seconds` | integer | `10` | — | yes | no | Netty channel flow-control setting. |
+| `io.netty.write_buffer.high_water_mark` | integer | `65536` | — | yes | no | Netty channel flow-control setting. |
+| `io.netty.write_buffer.low_water_mark` | integer | `32768` | — | yes | no | Netty channel flow-control setting. |
 | `login.news.limit` | integer | `0` | — | yes | no | Built-in login endpoint setting. |
 | `login.remember.duration.days` | integer | `0` | — | yes | no | Built-in login endpoint setting. |
 | `login.remember.enabled` | boolean | `false` | — | yes | no | Built-in login endpoint setting. |


### PR DESCRIPTION
Hardens game, WebSocket, HTTP, and RCON connection handling in one network-safety batch. RCON replies drain before close, WebSocket codecs reject unexpected frames, HTTP-only handlers are removed after upgrade, authenticated-client lookup retains its legacy fallback, unwritable channels are bounded without dropping packets, and blocking HTTP handlers use a dedicated configurable worker group.

Manual testing:
- Send an RCON command and confirm the complete response arrives before the connection closes.
- Connect through WebSocket, send a non-binary or fragmented game frame, and confirm only that connection closes.
- Throttle a client with low write-buffer water marks and confirm it disconnects only after the configured grace period.
- Exercise secure assets, badge images, the badge leaderboard, and emulator stats while game clients are active; confirm HTTP responses remain ordered and game traffic stays responsive.