### PR TITLE
feat(wired): expose furniture opacity as a runtime variable

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomWiredRuntime.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomWiredRuntime.java
@@ -62,6 +62,31 @@ public final class RoomWiredRuntime {
         return this.opacity.snapshot(userId);
     }
 
+    /** Room-wide opacity for one item, ignoring per-user overlays. Used by the {@code @opacity} variable. */
+    public int globalOpacity(HabboItem item) {
+        return item == null ? 100 : this.opacity.globalOpacity(item.getId());
+    }
+
+    /**
+     * Sets the room-wide opacity for one item and pushes it to every client that announced opacity
+     * support. Click-through is preserved, so a variable write only changes how transparent the item
+     * is.
+     */
+    public boolean setGlobalOpacity(Room room, HabboItem item, int opacity) {
+        if (room == null || item == null) {
+            return false;
+        }
+
+        boolean clickThrough = this.opacity.globalClickThrough(item.getId());
+        List<WiredOpacityState> applied = this.opacity.applyGlobal(List.of(item), opacity, clickThrough);
+        if (applied.isEmpty()) {
+            return false;
+        }
+
+        WiredOpacityBroadcaster.broadcast(room, applied, 0, 0);
+        return true;
+    }
+
     void forgetOpacity(HabboItem item) {
         this.opacity.forgetItem(item);
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/WiredOpacityBroadcaster.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/WiredOpacityBroadcaster.java
@@ -1,0 +1,38 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.messages.outgoing.rooms.WiredFurniOpacityComposer;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Sends furniture opacity updates only to clients that announced opacity support, so clients that
+ * never negotiated the capability keep the historical rendering.
+ */
+public final class WiredOpacityBroadcaster {
+
+    private WiredOpacityBroadcaster() {}
+
+    public static void broadcast(Room room, Collection<WiredOpacityState> updates, int easing, int durationMs) {
+        if (room == null || updates == null || updates.isEmpty()) {
+            return;
+        }
+
+        List<WiredOpacityState> payload = List.copyOf(updates);
+        for (Habbo habbo : room.getHabbos()) {
+            if (!supportsOpacity(habbo)) {
+                continue;
+            }
+            habbo.getClient().sendResponse(new WiredFurniOpacityComposer(room.getId(), payload, easing, durationMs));
+        }
+    }
+
+    public static boolean supportsOpacity(Habbo habbo) {
+        return habbo != null
+                && habbo.getClient() != null
+                && habbo.getClient()
+                        .supportsWiredFeature(
+                                GameClient.WIRED_FEATURE_PROTOCOL_VERSION, GameClient.WIRED_FEATURE_OPACITY);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/WiredOpacityService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/WiredOpacityService.java
@@ -153,6 +153,18 @@ final class WiredOpacityService {
         return this.stateCount;
     }
 
+    /** Current room-wide opacity for one item, ignoring per-user overlays. */
+    synchronized int globalOpacity(int itemId) {
+        VisualState state = this.globalStates.get(itemId);
+        return state == null ? VisualState.DEFAULT.opacity() : state.opacity();
+    }
+
+    /** Current room-wide click-through for one item, ignoring per-user overlays. */
+    synchronized boolean globalClickThrough(int itemId) {
+        VisualState state = this.globalStates.get(itemId);
+        return state != null && state.clickThrough();
+    }
+
     private List<HabboItem> validItems(Collection<HabboItem> items) {
         if (items == null || items.isEmpty()) {
             return List.of();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredInternalVariableRegistry.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredInternalVariableRegistry.java
@@ -121,6 +121,8 @@ final class WiredInternalVariableRegistry {
                 Capability.FURNI_DESTINATION, "@state", "@position_x", "@position_y", "@rotation", "@altitude");
         builder.registerWhen(
                 ALWAYS_ENABLED, EnumSet.of(Capability.FURNI_REFERENCE, Capability.FURNI_DESTINATION), "@gravity");
+        builder.registerWhen(
+                ALWAYS_ENABLED, EnumSet.of(Capability.FURNI_REFERENCE, Capability.FURNI_DESTINATION), "@opacity");
         builder.register(
                 Capability.ROOM_REFERENCE,
                 "@furni_count",

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredInternalVariableSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredInternalVariableSupport.java
@@ -138,6 +138,7 @@ public final class WiredInternalVariableSupport {
             case "~teleport.target_id" -> item.getTeleportTargetId() > 0;
             case "@wallitem_offset" -> item.getBaseItem().getType() == FurnitureType.WALL;
             case "@gravity" -> item.getBaseItem().getType() == FurnitureType.FLOOR;
+            case "@opacity" -> true;
             case "@is_stackable" -> item.getBaseItem().allowStack();
             case "@can_stand_on" -> item.getBaseItem().allowWalk();
             case "@can_sit_on" -> item.getBaseItem().allowSit();
@@ -312,6 +313,7 @@ public final class WiredInternalVariableSupport {
                 (item.getBaseItem() != null) ? (int) item.getBaseItem().getLength() : null;
             case "@owner_id" -> item.getUserId();
             case "@gravity" -> room.getWiredRuntime().isGravityEnabled(item) ? 1 : 0;
+            case "@opacity" -> room.getWiredRuntime().globalOpacity(item);
             default -> null;
         };
     }
@@ -327,6 +329,11 @@ public final class WiredInternalVariableSupport {
             item.setExtradata(String.valueOf(normalizeFurniStateValue(item, value)));
             room.updateItemState(item);
             return true;
+        }
+
+        // Opacity applies to wall items too, so it is handled before the floor-only guard.
+        if ("@opacity".equals(normalized)) {
+            return room.getWiredRuntime().setGlobalOpacity(room, item, value);
         }
 
         if (item.getBaseItem() == null || item.getBaseItem().getType() != FurnitureType.FLOOR) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/wired/WiredFurniRuntimeStatePolicy.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/wired/WiredFurniRuntimeStatePolicy.java
@@ -3,12 +3,15 @@ package com.eu.habbo.messages.incoming.wired;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.core.WiredInternalVariableSupport;
+import java.util.Set;
 
 final class WiredFurniRuntimeStatePolicy {
     static final int ACTION_READ = 0;
     static final int ACTION_WRITE = 1;
     static final int MAX_KEY_LENGTH = 64;
     static final String GRAVITY_KEY = "@gravity";
+    static final String OPACITY_KEY = "@opacity";
+    private static final Set<String> ALLOWED_KEYS = Set.of(GRAVITY_KEY, OPACITY_KEY);
 
     private WiredFurniRuntimeStatePolicy() {}
 
@@ -28,7 +31,7 @@ final class WiredFurniRuntimeStatePolicy {
 
     static Result write(Room room, HabboItem item, String key, int value) {
         String normalized = normalizeAllowedKey(key);
-        if ((value != 0 && value != 1)
+        if (!isValueInRange(normalized, value)
                 || room == null
                 || item == null
                 || normalized.isEmpty()
@@ -48,7 +51,15 @@ final class WiredFurniRuntimeStatePolicy {
         }
 
         String normalized = WiredInternalVariableSupport.normalizeKey(key);
-        return GRAVITY_KEY.equals(normalized) ? normalized : "";
+        return ALLOWED_KEYS.contains(normalized) ? normalized : "";
+    }
+
+    /** Gravity is a flag; opacity is a percentage. Anything outside its own range is rejected. */
+    private static boolean isValueInRange(String normalizedKey, int value) {
+        if (OPACITY_KEY.equals(normalizedKey)) {
+            return value >= 0 && value <= 100;
+        }
+        return value == 0 || value == 1;
     }
 
     record Result(int value, boolean supported, boolean success) {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/wired/core/WiredInternalVariableRegistryCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/wired/core/WiredInternalVariableRegistryCompatibilityTest.java
@@ -17,7 +17,7 @@ class WiredInternalVariableRegistryCompatibilityTest {
                 Set.of("@position_x", "@position_y", "@direction"),
                 keys(WiredInternalVariableRegistry.Capability.USER_DESTINATION));
         assertEquals(
-                Set.of("@state", "@position_x", "@position_y", "@rotation", "@altitude", "@gravity"),
+                Set.of("@state", "@position_x", "@position_y", "@rotation", "@altitude", "@gravity", "@opacity"),
                 keys(WiredInternalVariableRegistry.Capability.FURNI_DESTINATION));
         assertEquals(
                 Set.of(
@@ -74,7 +74,8 @@ class WiredInternalVariableRegistryCompatibilityTest {
                         "@wallitem_offset",
                         "@dimensions.x",
                         "@dimensions.y",
-                        "@gravity"),
+                        "@gravity",
+                        "@opacity"),
                 keys(WiredInternalVariableRegistry.Capability.FURNI_REFERENCE));
         assertEquals(
                 Set.of(

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/wired/WiredFurniRuntimeStatePolicyTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/wired/WiredFurniRuntimeStatePolicyTest.java
@@ -3,7 +3,10 @@ package com.eu.habbo.messages.incoming.wired;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -50,6 +53,59 @@ class WiredFurniRuntimeStatePolicyTest {
         WiredFurniRuntimeStatePolicy.Result invalid = WiredFurniRuntimeStatePolicy.write(room, item, "@gravity", 2);
         assertFalse(invalid.supported());
         assertFalse(invalid.success());
+    }
+
+    @Test
+    void opacityIsReadableAndWritableAcrossItsFullPercentageRange() {
+        Room room = mock(Room.class);
+        RoomWiredRuntime runtime = mock(RoomWiredRuntime.class);
+        when(room.getWiredRuntime()).thenReturn(runtime);
+        HabboItem item = floorItem();
+        when(runtime.setGlobalOpacity(room, item, 40)).thenReturn(true);
+        when(runtime.globalOpacity(item)).thenReturn(40);
+
+        WiredFurniRuntimeStatePolicy.Result written = WiredFurniRuntimeStatePolicy.write(room, item, "@opacity", 40);
+
+        assertEquals(40, written.value());
+        assertTrue(written.supported());
+        assertTrue(written.success());
+        verify(runtime).setGlobalOpacity(room, item, 40);
+
+        WiredFurniRuntimeStatePolicy.Result read = WiredFurniRuntimeStatePolicy.read(room, item, " @opacity ");
+        assertEquals(40, read.value());
+        assertTrue(read.supported());
+    }
+
+    @Test
+    void opacityRejectsValuesOutsideZeroToHundredAndGravityStaysBoolean() {
+        Room room = mock(Room.class);
+        RoomWiredRuntime runtime = mock(RoomWiredRuntime.class);
+        when(room.getWiredRuntime()).thenReturn(runtime);
+        HabboItem item = floorItem();
+
+        assertFalse(
+                WiredFurniRuntimeStatePolicy.write(room, item, "@opacity", 101).supported());
+        assertFalse(
+                WiredFurniRuntimeStatePolicy.write(room, item, "@opacity", -1).supported());
+        assertFalse(
+                WiredFurniRuntimeStatePolicy.write(room, item, "@gravity", 40).supported());
+        verify(runtime, never()).setGlobalOpacity(any(), any(), anyInt());
+    }
+
+    @Test
+    void opacityAppliesToWallFurnitureUnlikeGravity() {
+        Room room = mock(Room.class);
+        RoomWiredRuntime runtime = mock(RoomWiredRuntime.class);
+        when(room.getWiredRuntime()).thenReturn(runtime);
+        HabboItem wall = mock(HabboItem.class);
+        Item wallBase = mock(Item.class);
+        when(wall.getBaseItem()).thenReturn(wallBase);
+        when(wallBase.getType()).thenReturn(FurnitureType.WALL);
+        when(runtime.setGlobalOpacity(room, wall, 0)).thenReturn(true);
+        when(runtime.globalOpacity(wall)).thenReturn(0);
+
+        assertTrue(WiredFurniRuntimeStatePolicy.write(room, wall, "@opacity", 0).success());
+        assertFalse(WiredFurniRuntimeStatePolicy.read(room, wall, "@gravity").supported());
     }
 
     @Test


### PR DESCRIPTION
Adds `@opacity` alongside `@gravity` so wired and the creator tools can read and write a furniture item's room-wide opacity.

- Reads the room-owned global opacity; writes go through the opacity service and reach only clients that announced opacity support.
- `@opacity` accepts 0-100 and works on wall furniture too. `@gravity` stays a 0/1 flag on floor items.
- Click-through is preserved on a variable write, so setting opacity only changes transparency.

Pairs with duckietm/Nitro-V3#346, which points the creator-tools opacity control at this protocol instead of the removed internal-variable id.

Local `-Pcoverage verify` green (1182 unit + 14 integration). Run on JDK 26, so the JDK 25 job and CodeQL stay CI-only.