### PR TITLE
feat(ai): add shared Polaris development skill

### DIFF
--- a/.agents/skills/polaris-development/SKILL.md
+++ b/.agents/skills/polaris-development/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: polaris-development
+description: Prepare, implement, review, or finish any Polaris Emulator feature, bugfix, refactor, migration, fixture, test, CI, packaging, or pull-request task. Use before changing Polaris code so work starts from current origin/dev, checks for overlapping work, preserves compatibility, selects the right fixtures and contracts, and reproduces the applicable CI gates before claiming merge readiness.
+---
+
+# Polaris development
+
+Treat `origin/dev` and the checked-in repository as live evidence. Never rely on an old checkout, an earlier conversation, PR labels, or remembered CI behavior.
+
+## Start from the live base
+
+Before planning or editing:
+
+1. Locate the Polaris repository root and read its tracked `AGENTS.md`, tracked `CLAUDE.md` when present, `POLARIS.md`, relevant local docs, and the active workflow files. Treat untracked guidance as local context, not project policy, until confirmed.
+2. Run `scripts/preflight.sh "<task keywords>"` from this skill. Use concrete domain terms such as class names, packet names, migrations, or issue wording.
+3. Report the current branch, `origin/dev` SHA, ahead/behind state, worktree state, and any overlapping code, commits, branches, issues, or PRs.
+4. Stop implementation when the worktree is dirty, the branch does not contain current `origin/dev`, or the current branch is `dev`/`main`. Preserve existing work. Do not reset, clean, stash, switch, rebase, or force-push it without explicit authorization.
+5. For an authorized implementation, use a clean `feature/<slug>` or `bugfix/<slug>` branch created from current `origin/dev`. If the current worktree cannot be aligned safely, create a separate Git worktree from `origin/dev` instead of disturbing it.
+
+Do not interpret “fetch succeeded” as “aligned.” Prove alignment with `git merge-base --is-ancestor origin/dev HEAD` after the fetch. Re-run this check immediately before publication because `dev` may move during the task.
+
+## Avoid duplicate work
+
+Search before designing:
+
+- Use `rg` across source, tests, migrations, protocol contracts, scripts, and docs.
+- Inspect `git log origin/dev -- <relevant paths>` and remote branches containing related commits.
+- When GitHub access is available, search open and merged PRs plus open issues using the task keywords.
+- Inspect existing fixtures and characterization tests before creating a new test harness.
+- Extend the established implementation, fixture, or contract when it owns the behavior. Create a new mechanism only when the existing one cannot express the requirement, and state why.
+
+Summarize the overlap check before substantial implementation. A similarly named class alone is not proof of duplication; trace the actual execution path and test coverage.
+
+## Design under Polaris constraints
+
+- Keep fixes self-contained in Polaris, including Polaris-owned migrations. Do not require CMS, Nitro, proxy, plugin, or deployed schema consumers to change.
+- Treat the public plugin surface as a frozen binary ABI. Preserve packages, signatures, classloading, resources, live collection behavior, object identity, lifecycle ordering, packet bytes, and persistence semantics where applicable.
+- Favor safe, data-preserving defaults and plain-language diagnostics for hotel owners. Keep strict or advanced behavior opt-in.
+- For a bugfix, first add a focused failing reproduction. For a refactor, first add characterization tests that pass on the unchanged implementation. Do not weaken a fixture, contract, baseline, or parity assertion to make new code pass.
+- Make the narrowest coherent change and keep unrelated cleanup out of the branch.
+
+Read [references/fixtures-and-contracts.md](references/fixtures-and-contracts.md) whenever the task touches persistence, migrations, plugins, packets, furni, e2e behavior, or compatibility. Read [references/ci-validation.md](references/ci-validation.md) before implementation planning and again before declaring the task complete.
+
+## Implement and validate
+
+1. Record a focused test or existing contract that proves the requested behavior.
+2. Implement the smallest compatible change.
+3. Run the focused test, then the broader gates selected from the CI reference.
+4. Compare the final diff with `origin/dev`; check for generated files, stale contracts, accidental assets, secrets, logs, JARs, backups, or unrelated edits.
+5. Fetch again and prove the branch still contains current `origin/dev`. If it no longer does, integrate the new base safely and rerun affected gates.
+6. Report exact commands and results. Separate passed gates from gates not run, environmental limitations, and residual compatibility risk. Never call work “CI-ready,” “merge-ready,” or regression-free when a required gate was skipped or only inferred.
+
+## Git and publication
+
+- Use Conventional Commits.
+- Keep commit and pull-request descriptions concise, lean, informative, and ADHD-friendly. Make them easy to understand at a glance.
+- Do not add dedicated “Why” or “Verification” sections. Use a short overview and only a few compact bullets when they materially improve clarity.
+- Mention important test status briefly without turning the description into a validation report.
+- Do not push, open a PR, merge, alter remote branches, or accept ABI/baseline divergence unless the user explicitly requests that action.

--- a/.agents/skills/polaris-development/agents/openai.yaml
+++ b/.agents/skills/polaris-development/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Polaris Development"
+  short_description: "Align, implement, and verify Polaris changes"
+  default_prompt: "Use $polaris-development to prepare and implement this Polaris task against the latest dev branch."

--- a/.agents/skills/polaris-development/references/ci-validation.md
+++ b/.agents/skills/polaris-development/references/ci-validation.md
@@ -1,0 +1,62 @@
+# Polaris CI and local validation
+
+Read `.github/workflows/ci.yml`, `.github/workflows/codeql.yml`, `Emulator/pom.xml`, and relevant scripts from current `origin/dev` before choosing commands. These files override this reference if the pipeline evolves.
+
+## Baseline environment
+
+- Use JDK 25 for exact parity with the main build-and-test job. Current Polaris also permits JDK 26 and CI runs a separate JDK 26 clean-package compatibility job; verify the current range in `Emulator/pom.xml`.
+- Use the committed Maven wrapper. From the repository root, invoke `./Emulator/mvnw -f Emulator/pom.xml ...`.
+- Docker is required for Testcontainers integration tests.
+- CI formatting is ratcheted from the PR base. Check only the changed surface; do not reformat unrelated legacy code.
+
+## Validation ladder
+
+Run the narrowest useful test first, then expand:
+
+```bash
+./Emulator/mvnw -f Emulator/pom.xml test -Dtest=<TestClass[#method]>
+./Emulator/mvnw -f Emulator/pom.xml test
+./Emulator/mvnw -B -f Emulator/pom.xml -Pcoverage verify -Dspotless.ratchetFrom=origin/dev
+```
+
+The last command is the closest local equivalent of the primary GitHub CI job: compile, unit tests, Failsafe integration tests, packaging/contract checks, coverage, Spotless, and configured analysis. Run it before merge readiness unless the task is documentation-only and cannot affect executable or workflow behavior.
+
+Also run the repository's build-handoff test when build/release scripts, Maven packaging, or artifact handoff changes:
+
+```bash
+./scripts/build-latest.test.sh
+```
+
+## Change-specific gates
+
+| Change area | Additional required evidence |
+|---|---|
+| Migration, schema, DB compatibility | Regenerated runtime schema contract when appropriate; `MigrationRunnerIT` on MariaDB 10.11, 11.4, and 12.3; migration backup/drop/restore test |
+| Plugin API, classloading, resources, dependencies | ABI tests, historical plugin fixtures, and `PackagedJarContractIT` against the assembled JAR |
+| Packet or RCON | Relevant contract catalog/coverage tests and byte/field-order compatibility tests |
+| Networking, concurrency, lifecycle | Focused race/lifecycle reproduction plus full `verify`; repeat or stress the flaky boundary when useful |
+| Packaging, shading, service loading | JDK 25 full verify, isolated runnable-JAR contract, and JDK 26 `clean package` compatibility |
+| Furni import or assets | Canonical furni verification script against the exact staged SQL/export and Nitro tree; retain the JSON report |
+| E2E renderer behavior | Emulator fixture tests plus the companion renderer E2E path documented under `e2e/` |
+| Workflow or build configuration | Validate YAML/scripts, run the affected local command, and inspect the resulting artifact rather than relying on syntax alone |
+
+Run the migration matrix command with the current image value copied from `.github/workflows/ci.yml`, for example:
+
+```bash
+POLARIS_TEST_MARIADB_IMAGE='<current-ci-image>' \
+  ./Emulator/mvnw -B -f Emulator/pom.xml test-compile \
+  failsafe:integration-test failsafe:verify -Dit.test=MigrationRunnerIT
+```
+
+GitHub also runs CodeQL separately. Treat a local compile or unit pass as insufficient evidence for security-analysis status.
+
+## Completion report
+
+State:
+
+- base SHA and final relationship to current `origin/dev`;
+- focused and broad commands run, with pass/fail counts where available;
+- fixtures/contracts added or intentionally reused;
+- CI-only gates still pending;
+- any unavailable Docker, JDK, OS, service, client, plugin corpus, or production-like evidence;
+- residual risk that tests do not prove.

--- a/.agents/skills/polaris-development/references/fixtures-and-contracts.md
+++ b/.agents/skills/polaris-development/references/fixtures-and-contracts.md
@@ -1,0 +1,48 @@
+# Polaris fixtures and contracts
+
+Select and extend the fixture that matches the affected boundary. Do not create parallel truth sources.
+
+## Database and migrations
+
+- The migration chain in `Emulator/src/main/resources/db/migration/` is authoritative. `Database/` is historical/dev seed material, not a production migration source.
+- `Emulator/src/test/resources/db/fixture/` represents legacy Arcturus Morningstar adoption. Use the schema and running-hotel fixtures through the existing migration integration tests; do not hand-edit them merely to conceal a migration failure.
+- After an intentional migration/schema change, regenerate `Emulator/src/main/resources/db/runtime-schema-contract.json` with:
+
+  ```bash
+  ./Emulator/mvnw -f Emulator/pom.xml -Pupdate-runtime-schema-contract verify
+  ```
+
+  Review the contract diff semantically. A regenerated file is evidence of the new schema, not proof the migration is safe.
+- Migration work requires `MigrationRunnerIT` across the CI MariaDB matrix and the backup/restore test described in the CI reference.
+
+## Plugin compatibility
+
+- `Emulator/abi-baseline/` contains the Morningstar and released-Polaris API baselines.
+- `Emulator/src/test/resources/plugin-fixtures/` contains real precompiled-behavior sources and resources. `LegacyPluginFixtureCompiler` compiles them against their historical baseline, and `PackagedJarContractIT` loads them through the assembled Polaris JAR.
+- Extend representative plugin fixtures for plugin-visible changes. Source/reflection assertions are supplemental; they do not replace loading precompiled fixtures through the packaged artifact.
+- Never regenerate accepted ABI divergence files or their reviewed digests just to pass CI. That requires explicit maintainer approval and semantic review of every divergence.
+
+## Packet and RCON contracts
+
+- `protocol/packet-field-contracts.json` and `protocol/rcon-contract.json` freeze field order and types.
+- Java examples under `Emulator/src/test/resources/packet-contracts/` exercise the signature extractors.
+- Update a contract only for an intentional protocol change already compatible with supported clients. If compatibility is uncertain, preserve the wire format and adapt internally.
+
+## Furni consistency fixture
+
+Use `docs/FURNI_IMPORT_PIPELINE.md` as the canonical cross-project acceptance procedure. A furni import is one reviewed package containing:
+
+- the intended `items_base` and `catalog_items` rows;
+- the matching `FurnitureData.json` entry;
+- the `.nitro` bundle and icon;
+- the `.swf` when the deployment requires legacy assets;
+- correct redeemable-credit logic when the classname encodes currency.
+
+Validate the exact staged database/export and Nitro assets with `scripts/verify-furni-import.sh` or `.ps1`. Archive the JSON report. Exit `0` means consistent, `1` means findings, and `2` means the audit could not run. CI always uploads `Emulator/target/furni-consistency-fixture.json`; inspect that artifact when the gate fails. Never accept a database-only or files-only import.
+
+## E2E and behavioral fixtures
+
+- Use `e2e/` only with its disposable `polaris_e2e_*` schema and dedicated ports. Never point fixture setup at hotel-owner production data.
+- Extend existing `*ContractTest`, characterization, lifecycle, concurrency, and packaged-JAR tests at the boundary being changed.
+- Keep fixtures deterministic and minimal. Make intended domain state explicit rather than relying on defaults, local IDs, credentials, or an existing developer database.
+- A changed expectation is legitimate only when the product contract intentionally changed. Explain that change in the test and review; otherwise preserve the fixture and fix the implementation.

--- a/.agents/skills/polaris-development/scripts/preflight.sh
+++ b/.agents/skills/polaris-development/scripts/preflight.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -u
+
+allow_dirty=false
+if [[ "${1:-}" == "--allow-dirty" ]]; then
+    allow_dirty=true
+    shift
+fi
+search_terms="$*"
+
+failures=0
+warn() { printf 'WARN: %s\n' "$*" >&2; }
+fail() { printf 'FAIL: %s\n' "$*" >&2; failures=$((failures + 1)); }
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    printf 'FAIL: run inside a Polaris Git worktree\n' >&2
+    exit 2
+}
+cd "$repo_root" || exit 2
+
+if ! git remote get-url origin >/dev/null 2>&1; then
+    printf 'FAIL: origin remote is not configured\n' >&2
+    exit 2
+fi
+
+printf 'Repository: %s\n' "$repo_root"
+printf 'Fetching origin...\n'
+if ! git fetch origin --prune; then
+    printf 'FAIL: could not refresh origin; do not implement from an unverified base\n' >&2
+    exit 2
+fi
+
+if ! git show-ref --verify --quiet refs/remotes/origin/dev; then
+    printf 'FAIL: origin/dev does not exist\n' >&2
+    exit 2
+fi
+
+branch="$(git branch --show-current)"
+head_sha="$(git rev-parse HEAD)"
+dev_sha="$(git rev-parse origin/dev)"
+printf 'Branch: %s\n' "${branch:-DETACHED}"
+printf 'HEAD: %s\n' "$head_sha"
+printf 'origin/dev: %s\n' "$dev_sha"
+
+if [[ -z "$branch" ]]; then
+    fail 'detached HEAD; create a task branch from origin/dev'
+elif [[ "$branch" == "dev" || "$branch" == "main" ]]; then
+    fail "do not implement directly on $branch"
+fi
+
+read -r ahead behind < <(git rev-list --left-right --count HEAD...origin/dev)
+printf 'Ahead/behind origin/dev: %s/%s\n' "$ahead" "$behind"
+if ! git merge-base --is-ancestor origin/dev HEAD; then
+    fail 'HEAD does not contain current origin/dev; align safely before implementation'
+fi
+
+status="$(git status --porcelain=v1 --untracked-files=all)"
+if [[ -n "$status" ]]; then
+    printf 'Worktree changes:\n%s\n' "$status"
+    if [[ "$allow_dirty" == true ]]; then
+        warn 'dirty worktree allowed for this audit only'
+    else
+        fail 'worktree is dirty; preserve it and use a clean branch/worktree'
+    fi
+else
+    printf 'Worktree: clean\n'
+fi
+
+java_line="$(java -version 2>&1 | head -n 1 || true)"
+printf 'Java: %s\n' "${java_line:-unavailable}"
+if [[ "$java_line" =~ \"25([.\"]|$) ]]; then
+    printf 'Java gate: JDK 25 primary-CI parity\n'
+elif [[ "$java_line" =~ \"26([.\"]|$) ]]; then
+    warn 'JDK 26 is supported for packaging, but the primary full CI job still runs on JDK 25'
+else
+    fail 'use a JDK allowed by current Emulator/pom.xml (CI currently exercises JDK 25 and 26)'
+fi
+
+if [[ -n "$search_terms" ]]; then
+    printf '\nRecent matching commits on origin/dev:\n'
+    read -r -a search_words <<< "$search_terms"
+    grep_arguments=()
+    for word in "${search_words[@]}"; do
+        grep_arguments+=(--grep="$word")
+    done
+    git log origin/dev -i --oneline "${grep_arguments[@]}" -n 20 || true
+
+    if command -v gh >/dev/null 2>&1; then
+        remote_url="$(git remote get-url origin)"
+        repo_slug="$(printf '%s' "$remote_url" | sed -E 's#^git@[^:]+:##; s#^https?://[^/]+/##; s#\.git$##')"
+        printf '\nMatching GitHub issues and pull requests:\n'
+        if ! gh search issues "$search_terms" --repo "$repo_slug" --include-prs --limit 20 \
+            --json number,title,state,isPullRequest,url 2>/dev/null; then
+            warn 'GitHub overlap search was unavailable; search PRs/issues manually'
+        fi
+    else
+        warn 'gh is unavailable; search GitHub PRs/issues manually'
+    fi
+else
+    warn 'no task keywords supplied; code/history/PR overlap search remains required'
+fi
+
+if ((failures > 0)); then
+    printf '\nPreflight blocked with %d failure(s).\n' "$failures" >&2
+    exit 1
+fi
+
+printf '\nPreflight passed. Record origin/dev=%s in the task notes.\n' "$dev_sha"

--- a/.claude/skills/polaris-development/SKILL.md
+++ b/.claude/skills/polaris-development/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: polaris-development
+description: Prepare, implement, review, or finish any Polaris Emulator feature, bugfix, refactor, migration, fixture, test, CI, packaging, or pull-request task. Use before changing Polaris code so work starts from current origin/dev, checks for overlapping work, preserves compatibility, selects the right fixtures and contracts, and reproduces the applicable CI gates before claiming merge readiness.
+---
+
+# Polaris development
+
+Read `../../../.agents/skills/polaris-development/SKILL.md` completely, then follow it as the canonical workflow for this task. Resolve all of its relative links and scripts from `.agents/skills/polaris-development/`.
+
+Do not start implementation until its live-base preflight and overlap checks have completed.


### PR DESCRIPTION
Adds a shared Polaris development skill for ChatGPT/Codex and Claude.

- Guards work against current `origin/dev` and checks for overlapping work.
- Documents fixture, contract, and CI expectations.
- Includes executable preflight checks for branch state, worktree safety, Java, and GitHub overlap.

Both skill entrypoints validate, and the preflight script passes its syntax check.
