### PR TITLE
Fix messenger history and add wired furniture opacity

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -231,6 +231,7 @@ import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectForwa
 import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectFreeze;
 import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectFurniToFurni;
 import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectFurniToUser;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectFurniOpacity;
 import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement;
 import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveBadge;
 import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveCredits;
@@ -721,6 +722,7 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_act_give_var", WiredEffectGiveVariable.class));
         this.interactionsList.add(new ItemInteraction("wf_act_remove_var", WiredEffectRemoveVariable.class));
         this.interactionsList.add(new ItemInteraction("wf_act_change_var_val", WiredEffectChangeVariableValue.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_furni_opacity", WiredEffectFurniOpacity.class));
 
         this.interactionsList.add(new ItemInteraction("wf_cnd_has_furni_on", WiredConditionFurniHaveFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_furnis_hv_avtrs", WiredConditionFurniHaveHabbo.class));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectFurniOpacity.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectFurniOpacity.java
@@ -1,0 +1,247 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+import com.eu.habbo.messages.outgoing.rooms.items.WiredFurniOpacityComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Applies a transient opacity and click-through state to furniture selected by
+ * the current Wired source. The state belongs to the receiving client, just
+ * like the original Wired opacity effect.
+ */
+public class WiredEffectFurniOpacity extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.FURNI_OPACITY;
+
+    private static final int VISIBILITY_EVERYONE = 0;
+    private static final int VISIBILITY_TRIGGERING_USER = 1;
+    private static final int EASING_INSTANT = 0;
+    private static final int EASING_MAX = 4;
+
+    private final List<HabboItem> items = new ArrayList<>();
+    private int opacity = 100;
+    private int visibility = VISIBILITY_EVERYONE;
+    private boolean clickThrough;
+    private int easing = EASING_INSTANT;
+    private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectFurniOpacity(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectFurniOpacity(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) return;
+
+        List<HabboItem> effectiveItems = WiredSourceUtil.resolveItems(ctx, this.furniSource, this.items)
+                .stream()
+                .filter(item -> item != null && item.getRoomId() == this.getRoomId())
+                .collect(Collectors.toList());
+
+        if (this.furniSource == WiredSourceUtil.SOURCE_SELECTED) {
+            this.items.removeIf(item -> item == null || item.getRoomId() != this.getRoomId() || room.getHabboItem(item.getId()) == null);
+        }
+
+        if (effectiveItems.isEmpty()) return;
+
+        WiredFurniOpacityComposer composer = new WiredFurniOpacityComposer(effectiveItems, this.opacity, this.clickThrough, this.easing);
+
+        if (this.visibility == VISIBILITY_TRIGGERING_USER) {
+            Habbo actor = ctx.actor().map(room::getHabbo).orElse(null);
+
+            if (actor != null && actor.getClient() != null) {
+                actor.getClient().sendResponse(composer.compose());
+            }
+
+            return;
+        }
+
+        room.sendComposer(composer.compose());
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+                this.getDelay(),
+                this.items.stream().map(HabboItem::getId).collect(Collectors.toList()),
+                this.opacity,
+                this.visibility,
+                this.clickThrough,
+                this.easing,
+                this.furniSource
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.items.clear();
+
+        JsonData data = WiredUtilityPayloadGuard.fromJson(set.getString("wired_data"), JsonData.class);
+        if (data == null) {
+            this.onPickUp();
+            return;
+        }
+
+        this.setDelay(WiredUtilityPayloadGuard.delay(data.delay));
+        this.opacity = normalizeOpacity(data.opacity);
+        this.visibility = normalizeVisibility(data.visibility);
+        this.clickThrough = data.clickThrough;
+        this.easing = normalizeEasing(data.easing);
+        this.furniSource = WiredUtilityPayloadGuard.furniSource(data.furniSource);
+
+        if (data.itemIds != null) {
+            for (Integer itemId : data.itemIds) {
+                if (itemId == null) continue;
+
+                HabboItem item = room.getHabboItem(itemId);
+                if (item != null) this.items.add(item);
+            }
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.items.clear();
+        this.opacity = 100;
+        this.visibility = VISIBILITY_EVERYONE;
+        this.clickThrough = false;
+        this.easing = EASING_INSTANT;
+        this.furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        List<HabboItem> validItems = this.items.stream()
+                .filter(item -> item != null && item.getRoomId() == this.getRoomId() && room.getHabboItem(item.getId()) != null)
+                .collect(Collectors.toList());
+
+        this.items.clear();
+        this.items.addAll(validItems);
+
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(validItems.size());
+        for (HabboItem item : validItems) {
+            message.appendInt(item.getId());
+        }
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(5);
+        message.appendInt(this.opacity);
+        message.appendInt(this.visibility);
+        message.appendInt(this.clickThrough ? 1 : 0);
+        message.appendInt(this.easing);
+        message.appendInt(this.furniSource);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+        if (params.length < 5) throw new WiredSaveException("Invalid opacity Wired settings");
+
+        int delay = settings.getDelay();
+        if (delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20)) {
+            throw new WiredSaveException("Delay too long");
+        }
+
+        if (settings.getFurniIds().length > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) {
+            throw new WiredSaveException("Too many furni selected");
+        }
+
+        Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
+        if (room == null) throw new WiredSaveException("Room not found");
+
+        List<HabboItem> newItems = new ArrayList<>();
+        for (int itemId : settings.getFurniIds()) {
+            HabboItem item = room.getHabboItem(itemId);
+            if (item == null) throw new WiredSaveException(String.format("Item %s not found", itemId));
+            newItems.add(item);
+        }
+
+        this.opacity = normalizeOpacity(params[0]);
+        this.visibility = normalizeVisibility(params[1]);
+        this.clickThrough = params[2] == 1;
+        this.easing = normalizeEasing(params[3]);
+        this.furniSource = WiredUtilityPayloadGuard.furniSource(params[4]);
+        if (!newItems.isEmpty() && this.furniSource == WiredSourceUtil.SOURCE_TRIGGER) {
+            this.furniSource = WiredSourceUtil.SOURCE_SELECTED;
+        }
+        this.items.clear();
+        if (this.furniSource == WiredSourceUtil.SOURCE_SELECTED) this.items.addAll(newItems);
+        this.setDelay(delay);
+
+        return true;
+    }
+
+    private int normalizeOpacity(int value) {
+        return Math.max(0, Math.min(100, value));
+    }
+
+    private int normalizeVisibility(int value) {
+        return value == VISIBILITY_TRIGGERING_USER ? VISIBILITY_TRIGGERING_USER : VISIBILITY_EVERYONE;
+    }
+
+    private int normalizeEasing(int value) {
+        return Math.max(EASING_INSTANT, Math.min(EASING_MAX, value));
+    }
+
+    static class JsonData {
+        int delay;
+        List<Integer> itemIds;
+        int opacity;
+        int visibility;
+        boolean clickThrough;
+        int easing;
+        int furniSource;
+
+        JsonData(int delay, List<Integer> itemIds, int opacity, int visibility, boolean clickThrough, int easing, int furniSource) {
+            this.delay = delay;
+            this.itemIds = itemIds;
+            this.opacity = opacity;
+            this.visibility = visibility;
+            this.clickThrough = clickThrough;
+            this.easing = easing;
+            this.furniSource = furniSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
@@ -21,6 +21,8 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
 
     @Override
     public List<MessengerConversationSummary> listConversations(int userId) {
+        ensureLegacyDirectConversations(userId);
+
         String sql = """
                 SELECT c.id, c.type,
                        CASE WHEN c.type = 'direct' THEN COALESCE(MAX(CASE WHEN peer.user_id <> ? THEN peer.user_id END), 0) ELSE 0 END AS participant_id,
@@ -95,6 +97,11 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
 
     @Override
     public List<MessengerStoredMessage> loadHistory(long conversationId, int userId, long beforeMessageId, int limit) {
+        int[] directParticipants = findDirectParticipants(conversationId, userId);
+        if (directParticipants != null) {
+            return loadLegacyDirectHistory(conversationId, directParticipants[0], directParticipants[1], beforeMessageId, limit);
+        }
+
         String sql = """
                 SELECT m.id, m.conversation_id, m.sender_id, m.type, m.message, m.metadata,
                        UNIX_TIMESTAMP(m.created_at) AS created_at
@@ -132,6 +139,109 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
             return messages;
         } catch (SQLException exception) {
             throw new IllegalStateException("failed to load messenger history", exception);
+        }
+    }
+
+    private void ensureLegacyDirectConversations(int userId) {
+        String conversationsSql = """
+                INSERT INTO messenger_conversations (type, direct_key, created_at, updated_at)
+                SELECT 'direct',
+                       CONCAT(LEAST(user_from_id, user_to_id), ':', GREATEST(user_from_id, user_to_id)),
+                       MIN(FROM_UNIXTIME(timestamp)),
+                       MAX(FROM_UNIXTIME(timestamp))
+                FROM chatlogs_private
+                WHERE (user_from_id = ? OR user_to_id = ?)
+                  AND user_from_id > 0
+                  AND user_to_id > 0
+                  AND user_from_id <> user_to_id
+                GROUP BY LEAST(user_from_id, user_to_id), GREATEST(user_from_id, user_to_id)
+                ON DUPLICATE KEY UPDATE updated_at = GREATEST(updated_at, VALUES(updated_at))
+                """;
+        String membersSql = """
+                INSERT IGNORE INTO messenger_members (conversation_id, user_id)
+                SELECT id, CAST(SUBSTRING_INDEX(direct_key, ':', 1) AS UNSIGNED)
+                FROM messenger_conversations
+                WHERE type = 'direct'
+                  AND (SUBSTRING_INDEX(direct_key, ':', 1) = ? OR SUBSTRING_INDEX(direct_key, ':', -1) = ?)
+                UNION ALL
+                SELECT id, CAST(SUBSTRING_INDEX(direct_key, ':', -1) AS UNSIGNED)
+                FROM messenger_conversations
+                WHERE type = 'direct'
+                  AND (SUBSTRING_INDEX(direct_key, ':', 1) = ? OR SUBSTRING_INDEX(direct_key, ':', -1) = ?)
+                """;
+        try (Connection connection = dataSource.getConnection()) {
+            try (PreparedStatement statement = connection.prepareStatement(conversationsSql)) {
+                statement.setInt(1, userId);
+                statement.setInt(2, userId);
+                statement.executeUpdate();
+            }
+            try (PreparedStatement statement = connection.prepareStatement(membersSql)) {
+                statement.setInt(1, userId);
+                statement.setInt(2, userId);
+                statement.setInt(3, userId);
+                statement.setInt(4, userId);
+                statement.executeUpdate();
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("failed to initialize legacy messenger conversations", exception);
+        }
+    }
+
+    private int[] findDirectParticipants(long conversationId, int userId) {
+        String sql = "SELECT direct_key FROM messenger_conversations WHERE id = ? AND type = 'direct'";
+        try (Connection connection = dataSource.getConnection(); PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, conversationId);
+            try (ResultSet result = statement.executeQuery()) {
+                if (!result.next()) return null;
+
+                String[] participantIds = result.getString("direct_key").split(":", 2);
+                if (participantIds.length != 2) return null;
+
+                int firstUserId = Integer.parseInt(participantIds[0]);
+                int secondUserId = Integer.parseInt(participantIds[1]);
+                if (firstUserId != userId && secondUserId != userId) return null;
+
+                return new int[]{firstUserId, secondUserId};
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("failed to resolve direct messenger conversation", exception);
+        }
+    }
+
+    private List<MessengerStoredMessage> loadLegacyDirectHistory(long conversationId, int firstUserId, int secondUserId, long beforeMessageId, int limit) {
+        String sql = """
+                SELECT id, user_from_id, message, timestamp
+                FROM chatlogs_private
+                WHERE ((user_from_id = ? AND user_to_id = ?) OR (user_from_id = ? AND user_to_id = ?))
+                  AND (? = 0 OR id < ?)
+                ORDER BY id DESC
+                LIMIT ?
+                """;
+        List<MessengerStoredMessage> messages = new ArrayList<>();
+        try (Connection connection = dataSource.getConnection(); PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setInt(1, firstUserId);
+            statement.setInt(2, secondUserId);
+            statement.setInt(3, secondUserId);
+            statement.setInt(4, firstUserId);
+            statement.setLong(5, beforeMessageId);
+            statement.setLong(6, beforeMessageId);
+            statement.setInt(7, limit + 1);
+            try (ResultSet result = statement.executeQuery()) {
+                while (result.next()) {
+                    messages.add(new MessengerStoredMessage(
+                            result.getLong("id"),
+                            conversationId,
+                            result.getInt("user_from_id"),
+                            0,
+                            result.getString("message"),
+                            null,
+                            result.getLong("timestamp")
+                    ));
+                }
+            }
+            return messages;
+        } catch (SQLException exception) {
+            throw new IllegalStateException("failed to load legacy direct messenger history", exception);
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryService.java
@@ -7,8 +7,8 @@ import java.util.List;
 public final class MessengerHistoryService {
     public static final int DEFAULT_RETENTION_DAYS = 30;
     public static final int DEFAULT_MAX_MESSAGES = 500;
-    public static final int DEFAULT_PAGE_SIZE = 30;
-    public static final int MAX_PAGE_SIZE = 50;
+    public static final int DEFAULT_PAGE_SIZE = 500;
+    public static final int MAX_PAGE_SIZE = 500;
 
     private final MessengerHistoryRepository repository;
     private final int retentionDays;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
@@ -795,7 +795,7 @@ public class HabboStats implements Runnable {
 
     public void unignoreUser(int userId) {
         if (this.userIgnored(userId)) {
-            this.ignoredUsers.remove(userId);
+            this.ignoredUsers.rem(userId);
 
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
                  PreparedStatement statement = connection.prepareStatement("DELETE FROM users_ignored WHERE user_id = ? AND target_id = ?")) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredEffectType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredEffectType.java
@@ -70,6 +70,7 @@ public enum WiredEffectType {
     CANCEL_TRANSACTION(105),
     PLACE_FURNI(106),
     REMOVE_FURNI(107),
+    FURNI_OPACITY(114),
     MOVE_FURNI_AS_GROUP(95),
     REMOTE_SELECTOR(96),
     // Negative-branch effects that reuse the SHOW_MESSAGE(7) client dialog (text). Distinct enum

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -133,6 +133,7 @@ public class Outgoing {
     public final static int TranslationLanguagesComposer = 5106; // CUSTOM
     public final static int TranslationResultComposer = 5107; // CUSTOM
     public final static int AreaHideComposer = 6001; // CUSTOM
+    public final static int WiredFurniOpacityComposer = 6002; // CUSTOM
     public final static int RoomPaintComposer = 2454; // PRODUCTION-201611291003-338511768
     public final static int MarketplaceConfigComposer = 1823; // PRODUCTION-201611291003-338511768
     public final static int AddBotComposer = 1352; // PRODUCTION-201611291003-338511768

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/WiredFurniOpacityComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/WiredFurniOpacityComposer.java
@@ -1,0 +1,39 @@
+package com.eu.habbo.messages.outgoing.rooms.items;
+
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+import java.util.Collection;
+
+/** Sends a transient, client-side opacity update for Wired-selected furniture. */
+public class WiredFurniOpacityComposer extends MessageComposer {
+    private final Collection<HabboItem> items;
+    private final int opacity;
+    private final boolean clickThrough;
+    private final int easing;
+
+    public WiredFurniOpacityComposer(Collection<HabboItem> items, int opacity, boolean clickThrough, int easing) {
+        this.items = items;
+        this.opacity = opacity;
+        this.clickThrough = clickThrough;
+        this.easing = easing;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.WiredFurniOpacityComposer);
+        this.response.appendInt(this.items.size());
+
+        for (HabboItem item : this.items) {
+            this.response.appendInt(item.getId());
+        }
+
+        this.response.appendInt(this.opacity);
+        this.response.appendBoolean(this.clickThrough);
+        this.response.appendInt(this.easing);
+
+        return this.response;
+    }
+}

--- a/Emulator/src/main/resources/db/migration/V20260723140000__chatlog_utf8mb4.sql
+++ b/Emulator/src/main/resources/db/migration/V20260723140000__chatlog_utf8mb4.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `chatlogs_private`
+    DROP INDEX `message`,
+    MODIFY `message` VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    ADD INDEX `message` (`message`(191));
+
+ALTER TABLE `chatlogs_room`
+    MODIFY `message` VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;


### PR DESCRIPTION
Includes the existing messenger history and chat logging fix plus the wired furniture opacity effect: configurable visibility, opacity, easing, click-through, and furni source selection.