### PR TITLE
feat(wired): add capability-gated movement styles

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
@@ -28,6 +28,8 @@ public class GameClient {
 
     // Bit 0 - the client understands per-furniture opacity updates.
     public static final int WIRED_FEATURE_OPACITY = 1;
+    public static final int WIRED_FEATURE_MOVE_STYLE = 2;
+    private static final int WIRED_FEATURE_KNOWN_MASK = WIRED_FEATURE_OPACITY | WIRED_FEATURE_MOVE_STYLE;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GameClient.class);
 
@@ -86,7 +88,7 @@ public class GameClient {
     /** Stores only the WIRED capabilities understood by this emulator build. */
     public void setWiredFeatureCapabilities(int protocolVersion, int capabilities) {
         this.wiredFeatureProtocolVersion = Math.max(0, protocolVersion);
-        this.wiredFeatureCapabilities = Math.max(0, capabilities) & WIRED_FEATURE_OPACITY;
+        this.wiredFeatureCapabilities = Math.max(0, capabilities) & WIRED_FEATURE_KNOWN_MASK;
     }
 
     /** Returns whether this client advertised the required protocol and capability bit. */

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraMovementCurve.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraMovementCurve.java
@@ -26,10 +26,17 @@ public class WiredExtraMovementCurve extends InteractionWiredExtra {
     public static final int CURVE_EASE_IN = 1;
     public static final int CURVE_EASE_OUT = 2;
     public static final int CURVE_EASE_IN_OUT = 3;
+    public static final int CURVE_BOUNCE = 4;
+    public static final int CURVE_ELASTIC = 5;
+    public static final int CURVE_DROP = 6;
     private static final int CURVE_MIN = CURVE_LINEAR;
-    private static final int CURVE_MAX = CURVE_EASE_IN_OUT;
+    private static final int CURVE_MAX = CURVE_DROP;
+    public static final int INTENSITY_MIN = 0;
+    public static final int INTENSITY_MAX = 100;
+    public static final int INTENSITY_DEFAULT = 100;
 
     private int curveType = CURVE_LINEAR;
+    private int intensity = INTENSITY_DEFAULT;
 
     public WiredExtraMovementCurve(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
@@ -57,12 +64,15 @@ public class WiredExtraMovementCurve extends InteractionWiredExtra {
         }
 
         this.curveType = normalizeCurve(value);
+        if (settings.getIntParams().length > 1) {
+            this.intensity = normalizeIntensity(settings.getIntParams()[1]);
+        }
         return true;
     }
 
     @Override
     public String getWiredData() {
-        return WiredManager.getGson().toJson(new JsonData(this.curveType));
+        return WiredManager.getGson().toJson(new JsonData(this.curveType, this.intensity));
     }
 
     @Override
@@ -73,8 +83,9 @@ public class WiredExtraMovementCurve extends InteractionWiredExtra {
         message.appendInt(this.getBaseItem().getSpriteId());
         message.appendInt(this.getId());
         message.appendString("");
-        message.appendInt(1);
+        message.appendInt(2);
         message.appendInt(this.curveType);
+        message.appendInt(this.intensity);
         message.appendInt(0);
         message.appendInt(CODE);
         message.appendInt(0);
@@ -93,6 +104,8 @@ public class WiredExtraMovementCurve extends InteractionWiredExtra {
         if (wiredData.startsWith("{")) {
             JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
             this.curveType = normalizeCurve((data != null) ? data.curveType : CURVE_LINEAR);
+            this.intensity = normalizeIntensity(
+                    (data != null && data.intensity != null) ? data.intensity : INTENSITY_DEFAULT);
             return;
         }
 
@@ -106,6 +119,7 @@ public class WiredExtraMovementCurve extends InteractionWiredExtra {
     @Override
     public void onPickUp() {
         this.curveType = CURVE_LINEAR;
+        this.intensity = INTENSITY_DEFAULT;
     }
 
     @Override
@@ -122,15 +136,26 @@ public class WiredExtraMovementCurve extends InteractionWiredExtra {
         return this.curveType;
     }
 
+    public int getIntensity() {
+        return this.intensity;
+    }
+
     private static int normalizeCurve(int value) {
         return Math.max(CURVE_MIN, Math.min(CURVE_MAX, value));
     }
 
+    private static int normalizeIntensity(int value) {
+        return Math.max(INTENSITY_MIN, Math.min(INTENSITY_MAX, value));
+    }
+
     static class JsonData {
         int curveType;
+        // Wrapper so payloads saved before the intensity field existed load as "default", not 0.
+        Integer intensity;
 
-        JsonData(int curveType) {
+        JsonData(int curveType, int intensity) {
             this.curveType = curveType;
+            this.intensity = intensity;
         }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraMovementCurve.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraMovementCurve.java
@@ -8,7 +8,6 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.messages.ServerMessage;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
@@ -42,7 +41,8 @@ public class WiredExtraMovementCurve extends InteractionWiredExtra {
         super(set, baseItem);
     }
 
-    public WiredExtraMovementCurve(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+    public WiredExtraMovementCurve(
+            int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
     }
 
@@ -55,7 +55,9 @@ public class WiredExtraMovementCurve extends InteractionWiredExtra {
     public boolean saveData(WiredSettings settings, GameClient gameClient) {
         int value = (settings.getIntParams().length > 0) ? settings.getIntParams()[0] : this.curveType;
 
-        if (value == this.curveType && settings.getStringParam() != null && !settings.getStringParam().isEmpty()) {
+        if (value == this.curveType
+                && settings.getStringParam() != null
+                && !settings.getStringParam().isEmpty()) {
             try {
                 value = Integer.parseInt(settings.getStringParam());
             } catch (NumberFormatException ignored) {
@@ -104,8 +106,8 @@ public class WiredExtraMovementCurve extends InteractionWiredExtra {
         if (wiredData.startsWith("{")) {
             JsonData data = WiredExtraPayloadGuard.fromJson(wiredData, JsonData.class);
             this.curveType = normalizeCurve((data != null) ? data.curveType : CURVE_LINEAR);
-            this.intensity = normalizeIntensity(
-                    (data != null && data.intensity != null) ? data.intensity : INTENSITY_DEFAULT);
+            this.intensity =
+                    normalizeIntensity((data != null && data.intensity != null) ? data.intensity : INTENSITY_DEFAULT);
             return;
         }
 
@@ -123,9 +125,7 @@ public class WiredExtraMovementCurve extends InteractionWiredExtra {
     }
 
     @Override
-    public void onWalk(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {
-
-    }
+    public void onWalk(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {}
 
     @Override
     public boolean hasConfiguration() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/WiredGravityService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/WiredGravityService.java
@@ -4,6 +4,7 @@ import com.eu.habbo.WiredPlatform;
 import com.eu.habbo.habbohotel.items.FurnitureType;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.core.WiredMoveStyleHelper;
 import com.eu.habbo.messages.outgoing.rooms.WiredMovementsComposer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -205,6 +206,7 @@ final class WiredGravityService {
         }
 
         List<WiredMovementsComposer.MovementData> movements = new ArrayList<>();
+        List<Integer> fallenItemIds = new ArrayList<>();
         long retryAfterMs = 0L;
         for (WiredGravityPlanner.Fall fall : plan.falls()) {
             if (!sameGeneration(expectedGeneration)) {
@@ -239,6 +241,7 @@ final class WiredGravityService {
             }
 
             movingUntil.put(item.getId(), now + durationMs);
+            fallenItemIds.add(item.getId());
             movements.add(WiredMovementsComposer.furniMovement(
                     item.getId(),
                     expected.x(),
@@ -254,6 +257,8 @@ final class WiredGravityService {
         }
 
         if (!movements.isEmpty()) {
+            WiredMoveStyleHelper.broadcast(
+                    room, fallenItemIds, WiredMoveStyleHelper.STYLE_DROP, WiredMoveStyleHelper.DROP_INTENSITY);
             room.sendComposer(new WiredMovementsComposer(movements).compose());
         }
         return retryAfterMs;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredMoveCarryHelper.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredMoveCarryHelper.java
@@ -6,6 +6,7 @@ import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraAnimatio
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMoveCarryUsers;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMoveNoAnimation;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovePhysics;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve;
 import com.eu.habbo.habbohotel.rooms.FurnitureMovementError;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
@@ -270,6 +271,7 @@ public final class WiredMoveCarryHelper {
                 applyInstantCarryState(room, movingItem, targetTile, rotation, carryContext);
             } else if (oldLocation != null) {
                 room.getWiredRuntime().markFurnitureMoving(movingItem, animationDuration);
+                sendMoveStyleHint(room, stackItem, movingItem);
                 sendAnimatedMove(
                         room,
                         movingItem,
@@ -1237,6 +1239,22 @@ public final class WiredMoveCarryHelper {
         }
 
         return null;
+    }
+
+    private static void sendMoveStyleHint(Room room, HabboItem stackItem, HabboItem movingItem) {
+        Collection<InteractionWiredExtra> extras = getMovementExtras(room, stackItem);
+        if (extras == null) {
+            return;
+        }
+
+        for (InteractionWiredExtra extra : extras) {
+            if (extra instanceof WiredExtraMovementCurve curve
+                    && curve.getCurveType() != WiredExtraMovementCurve.CURVE_LINEAR) {
+                WiredMoveStyleHelper.broadcast(
+                        room, List.of(movingItem.getId()), curve.getCurveType(), curve.getIntensity());
+                return;
+            }
+        }
     }
 
     private static Collection<InteractionWiredExtra> getMovementExtras(Room room, HabboItem stackItem) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredMoveStyleHelper.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredMoveStyleHelper.java
@@ -1,0 +1,38 @@
+package com.eu.habbo.habbohotel.wired.core;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.messages.outgoing.rooms.WiredFurniMoveStyleComposer;
+import java.util.Collection;
+
+/**
+ * Sends the capability-gated move-style hint (header 5110) ahead of wired movement packets.
+ * Clients that never announced {@link GameClient#WIRED_FEATURE_MOVE_STYLE} receive nothing and
+ * keep the historical linear animation.
+ */
+public final class WiredMoveStyleHelper {
+    public static final int STYLE_LINEAR = 0;
+    public static final int STYLE_DROP = 6;
+    public static final int DROP_INTENSITY = 100;
+
+    private WiredMoveStyleHelper() {}
+
+    public static void broadcast(Room room, Collection<Integer> itemIds, int style, int intensity) {
+        if (room == null || itemIds == null || itemIds.isEmpty() || style == STYLE_LINEAR) {
+            return;
+        }
+
+        var message = new WiredFurniMoveStyleComposer(itemIds, style, intensity).compose();
+        for (Habbo habbo : room.getHabbos()) {
+            if (habbo == null || habbo.getClient() == null) {
+                continue;
+            }
+            if (habbo.getClient()
+                    .supportsWiredFeature(
+                            GameClient.WIRED_FEATURE_PROTOCOL_VERSION, GameClient.WIRED_FEATURE_MOVE_STYLE)) {
+                habbo.getClient().sendResponse(message);
+            }
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/WiredFurniMoveStyleComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/WiredFurniMoveStyleComposer.java
@@ -1,0 +1,43 @@
+package com.eu.habbo.messages.outgoing.rooms;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import java.util.Collection;
+
+/**
+ * Capability-gated hint that upcoming wired movements for these items should animate with a
+ * non-linear style. Sent only to clients that announced {@code WIRED_FEATURE_MOVE_STYLE}; the
+ * legacy {@link WiredMovementsComposer} packet is never altered, so unaware clients simply keep
+ * the linear animation.
+ */
+public class WiredFurniMoveStyleComposer extends MessageComposer {
+    private static final int HEADER = 5110;
+    private static final int MAXIMUM_ITEMS = 1_000;
+
+    private final Collection<Integer> itemIds;
+    private final int style;
+    private final int intensity;
+
+    public WiredFurniMoveStyleComposer(Collection<Integer> itemIds, int style, int intensity) {
+        this.itemIds = itemIds;
+        this.style = Math.max(0, Math.min(6, style));
+        this.intensity = Math.max(0, Math.min(100, intensity));
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(HEADER);
+        int count = Math.min(this.itemIds.size(), MAXIMUM_ITEMS);
+        this.response.appendInt(count);
+        int written = 0;
+        for (Integer itemId : this.itemIds) {
+            if (written++ >= count) {
+                break;
+            }
+            this.response.appendInt(itemId);
+        }
+        this.response.appendInt(this.style);
+        this.response.appendInt(this.intensity);
+        return this.response;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/wired/core/WiredMoveStyleHelperTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/wired/core/WiredMoveStyleHelperTest.java
@@ -1,0 +1,53 @@
+package com.eu.habbo.habbohotel.wired.core;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.messages.ServerMessage;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class WiredMoveStyleHelperTest {
+
+    @Test
+    void onlyCapableClientsReceiveTheStyleHint() {
+        Room room = mock(Room.class);
+        Habbo capable = habbo(true);
+        Habbo legacy = habbo(false);
+        when(room.getHabbos()).thenReturn(List.of(capable, legacy));
+
+        WiredMoveStyleHelper.broadcast(room, List.of(101), WiredMoveStyleHelper.STYLE_DROP, 100);
+
+        verify(capable.getClient()).sendResponse(any(ServerMessage.class));
+        verify(legacy.getClient(), never()).sendResponse(any(ServerMessage.class));
+    }
+
+    @Test
+    void linearStyleAndEmptyTargetsSendNothing() {
+        Room room = mock(Room.class);
+        Habbo capable = habbo(true);
+        when(room.getHabbos()).thenReturn(List.of(capable));
+
+        WiredMoveStyleHelper.broadcast(room, List.of(101), WiredMoveStyleHelper.STYLE_LINEAR, 100);
+        WiredMoveStyleHelper.broadcast(room, List.of(), WiredMoveStyleHelper.STYLE_DROP, 100);
+        WiredMoveStyleHelper.broadcast(null, List.of(101), WiredMoveStyleHelper.STYLE_DROP, 100);
+
+        verify(capable.getClient(), never()).sendResponse(any(ServerMessage.class));
+    }
+
+    private static Habbo habbo(boolean capable) {
+        Habbo habbo = mock(Habbo.class);
+        GameClient client = mock(GameClient.class);
+        when(habbo.getClient()).thenReturn(client);
+        when(client.supportsWiredFeature(
+                        GameClient.WIRED_FEATURE_PROTOCOL_VERSION, GameClient.WIRED_FEATURE_MOVE_STYLE))
+                .thenReturn(capable);
+        return habbo;
+    }
+}

--- a/Emulator/src/test/resources/wired-compatibility/persistence-matrix-v1.txt
+++ b/Emulator/src/test/resources/wired-compatibility/persistence-matrix-v1.txt
@@ -1151,11 +1151,11 @@ CASE legacy-zero OUT eyJrZWVwQWx0aXR1ZGUiOmZhbHNlLCJtb3ZlVGhyb3VnaEZ1cm5pIjpmYWx
 CASE legacy-tab OUT eyJrZWVwQWx0aXR1ZGUiOmZhbHNlLCJtb3ZlVGhyb3VnaEZ1cm5pIjpmYWxzZSwibW92ZVRocm91Z2hVc2VycyI6ZmFsc2UsImJsb2NrQnlGdXJuaSI6ZmFsc2UsIm1vdmVUaHJvdWdoRnVybmlTb3VyY2UiOjAsImJsb2NrQnlGdXJuaVNvdXJjZSI6MCwibW92ZVRocm91Z2hVc2Vyc1NvdXJjZSI6MH0=
 
 TYPE com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve
-CASE blank OUT eyJjdXJ2ZVR5cGUiOjB9
-CASE json-empty OUT eyJjdXJ2ZVR5cGUiOjB9
-CASE json-malformed OUT eyJjdXJ2ZVR5cGUiOjB9
-CASE legacy-zero OUT eyJjdXJ2ZVR5cGUiOjB9
-CASE legacy-tab OUT eyJjdXJ2ZVR5cGUiOjB9
+CASE blank OUT eyJjdXJ2ZVR5cGUiOjAsImludGVuc2l0eSI6MTAwfQ==
+CASE json-empty OUT eyJjdXJ2ZVR5cGUiOjAsImludGVuc2l0eSI6MTAwfQ==
+CASE json-malformed OUT eyJjdXJ2ZVR5cGUiOjAsImludGVuc2l0eSI6MTAwfQ==
+CASE legacy-zero OUT eyJjdXJ2ZVR5cGUiOjAsImludGVuc2l0eSI6MTAwfQ==
+CASE legacy-tab OUT eyJjdXJ2ZVR5cGUiOjAsImludGVuc2l0eSI6MTAwfQ==
 
 TYPE com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraOrEval
 CASE blank OUT eyJldmFsdWF0aW9uTW9kZSI6MCwiZnVybmlTb3VyY2UiOjAsImNvbXBhcmVWYWx1ZSI6MSwiaXRlbUlkcyI6W119

--- a/Emulator/src/test/resources/wired-compatibility/public-surface-v1.txt
+++ b/Emulator/src/test/resources/wired-compatibility/public-surface-v1.txt
@@ -3116,14 +3116,21 @@ METHOD public com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraM
 
 TYPE public com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve extends com.eu.habbo.habbohotel.items.interactions.InteractionWiredExtra
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#CODE:int
+FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#CURVE_BOUNCE:int
+FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#CURVE_DROP:int
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#CURVE_EASE_IN:int
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#CURVE_EASE_IN_OUT:int
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#CURVE_EASE_OUT:int
+FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#CURVE_ELASTIC:int
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#CURVE_LINEAR:int
+FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#INTENSITY_DEFAULT:int
+FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#INTENSITY_MAX:int
+FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#INTENSITY_MIN:int
 CONSTRUCTOR public com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve(int,int,com.eu.habbo.habbohotel.items.Item,java.lang.String,int,int) throws -
 CONSTRUCTOR public com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve(java.sql.ResultSet,com.eu.habbo.habbohotel.items.Item) throws java.sql.SQLException
 METHOD public com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#execute(com.eu.habbo.habbohotel.rooms.RoomUnit,com.eu.habbo.habbohotel.rooms.Room,java.lang.Object[]):boolean throws -
 METHOD public com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#getCurveType(-):int throws -
+METHOD public com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#getIntensity(-):int throws -
 METHOD public com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#getWiredData(-):java.lang.String throws -
 METHOD public com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#hasConfiguration(-):boolean throws -
 METHOD public com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraMovementCurve#loadWiredData(java.sql.ResultSet,com.eu.habbo.habbohotel.rooms.Room):void throws java.sql.SQLException
@@ -5415,6 +5422,12 @@ METHOD public static com.eu.habbo.habbohotel.wired.core.WiredMoveCarryHelper#res
 METHOD public static com.eu.habbo.habbohotel.wired.core.WiredMoveCarryHelper#resolveMoveStepElapsed(com.eu.habbo.habbohotel.rooms.RoomUnit):int throws -
 METHOD public static com.eu.habbo.habbohotel.wired.core.WiredMoveCarryHelper#shouldSuppressStatusComposer(com.eu.habbo.habbohotel.rooms.RoomUnit):boolean throws -
 METHOD public static com.eu.habbo.habbohotel.wired.core.WiredMoveCarryHelper#shouldSuppressStatusUpdate(com.eu.habbo.habbohotel.rooms.RoomUnit):boolean throws -
+
+TYPE public final com.eu.habbo.habbohotel.wired.core.WiredMoveStyleHelper extends java.lang.Object
+FIELD public static final com.eu.habbo.habbohotel.wired.core.WiredMoveStyleHelper#DROP_INTENSITY:int
+FIELD public static final com.eu.habbo.habbohotel.wired.core.WiredMoveStyleHelper#STYLE_DROP:int
+FIELD public static final com.eu.habbo.habbohotel.wired.core.WiredMoveStyleHelper#STYLE_LINEAR:int
+METHOD public static com.eu.habbo.habbohotel.wired.core.WiredMoveStyleHelper#broadcast(com.eu.habbo.habbohotel.rooms.Room,java.util.Collection<java.lang.Integer>,int,int):void throws -
 
 TYPE public final com.eu.habbo.habbohotel.wired.core.WiredMovementPhysics extends java.lang.Object
 FIELD public static final com.eu.habbo.habbohotel.wired.core.WiredMovementPhysics#NONE:com.eu.habbo.habbohotel.wired.core.WiredMovementPhysics

--- a/protocol/packet-field-contracts.json
+++ b/protocol/packet-field-contracts.json
@@ -22261,6 +22261,22 @@
       "reason": "Java analyzer: Data-dependent packet operations in ForEachStmt inside composeInternal; TypeScript analyzer: Data-dependent packet operations in ForStatement inside parse"
     },
     {
+      "name": "WIRED_FURNI_MOVE_STYLE",
+      "direction": "server_to_client",
+      "header": 5110,
+      "java": {
+        "symbol": "WiredFurniMoveStyleComposer",
+        "className": "WiredFurniMoveStyleComposer",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/WiredFurniMoveStyleComposer.java"
+      },
+      "typescript": {
+        "symbol": "WIRED_FURNI_MOVE_STYLE",
+        "className": "WiredFurniMoveStyleParser",
+        "path": "packages/communication/src/messages/parser/roomevents/WiredFurniMoveStyleParser.ts"
+      },
+      "reason": "Java analyzer: Data-dependent packet operations in ForEachStmt inside composeInternal; TypeScript analyzer: Data-dependent packet operations in ForStatement inside parse"
+    },
+    {
       "name": "AREA_HIDE",
       "direction": "server_to_client",
       "header": 6001,


### PR DESCRIPTION
Stacked on #520 (last in the wired stack: #516 <- #518 <- #519 <- #520 <- this).

Adds bounce, elastic and drop movement styles with a 0-100 intensity to the existing movement curve extra (`wf_xtra_mov_curve`), and drop-styled gravity settle falls. The style travels as a separate opt-in hint packet (header 5110) sent only to clients that announce the new move-style capability bit - the legacy `WiredMovements` packet layout is untouched, so clients without the capability keep the historical linear animation.

- `WiredExtraMovementCurve`: styles 4-6 + intensity, persisted as `[curveType, intensity]`; pre-intensity payloads load as default 100.
- New `WiredFurniMoveStyleComposer` (5110) + `WiredMoveStyleHelper` broadcast, gated per client via `WIRED_FEATURE_MOVE_STYLE`.
- Send sites: wired move path (`WiredMoveCarryHelper`) and gravity falls (`WiredGravityService`).
- `protocol/packet-field-contracts.json` entry added; both compatibility fixtures regenerated with hand-verified, intentional-only deltas (persistence: curve extra intensity field; public surface: purely additive).
- Full suite green in this branch's worktree: 1179 tests, 0 failures, 0 errors, 7 intentional skips. Companion PRs: duckietm/Nitro-V3#342 (editor UI + capability announce), duckietm/Nitro_Render_V3#139 (parser + eased rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)