### PR TITLE
fix(messenger): repair history clamp test on dev

### DIFF
--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryServiceTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryServiceTest.java
@@ -32,9 +32,9 @@ class MessengerHistoryServiceTest {
         repository.rows.add(new MessengerStoredMessage(1, 9, 7, 0, "first", null, 100));
         MessengerHistoryService service = new MessengerHistoryService(repository, 30, 500);
 
-        MessengerHistoryPage page = service.loadHistory(9, 7, 0, 500);
+        MessengerHistoryPage page = service.loadHistory(9, 7, 0, MessengerHistoryService.MAX_PAGE_SIZE + 4_500);
 
-        assertEquals(50, repository.requestedLimit);
+        assertEquals(MessengerHistoryService.MAX_PAGE_SIZE, repository.requestedLimit);
         assertEquals(List.of(1L, 2L, 3L), page.messages().stream().map(MessengerStoredMessage::id).toList());
     }
 

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryServiceTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryServiceTest.java
@@ -1,12 +1,11 @@
 package com.eu.habbo.habbohotel.messenger.history;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
 
 class MessengerHistoryServiceTest {
     @Test
@@ -35,7 +34,9 @@ class MessengerHistoryServiceTest {
         MessengerHistoryPage page = service.loadHistory(9, 7, 0, MessengerHistoryService.MAX_PAGE_SIZE + 4_500);
 
         assertEquals(MessengerHistoryService.MAX_PAGE_SIZE, repository.requestedLimit);
-        assertEquals(List.of(1L, 2L, 3L), page.messages().stream().map(MessengerStoredMessage::id).toList());
+        assertEquals(
+                List.of(1L, 2L, 3L),
+                page.messages().stream().map(MessengerStoredMessage::id).toList());
     }
 
     @Test
@@ -82,18 +83,21 @@ class MessengerHistoryServiceTest {
         }
 
         @Override
-        public List<MessengerStoredMessage> loadHistory(long conversationId, int userId, long beforeMessageId, int limit) {
+        public List<MessengerStoredMessage> loadHistory(
+                long conversationId, int userId, long beforeMessageId, int limit) {
             requestedLimit = limit;
             return new ArrayList<>(rows);
         }
 
         @Override
-        public MessengerStoredMessage storeDirectMessage(int senderId, int recipientId, int type, String message, String metadata) {
+        public MessengerStoredMessage storeDirectMessage(
+                int senderId, int recipientId, int type, String message, String metadata) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public MessengerStoredMessage storeConversationMessage(long conversationId, int senderId, int type, String message, String metadata) {
+        public MessengerStoredMessage storeConversationMessage(
+                long conversationId, int senderId, int type, String message, String metadata) {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
Pre-existing dev-baseline test failure, unrelated to the wired work — currently `dev` is red, so every open emulator PR fails CI through the shared base.

The messenger history change raised `MAX_PAGE_SIZE` 50 → 500 but left `clampsHistoryLimitAndReturnsChronologicalMessages` asserting the old clamp of 50. Updated the test to request above the cap and assert clamping to `MAX_PAGE_SIZE`, so it tracks the constant rather than a stale literal.

No production change. Recommend merging first so the emulator revert/feature PRs go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)