### PR TITLE
fix(build): unblock Spotless on dev

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/database/migration/MigrationOptions.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/migration/MigrationOptions.java
@@ -22,28 +22,27 @@ public record MigrationOptions(Mode mode, boolean migrationsOnly) {
                 continue;
             }
             if (argument.startsWith("--migrations=")) {
-                String value = argument.substring("--migrations=".length())
-                        .trim()
-                        .toLowerCase(Locale.ROOT);
+                String value =
+                        argument.substring("--migrations=".length()).trim().toLowerCase(Locale.ROOT);
                 mode = switch (value) {
                     case "apply" -> Mode.APPLY;
                     case "validate", "status" -> Mode.VALIDATE;
                     case "repair" -> Mode.REPAIR;
-                    case "off" -> throw new IllegalArgumentException(
-                            "--migrations=off is intentionally not supported. "
-                                    + "Set db.migrate.on_startup=false explicitly in config.ini instead.");
-                    default -> throw new IllegalArgumentException(
-                            "Unsupported migration mode '" + value + "'; expected apply, validate or repair.");
+                    case "off" ->
+                        throw new IllegalArgumentException("--migrations=off is intentionally not supported. "
+                                + "Set db.migrate.on_startup=false explicitly in config.ini instead.");
+                    default ->
+                        throw new IllegalArgumentException(
+                                "Unsupported migration mode '" + value + "'; expected apply, validate or repair.");
                 };
                 continue;
             }
             // A silently ignored near-miss (--migration=apply, --migrations-only=true)
             // would boot the hotel when the operator asked for a migration step.
             if (argument.toLowerCase(Locale.ROOT).startsWith("--migration")) {
-                throw new IllegalArgumentException(
-                        "Unrecognised migration option '" + argument
-                                + "'; expected --migrations=apply, --migrations=validate, "
-                                + "--migrations=repair or --migrations-only.");
+                throw new IllegalArgumentException("Unrecognised migration option '" + argument
+                        + "'; expected --migrations=apply, --migrations=validate, "
+                        + "--migrations=repair or --migrations-only.");
             }
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/database/migration/MigrationRunner.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/migration/MigrationRunner.java
@@ -5,15 +5,14 @@ import com.eu.habbo.database.backup.MariaDbMigrationBackup;
 import com.eu.habbo.database.backup.MigrationBackup;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import java.util.Properties;
+import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationInfo;
 import org.flywaydb.core.api.MigrationInfoService;
 import org.flywaydb.core.api.output.MigrateResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.sql.DataSource;
-import java.util.Properties;
 
 /**
  * Runs Flyway migrations.
@@ -40,13 +39,14 @@ public final class MigrationRunner {
 
     private static final String KEY_ON_STARTUP = "db.migrate.on_startup";
 
-    private MigrationRunner() {
-    }
+    private MigrationRunner() {}
 
     /** Startup entry point, called before database-backed configuration is loaded. */
     public static void runAtStartup(HikariDataSource runtimeDataSource, ConfigurationManager config) {
         if (!config.getBoolean(KEY_ON_STARTUP, true)) {
-            LOGGER.warn("[migrate] {}=false — skipping automatic schema migration. The operator is responsible for schema state.", KEY_ON_STARTUP);
+            LOGGER.warn(
+                    "[migrate] {}=false — skipping automatic schema migration. The operator is responsible for schema state.",
+                    KEY_ON_STARTUP);
             return;
         }
 
@@ -54,15 +54,11 @@ public final class MigrationRunner {
     }
 
     /** Applies migrations immediately, regardless of the startup config switch. */
-    public static MigrateResult migrateAtStartup(
-            HikariDataSource runtimeDataSource,
-            ConfigurationManager config) {
+    public static MigrateResult migrateAtStartup(HikariDataSource runtimeDataSource, ConfigurationManager config) {
         // The runtime datasource rewrites legacy plugin SQL. Migrations require an
         // unwrapped pool so their DDL cannot be silently translated.
         try (HikariDataSource rawMigrationDataSource = rawMigrationDataSource(runtimeDataSource)) {
-            return migrate(
-                    rawMigrationDataSource,
-                    MariaDbMigrationBackup.resolve(config, rawMigrationDataSource));
+            return migrate(rawMigrationDataSource, MariaDbMigrationBackup.resolve(config, rawMigrationDataSource));
         }
     }
 
@@ -102,7 +98,8 @@ public final class MigrationRunner {
         LOGGER.info("[migrate] Detected schema state: {}", state);
         try {
             if (state != SchemaPreflight.State.EMPTY && state != SchemaPreflight.State.UNKNOWN) {
-                java.util.List<String> pending = java.util.Arrays.stream(flyway.info().pending())
+                java.util.List<String> pending = java.util.Arrays.stream(
+                                flyway.info().pending())
                         .filter(migration -> !isBaselineSkippedDuringAdoption(state, migration))
                         .map(migration -> migration.getVersion() == null
                                 ? migration.getDescription()
@@ -110,29 +107,35 @@ public final class MigrationRunner {
                         .toList();
                 if (!pending.isEmpty()) migrationBackup.beforeMigrations(pending);
             }
-            MigrateResult result = switch (state) {
-                case UNKNOWN -> throw new MigrationException(
-                        "Refusing to migrate: the database is non-empty but is not a recognised Arc/Polaris schema. "
-                                + "No changes were made. Check that db.database points at the correct database, or see the "
-                                + "conversion/recovery instructions before proceeding.");
-                case RECOGNISED_EXISTING -> {
-                    LOGGER.warn("[migrate] Existing Arcturus/Polaris hotel detected with no migration history. "
-                            + "Polaris will preserve the hotel data, record adoption baseline V{}, and apply the required upgrades now. "
-                            + "A full database backup before first startup is strongly recommended.", BASELINE_VERSION);
-                    flyway.baseline();
-                    yield flyway.migrate();
-                }
-                case EMPTY, MANAGED -> flyway.migrate();
-                default -> throw new MigrationException("Unhandled schema state: " + state);
-            };
+            MigrateResult result =
+                    switch (state) {
+                        case UNKNOWN ->
+                            throw new MigrationException(
+                                    "Refusing to migrate: the database is non-empty but is not a recognised Arc/Polaris schema. "
+                                            + "No changes were made. Check that db.database points at the correct database, or see the "
+                                            + "conversion/recovery instructions before proceeding.");
+                        case RECOGNISED_EXISTING -> {
+                            LOGGER.warn(
+                                    "[migrate] Existing Arcturus/Polaris hotel detected with no migration history. "
+                                            + "Polaris will preserve the hotel data, record adoption baseline V{}, and apply the required upgrades now. "
+                                            + "A full database backup before first startup is strongly recommended.",
+                                    BASELINE_VERSION);
+                            flyway.baseline();
+                            yield flyway.migrate();
+                        }
+                        case EMPTY, MANAGED -> flyway.migrate();
+                        default -> throw new MigrationException("Unhandled schema state: " + state);
+                    };
             RuntimeSchemaValidator.validate(dataSource);
             LOGGER.info("[migrate] Runtime schema invariants validated.");
             return result;
         } catch (MigrationException e) {
             throw e;
         } catch (Exception e) {
-            throw new MigrationException("Migration failed; the emulator will not start against a half-upgraded schema. "
-                    + "Inspect the error, restore from backup or forward-fix, then retry.", e);
+            throw new MigrationException(
+                    "Migration failed; the emulator will not start against a half-upgraded schema. "
+                            + "Inspect the error, restore from backup or forward-fix, then retry.",
+                    e);
         }
     }
 
@@ -155,9 +158,13 @@ public final class MigrationRunner {
 
             MigrationInfoService info = flyway.info();
             MigrationInfo current = info.current();
-            out.append("Current version: ").append(current == null ? "(none)" : current.getVersion()).append('\n');
+            out.append("Current version: ")
+                    .append(current == null ? "(none)" : current.getVersion())
+                    .append('\n');
             if (state == SchemaPreflight.State.RECOGNISED_EXISTING) {
-                out.append("Adoption: record baseline V").append(BASELINE_VERSION).append('\n');
+                out.append("Adoption: record baseline V")
+                        .append(BASELINE_VERSION)
+                        .append('\n');
             }
 
             MigrationInfo[] pending = info.pending();
@@ -170,8 +177,11 @@ public final class MigrationRunner {
             out.append("Pending migrations: ").append(pendingCount).append('\n');
             for (MigrationInfo migration : pending) {
                 if (!isBaselineSkippedDuringAdoption(state, migration)) {
-                    out.append("  - V").append(migration.getVersion()).append(' ')
-                            .append(migration.getDescription()).append('\n');
+                    out.append("  - V")
+                            .append(migration.getVersion())
+                            .append(' ')
+                            .append(migration.getDescription())
+                            .append('\n');
                 }
             }
             // A fully migrated database must also satisfy the runtime contract, so
@@ -184,8 +194,10 @@ public final class MigrationRunner {
         } catch (MigrationException e) {
             throw e;
         } catch (Exception e) {
-            throw new MigrationException("Migration status failed; the schema history could not be "
-                    + "validated against the packaged migrations. No changes were made.", e);
+            throw new MigrationException(
+                    "Migration status failed; the schema history could not be "
+                            + "validated against the packaged migrations. No changes were made.",
+                    e);
         }
     }
 
@@ -210,14 +222,14 @@ public final class MigrationRunner {
             LOGGER.info("[migrate] Schema history repaired: recorded checksums realigned with the packaged "
                     + "migrations and any failed rows cleared. Run a normal startup to apply pending migrations.");
         } catch (Exception e) {
-            throw new MigrationException("Migration repair failed; the schema history could not be realigned "
-                    + "with the packaged migrations. No hotel data was changed.", e);
+            throw new MigrationException(
+                    "Migration repair failed; the schema history could not be realigned "
+                            + "with the packaged migrations. No hotel data was changed.",
+                    e);
         }
     }
 
-    private static boolean isBaselineSkippedDuringAdoption(
-            SchemaPreflight.State state,
-            MigrationInfo migration) {
+    private static boolean isBaselineSkippedDuringAdoption(SchemaPreflight.State state, MigrationInfo migration) {
         return state == SchemaPreflight.State.RECOGNISED_EXISTING
                 && migration.getVersion() != null
                 && BASELINE_VERSION.equals(migration.getVersion().getVersion());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandHandler.java
@@ -14,20 +14,19 @@ import com.eu.habbo.habbohotel.rooms.RoomRightLevels;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserTypingComposer;
 import com.eu.habbo.plugin.events.users.UserCommandEvent;
 import com.eu.habbo.plugin.events.users.UserExecuteCommandEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CommandHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CommandHandler.class);
 
-    private final static Map<String, Command> commands = new HashMap<>(5);
+    private static final Map<String, Command> commands = new HashMap<>(5);
     private static final Comparator<Command> ALPHABETICAL_ORDER = new Comparator<Command>() {
         public int compare(Command c1, Command c2) {
             int res = String.CASE_INSENSITIVE_ORDER.compare(c1.permission, c2.permission);
@@ -42,23 +41,20 @@ public class CommandHandler {
     }
 
     public static void addCommand(Command command) {
-        if (command == null)
-            return;
+        if (command == null) return;
 
         commands.put(command.getClass().getName(), command);
     }
 
-
     public static void addCommand(Class<? extends Command> command) {
         try {
-            //command.getConstructor().setAccessible(true);
+            // command.getConstructor().setAccessible(true);
             addCommand(command.getDeclaredConstructor().newInstance());
             LOGGER.debug("Added command: {}", command.getName());
         } catch (Exception e) {
             LOGGER.error("Caught exception", e);
         }
     }
-
 
     public static boolean handleCommand(GameClient gameClient, String commandLine) {
         if (gameClient != null && commandLine != null) {
@@ -72,19 +68,67 @@ public class CommandHandler {
                         for (String s : command.keys) {
                             if (s.equalsIgnoreCase(parts[0])) {
                                 boolean succes = false;
-                                if (command.permission == null || gameClient.getHabbo().hasPermission(command.permission, gameClient.getHabbo().getHabboInfo().getCurrentRoom() != null && (gameClient.getHabbo().getHabboInfo().getCurrentRoom().hasRights(gameClient.getHabbo())) || gameClient.getHabbo().hasPermission(Permission.ACC_PLACEFURNI) || (gameClient.getHabbo().getHabboInfo().getCurrentRoom() != null && gameClient.getHabbo().getHabboInfo().getCurrentRoom().getGuildId() > 0 && gameClient.getHabbo().getHabboInfo().getCurrentRoom().getGuildRightLevel(gameClient.getHabbo()).isEqualOrGreaterThan(RoomRightLevels.GUILD_RIGHTS)))) {
+                                if (command.permission == null
+                                        || gameClient
+                                                .getHabbo()
+                                                .hasPermission(
+                                                        command.permission,
+                                                        gameClient
+                                                                                        .getHabbo()
+                                                                                        .getHabboInfo()
+                                                                                        .getCurrentRoom()
+                                                                                != null
+                                                                        && (gameClient
+                                                                                .getHabbo()
+                                                                                .getHabboInfo()
+                                                                                .getCurrentRoom()
+                                                                                .hasRights(gameClient.getHabbo()))
+                                                                || gameClient
+                                                                        .getHabbo()
+                                                                        .hasPermission(Permission.ACC_PLACEFURNI)
+                                                                || (gameClient
+                                                                                        .getHabbo()
+                                                                                        .getHabboInfo()
+                                                                                        .getCurrentRoom()
+                                                                                != null
+                                                                        && gameClient
+                                                                                        .getHabbo()
+                                                                                        .getHabboInfo()
+                                                                                        .getCurrentRoom()
+                                                                                        .getGuildId()
+                                                                                > 0
+                                                                        && gameClient
+                                                                                .getHabbo()
+                                                                                .getHabboInfo()
+                                                                                .getCurrentRoom()
+                                                                                .getGuildRightLevel(
+                                                                                        gameClient.getHabbo())
+                                                                                .isEqualOrGreaterThan(
+                                                                                        RoomRightLevels
+                                                                                                .GUILD_RIGHTS)))) {
                                     try {
-                                        UserExecuteCommandEvent userExecuteCommandEvent = new UserExecuteCommandEvent(gameClient.getHabbo(), command, parts);
+                                        UserExecuteCommandEvent userExecuteCommandEvent =
+                                                new UserExecuteCommandEvent(gameClient.getHabbo(), command, parts);
                                         Emulator.getPluginManager().fireEvent(userExecuteCommandEvent);
 
-                                        if(userExecuteCommandEvent.isCancelled()) {
+                                        if (userExecuteCommandEvent.isCancelled()) {
                                             return userExecuteCommandEvent.isSuccess();
                                         }
 
                                         if (gameClient.getHabbo().getHabboInfo().getCurrentRoom() != null)
-                                            gameClient.getHabbo().getHabboInfo().getCurrentRoom().sendComposer(new RoomUserTypingComposer(gameClient.getHabbo().getRoomUnit(), false).compose());
+                                            gameClient
+                                                    .getHabbo()
+                                                    .getHabboInfo()
+                                                    .getCurrentRoom()
+                                                    .sendComposer(new RoomUserTypingComposer(
+                                                                    gameClient
+                                                                            .getHabbo()
+                                                                            .getRoomUnit(),
+                                                                    false)
+                                                            .compose());
 
-                                        UserCommandEvent event = new UserCommandEvent(gameClient.getHabbo(), parts, command.handle(gameClient, parts));
+                                        UserCommandEvent event = new UserCommandEvent(
+                                                gameClient.getHabbo(), parts, command.handle(gameClient, parts));
                                         Emulator.getPluginManager().fireEvent(event);
 
                                         succes = event.succes;
@@ -92,8 +136,20 @@ public class CommandHandler {
                                         LOGGER.error("Caught exception", e);
                                     }
 
-                                    if (gameClient.getHabbo().getHabboInfo().getRank().isLogCommands()) {
-                                        Emulator.getDatabaseLogger().store(new CommandLog(gameClient.getHabbo().getHabboInfo().getId(), command, commandLine, succes));
+                                    if (gameClient
+                                            .getHabbo()
+                                            .getHabboInfo()
+                                            .getRank()
+                                            .isLogCommands()) {
+                                        Emulator.getDatabaseLogger()
+                                                .store(new CommandLog(
+                                                        gameClient
+                                                                .getHabbo()
+                                                                .getHabboInfo()
+                                                                .getId(),
+                                                        command,
+                                                        commandLine,
+                                                        succes));
                                     }
                                 }
 
@@ -105,14 +161,12 @@ public class CommandHandler {
             } else {
                 String[] args = commandLine.split(" ");
 
-                if (args.length <= 1)
-                    return false;
+                if (args.length <= 1) return false;
 
                 if (gameClient.getHabbo().getHabboInfo().getCurrentRoom() != null) {
                     Room room = gameClient.getHabbo().getHabboInfo().getCurrentRoom();
 
-                    if (room.getCurrentPets().isEmpty())
-                        return false;
+                    if (room.getCurrentPets().isEmpty()) return false;
 
                     for (Pet pet : room.getCurrentPets().values()) {
                         if (pet != null) {
@@ -128,16 +182,25 @@ public class CommandHandler {
                                 for (PetCommand command : pet.getPetData().getPetCommands()) {
                                     if (command.key.equalsIgnoreCase(s.toString())) {
                                         if (pet instanceof RideablePet && ((RideablePet) pet).getRider() != null) {
-                                            if (((RideablePet) pet).getRider().getHabboInfo().getId() == gameClient.getHabbo().getHabboInfo().getId()) {
-                                                ((RideablePet) pet).getRider().getHabboInfo().dismountPet();
+                                            if (((RideablePet) pet)
+                                                            .getRider()
+                                                            .getHabboInfo()
+                                                            .getId()
+                                                    == gameClient
+                                                            .getHabbo()
+                                                            .getHabboInfo()
+                                                            .getId()) {
+                                                ((RideablePet) pet)
+                                                        .getRider()
+                                                        .getHabboInfo()
+                                                        .dismountPet();
                                             }
                                             break;
                                         }
 
                                         if (command.level <= pet.getLevel())
                                             pet.handleCommand(command, gameClient.getHabbo(), args);
-                                        else
-                                            pet.say(pet.getPetData().randomVocal(PetVocalsType.UNKNOWN_COMMAND));
+                                        else pet.say(pet.getPetData().randomVocal(PetVocalsType.UNKNOWN_COMMAND));
 
                                         break;
                                     }
@@ -301,13 +364,16 @@ public class CommandHandler {
     public List<Command> getCommandsForRank(int rankId) {
         List<Command> allowedCommands = new ArrayList<>();
         if (Emulator.getGameEnvironment().getPermissionsManager().rankExists(rankId)) {
-            Map<String, Permission> permissions = Emulator.getGameEnvironment().getPermissionsManager().getRank(rankId).getPermissions();
+            Map<String, Permission> permissions = Emulator.getGameEnvironment()
+                    .getPermissionsManager()
+                    .getRank(rankId)
+                    .getPermissions();
 
             for (Command command : commands.values()) {
-                if (allowedCommands.contains(command))
-                    continue;
+                if (allowedCommands.contains(command)) continue;
 
-                if (permissions.containsKey(command.permission) && permissions.get(command.permission).setting != PermissionSetting.DISALLOWED) {
+                if (permissions.containsKey(command.permission)
+                        && permissions.get(command.permission).setting != PermissionSetting.DISALLOWED) {
                     allowedCommands.add(command);
                 }
             }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionCustomValues.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionCustomValues.java
@@ -6,7 +6,6 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -15,7 +14,8 @@ import java.util.Map;
 public abstract class InteractionCustomValues extends HabboItem {
     public final Map<String, String> values = new HashMap<>();
 
-    public InteractionCustomValues(ResultSet set, Item baseItem, Map<String, String> defaultValues) throws SQLException {
+    public InteractionCustomValues(ResultSet set, Item baseItem, Map<String, String> defaultValues)
+            throws SQLException {
         super(set, baseItem);
 
         this.values.putAll(defaultValues);
@@ -31,7 +31,14 @@ public abstract class InteractionCustomValues extends HabboItem {
         }
     }
 
-    public InteractionCustomValues(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells, Map<String, String> defaultValues) {
+    public InteractionCustomValues(
+            int id,
+            int userId,
+            Item item,
+            String extradata,
+            int limitedStack,
+            int limitedSells,
+            Map<String, String> defaultValues) {
         super(id, userId, item, extradata, limitedStack, limitedSells);
 
         this.values.putAll(defaultValues);
@@ -48,9 +55,7 @@ public abstract class InteractionCustomValues extends HabboItem {
     }
 
     @Override
-    public void onWalk(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {
-
-    }
+    public void onWalk(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {}
 
     @Override
     public void run() {
@@ -82,7 +87,5 @@ public abstract class InteractionCustomValues extends HabboItem {
         super.serializeExtradata(serverMessage);
     }
 
-    public void onCustomValuesSaved(Room room, GameClient client, Map<String, String> oldValues) {
-
-    }
+    public void onCustomValuesSaved(Room room, GameClient client, Map<String, String> oldValues) {}
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
@@ -1,6 +1,5 @@
 package com.eu.habbo.habbohotel.messenger.history;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -8,6 +7,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import javax.sql.DataSource;
 
 public final class JdbcMessengerHistoryRepository implements MessengerHistoryRepository {
     private static final int CLEANUP_BATCH_SIZE = 1000;
@@ -40,7 +40,8 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
                 ORDER BY c.updated_at DESC
                 """;
         List<MessengerConversationSummary> summaries = new ArrayList<>();
-        try (Connection connection = dataSource.getConnection(); PreparedStatement statement = connection.prepareStatement(sql)) {
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setInt(1, userId);
             statement.setInt(2, userId);
             statement.setInt(3, userId);
@@ -54,8 +55,7 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
                             result.getString("display_name"),
                             result.getLong("last_message_id"),
                             result.getInt("unread_count"),
-                            result.getLong("updated_at")
-                    ));
+                            result.getLong("updated_at")));
                 }
             }
             return summaries;
@@ -66,9 +66,10 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
 
     @Override
     public boolean isActiveMember(long conversationId, int userId) {
-        String sql = "SELECT 1 FROM messenger_members WHERE conversation_id = ? AND user_id = ? AND left_at IS NULL LIMIT 1";
+        String sql =
+                "SELECT 1 FROM messenger_members WHERE conversation_id = ? AND user_id = ? AND left_at IS NULL LIMIT 1";
         try (Connection connection = dataSource.getConnection();
-             PreparedStatement statement = connection.prepareStatement(sql)) {
+                PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setLong(1, conversationId);
             statement.setInt(2, userId);
             try (ResultSet result = statement.executeQuery()) {
@@ -84,7 +85,7 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
         String sql = "SELECT user_id FROM messenger_members WHERE conversation_id = ? AND left_at IS NULL";
         List<Integer> userIds = new ArrayList<>();
         try (Connection connection = dataSource.getConnection();
-             PreparedStatement statement = connection.prepareStatement(sql)) {
+                PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setLong(1, conversationId);
             try (ResultSet result = statement.executeQuery()) {
                 while (result.next()) userIds.add(result.getInt("user_id"));
@@ -99,7 +100,8 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
     public List<MessengerStoredMessage> loadHistory(long conversationId, int userId, long beforeMessageId, int limit) {
         int[] directParticipants = findDirectParticipants(conversationId, userId);
         if (directParticipants != null) {
-            return loadLegacyDirectHistory(conversationId, directParticipants[0], directParticipants[1], beforeMessageId, limit);
+            return loadLegacyDirectHistory(
+                    conversationId, directParticipants[0], directParticipants[1], beforeMessageId, limit);
         }
 
         String sql = """
@@ -117,7 +119,7 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
                 """;
         List<MessengerStoredMessage> messages = new ArrayList<>();
         try (Connection connection = dataSource.getConnection();
-             PreparedStatement statement = connection.prepareStatement(sql)) {
+                PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setInt(1, userId);
             statement.setLong(2, conversationId);
             statement.setLong(3, beforeMessageId);
@@ -132,8 +134,7 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
                             result.getInt("type"),
                             result.getString("message"),
                             result.getString("metadata"),
-                            result.getLong("created_at")
-                    ));
+                            result.getLong("created_at")));
                 }
             }
             return messages;
@@ -189,7 +190,8 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
 
     private int[] findDirectParticipants(long conversationId, int userId) {
         String sql = "SELECT direct_key FROM messenger_conversations WHERE id = ? AND type = 'direct'";
-        try (Connection connection = dataSource.getConnection(); PreparedStatement statement = connection.prepareStatement(sql)) {
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setLong(1, conversationId);
             try (ResultSet result = statement.executeQuery()) {
                 if (!result.next()) return null;
@@ -201,14 +203,15 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
                 int secondUserId = Integer.parseInt(participantIds[1]);
                 if (firstUserId != userId && secondUserId != userId) return null;
 
-                return new int[]{firstUserId, secondUserId};
+                return new int[] {firstUserId, secondUserId};
             }
         } catch (SQLException exception) {
             throw new IllegalStateException("failed to resolve direct messenger conversation", exception);
         }
     }
 
-    private List<MessengerStoredMessage> loadLegacyDirectHistory(long conversationId, int firstUserId, int secondUserId, long beforeMessageId, int limit) {
+    private List<MessengerStoredMessage> loadLegacyDirectHistory(
+            long conversationId, int firstUserId, int secondUserId, long beforeMessageId, int limit) {
         String sql = """
                 SELECT id, user_from_id, message, timestamp
                 FROM chatlogs_private
@@ -218,7 +221,8 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
                 LIMIT ?
                 """;
         List<MessengerStoredMessage> messages = new ArrayList<>();
-        try (Connection connection = dataSource.getConnection(); PreparedStatement statement = connection.prepareStatement(sql)) {
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setInt(1, firstUserId);
             statement.setInt(2, secondUserId);
             statement.setInt(3, secondUserId);
@@ -235,8 +239,7 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
                             0,
                             result.getString("message"),
                             null,
-                            result.getLong("timestamp")
-                    ));
+                            result.getLong("timestamp")));
                 }
             }
             return messages;
@@ -246,14 +249,18 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
     }
 
     @Override
-    public MessengerStoredMessage storeDirectMessage(int senderId, int recipientId, int type, String message, String metadata) {
-        String conversationSql = "INSERT INTO messenger_conversations (type, direct_key) VALUES ('direct', ?) ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id), updated_at = CURRENT_TIMESTAMP";
-        String memberSql = "INSERT INTO messenger_members (conversation_id, user_id) VALUES (?, ?) ON DUPLICATE KEY UPDATE left_at = NULL, left_message_id = NULL";
+    public MessengerStoredMessage storeDirectMessage(
+            int senderId, int recipientId, int type, String message, String metadata) {
+        String conversationSql =
+                "INSERT INTO messenger_conversations (type, direct_key) VALUES ('direct', ?) ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id), updated_at = CURRENT_TIMESTAMP";
+        String memberSql =
+                "INSERT INTO messenger_members (conversation_id, user_id) VALUES (?, ?) ON DUPLICATE KEY UPDATE left_at = NULL, left_message_id = NULL";
         try (Connection connection = dataSource.getConnection()) {
             connection.setAutoCommit(false);
             try {
                 long conversationId;
-                try (PreparedStatement statement = connection.prepareStatement(conversationSql, Statement.RETURN_GENERATED_KEYS)) {
+                try (PreparedStatement statement =
+                        connection.prepareStatement(conversationSql, Statement.RETURN_GENERATED_KEYS)) {
                     statement.setString(1, MessengerHistoryService.directKey(senderId, recipientId));
                     statement.executeUpdate();
                     try (ResultSet keys = statement.getGeneratedKeys()) {
@@ -270,7 +277,8 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
                     statement.addBatch();
                     statement.executeBatch();
                 }
-                MessengerStoredMessage stored = insertMessage(connection, conversationId, senderId, type, message, metadata);
+                MessengerStoredMessage stored =
+                        insertMessage(connection, conversationId, senderId, type, message, metadata);
                 connection.commit();
                 return stored;
             } catch (SQLException exception) {
@@ -285,11 +293,13 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
     }
 
     @Override
-    public MessengerStoredMessage storeConversationMessage(long conversationId, int senderId, int type, String message, String metadata) {
+    public MessengerStoredMessage storeConversationMessage(
+            long conversationId, int senderId, int type, String message, String metadata) {
         try (Connection connection = dataSource.getConnection()) {
             connection.setAutoCommit(false);
             try {
-                MessengerStoredMessage stored = insertMessage(connection, conversationId, senderId, type, message, metadata);
+                MessengerStoredMessage stored =
+                        insertMessage(connection, conversationId, senderId, type, message, metadata);
                 connection.commit();
                 return stored;
             } catch (SQLException exception) {
@@ -303,8 +313,11 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
         }
     }
 
-    private MessengerStoredMessage insertMessage(Connection connection, long conversationId, int senderId, int type, String message, String metadata) throws SQLException {
-        String sql = "INSERT INTO messenger_messages (conversation_id, sender_id, type, message, metadata) VALUES (?, ?, ?, ?, ?)";
+    private MessengerStoredMessage insertMessage(
+            Connection connection, long conversationId, int senderId, int type, String message, String metadata)
+            throws SQLException {
+        String sql =
+                "INSERT INTO messenger_messages (conversation_id, sender_id, type, message, metadata) VALUES (?, ?, ?, ?, ?)";
         long messageId;
         try (PreparedStatement statement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
             statement.setLong(1, conversationId);
@@ -318,11 +331,13 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
                 messageId = keys.getLong(1);
             }
         }
-        try (PreparedStatement statement = connection.prepareStatement("UPDATE messenger_conversations SET updated_at = CURRENT_TIMESTAMP WHERE id = ?")) {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "UPDATE messenger_conversations SET updated_at = CURRENT_TIMESTAMP WHERE id = ?")) {
             statement.setLong(1, conversationId);
             statement.executeUpdate();
         }
-        return new MessengerStoredMessage(messageId, conversationId, senderId, type, message, metadata, System.currentTimeMillis() / 1000L);
+        return new MessengerStoredMessage(
+                messageId, conversationId, senderId, type, message, metadata, System.currentTimeMillis() / 1000L);
     }
 
     @Override
@@ -342,7 +357,8 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
                         AND (member.left_message_id IS NULL OR message.id <= member.left_message_id)
                   )
                 """;
-        try (Connection connection = dataSource.getConnection(); PreparedStatement statement = connection.prepareStatement(sql)) {
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setLong(1, messageId);
             statement.setLong(2, conversationId);
             statement.setInt(3, userId);
@@ -355,7 +371,8 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
 
     @Override
     public void cleanupRetention(int days, int maxMessagesPerConversation) {
-        String deleteExpired = "DELETE FROM messenger_messages WHERE created_at < UTC_TIMESTAMP() - INTERVAL ? DAY LIMIT ?";
+        String deleteExpired =
+                "DELETE FROM messenger_messages WHERE created_at < UTC_TIMESTAMP() - INTERVAL ? DAY LIMIT ?";
         String deleteOverflow = """
                 DELETE messages FROM messenger_messages messages
                 JOIN (

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryService.java
@@ -18,21 +18,26 @@ public final class MessengerHistoryService {
         this(repository, DEFAULT_RETENTION_DAYS, DEFAULT_MAX_MESSAGES);
     }
 
-    public MessengerHistoryService(MessengerHistoryRepository repository, int retentionDays, int maxMessagesPerConversation) {
+    public MessengerHistoryService(
+            MessengerHistoryRepository repository, int retentionDays, int maxMessagesPerConversation) {
         if (repository == null) throw new IllegalArgumentException("repository is required");
         if (retentionDays <= 0) throw new IllegalArgumentException("retentionDays must be positive");
-        if (maxMessagesPerConversation <= 0) throw new IllegalArgumentException("maxMessagesPerConversation must be positive");
+        if (maxMessagesPerConversation <= 0)
+            throw new IllegalArgumentException("maxMessagesPerConversation must be positive");
         this.repository = repository;
         this.retentionDays = retentionDays;
         this.maxMessagesPerConversation = maxMessagesPerConversation;
     }
 
     public MessengerHistoryPage loadHistory(long conversationId, int userId, long beforeMessageId, int requestedLimit) {
-        if (conversationId <= 0 || userId <= 0) throw new IllegalArgumentException("conversationId and userId must be positive");
-        if (!repository.isActiveMember(conversationId, userId)) throw new SecurityException("conversation access denied");
+        if (conversationId <= 0 || userId <= 0)
+            throw new IllegalArgumentException("conversationId and userId must be positive");
+        if (!repository.isActiveMember(conversationId, userId))
+            throw new SecurityException("conversation access denied");
 
         int limit = Math.max(1, Math.min(MAX_PAGE_SIZE, requestedLimit));
-        List<MessengerStoredMessage> loaded = repository.loadHistory(conversationId, userId, Math.max(0, beforeMessageId), limit);
+        List<MessengerStoredMessage> loaded =
+                repository.loadHistory(conversationId, userId, Math.max(0, beforeMessageId), limit);
         boolean hasMore = loaded.size() > limit;
         List<MessengerStoredMessage> page = new ArrayList<>(hasMore ? loaded.subList(0, limit) : loaded);
         Collections.reverse(page);
@@ -44,14 +49,17 @@ public final class MessengerHistoryService {
         return List.copyOf(repository.listConversations(userId));
     }
 
-    public MessengerStoredMessage sendMessage(long conversationId, int senderId, int recipientId, int type, String message, String metadata) {
+    public MessengerStoredMessage sendMessage(
+            long conversationId, int senderId, int recipientId, int type, String message, String metadata) {
         if (senderId <= 0) throw new IllegalArgumentException("senderId must be positive");
         if (type < 0 || type > 3) throw new IllegalArgumentException("unsupported message type");
         String normalized = message == null ? "" : message.strip();
-        if (normalized.isEmpty() || normalized.length() > 255) throw new IllegalArgumentException("message length must be 1..255");
+        if (normalized.isEmpty() || normalized.length() > 255)
+            throw new IllegalArgumentException("message length must be 1..255");
         if (metadata != null && metadata.length() > 1024) throw new IllegalArgumentException("metadata is too long");
         if (conversationId > 0) {
-            if (!repository.isActiveMember(conversationId, senderId)) throw new SecurityException("conversation access denied");
+            if (!repository.isActiveMember(conversationId, senderId))
+                throw new SecurityException("conversation access denied");
             return repository.storeConversationMessage(conversationId, senderId, type, normalized, metadata);
         }
         if (recipientId <= 0 || recipientId == senderId) throw new IllegalArgumentException("invalid direct recipient");
@@ -59,14 +67,17 @@ public final class MessengerHistoryService {
     }
 
     public boolean markRead(long conversationId, int userId, long messageId) {
-        if (conversationId <= 0 || userId <= 0 || messageId <= 0) throw new IllegalArgumentException("invalid read cursor");
-        if (!repository.isActiveMember(conversationId, userId)) throw new SecurityException("conversation access denied");
+        if (conversationId <= 0 || userId <= 0 || messageId <= 0)
+            throw new IllegalArgumentException("invalid read cursor");
+        if (!repository.isActiveMember(conversationId, userId))
+            throw new SecurityException("conversation access denied");
         return repository.markRead(conversationId, userId, messageId);
     }
 
     public List<Integer> listActiveMemberIds(long conversationId, int requestingUserId) {
         if (conversationId <= 0 || requestingUserId <= 0) throw new IllegalArgumentException("invalid conversation");
-        if (!repository.isActiveMember(conversationId, requestingUserId)) throw new SecurityException("conversation access denied");
+        if (!repository.isActiveMember(conversationId, requestingUserId))
+            throw new SecurityException("conversation access denied");
         return List.copyOf(repository.listActiveMemberIds(conversationId));
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
@@ -18,13 +18,21 @@ import gnu.trove.map.hash.THashMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
+import java.lang.reflect.Constructor;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.lang.reflect.Constructor;
-import java.sql.*;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class HabboStats implements Runnable {
 
@@ -166,15 +174,20 @@ public class HabboStats implements Runnable {
 
         this.nuxReward = this.nux;
 
-        this.subscriptions = Emulator.getGameEnvironment().getSubscriptionManager().getSubscriptionsForUser(this.habboInfo.getId());
+        this.subscriptions =
+                Emulator.getGameEnvironment().getSubscriptionManager().getSubscriptionsForUser(this.habboInfo.getId());
 
-        try (PreparedStatement statement = set.getStatement().getConnection().prepareStatement("SELECT * FROM user_window_settings WHERE user_id = ? LIMIT 1")) {
+        try (PreparedStatement statement = set.getStatement()
+                .getConnection()
+                .prepareStatement("SELECT * FROM user_window_settings WHERE user_id = ? LIMIT 1")) {
             statement.setInt(1, this.habboInfo.getId());
             try (ResultSet nSet = statement.executeQuery()) {
                 if (nSet.next()) {
                     this.navigatorWindowSettings = new HabboNavigatorWindowSettings(nSet);
                 } else {
-                    try (PreparedStatement stmt = statement.getConnection().prepareStatement("INSERT INTO user_window_settings (user_id) VALUES (?)")) {
+                    try (PreparedStatement stmt = statement
+                            .getConnection()
+                            .prepareStatement("INSERT INTO user_window_settings (user_id) VALUES (?)")) {
                         stmt.setInt(1, this.habboInfo.getId());
                         stmt.executeUpdate();
                     }
@@ -184,26 +197,31 @@ public class HabboStats implements Runnable {
             }
         }
 
-        try (PreparedStatement statement = set.getStatement().getConnection().prepareStatement("SELECT * FROM users_navigator_settings WHERE user_id = ?")) {
+        try (PreparedStatement statement = set.getStatement()
+                .getConnection()
+                .prepareStatement("SELECT * FROM users_navigator_settings WHERE user_id = ?")) {
             statement.setInt(1, this.habboInfo.getId());
             try (ResultSet nSet = statement.executeQuery()) {
                 while (nSet.next()) {
-                    this.navigatorWindowSettings.addDisplayMode(nSet.getString("caption"), new HabboNavigatorPersonalDisplayMode(nSet));
+                    this.navigatorWindowSettings.addDisplayMode(
+                            nSet.getString("caption"), new HabboNavigatorPersonalDisplayMode(nSet));
                 }
             }
         }
 
-        try (PreparedStatement favoriteRoomsStatement = set.getStatement().getConnection().prepareStatement("SELECT * FROM users_favorite_rooms WHERE user_id = ?")) {
+        try (PreparedStatement favoriteRoomsStatement = set.getStatement()
+                .getConnection()
+                .prepareStatement("SELECT * FROM users_favorite_rooms WHERE user_id = ?")) {
             favoriteRoomsStatement.setInt(1, this.habboInfo.getId());
             try (ResultSet favoriteSet = favoriteRoomsStatement.executeQuery()) {
                 while (favoriteSet.next()) {
                     this.favoriteRooms.add(favoriteSet.getInt("room_id"));
                 }
             }
-
         }
 
-        try (PreparedStatement recipesStatement = set.getStatement().getConnection().prepareStatement("SELECT * FROM users_recipes WHERE user_id = ?")) {
+        try (PreparedStatement recipesStatement =
+                set.getStatement().getConnection().prepareStatement("SELECT * FROM users_recipes WHERE user_id = ?")) {
             recipesStatement.setInt(1, this.habboInfo.getId());
             try (ResultSet recipeSet = recipesStatement.executeQuery()) {
                 while (recipeSet.next()) {
@@ -212,7 +230,9 @@ public class HabboStats implements Runnable {
             }
         }
 
-        try (PreparedStatement calendarRewardsStatement = set.getStatement().getConnection().prepareStatement("SELECT * FROM calendar_rewards_claimed WHERE user_id = ?")) {
+        try (PreparedStatement calendarRewardsStatement = set.getStatement()
+                .getConnection()
+                .prepareStatement("SELECT * FROM calendar_rewards_claimed WHERE user_id = ?")) {
             calendarRewardsStatement.setInt(1, this.habboInfo.getId());
             try (ResultSet rewardSet = calendarRewardsStatement.executeQuery()) {
                 while (rewardSet.next()) {
@@ -221,7 +241,10 @@ public class HabboStats implements Runnable {
             }
         }
 
-        try (PreparedStatement ltdPurchaseLogStatement = set.getStatement().getConnection().prepareStatement("SELECT catalog_item_id, timestamp FROM catalog_items_limited WHERE user_id = ? AND timestamp > ?")) {
+        try (PreparedStatement ltdPurchaseLogStatement = set.getStatement()
+                .getConnection()
+                .prepareStatement(
+                        "SELECT catalog_item_id, timestamp FROM catalog_items_limited WHERE user_id = ? AND timestamp > ?")) {
             ltdPurchaseLogStatement.setInt(1, this.habboInfo.getId());
             ltdPurchaseLogStatement.setInt(2, Emulator.getIntUnixTimestamp() - 86400);
             try (ResultSet ltdSet = ltdPurchaseLogStatement.executeQuery()) {
@@ -231,7 +254,9 @@ public class HabboStats implements Runnable {
             }
         }
 
-        try (PreparedStatement ignoredPlayersStatement = set.getStatement().getConnection().prepareStatement("SELECT target_id FROM users_ignored WHERE user_id = ?")) {
+        try (PreparedStatement ignoredPlayersStatement = set.getStatement()
+                .getConnection()
+                .prepareStatement("SELECT target_id FROM users_ignored WHERE user_id = ?")) {
             ignoredPlayersStatement.setInt(1, this.habboInfo.getId());
             try (ResultSet ignoredSet = ignoredPlayersStatement.executeQuery()) {
                 while (ignoredSet.next()) {
@@ -240,7 +265,9 @@ public class HabboStats implements Runnable {
             }
         }
 
-        try (PreparedStatement loadOfferPurchaseStatement = set.getStatement().getConnection().prepareStatement("SELECT * FROM users_target_offer_purchases WHERE user_id = ?")) {
+        try (PreparedStatement loadOfferPurchaseStatement = set.getStatement()
+                .getConnection()
+                .prepareStatement("SELECT * FROM users_target_offer_purchases WHERE user_id = ?")) {
             loadOfferPurchaseStatement.setInt(1, this.habboInfo.getId());
             try (ResultSet offerSet = loadOfferPurchaseStatement.executeQuery()) {
                 while (offerSet.next()) {
@@ -249,7 +276,9 @@ public class HabboStats implements Runnable {
             }
         }
 
-        try (PreparedStatement loadRoomsVisit = set.getStatement().getConnection().prepareStatement("SELECT DISTINCT room_id FROM room_enter_log WHERE user_id = ?")) {
+        try (PreparedStatement loadRoomsVisit = set.getStatement()
+                .getConnection()
+                .prepareStatement("SELECT DISTINCT room_id FROM room_enter_log WHERE user_id = ?")) {
             loadRoomsVisit.setInt(1, this.habboInfo.getId());
             try (ResultSet roomSet = loadRoomsVisit.executeQuery()) {
                 while (roomSet.next()) {
@@ -262,7 +291,9 @@ public class HabboStats implements Runnable {
     private static HabboStats createNewStats(HabboInfo habboInfo) {
         habboInfo.firstVisit = true;
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO users_settings (user_id) VALUES (?)")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("INSERT INTO users_settings (user_id) VALUES (?)")) {
             statement.setInt(1, habboInfo.getId());
             statement.executeUpdate();
         } catch (SQLException e) {
@@ -275,7 +306,8 @@ public class HabboStats implements Runnable {
     public static HabboStats load(HabboInfo habboInfo) {
         HabboStats stats = null;
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
-            try (PreparedStatement statement = connection.prepareStatement("SELECT * FROM users_settings WHERE user_id = ? LIMIT 1")) {
+            try (PreparedStatement statement =
+                    connection.prepareStatement("SELECT * FROM users_settings WHERE user_id = ? LIMIT 1")) {
                 statement.setInt(1, habboInfo.getId());
                 try (ResultSet set = statement.executeQuery()) {
                     set.next();
@@ -288,7 +320,8 @@ public class HabboStats implements Runnable {
             }
 
             if (stats != null) {
-                try (PreparedStatement statement = connection.prepareStatement("SELECT guild_id FROM guilds_members WHERE user_id = ? AND level_id < 3 LIMIT 100")) {
+                try (PreparedStatement statement = connection.prepareStatement(
+                        "SELECT guild_id FROM guilds_members WHERE user_id = ? AND level_id < 3 LIMIT 100")) {
                     statement.setInt(1, habboInfo.getId());
                     try (ResultSet set = statement.executeQuery()) {
                         while (set.next()) {
@@ -299,7 +332,8 @@ public class HabboStats implements Runnable {
 
                 Collections.sort(stats.guilds);
 
-                try (PreparedStatement statement = connection.prepareStatement("SELECT room_id FROM room_votes WHERE user_id = ?")) {
+                try (PreparedStatement statement =
+                        connection.prepareStatement("SELECT room_id FROM room_votes WHERE user_id = ?")) {
                     statement.setInt(1, habboInfo.getId());
                     try (ResultSet set = statement.executeQuery()) {
                         while (set.next()) {
@@ -308,11 +342,14 @@ public class HabboStats implements Runnable {
                     }
                 }
 
-                try (PreparedStatement statement = connection.prepareStatement("SELECT * FROM users_achievements WHERE user_id = ?")) {
+                try (PreparedStatement statement =
+                        connection.prepareStatement("SELECT * FROM users_achievements WHERE user_id = ?")) {
                     statement.setInt(1, habboInfo.getId());
                     try (ResultSet set = statement.executeQuery()) {
                         while (set.next()) {
-                            Achievement achievement = Emulator.getGameEnvironment().getAchievementManager().getAchievement(set.getString("achievement_name"));
+                            Achievement achievement = Emulator.getGameEnvironment()
+                                    .getAchievementManager()
+                                    .getAchievement(set.getString("achievement_name"));
 
                             if (achievement != null) {
                                 stats.achievementProgress.put(achievement, set.getInt("progress"));
@@ -335,7 +372,8 @@ public class HabboStats implements Runnable {
         int onlineTime = Emulator.getIntUnixTimestamp() - onlineTimeLast;
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
-            try (PreparedStatement statement = connection.prepareStatement("UPDATE users_settings SET achievement_score = ?, respects_received = ?, respects_given = ?, daily_respect_points = ?, block_following = ?, block_friendrequests = ?, online_time = online_time + ?, guild_id = ?, daily_pet_respect_points = ?, club_expire_timestamp = ?, login_streak = ?, rent_space_id = ?, rent_space_endtime = ?, volume_system = ?, volume_furni = ?, volume_trax = ?, block_roominvites = ?, old_chat = ?, block_camera_follow = ?, chat_color = ?, hof_points = ?, block_alerts = ?, talent_track_citizenship_level = ?, talent_track_helpers_level = ?, ignore_bots = ?, ignore_pets = ?, nux = ?, mute_end_timestamp = ?, allow_name_change = ?, perk_trade = ?, can_trade = ?, `forums_post_count` = ?, ui_flags = ?, has_gotten_default_saved_searches = ?, max_friends = ?, max_rooms = ?, last_hc_payday = ?, hc_gifts_claimed = ?, builders_club_bonus_furni = ?, hide_online = ? WHERE user_id = ? LIMIT 1")) {
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "UPDATE users_settings SET achievement_score = ?, respects_received = ?, respects_given = ?, daily_respect_points = ?, block_following = ?, block_friendrequests = ?, online_time = online_time + ?, guild_id = ?, daily_pet_respect_points = ?, club_expire_timestamp = ?, login_streak = ?, rent_space_id = ?, rent_space_endtime = ?, volume_system = ?, volume_furni = ?, volume_trax = ?, block_roominvites = ?, old_chat = ?, block_camera_follow = ?, chat_color = ?, hof_points = ?, block_alerts = ?, talent_track_citizenship_level = ?, talent_track_helpers_level = ?, ignore_bots = ?, ignore_pets = ?, nux = ?, mute_end_timestamp = ?, allow_name_change = ?, perk_trade = ?, can_trade = ?, `forums_post_count` = ?, ui_flags = ?, has_gotten_default_saved_searches = ?, max_friends = ?, max_rooms = ?, last_hc_payday = ?, hc_gifts_claimed = ?, builders_club_bonus_furni = ?, hide_online = ? WHERE user_id = ? LIMIT 1")) {
                 statement.setInt(1, this.achievementScore);
                 statement.setInt(2, this.respectPointsReceived);
                 statement.setInt(3, this.respectPointsGiven);
@@ -377,11 +415,12 @@ public class HabboStats implements Runnable {
                 statement.setInt(39, this.buildersClubBonusFurni);
                 statement.setString(40, this.hideOnline ? "1" : "0");
                 statement.setInt(41, this.habboInfo.getId());
-                
+
                 statement.executeUpdate();
             }
 
-            try (PreparedStatement statement = connection.prepareStatement("UPDATE user_window_settings SET x = ?, y = ?, width = ?, height = ?, open_searches = ? WHERE user_id = ? LIMIT 1")) {
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "UPDATE user_window_settings SET x = ?, y = ?, width = ?, height = ?, open_searches = ? WHERE user_id = ? LIMIT 1")) {
                 statement.setInt(1, this.navigatorWindowSettings.x);
                 statement.setInt(2, this.navigatorWindowSettings.y);
                 statement.setInt(3, this.navigatorWindowSettings.width);
@@ -392,7 +431,8 @@ public class HabboStats implements Runnable {
             }
 
             if (!this.offerCache.isEmpty()) {
-                try (PreparedStatement statement = connection.prepareStatement("UPDATE users_target_offer_purchases SET state = ?, amount = ?, last_purchase = ? WHERE user_id = ? AND offer_id = ?")) {
+                try (PreparedStatement statement = connection.prepareStatement(
+                        "UPDATE users_target_offer_purchases SET state = ?, amount = ?, last_purchase = ? WHERE user_id = ? AND offer_id = ?")) {
                     for (HabboOfferPurchase purchase : this.offerCache.values()) {
                         if (!purchase.needsUpdate()) continue;
 
@@ -430,8 +470,7 @@ public class HabboStats implements Runnable {
 
     public boolean hasGuild(int guildId) {
         for (int i : this.guilds) {
-            if (i == guildId)
-                return true;
+            if (i == guildId) return true;
         }
 
         return false;
@@ -493,8 +532,10 @@ public class HabboStats implements Runnable {
     }
 
     public Subscription getSubscription(String subscriptionType) {
-        for(Subscription subscription : subscriptions) {
-            if(subscription.getSubscriptionType().equalsIgnoreCase(subscriptionType) && subscription.isActive() && subscription.getRemaining() > 0) {
+        for (Subscription subscription : subscriptions) {
+            if (subscription.getSubscriptionType().equalsIgnoreCase(subscriptionType)
+                    && subscription.isActive()
+                    && subscription.getRemaining() > 0) {
                 return subscription;
             }
         }
@@ -509,8 +550,7 @@ public class HabboStats implements Runnable {
     public int getSubscriptionExpireTimestamp(String subscriptionType) {
         Subscription subscription = getSubscription(subscriptionType);
 
-        if(subscription == null)
-            return 0;
+        if (subscription == null) return 0;
 
         return subscription.getTimestampEnd();
     }
@@ -518,17 +558,24 @@ public class HabboStats implements Runnable {
     public Subscription createSubscription(String subscriptionType, int duration) {
         Subscription subscription = getSubscription(subscriptionType);
 
-        if(subscription != null) {
-            if (!Emulator.getPluginManager().fireEvent(new UserSubscriptionExtendedEvent(this.habboInfo.getId(), subscription, duration)).isCancelled()) {
+        if (subscription != null) {
+            if (!Emulator.getPluginManager()
+                    .fireEvent(new UserSubscriptionExtendedEvent(this.habboInfo.getId(), subscription, duration))
+                    .isCancelled()) {
                 subscription.addDuration(duration);
                 subscription.onExtended(duration);
             }
             return subscription;
         }
 
-        if (!Emulator.getPluginManager().fireEvent(new UserSubscriptionCreatedEvent(this.habboInfo.getId(), subscriptionType, duration)).isCancelled()) {
+        if (!Emulator.getPluginManager()
+                .fireEvent(new UserSubscriptionCreatedEvent(this.habboInfo.getId(), subscriptionType, duration))
+                .isCancelled()) {
             int startTimestamp = Emulator.getIntUnixTimestamp();
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO `users_subscriptions` (`user_id`, `subscription_type`, `timestamp_start`, `duration`, `active`) VALUES (?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    PreparedStatement statement = connection.prepareStatement(
+                            "INSERT INTO `users_subscriptions` (`user_id`, `subscription_type`, `timestamp_start`, `duration`, `active`) VALUES (?, ?, ?, ?, ?)",
+                            Statement.RETURN_GENERATED_KEYS)) {
                 statement.setInt(1, this.habboInfo.getId());
                 statement.setString(2, subscriptionType);
                 statement.setInt(3, startTimestamp);
@@ -537,16 +584,29 @@ public class HabboStats implements Runnable {
                 statement.execute();
                 try (ResultSet set = statement.getGeneratedKeys()) {
                     if (set.next()) {
-                        Class<? extends Subscription> subClazz = Emulator.getGameEnvironment().getSubscriptionManager().getSubscriptionClass(subscriptionType);
+                        Class<? extends Subscription> subClazz = Emulator.getGameEnvironment()
+                                .getSubscriptionManager()
+                                .getSubscriptionClass(subscriptionType);
                         try {
-                            Constructor<? extends Subscription> c = subClazz.getConstructor(Integer.class, Integer.class, String.class, Integer.class, Integer.class, Boolean.class);
+                            Constructor<? extends Subscription> c = subClazz.getConstructor(
+                                    Integer.class,
+                                    Integer.class,
+                                    String.class,
+                                    Integer.class,
+                                    Integer.class,
+                                    Boolean.class);
                             c.setAccessible(true);
-                            Subscription sub = c.newInstance(set.getInt(1), this.habboInfo.getId(), subscriptionType, startTimestamp, duration, true);
+                            Subscription sub = c.newInstance(
+                                    set.getInt(1),
+                                    this.habboInfo.getId(),
+                                    subscriptionType,
+                                    startTimestamp,
+                                    duration,
+                                    true);
                             this.subscriptions.add(sub);
                             sub.onCreated();
                             return sub;
-                        }
-                        catch (Exception e) {
+                        } catch (Exception e) {
                             LOGGER.error("Caught exception", e);
                         }
                     }
@@ -567,11 +627,11 @@ public class HabboStats implements Runnable {
         Subscription subscription = getSubscription(Subscription.HABBO_CLUB);
         int duration = clubExpireTimestamp - Emulator.getIntUnixTimestamp();
 
-        if(subscription != null) {
+        if (subscription != null) {
             duration = clubExpireTimestamp - subscription.getTimestampStart();
         }
 
-        if(duration > 0) {
+        if (duration > 0) {
             createSubscription(Subscription.HABBO_CLUB, duration);
         }
     }
@@ -582,8 +642,8 @@ public class HabboStats implements Runnable {
 
     public int getPastTimeAsClub() {
         int pastTimeAsHC = 0;
-        for(Subscription subs : this.subscriptions) {
-            if(subs.getSubscriptionType().equalsIgnoreCase(Subscription.HABBO_CLUB)) {
+        for (Subscription subs : this.subscriptions) {
+            if (subs.getSubscriptionType().equalsIgnoreCase(Subscription.HABBO_CLUB)) {
                 pastTimeAsHC += subs.getDuration() - (Math.max(subs.getRemaining(), 0));
             }
         }
@@ -592,12 +652,12 @@ public class HabboStats implements Runnable {
 
     public int getTimeTillNextClubGift() {
         int pastTimeAsClub = getPastTimeAsClub();
-        int totalGifts = (int)Math.ceil(pastTimeAsClub / 2678400.0);
+        int totalGifts = (int) Math.ceil(pastTimeAsClub / 2678400.0);
         return (totalGifts * 2678400) - pastTimeAsClub;
     }
 
     public int getRemainingClubGifts() {
-        int totalGifts = (int)Math.ceil(getPastTimeAsClub() / 2678400.0);
+        int totalGifts = (int) Math.ceil(getPastTimeAsClub() / 2678400.0);
         return totalGifts - this.hcGiftsClaimed;
     }
 
@@ -636,13 +696,13 @@ public class HabboStats implements Runnable {
     }
 
     public boolean addFavoriteRoom(int roomId) {
-        if (this.favoriteRooms.contains(roomId))
-            return false;
+        if (this.favoriteRooms.contains(roomId)) return false;
 
-        if (Emulator.getConfig().getInt("hotel.rooms.max.favorite") <= this.favoriteRooms.size())
-            return false;
+        if (Emulator.getConfig().getInt("hotel.rooms.max.favorite") <= this.favoriteRooms.size()) return false;
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO users_favorite_rooms (user_id, room_id) VALUES (?, ?)")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "INSERT INTO users_favorite_rooms (user_id, room_id) VALUES (?, ?)")) {
             statement.setInt(1, this.habboInfo.getId());
             statement.setInt(2, roomId);
             statement.execute();
@@ -658,7 +718,9 @@ public class HabboStats implements Runnable {
         int index = this.favoriteRooms.indexOf(roomId);
         if (index >= 0) {
             this.favoriteRooms.removeInt(index);
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("DELETE FROM users_favorite_rooms WHERE user_id = ? AND room_id = ? LIMIT 1")) {
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                    PreparedStatement statement = connection.prepareStatement(
+                            "DELETE FROM users_favorite_rooms WHERE user_id = ? AND room_id = ? LIMIT 1")) {
                 statement.setInt(1, this.habboInfo.getId());
                 statement.setInt(2, roomId);
                 statement.execute();
@@ -672,9 +734,13 @@ public class HabboStats implements Runnable {
         return this.favoriteRooms.contains(roomId);
     }
 
-    public boolean visitedRoom(int roomId) { return this.roomsVists.contains(roomId); }
+    public boolean visitedRoom(int roomId) {
+        return this.roomsVists.contains(roomId);
+    }
 
-    public void addVisitRoom(int roomId) { this.roomsVists.add(roomId); }
+    public void addVisitRoom(int roomId) {
+        this.roomsVists.add(roomId);
+    }
 
     public IntArrayList getFavoriteRooms() {
         return this.favoriteRooms;
@@ -685,10 +751,11 @@ public class HabboStats implements Runnable {
     }
 
     public boolean addRecipe(int id) {
-        if (this.secretRecipes.contains(id))
-            return false;
+        if (this.secretRecipes.contains(id)) return false;
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO users_recipes (user_id, recipe) VALUES (?, ?)")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("INSERT INTO users_recipes (user_id, recipe) VALUES (?, ?)")) {
             statement.setInt(1, this.habboInfo.getId());
             statement.setInt(2, id);
             statement.execute();
@@ -701,19 +768,15 @@ public class HabboStats implements Runnable {
     }
 
     public int talentTrackLevel(TalentTrackType type) {
-        if (type == TalentTrackType.CITIZENSHIP)
-            return this.citizenshipLevel;
-        else if (type == TalentTrackType.HELPER)
-            return this.helpersLevel;
+        if (type == TalentTrackType.CITIZENSHIP) return this.citizenshipLevel;
+        else if (type == TalentTrackType.HELPER) return this.helpersLevel;
 
         return -1;
     }
 
     public void setTalentLevel(TalentTrackType type, int level) {
-        if (type == TalentTrackType.CITIZENSHIP)
-            this.citizenshipLevel = level;
-        else if (type == TalentTrackType.HELPER)
-            this.helpersLevel = level;
+        if (type == TalentTrackType.CITIZENSHIP) this.citizenshipLevel = level;
+        else if (type == TalentTrackType.HELPER) this.helpersLevel = level;
     }
 
     public int getMuteEndTime() {
@@ -772,8 +835,13 @@ public class HabboStats implements Runnable {
     public boolean ignoreUser(GameClient gameClient, int userId) {
         final Habbo target = Emulator.getGameEnvironment().getHabboManager().getHabbo(userId);
 
-        if (!Emulator.getConfig().getBoolean("hotel.allow.ignore.staffs") && target.hasPermission(Permission.ACC_UNIGNORABLE)) {
-            gameClient.getHabbo().whisper(Emulator.getTexts().getValue("generic.error.ignore_higher_rank"), RoomChatMessageBubbles.ALERT);
+        if (!Emulator.getConfig().getBoolean("hotel.allow.ignore.staffs")
+                && target.hasPermission(Permission.ACC_UNIGNORABLE)) {
+            gameClient
+                    .getHabbo()
+                    .whisper(
+                            Emulator.getTexts().getValue("generic.error.ignore_higher_rank"),
+                            RoomChatMessageBubbles.ALERT);
             return false;
         }
 
@@ -781,7 +849,8 @@ public class HabboStats implements Runnable {
             this.ignoredUsers.add(userId);
 
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                 PreparedStatement statement = connection.prepareStatement("INSERT INTO users_ignored (user_id, target_id) VALUES (?, ?)")) {
+                    PreparedStatement statement = connection.prepareStatement(
+                            "INSERT INTO users_ignored (user_id, target_id) VALUES (?, ?)")) {
                 statement.setInt(1, this.habboInfo.getId());
                 statement.setInt(2, userId);
                 statement.execute();
@@ -798,7 +867,8 @@ public class HabboStats implements Runnable {
             this.ignoredUsers.rem(userId);
 
             try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-                 PreparedStatement statement = connection.prepareStatement("DELETE FROM users_ignored WHERE user_id = ? AND target_id = ?")) {
+                    PreparedStatement statement = connection.prepareStatement(
+                            "DELETE FROM users_ignored WHERE user_id = ? AND target_id = ?")) {
                 statement.setInt(1, this.habboInfo.getId());
                 statement.setInt(2, userId);
                 statement.execute();
@@ -842,8 +912,8 @@ public class HabboStats implements Runnable {
         this.blockFriendRequests = blockFriendRequests;
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement(
-                     "UPDATE users_settings SET hide_online = ?, block_following = ?, block_friendrequests = ? WHERE user_id = ? LIMIT 1")) {
+                PreparedStatement statement = connection.prepareStatement(
+                        "UPDATE users_settings SET hide_online = ?, block_following = ?, block_friendrequests = ? WHERE user_id = ? LIMIT 1")) {
             statement.setString(1, hideOnline ? "1" : "0");
             statement.setString(2, blockFollowing ? "1" : "0");
             statement.setString(3, blockFriendRequests ? "1" : "0");
@@ -854,8 +924,7 @@ public class HabboStats implements Runnable {
         }
     }
 
-    private static final Set<String> PERSIST_FLAG_COLUMNS =
-            Set.of("mentions_enabled", "mass_mentions_enabled");
+    private static final Set<String> PERSIST_FLAG_COLUMNS = Set.of("mentions_enabled", "mass_mentions_enabled");
 
     private void persistFlag(String column, boolean enabled) {
         if (!PERSIST_FLAG_COLUMNS.contains(column)) {
@@ -864,7 +933,8 @@ public class HabboStats implements Runnable {
         }
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("UPDATE users_settings SET `" + column + "` = ? WHERE user_id = ? LIMIT 1")) {
+                PreparedStatement statement = connection.prepareStatement(
+                        "UPDATE users_settings SET `" + column + "` = ? WHERE user_id = ? LIMIT 1")) {
             statement.setString(1, enabled ? "1" : "0");
             statement.setInt(2, this.habboInfo.getId());
             statement.executeUpdate();
@@ -965,7 +1035,8 @@ public class HabboStats implements Runnable {
 
     private void persistTags() {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("UPDATE users_settings SET `tags` = ? WHERE user_id = ? LIMIT 1")) {
+                PreparedStatement statement =
+                        connection.prepareStatement("UPDATE users_settings SET `tags` = ? WHERE user_id = ? LIMIT 1")) {
             statement.setString(1, this.tags == null ? "" : String.join(";", this.tags));
             statement.setInt(2, this.habboInfo.getId());
             statement.executeUpdate();

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/gamecenter/GameCenterJoinGameEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/gamecenter/GameCenterJoinGameEvent.java
@@ -15,14 +15,14 @@ public class GameCenterJoinGameEvent extends MessageHandler {
     public void handle() throws Exception {
         int gameId = this.packet.readInt();
 
-        if (gameId == 0) //SnowStorm
+        if (gameId == 0) // SnowStorm
         {
             if (Emulator.getConfig().getBoolean("gamecenter.snowwar.enabled", true)) {
                 SnowWarManager.getInstance().joinQueue(this.client.getHabbo());
             } else {
                 this.client.sendResponse(new SnowStormGenericErrorComposer(SnowWarConstants.ERROR_INTERNAL));
             }
-        } else if (gameId == 3) //BaseJump
+        } else if (gameId == 3) // BaseJump
         {
             this.client.sendResponse(new GameCenterAchievementsConfigurationComposer());
             this.client.sendResponse(new BaseJumpLoadGameURLComposer());

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/snowwar/SnowStormLevelDataComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/snowwar/SnowStormLevelDataComposer.java
@@ -7,7 +7,6 @@ import com.eu.habbo.habbohotel.games.snowwar.objects.SnowWarMachineObject;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-
 import java.util.List;
 
 /**
@@ -40,7 +39,8 @@ public class SnowStormLevelDataComposer extends MessageComposer {
             this.response.appendInt(player.getTeamId());
             this.response.appendString(player.getHabbo().getHabboInfo().getUsername());
             this.response.appendString(player.getHabbo().getHabboInfo().getLook());
-            this.response.appendString(player.getHabbo().getHabboInfo().getGender().name().toUpperCase());
+            this.response.appendString(
+                    player.getHabbo().getHabboInfo().getGender().name().toUpperCase());
         }
 
         this.response.appendString(this.game.getMap().getHeightmapForPacket());

--- a/Emulator/src/test/java/com/eu/habbo/database/migration/MigrationOptionsTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/migration/MigrationOptionsTest.java
@@ -1,11 +1,11 @@
 package com.eu.habbo.database.migration;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 class MigrationOptionsTest {
 
@@ -19,7 +19,7 @@ class MigrationOptionsTest {
 
     @Test
     void migrationsOnlyForcesApplyWithoutStartingTheHotel() {
-        MigrationOptions options = MigrationOptions.parse(new String[]{"--migrations-only"});
+        MigrationOptions options = MigrationOptions.parse(new String[] {"--migrations-only"});
 
         assertEquals(MigrationOptions.Mode.CONFIGURED, options.mode());
         assertTrue(options.migrationsOnly());
@@ -29,35 +29,29 @@ class MigrationOptionsTest {
     void explicitApplyAndValidateModesAreSupported() {
         assertEquals(
                 MigrationOptions.Mode.APPLY,
-                MigrationOptions.parse(new String[]{"--migrations=apply"}).mode());
+                MigrationOptions.parse(new String[] {"--migrations=apply"}).mode());
         assertEquals(
                 MigrationOptions.Mode.VALIDATE,
-                MigrationOptions.parse(new String[]{"--migrations=validate"}).mode());
+                MigrationOptions.parse(new String[] {"--migrations=validate"}).mode());
         assertEquals(
                 MigrationOptions.Mode.VALIDATE,
-                MigrationOptions.parse(new String[]{"--migrations=status"}).mode());
+                MigrationOptions.parse(new String[] {"--migrations=status"}).mode());
         assertEquals(
                 MigrationOptions.Mode.REPAIR,
-                MigrationOptions.parse(new String[]{"--migrations=repair"}).mode());
+                MigrationOptions.parse(new String[] {"--migrations=repair"}).mode());
     }
 
     @Test
     void offRequiresTheVisibleConfigurationSwitch() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> MigrationOptions.parse(new String[]{"--migrations=off"}));
+        assertThrows(IllegalArgumentException.class, () -> MigrationOptions.parse(new String[] {"--migrations=off"}));
     }
 
     @Test
     void nearMissMigrationOptionsAreRejectedInsteadOfBootingTheHotel() {
+        assertThrows(IllegalArgumentException.class, () -> MigrationOptions.parse(new String[] {"--migration=apply"}));
         assertThrows(
-                IllegalArgumentException.class,
-                () -> MigrationOptions.parse(new String[]{"--migration=apply"}));
+                IllegalArgumentException.class, () -> MigrationOptions.parse(new String[] {"--migrations-only=true"}));
         assertThrows(
-                IllegalArgumentException.class,
-                () -> MigrationOptions.parse(new String[]{"--migrations-only=true"}));
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> MigrationOptions.parse(new String[]{"--Migrations=validate"}));
+                IllegalArgumentException.class, () -> MigrationOptions.parse(new String[] {"--Migrations=validate"}));
     }
 }


### PR DESCRIPTION
`dev` is red on Spotless, not on tests.

`HabboStats` uses `java.sql.*` and `java.util.*`. The wildcard-import lint forbids both and `spotlessApply` cannot auto-fix them, so the build stops with a lint error before formatting even runs.

- Replaces the two wildcards with the specific imports the file uses.
- Applies the pending formatting to the 10 files in the push-build ratchet range (imports and layout only).

Local `-Pcoverage verify` with the same ratchet base as the failing dev build: 1182 unit + 14 integration green, Spotless clean.