### PR TITLE
fix(plugins): dispatch static @EventHandler methods

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/PluginManager.java
@@ -28,6 +28,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.text.ParsePosition;
@@ -385,7 +386,8 @@ public class PluginManager {
             Method method,
             EventHandler annotation,
             Class<? extends Event> eventType,
-            MethodHandle handle) {
+            MethodHandle handle,
+            boolean staticMethod) {
 
         private static final Comparator<HandlerInvocation> CORRECTED_ORDER =
                 Comparator.comparingInt(HandlerInvocation::prioritySlot).thenComparing(HandlerInvocation::stableKey);
@@ -406,7 +408,8 @@ public class PluginManager {
                         method,
                         method.getAnnotation(EventHandler.class),
                         method.getParameterTypes()[0].asSubclass(Event.class),
-                        MethodHandles.lookup().unreflect(method));
+                        MethodHandles.lookup().unreflect(method),
+                        Modifier.isStatic(method.getModifiers()));
             } catch (IllegalAccessException exception) {
                 throw new IllegalStateException("Unable to cache plugin event handler " + method, exception);
             }
@@ -441,7 +444,11 @@ public class PluginManager {
 
         void invoke(Event event) {
             try {
-                if (this.plugin == null) {
+                // The receiver is bound only for instance methods. A static @EventHandler
+                // (the classic Arcturus/Morningstar pattern) unreflects to a no-receiver
+                // handle, so passing this.plugin would raise WrongMethodTypeException.
+                // Legacy reflection ignored the receiver for static methods; preserve that.
+                if (this.staticMethod) {
                     this.handle.invoke(event);
                 } else {
                     this.handle.invoke(this.plugin, event);

--- a/Emulator/src/test/java/com/eu/habbo/plugin/PluginEventBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/plugin/PluginEventBehaviorTest.java
@@ -75,6 +75,18 @@ class PluginEventBehaviorTest {
     }
 
     @Test
+    void legacyDispatchInvokesStaticPluginHandlers() {
+        List<String> calls = new ArrayList<>();
+        PluginManager manager = new PluginManager();
+        StaticHandlerPlugin plugin = new StaticHandlerPlugin(calls);
+        manager.getPlugins().add(plugin);
+        manager.registerEvents(plugin, plugin);
+
+        assertSame(TestEvent.class, manager.fireEvent(new TestEvent()).getClass());
+        assertEquals(List.of("static-plugin"), calls);
+    }
+
+    @Test
     void legacyDirectRegistrationMutationsTakeEffectWithoutManagerRegistration() throws Exception {
         List<String> calls = new ArrayList<>();
         PluginManager manager = new PluginManager();
@@ -140,6 +152,20 @@ class PluginEventBehaviorTest {
 
         public void onDirectEvent(TestEvent event) {
             calls.add("plugin");
+        }
+    }
+
+    private static final class StaticHandlerPlugin extends TestPlugin {
+        private static List<String> staticCalls;
+
+        StaticHandlerPlugin(List<String> calls) {
+            super(calls);
+            staticCalls = calls;
+        }
+
+        @EventHandler
+        public static void onEvent(TestEvent event) {
+            staticCalls.add("static-plugin");
         }
     }
 


### PR DESCRIPTION
## Problem

Legacy Arcturus/Morningstar plugins declare `@EventHandler` methods as `public static void`. After the modernization to cached `MethodHandle` dispatch (`bde7f677 fix(plugins): publish atomic event dispatch tables`), every static plugin handler threw `WrongMethodTypeException` and silently never ran — e.g. `EmulatorLoadedEvent` was dropped for both bundled test plugins (WordGuesser, Fun Commands).

## Root cause

`unreflect` on a static method yields a **no-receiver** handle (`(EventType)void`). `HandlerInvocation.invoke()` branched on `plugin == null` (default-vs-plugin) and always prepended `this.plugin` as a receiver for plugin handlers — a type mismatch for static methods.

The old reflection path `method.invoke(plugin, event)` ignored the receiver for static methods, so this worked before the swap.

## Fix

Cache `Modifier.isStatic(...)` on `HandlerInvocation` at capture time and branch `invoke()` on that instead of `plugin == null`, restoring exact reflection parity (static → no receiver, instance → plugin receiver).

## Tests

- Added `legacyDispatchInvokesStaticPluginHandlers` — a static-handler plugin fixture (the case the existing suite never covered). **Red before the fix** (`expected: <[static-plugin]> but was: <[]>`), green after.
- Full unit suite: **1024 tests, 0 failures**.
- Verified end-to-end: rebuilt jar boots with both real plugin jars, **0 `WrongMethodTypeException`**, both `onEmulatorLoaded` handlers execute.

Preserves the frozen plugin ABI — legacy jars run unchanged with no recompilation.