### PR TITLE
fix(build): support JDK 26 packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,28 @@ jobs:
           path: Emulator/target/furni-consistency-fixture.json
           if-no-files-found: error
 
+  jdk26-package:
+    name: JDK 26 package compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: Emulator
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 26
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "26"
+          cache: maven
+
+      - name: Build clean package
+        run: ./mvnw -B clean package
+
   migration-matrix:
     name: Migrations on MariaDB ${{ matrix.mariadb }}
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,9 @@ coordinated changes.
 
 ## Development setup
 
-Use JDK 25, Maven 3.9.11, and the wrapper in `Emulator/`. Docker is needed for
-the Testcontainers integration suite.
+Use JDK 25 or 26 and the Maven 3.9.11 wrapper in `Emulator/`. Builds continue
+to emit Java 25 bytecode, and release artifacts are produced on JDK 25. Docker
+is needed for the Testcontainers integration suite.
 
 ```bash
 ./Emulator/mvnw -f Emulator/pom.xml test

--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -13,6 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>2026-07-20T00:00:00Z</project.build.outputTimestamp>
         <maven.compiler.release>25</maven.compiler.release>
+        <maven.build.java.version>[25,27)</maven.build.java.version>
 
         <netty.version>4.2.16.Final</netty.version>
         <gson.version>2.14.0</gson.version>
@@ -119,7 +120,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[25,26)</version>
+                                    <version>${maven.build.java.version}</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>[3.9.11,4)</version>

--- a/Emulator/src/test/java/com/eu/habbo/build/MavenBuildEnvironmentContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/build/MavenBuildEnvironmentContractTest.java
@@ -18,7 +18,8 @@ class MavenBuildEnvironmentContractTest {
         assertTrue(pom.contains("<project.build.outputTimestamp>"));
         assertTrue(pom.contains("<artifactId>maven-enforcer-plugin</artifactId>"));
         assertTrue(pom.contains("<requireJavaVersion>"));
-        assertTrue(pom.contains("<version>[25,26)</version>"));
+        assertTrue(pom.contains("<maven.build.java.version>[25,27)</maven.build.java.version>"));
+        assertTrue(pom.contains("<version>${maven.build.java.version}</version>"));
         assertTrue(pom.contains("<requireMavenVersion>"));
         assertTrue(pom.contains("<version>[3.9.11,4)</version>"));
         assertTrue(pom.contains("<dependencyConvergence/>"));
@@ -52,6 +53,9 @@ class MavenBuildEnvironmentContractTest {
         String codeQl = Files.readString(Path.of("..", ".github", "workflows", "codeql.yml"));
 
         assertTrue(ci.contains("run: ./mvnw -B -Pcoverage verify"));
+        assertTrue(ci.contains("name: JDK 26 package compatibility"));
+        assertTrue(ci.contains("java-version: \"26\""));
+        assertTrue(ci.contains("run: ./mvnw -B clean package"));
         assertFalse(ci.contains("run: mvn "));
         assertTrue(codeQl.contains("run: ./mvnw -B -DskipTests package"));
     }


### PR DESCRIPTION
Restores the normal clean-package workflow for developers whose default shell uses JDK 26. The build now accepts JDK 25 or 26 while continuing to emit Java 25 bytecode and keeping release artifacts pinned to JDK 25.

Adds a dedicated JDK 26 clean-package CI check so the compatibility remains covered.

Validated locally with clean package and all 1,002 unit tests on JDK 26, plus the full JDK 25 verify lifecycle with 14 MariaDB integration tests, packaging, Spotless, SpotBugs, and coverage.