### PR TITLE
build: complete modernization safeguards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{md,yml,yaml}]
+trim_trailing_whitespace = false
+
+[*.ps1]
+indent_style = space
+indent_size = 4
+
+[*.{java,xml,json}]
+indent_style = space
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,15 @@
+* text=auto eol=lf
+
+*.jar binary
+*.zip binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.swf binary
+
 # MigrationRunnerIT compares this file byte-for-byte against a generated
 # LF-terminated string; keep it LF on every platform and checkout mode.
 Emulator/src/main/resources/db/runtime-schema-contract.json text eol=lf

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+Describe the complete change and its operator or developer impact.
+
+Compatibility:
+- [ ] The public API, fields, live collections, packet layouts, and plugin behavior remain compatible.
+- [ ] Plugin-facing or packaging changes exercise precompiled fixtures and the assembled jar.
+- [ ] Database changes use a new Polaris migration and preserve supported upgrades.
+
+Manual testing:
+- None, or list only the hotel actions a reviewer must perform.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Verify local build handoff
-        shell: pwsh
-        run: ../scripts/build-latest.test.ps1
+        run: ../scripts/build-latest.test.sh
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,17 @@
-logging/
+/logging/*.json
+/logging/*.log
+/logging/*.txt
+/logging/*.zip
+/Emulator/logging/
 *.iml
 .idea/
 target/**
 TODO.txt
 packet.pkt
 plugins/**
-src/test/
 target/
 config.ini
-*.txt
 !Emulator/abi-baseline/*.txt
-*.log
-*.zip
 .DS_Store
 
 /Emulator/plugins

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to Polaris
+
+Polaris is used by live hotels and keeps the established Arcturus/Morningstar
+integration surface compatible. Existing plugin jars must continue to load
+without recompilation, and clients, CMSs, proxies, and databases must not need
+coordinated changes.
+
+## Development setup
+
+Use JDK 25, Maven 3.9.11, and the wrapper in `Emulator/`. Docker is needed for
+the Testcontainers integration suite.
+
+```bash
+./Emulator/mvnw -f Emulator/pom.xml test
+./Emulator/mvnw -f Emulator/pom.xml verify
+```
+
+Run the smallest focused test first. Refactors follow a test-first workflow:
+add characterization tests against the unchanged implementation, confirm they
+pass, and keep them unchanged through the extraction. Bug fixes start with a
+narrow failing reproduction.
+
+## Compatibility
+
+- Keep public `com.eu.habbo.*` classes, signatures, fields, live collections,
+  plugin metadata, and plugin classloading behavior compatible.
+- Preserve packet field order and types.
+- Keep database migrations self-contained in Polaris and never edit a released
+  migration.
+- Test plugin-facing changes against the assembled jar and representative
+  precompiled fixtures, not only the Maven dependency classpath.
+- Do not remove or relocate bundled dependencies without a plugin-classpath
+  compatibility decision.
+
+Read `POLARIS.md` before changing plugin compatibility, the legacy SQL bridge,
+or public integration behavior.
+
+## Git and pull requests
+
+Use `feature/`, `bugfix/`, or `refactor/` branch prefixes and Conventional
+Commits. Keep each pull request reviewable, with a concise title and factual
+description. Add simple manual hotel steps only when automated checks cannot
+cover the behavior.

--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -136,6 +136,7 @@
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <release>${maven.compiler.release}</release>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEngine.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEngine.java
@@ -33,9 +33,9 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1570,7 +1570,7 @@ public final class WiredEngine {
     }
 
     static int selectRandomIndex(int bound) {
-        return new Random().nextInt(bound);
+        return ThreadLocalRandom.current().nextInt(bound);
     }
 
     private WiredExtraUnseen getUnseenExtra(Room room, WiredStack stack) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEngine.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEngine.java
@@ -987,7 +987,7 @@ public final class WiredEngine {
                         toExecute.size(),
                         randomExtra.getSkipExecutions());
             } else {
-                int randomIndex = new Random().nextInt(effects.size());
+                int randomIndex = selectRandomIndex(effects.size());
                 toExecute = Collections.singletonList(effects.get(randomIndex));
                 debug(ctx.room(), "Random mode: selected effect {}/{}", randomIndex + 1, effects.size());
             }
@@ -1567,6 +1567,10 @@ public final class WiredEngine {
         InteractionWiredExtra extra = getStackExtra(room, stack, WiredExtraRandom.class);
 
         return (extra instanceof WiredExtraRandom) ? (WiredExtraRandom) extra : null;
+    }
+
+    static int selectRandomIndex(int bound) {
+        return new Random().nextInt(bound);
     }
 
     private WiredExtraUnseen getUnseenExtra(Room room, WiredStack stack) {

--- a/Emulator/src/test/java/com/eu/habbo/build/RepositoryHygieneContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/build/RepositoryHygieneContractTest.java
@@ -1,0 +1,78 @@
+package com.eu.habbo.build;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RepositoryHygieneContractTest {
+
+    private static final Path REPOSITORY_ROOT = Path.of("..");
+
+    @Test
+    void repositoryDefinesPortableTextAndIgnoreRules() throws Exception {
+        String editorConfig = read(".editorconfig");
+        assertTrue(editorConfig.contains("root = true"));
+        assertTrue(editorConfig.contains("charset = utf-8"));
+        assertTrue(editorConfig.contains("end_of_line = lf"));
+
+        String attributes = read(".gitattributes");
+        assertTrue(attributes.contains("* text=auto eol=lf"));
+        assertTrue(attributes.contains("*.jar binary"));
+        assertTrue(attributes.contains("*.png binary"));
+        assertTrue(attributes.contains("*.zip binary"));
+
+        List<String> ignoredLines = Files.readAllLines(REPOSITORY_ROOT.resolve(".gitignore"));
+        assertFalse(ignoredLines.contains("*.txt"));
+        assertFalse(ignoredLines.contains("*.log"));
+        assertFalse(ignoredLines.contains("*.zip"));
+        assertFalse(ignoredLines.contains("src/test/"));
+        assertTrue(ignoredLines.contains("/logging/*.log"));
+    }
+
+    @Test
+    void contributorAndPullRequestGuidanceProtectCompatibility() throws Exception {
+        String contributing = read("CONTRIBUTING.md");
+        assertTrue(contributing.contains("Existing plugin jars must continue to load"));
+        assertTrue(contributing.contains("feature/"));
+        assertTrue(contributing.contains("bugfix/"));
+        assertTrue(contributing.contains("refactor/"));
+        assertTrue(contributing.contains("test-first"));
+
+        String pullRequestTemplate = read(".github/pull_request_template.md");
+        assertTrue(pullRequestTemplate.contains("Compatibility"));
+        assertTrue(pullRequestTemplate.contains("public API"));
+        assertTrue(pullRequestTemplate.contains("plugin"));
+        assertTrue(pullRequestTemplate.contains("Manual testing"));
+    }
+
+    @Test
+    void buildHelpersHavePortableShellEntrypoints() throws Exception {
+        assertShellScript("scripts/build-latest.sh");
+        assertShellScript("scripts/build-latest.test.sh");
+        assertShellScript("scripts/verify-furni-import.sh");
+    }
+
+    @Test
+    void projectPoliciesAndCompilerMetadataAreDocumented() throws Exception {
+        assertTrue(read("docs/architecture.md").contains("Compatibility facades"));
+        assertTrue(read("docs/plugin-author-guide.md").contains("plugin.json"));
+        assertTrue(read("docs/versioning-and-release.md").contains("green `verify`"));
+        assertTrue(read("Emulator/pom.xml").contains("<parameters>true</parameters>"));
+    }
+
+    private static void assertShellScript(String relativePath) throws Exception {
+        String script = read(relativePath);
+        assertTrue(script.startsWith("#!/usr/bin/env bash"), relativePath);
+        assertTrue(script.contains("set -euo pipefail"), relativePath);
+    }
+
+    private static String read(String relativePath) throws Exception {
+        Path path = REPOSITORY_ROOT.resolve(relativePath);
+        assertTrue(Files.isRegularFile(path), relativePath + " must exist");
+        return Files.readString(path);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/indexing/DatabaseIndexMigrationExecutionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/indexing/DatabaseIndexMigrationExecutionContractTest.java
@@ -1,23 +1,20 @@
 package com.eu.habbo.database.indexing;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class DatabaseIndexMigrationExecutionContractTest {
 
     @Test
     void indexMigrationRunsAsAFailsafeTestcontainersTest() throws Exception {
-        Path legacyTest = Path.of(
-                "src/test/java/com/eu/habbo/database/indexing/"
-                        + "DatabaseIndexMigrationIntegrationTest.java");
-        Path integrationTest = Path.of(
-                "src/test/java/com/eu/habbo/database/indexing/"
-                        + "DatabaseIndexMigrationIT.java");
+        Path legacyTest =
+                Path.of("src/test/java/com/eu/habbo/database/indexing/" + "DatabaseIndexMigrationIntegrationTest.java");
+        Path integrationTest =
+                Path.of("src/test/java/com/eu/habbo/database/indexing/" + "DatabaseIndexMigrationIT.java");
 
         assertFalse(Files.exists(legacyTest));
         assertTrue(Files.exists(integrationTest));

--- a/Emulator/src/test/java/com/eu/habbo/database/indexing/DatabaseIndexMigrationExecutionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/indexing/DatabaseIndexMigrationExecutionContractTest.java
@@ -1,0 +1,30 @@
+package com.eu.habbo.database.indexing;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DatabaseIndexMigrationExecutionContractTest {
+
+    @Test
+    void indexMigrationRunsAsAFailsafeTestcontainersTest() throws Exception {
+        Path legacyTest = Path.of(
+                "src/test/java/com/eu/habbo/database/indexing/"
+                        + "DatabaseIndexMigrationIntegrationTest.java");
+        Path integrationTest = Path.of(
+                "src/test/java/com/eu/habbo/database/indexing/"
+                        + "DatabaseIndexMigrationIT.java");
+
+        assertFalse(Files.exists(legacyTest));
+        assertTrue(Files.exists(integrationTest));
+
+        String source = Files.readString(integrationTest);
+        assertTrue(source.contains("TestDatabase.freshDatabase("));
+        assertTrue(source.contains("System.getenv(\"CI\")"));
+        assertFalse(source.contains("MIGRATION_TEST_DB_HOST"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/indexing/DatabaseIndexMigrationIT.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/indexing/DatabaseIndexMigrationIT.java
@@ -1,9 +1,12 @@
 package com.eu.habbo.database.indexing;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import com.eu.habbo.database.TestDatabase;
 import com.zaxxer.hikari.HikariDataSource;
-import org.junit.jupiter.api.Test;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
@@ -14,11 +17,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import org.junit.jupiter.api.Test;
 
 class DatabaseIndexMigrationIT {
 
@@ -27,58 +26,55 @@ class DatabaseIndexMigrationIT {
             TestDatabase.sharedDataSource();
         } catch (Throwable error) {
             if ("true".equalsIgnoreCase(System.getenv("CI"))) {
-                throw new AssertionError(
-                        "Docker/Testcontainers is required in CI",
-                        error);
+                throw new AssertionError("Docker/Testcontainers is required in CI", error);
             }
-            assumeTrue(
-                    false,
-                    "Docker/Testcontainers is unavailable: " + error.getMessage());
+            assumeTrue(false, "Docker/Testcontainers is unavailable: " + error.getMessage());
         }
     }
 
     @Test
     void migrationReusesEquivalentIndexesAndIsIdempotentOnMariaDb() throws Exception {
         requireDocker();
-        try (HikariDataSource dataSource =
-                     TestDatabase.freshDatabase("index_migration");
-             Connection connection = dataSource.getConnection()) {
+        try (HikariDataSource dataSource = TestDatabase.freshDatabase("index_migration");
+                Connection connection = dataSource.getConnection()) {
             IndexContract contract = IndexContractLoader.load(getClass().getClassLoader());
             createContractTables(connection, contract);
-            execute(connection, "CREATE INDEX custom_badge_covering ON users_badges "
-                    + "(user_id, badge_code, slot_id)");
+            execute(
+                    connection,
+                    "CREATE INDEX custom_badge_covering ON users_badges " + "(user_id, badge_code, slot_id)");
 
-            String migration = Files.readString(Path.of(
-                    "src/main/resources/db/migration/V20260718190000__query_index_contract.sql"));
+            String migration = Files.readString(
+                    Path.of("src/main/resources/db/migration/V20260718190000__query_index_contract.sql"));
             executeMigration(connection, migration);
 
             IndexAuditReport first = new DatabaseIndexAuditor(connection, contract).audit();
             assertTrue(first.isComplete(), () -> "Missing indexes: " + first.missingRequirements());
-            assertFalse(indexExists(connection, "users_badges",
-                    "idx_users_badges_user_badge_slot"),
+            assertFalse(
+                    indexExists(connection, "users_badges", "idx_users_badges_user_badge_slot"),
                     "Equivalent custom indexes must be reused instead of duplicated");
             int indexCount = indexCount(connection);
 
             executeMigration(connection, migration);
-            assertEquals(indexCount, indexCount(connection),
-                    "Applying the index migration twice must not add indexes");
+            assertEquals(indexCount, indexCount(connection), "Applying the index migration twice must not add indexes");
         }
     }
 
-    private static void createContractTables(Connection connection, IndexContract contract)
-            throws Exception {
+    private static void createContractTables(Connection connection, IndexContract contract) throws Exception {
         Map<String, Set<String>> columnsByTable = new LinkedHashMap<>();
         for (IndexRequirement requirement : contract.requirements()) {
-            columnsByTable.computeIfAbsent(requirement.table(), ignored -> new LinkedHashSet<>())
+            columnsByTable
+                    .computeIfAbsent(requirement.table(), ignored -> new LinkedHashSet<>())
                     .addAll(requirement.columns());
         }
         for (Map.Entry<String, Set<String>> table : columnsByTable.entrySet()) {
-            StringBuilder sql = new StringBuilder("CREATE TABLE `")
-                    .append(table.getKey()).append("` (");
+            StringBuilder sql =
+                    new StringBuilder("CREATE TABLE `").append(table.getKey()).append("` (");
             int index = 0;
             for (String column : table.getValue()) {
                 if (index++ > 0) sql.append(", ");
-                sql.append('`').append(column).append("` ")
+                sql.append('`')
+                        .append(column)
+                        .append("` ")
                         .append(isTextColumn(column) ? "VARCHAR(64)" : "INT")
                         .append(" NOT NULL");
             }
@@ -92,7 +88,8 @@ class DatabaseIndexMigrationIT {
     }
 
     private static void executeMigration(Connection connection, String migration) throws Exception {
-        String executableSql = migration.lines()
+        String executableSql = migration
+                .lines()
                 .filter(line -> !line.stripLeading().startsWith("--"))
                 .collect(Collectors.joining("\n"));
         for (String statement : executableSql.split(";\\s*")) {
@@ -100,8 +97,7 @@ class DatabaseIndexMigrationIT {
         }
     }
 
-    private static boolean indexExists(Connection connection, String table, String index)
-            throws Exception {
+    private static boolean indexExists(Connection connection, String table, String index) throws Exception {
         try (var statement = connection.prepareStatement("""
                 SELECT COUNT(*)
                 FROM information_schema.STATISTICS
@@ -117,7 +113,7 @@ class DatabaseIndexMigrationIT {
 
     private static int indexCount(Connection connection) throws Exception {
         try (Statement statement = connection.createStatement();
-             ResultSet rows = statement.executeQuery("""
+                ResultSet rows = statement.executeQuery("""
                      SELECT COUNT(DISTINCT TABLE_NAME, INDEX_NAME)
                      FROM information_schema.STATISTICS
                      WHERE TABLE_SCHEMA = DATABASE()
@@ -132,5 +128,4 @@ class DatabaseIndexMigrationIT {
             statement.execute(sql);
         }
     }
-
 }

--- a/Emulator/src/test/java/com/eu/habbo/database/indexing/DatabaseIndexMigrationIT.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/indexing/DatabaseIndexMigrationIT.java
@@ -1,45 +1,48 @@
 package com.eu.habbo.database.indexing;
 
-import org.junit.jupiter.api.Assumptions;
+import com.eu.habbo.database.TestDatabase;
+import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-class DatabaseIndexMigrationIntegrationTest {
+class DatabaseIndexMigrationIT {
+
+    private static void requireDocker() {
+        try {
+            TestDatabase.sharedDataSource();
+        } catch (Throwable error) {
+            if ("true".equalsIgnoreCase(System.getenv("CI"))) {
+                throw new AssertionError(
+                        "Docker/Testcontainers is required in CI",
+                        error);
+            }
+            assumeTrue(
+                    false,
+                    "Docker/Testcontainers is unavailable: " + error.getMessage());
+        }
+    }
+
     @Test
     void migrationReusesEquivalentIndexesAndIsIdempotentOnMariaDb() throws Exception {
-        String host = System.getenv("MIGRATION_TEST_DB_HOST");
-        Assumptions.assumeTrue(host != null && !host.isBlank(),
-                "Set MIGRATION_TEST_DB_HOST to opt into the MariaDB integration test");
-        assertTrue(isLoopback(host), "Migration integration tests require a loopback MariaDB host");
-
-        String port = environment("MIGRATION_TEST_DB_PORT", "3306");
-        String user = environment("MIGRATION_TEST_DB_USER", "root");
-        String password = environment("MIGRATION_TEST_DB_PASSWORD", "");
-        String schema = "polaris_index_test_" + UUID.randomUUID().toString().replace("-", "");
-        String serverUrl = "jdbc:mariadb://" + host + ":" + port + "/";
-
-        try (Connection admin = DriverManager.getConnection(serverUrl, user, password)) {
-            execute(admin, "CREATE DATABASE `" + schema
-                    + "` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
-        }
-
-        try (Connection connection = DriverManager.getConnection(serverUrl + schema, user, password)) {
+        requireDocker();
+        try (HikariDataSource dataSource =
+                     TestDatabase.freshDatabase("index_migration");
+             Connection connection = dataSource.getConnection()) {
             IndexContract contract = IndexContractLoader.load(getClass().getClassLoader());
             createContractTables(connection, contract);
             execute(connection, "CREATE INDEX custom_badge_covering ON users_badges "
@@ -59,10 +62,6 @@ class DatabaseIndexMigrationIntegrationTest {
             executeMigration(connection, migration);
             assertEquals(indexCount, indexCount(connection),
                     "Applying the index migration twice must not add indexes");
-        } finally {
-            try (Connection admin = DriverManager.getConnection(serverUrl, user, password)) {
-                execute(admin, "DROP DATABASE IF EXISTS `" + schema + "`");
-            }
         }
     }
 
@@ -134,12 +133,4 @@ class DatabaseIndexMigrationIntegrationTest {
         }
     }
 
-    private static boolean isLoopback(String host) {
-        return host.equals("127.0.0.1") || host.equals("localhost") || host.equals("::1");
-    }
-
-    private static String environment(String name, String defaultValue) {
-        String value = System.getenv(name);
-        return value == null ? defaultValue : value;
-    }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/wired/core/WiredRandomSelectionJfrProfileTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/wired/core/WiredRandomSelectionJfrProfileTest.java
@@ -30,10 +30,12 @@ class WiredRandomSelectionJfrProfileTest {
         runSelections(WARMUP_SELECTIONS);
         long startedAt = System.nanoTime();
         try (Recording recording = new Recording()) {
-            recording.enable("jdk.ObjectAllocationInNewTLAB")
+            recording
+                    .enable("jdk.ObjectAllocationInNewTLAB")
                     .withThreshold(Duration.ZERO)
                     .withStackTrace();
-            recording.enable("jdk.ObjectAllocationOutsideTLAB")
+            recording
+                    .enable("jdk.ObjectAllocationOutsideTLAB")
                     .withThreshold(Duration.ZERO)
                     .withStackTrace();
             recording.start();
@@ -44,8 +46,7 @@ class WiredRandomSelectionJfrProfileTest {
 
         ProfileSummary summary = summarize(recordingPath, System.nanoTime() - startedAt);
         Files.writeString(summaryPath, summary.format());
-        System.out.println("WIRED_RANDOM_JFR "
-                + summary.format().replace(System.lineSeparator(), " | "));
+        System.out.println("WIRED_RANDOM_JFR " + summary.format().replace(System.lineSeparator(), " | "));
 
         assertNotEquals(0, blackhole);
     }
@@ -58,8 +59,7 @@ class WiredRandomSelectionJfrProfileTest {
         blackhole = result;
     }
 
-    private static ProfileSummary summarize(Path recordingPath, long elapsedNanos)
-            throws Exception {
+    private static ProfileSummary summarize(Path recordingPath, long elapsedNanos) throws Exception {
         long randomAllocations = 0;
         long randomAllocationBytes = 0;
         long totalAllocations = 0;
@@ -108,8 +108,7 @@ class WiredRandomSelectionJfrProfileTest {
                     randomAllocationBytes=%d
                     totalAllocations=%d
                     totalAllocationBytes=%d
-                    """
-                    .formatted(
+                    """.formatted(
                             selections,
                             elapsedNanos,
                             randomAllocations,

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/wired/core/WiredRandomSelectionJfrProfileTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/wired/core/WiredRandomSelectionJfrProfileTest.java
@@ -1,0 +1,121 @@
+package com.eu.habbo.habbohotel.wired.core;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedClass;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@EnabledIfSystemProperty(named = "polaris.profile.wired-random", matches = "true")
+class WiredRandomSelectionJfrProfileTest {
+
+    private static final int WARMUP_SELECTIONS = 100_000;
+    private static final int PROFILE_SELECTIONS = 2_000_000;
+    private static volatile long blackhole;
+
+    @Test
+    void capturesRandomSelectionAllocations() throws Exception {
+        Path profileDirectory = Path.of("target", "profiles");
+        Files.createDirectories(profileDirectory);
+        String variant = System.getProperty("polaris.profile.wired-random.variant", "baseline");
+        Path recordingPath = profileDirectory.resolve("wired-random-" + variant + ".jfr");
+        Path summaryPath = profileDirectory.resolve("wired-random-" + variant + ".txt");
+
+        runSelections(WARMUP_SELECTIONS);
+        long startedAt = System.nanoTime();
+        try (Recording recording = new Recording()) {
+            recording.enable("jdk.ObjectAllocationInNewTLAB")
+                    .withThreshold(Duration.ZERO)
+                    .withStackTrace();
+            recording.enable("jdk.ObjectAllocationOutsideTLAB")
+                    .withThreshold(Duration.ZERO)
+                    .withStackTrace();
+            recording.start();
+            runSelections(PROFILE_SELECTIONS);
+            recording.stop();
+            recording.dump(recordingPath);
+        }
+
+        ProfileSummary summary = summarize(recordingPath, System.nanoTime() - startedAt);
+        Files.writeString(summaryPath, summary.format());
+        System.out.println("WIRED_RANDOM_JFR "
+                + summary.format().replace(System.lineSeparator(), " | "));
+
+        assertNotEquals(0, blackhole);
+    }
+
+    private static void runSelections(int count) {
+        long result = 0;
+        for (int selection = 0; selection < count; selection++) {
+            result += WiredEngine.selectRandomIndex(32);
+        }
+        blackhole = result;
+    }
+
+    private static ProfileSummary summarize(Path recordingPath, long elapsedNanos)
+            throws Exception {
+        long randomAllocations = 0;
+        long randomAllocationBytes = 0;
+        long totalAllocations = 0;
+        long totalAllocationBytes = 0;
+
+        try (RecordingFile recording = new RecordingFile(recordingPath)) {
+            while (recording.hasMoreEvents()) {
+                RecordedEvent event = recording.readEvent();
+                if (!event.getEventType().getName().startsWith("jdk.ObjectAllocation")) {
+                    continue;
+                }
+
+                totalAllocations++;
+                long allocationSize = event.getLong("allocationSize");
+                totalAllocationBytes += allocationSize;
+                RecordedClass allocatedClass = event.getClass("objectClass");
+                if ("java.util.Random".equals(allocatedClass.getName())) {
+                    randomAllocations++;
+                    randomAllocationBytes += allocationSize;
+                }
+            }
+        }
+
+        return new ProfileSummary(
+                PROFILE_SELECTIONS,
+                elapsedNanos,
+                randomAllocations,
+                randomAllocationBytes,
+                totalAllocations,
+                totalAllocationBytes);
+    }
+
+    private record ProfileSummary(
+            int selections,
+            long elapsedNanos,
+            long randomAllocations,
+            long randomAllocationBytes,
+            long totalAllocations,
+            long totalAllocationBytes) {
+
+        private String format() {
+            return """
+                    selections=%d
+                    elapsedNanos=%d
+                    randomAllocations=%d
+                    randomAllocationBytes=%d
+                    totalAllocations=%d
+                    totalAllocationBytes=%d
+                    """
+                    .formatted(
+                            selections,
+                            elapsedNanos,
+                            randomAllocations,
+                            randomAllocationBytes,
+                            totalAllocations,
+                            totalAllocationBytes);
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/wired/core/WiredRandomSelectionTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/wired/core/WiredRandomSelectionTest.java
@@ -1,0 +1,25 @@
+package com.eu.habbo.habbohotel.wired.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class WiredRandomSelectionTest {
+
+    @Test
+    void selectsOnlyIndexesInsideTheRequestedBound() {
+        for (int iteration = 0; iteration < 10_000; iteration++) {
+            int selected = WiredEngine.selectRandomIndex(7);
+
+            assertTrue(selected >= 0 && selected < 7);
+        }
+    }
+
+    @Test
+    void preservesSingleChoiceAndInvalidBoundBehavior() {
+        assertEquals(0, WiredEngine.selectRandomIndex(1));
+        assertThrows(IllegalArgumentException.class, () -> WiredEngine.selectRandomIndex(0));
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,59 @@
+# Polaris architecture
+
+Polaris is a Java 25 game server for Nitro-compatible Habbo hotels. The Maven
+module lives in `Emulator/`; the Nitro client, CMS, proxies, and plugins are
+separate integrations.
+
+## Compatibility facades
+
+`Emulator`, `GameEnvironment`, `Room`, `RoomManager`, and the established
+manager classes remain the public compatibility facades used by legacy code
+and precompiled plugins. Internal implementations may be extracted behind
+them, but public signatures, fields, live collections, packet layouts, and
+classloading behavior remain stable.
+
+```text
+Plugins, clients, CMSs, and proxies
+                 |
+                 v
+Emulator / GameEnvironment / Room facades
+                 |
+                 v
+Runtime services / room components / repositories
+                 |
+                 v
+MariaDB / task executors / Netty transports
+```
+
+## Runtime ownership
+
+`PolarisBootstrap` constructs the process in ordered phases.
+`PolarisRuntime` owns core process services, while `HotelServiceRegistry`
+records hotel-domain resources and disposes verified lifecycle owners in
+reverse order. Legacy static getters continue to forward to these owners.
+
+## Domain and persistence boundaries
+
+Room construction, loading, persistence, lifecycle, item indexing, placement,
+movement, and ownership are internal components behind `Room`. High-change
+managers follow the same pattern: protocol handlers parse and compose packets,
+application services own orchestration, and repositories receive explicit
+database dependencies.
+
+Flyway migrations under `Emulator/src/main/resources/db/migration/` are the
+runtime schema source of truth. The legacy SQL bridge keeps supported old
+plugin queries compatible; new Polaris code targets the current schema.
+
+## Networking and concurrency
+
+Netty event loops own socket work. Blocking HTTP, authentication, crypto, and
+persistence tasks use bounded workload-specific executors. Per-channel packet
+ordering is preserved, sustained unwritable channels are bounded, and internal
+broadcast optimizations retain the public defensive-copy contract.
+
+## Configuration and quality gates
+
+Typed configuration metadata documents first-party keys while unknown
+plugin-owned keys remain allowed. CI runs unit and Testcontainers integration
+tests, ABI and assembled-jar compatibility checks, formatting and architecture
+ratchets, static analysis, coverage, and supported MariaDB migration matrices.

--- a/docs/performance/wired-random-selection.md
+++ b/docs/performance/wired-random-selection.md
@@ -1,0 +1,36 @@
+# Wired random-selection JFR profile
+
+This profile exercises the fallback random-effect selector used when a wired
+stack enables random execution without a `WiredExtraRandom` item. It performs
+2,000,000 selections after a 100,000-selection warmup and records allocation
+events from the real `WiredEngine` selection seam.
+
+Run it from the repository root with JDK 25:
+
+```bash
+./Emulator/mvnw -f Emulator/pom.xml test \
+  -Dtest=WiredRandomSelectionJfrProfileTest \
+  -Dpolaris.profile.wired-random=true \
+  -Dpolaris.profile.wired-random.variant=local
+```
+
+The recording and text summary are written under
+`Emulator/target/profiles/wired-random-local.*`.
+
+## Result
+
+Captured on 2026-07-20 with Temurin 25.0.3+9:
+
+| Measurement | `new Random()` | `ThreadLocalRandom` |
+| --- | ---: | ---: |
+| Selections | 2,000,000 | 2,000,000 |
+| Recording window | 83.408 ms | 56.991 ms |
+| Recorded `Random` allocations | 7 | 0 |
+| Recorded `Random` allocation bytes | 224 | 0 |
+| Total recorded allocations | 75 | 1 |
+| Total recorded allocation bytes | 18,232 | 24 |
+
+JFR allocation events are sampled at allocation boundaries rather than a
+complete object count, so the recorded allocation totals are comparative
+signals. The optimized run removed every sampled `java.util.Random`
+allocation while preserving index bounds and invalid-bound behavior.

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -38,6 +38,19 @@ older table shapes, but unsafe translations deliberately pass through.
 Plugin-owned tables and columns are allowed. Do not edit Polaris migrations;
 ship separate idempotent setup owned by the plugin.
 
+## Bundled dependency policy
+
+The assembled jar currently keeps `netty-all` on the plugin-visible classpath.
+Slimming that surface would require the precompiled plugin corpus to prove
+compatibility first. The same rule keeps `resilience4j-circuitbreaker` even
+where Polaris has no direct import.
+
+Polaris deliberately uses Hibernate Validator without an Expression Language
+implementation and configures `ParameterMessageInterpolator`; plugins must not
+assume that the default EL-backed validator factory is available. Commons Math
+3.6.1 remains in use for compatibility and is tracked for opportunistic
+replacement rather than removal during routine modernization.
+
 ## Compatibility guidance
 
 - Compile against a released Polaris API or the intended Morningstar baseline.

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -1,0 +1,51 @@
+# Polaris plugin author guide
+
+Polaris loads plugin jars from `plugins/` through the established
+parent-first plugin classloader. Existing Arcturus/Morningstar plugin jars are
+supported without recompilation.
+
+## Plugin metadata
+
+Place `plugin.json` at the root of the jar:
+
+```json
+{
+  "name": "Example plugin",
+  "author": "Hotel developer",
+  "main": "example.polaris.ExamplePlugin"
+}
+```
+
+The main class extends `com.eu.habbo.plugin.HabboPlugin` and implements
+`onEnable`, `onDisable`, and `hasPermission`. Keep plugin-owned resources in
+the jar and load them through the plugin classloader.
+
+## Events
+
+Register listeners through the plugin manager and annotate callbacks with
+`@EventHandler`. Legacy all-handler dispatch remains the default. Hotels may
+opt into priority ordering and cancellation-aware dispatch with
+`polaris.events.honor_priority=true`; plugins should behave correctly in both
+modes unless they explicitly require the corrected mode.
+
+## Database access
+
+`Emulator.getDatabase().getDataSource()` remains a public
+`HikariDataSource`-compatible API. New plugins should use the current schema
+and prepared statements. The legacy SQL bridge supports a defined subset of
+older table shapes, but unsafe translations deliberately pass through.
+
+Plugin-owned tables and columns are allowed. Do not edit Polaris migrations;
+ship separate idempotent setup owned by the plugin.
+
+## Compatibility guidance
+
+- Compile against a released Polaris API or the intended Morningstar baseline.
+- Do not bundle classes in `com.eu.habbo.*` or shadow server dependencies.
+- Treat bundled third-party libraries as compatibility-sensitive, not as a
+  promise that every library will remain forever.
+- Test the precompiled jar against the assembled
+  `Polaris-*-jar-with-dependencies.jar`.
+- Keep packet reads and writes aligned with the established client contract.
+
+See `POLARIS.md` for the legacy bridge and compatibility details.

--- a/docs/versioning-and-release.md
+++ b/docs/versioning-and-release.md
@@ -1,0 +1,30 @@
+# Versioning and release policy
+
+Polaris uses `major.minor.patch` versions. Routine compatible releases advance
+the patch version. Additive release trains may advance the minor version after
+operator-facing review. A breaking public integration change requires an
+explicitly approved major-release policy; routine modernization must remain
+compatible.
+
+## Release gate
+
+No release is published unless the source commit has a green `verify` run.
+The release workflow follows a successful CI run on `main`, rebuilds with
+tests, records a SHA-256 checksum, and publishes the runnable jar, SBOM, and
+provenance attestations. Manual dispatch is restricted to `main` and uses the
+same tested build.
+
+## Release checklist
+
+1. Merge the ordered pull-request stack only after required checks are green.
+2. Confirm ABI, precompiled plugin, assembled-jar, and supported MariaDB
+   migration jobs pass.
+3. Review migrations and configuration changes for upgrade safety.
+4. Deploy to a canary hotel and exercise startup, login, rooms, catalog,
+   wired, plugins, and shutdown.
+5. Monitor startup, database, scheduler, packet, and plugin errors before
+   widening rollout.
+6. Retain the previous jar, configuration, and database backup for rollback.
+
+Database migration rollback depends on the affected table engines and must not
+be described as transaction-wide without executable evidence.

--- a/scripts/build-latest.sh
+++ b/scripts/build-latest.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+module_root="$repo_root/Emulator"
+destination="$repo_root/Latest_Compiled_Version"
+source_jar=""
+skip_tests=false
+
+usage() {
+    echo "Usage: $0 [--destination DIR] [--source-jar JAR] [--skip-tests]"
+}
+
+while (($#)); do
+    case "$1" in
+        --destination)
+            destination="${2:?Missing value for --destination}"
+            shift 2
+            ;;
+        --source-jar)
+            source_jar="${2:?Missing value for --source-jar}"
+            shift 2
+            ;;
+        --skip-tests)
+            skip_tests=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$source_jar" ]]; then
+    maven_args=(-B clean package)
+    if [[ "$skip_tests" == true ]]; then
+        maven_args+=(-DskipTests)
+    fi
+    (
+        cd "$module_root"
+        ./mvnw "${maven_args[@]}"
+    )
+
+    artifact_id="$(
+        cd "$module_root"
+        ./mvnw -q help:evaluate -Dexpression=project.artifactId -DforceStdout
+    )"
+    version="$(
+        cd "$module_root"
+        ./mvnw -q help:evaluate -Dexpression=project.version -DforceStdout
+    )"
+    source_jar="$module_root/target/$artifact_id-$version-jar-with-dependencies.jar"
+fi
+
+if [[ ! -f "$source_jar" ]]; then
+    echo "Built JAR not found: $source_jar" >&2
+    exit 1
+fi
+
+mkdir -p "$destination"
+file_name="$(basename -- "$source_jar")"
+final_jar="$destination/$file_name"
+temporary_jar="$final_jar.tmp-$$"
+final_hash="$final_jar.sha256"
+temporary_hash="$final_hash.tmp-$$"
+
+cleanup() {
+    rm -f -- "$temporary_jar" "$temporary_hash"
+}
+trap cleanup EXIT
+
+cp -- "$source_jar" "$temporary_jar"
+mv -f -- "$temporary_jar" "$final_jar"
+
+if command -v sha256sum >/dev/null 2>&1; then
+    hash="$(sha256sum "$final_jar" | awk '{print $1}')"
+else
+    hash="$(shasum -a 256 "$final_jar" | awk '{print $1}')"
+fi
+printf '%s  %s\n' "$hash" "$file_name" > "$temporary_hash"
+mv -f -- "$temporary_hash" "$final_hash"
+
+echo "JAR: $final_jar"
+echo "SHA256: $final_hash"

--- a/scripts/build-latest.test.sh
+++ b/scripts/build-latest.test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+temporary="$(mktemp -d "${TMPDIR:-/tmp}/polaris-build-latest.XXXXXX")"
+source_directory="$temporary/source"
+destination="$temporary/latest"
+source_jar="$source_directory/Polaris-4.2.50-jar-with-dependencies.jar"
+
+cleanup() {
+    rm -rf -- "$temporary"
+}
+trap cleanup EXIT
+
+mkdir -p "$source_directory"
+printf '\001\002\003\004\005\377' > "$source_jar"
+"$script_dir/build-latest.sh" --source-jar "$source_jar" --destination "$destination"
+
+copy="$destination/$(basename -- "$source_jar")"
+hash_file="$copy.sha256"
+test -f "$copy"
+test -f "$hash_file"
+cmp "$source_jar" "$copy"
+
+if command -v sha256sum >/dev/null 2>&1; then
+    source_hash="$(sha256sum "$source_jar" | awk '{print $1}')"
+else
+    source_hash="$(shasum -a 256 "$source_jar" | awk '{print $1}')"
+fi
+expected="$source_hash  $(basename -- "$copy")"
+actual="$(tr -d '\r\n' < "$hash_file")"
+[[ "$actual" == "$expected" ]]
+
+grep -q 'build-latest\.test\.sh' "$repo_root/.github/workflows/ci.yml"
+grep -q 'sha256sum' "$repo_root/.github/workflows/build-release.yml"
+grep -q '\.sha256' "$repo_root/.github/workflows/build-release.yml"
+
+echo "build-latest contract verified."

--- a/scripts/verify-furni-import.sh
+++ b/scripts/verify-furni-import.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+module_root="$repo_root/Emulator"
+items_source=""
+furniture_data=""
+nitro_root=""
+report=""
+items_json=false
+require_swf=false
+quiet=false
+
+usage() {
+    echo "Usage: $0 --items-source PATH --furniture-data PATH --nitro-root DIR --report PATH [--items-json] [--require-swf] [--quiet]"
+}
+
+while (($#)); do
+    case "$1" in
+        --items-source)
+            items_source="${2:?Missing value for --items-source}"
+            shift 2
+            ;;
+        --furniture-data)
+            furniture_data="${2:?Missing value for --furniture-data}"
+            shift 2
+            ;;
+        --nitro-root)
+            nitro_root="${2:?Missing value for --nitro-root}"
+            shift 2
+            ;;
+        --report)
+            report="${2:?Missing value for --report}"
+            shift 2
+            ;;
+        --items-json)
+            items_json=true
+            shift
+            ;;
+        --require-swf)
+            require_swf=true
+            shift
+            ;;
+        --quiet)
+            quiet=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+for required in items_source furniture_data nitro_root report; do
+    if [[ -z "${!required}" ]]; then
+        usage >&2
+        exit 2
+    fi
+done
+
+jar=""
+for candidate in "$module_root"/target/*-jar-with-dependencies.jar; do
+    if [[ -f "$candidate" ]] && { [[ -z "$jar" ]] || [[ "$candidate" -nt "$jar" ]]; }; then
+        jar="$candidate"
+    fi
+done
+if [[ -z "$jar" ]] || find "$module_root/src" -type f -newer "$jar" -print -quit | grep -q .; then
+    "$module_root/mvnw" -B -f "$module_root/pom.xml" -DskipTests package
+    jar=""
+    for candidate in "$module_root"/target/*-jar-with-dependencies.jar; do
+        if [[ -f "$candidate" ]] && { [[ -z "$jar" ]] || [[ "$candidate" -nt "$jar" ]]; }; then
+            jar="$candidate"
+        fi
+    done
+fi
+
+source_option="--items-sql-dump"
+if [[ "$items_json" == true ]]; then
+    source_option="--items"
+fi
+
+arguments=(
+    -cp "$jar"
+    com.eu.habbo.tools.furni.FurniConsistencyCli
+    "$source_option" "$(cd -- "$(dirname -- "$items_source")" && pwd)/$(basename -- "$items_source")"
+    --furniture-data "$(cd -- "$(dirname -- "$furniture_data")" && pwd)/$(basename -- "$furniture_data")"
+    --bundles "$nitro_root/nitro-assets/bundled/furniture"
+    --icons "$nitro_root/swf/dcr/hof_furni/icons"
+    --report "$report"
+)
+if [[ "$require_swf" == true ]]; then
+    arguments+=(--swf "$nitro_root/swf/dcr/hof_furni")
+fi
+if [[ "$quiet" == true ]]; then
+    arguments+=(--quiet)
+fi
+
+exec java "${arguments[@]}"


### PR DESCRIPTION
Completes the remaining modernization safeguards in one project-foundations batch. The database index migration now runs as a Testcontainers Failsafe test, wired random-effect selection reuses `ThreadLocalRandom` with recorded JFR evidence, compiler parameter names are retained, and repository text, ignore, contribution, and pull-request policies are explicit. Adds portable shell equivalents for the build and furni helpers plus architecture, plugin-author, and release-policy documentation.