### PR TITLE
fix(e2e): bind the harness listeners and stop hiding new direct messages

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
@@ -98,10 +98,19 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
 
     @Override
     public List<MessengerStoredMessage> loadHistory(long conversationId, int userId, long beforeMessageId, int limit) {
-        int[] directParticipants = findDirectParticipants(conversationId, userId);
-        if (directParticipants != null) {
-            return loadLegacyDirectHistory(
-                    conversationId, directParticipants[0], directParticipants[1], beforeMessageId, limit);
+        // Direct conversations adopted from chatlogs_private have no rows in
+        // messenger_messages, so they can only be read from the legacy table.
+        // Everything this emulator stores goes to messenger_messages, so the
+        // legacy read must stay a fallback — routing every direct conversation
+        // to it hides each message sent since the conversation was adopted.
+        // Deciding on the conversation rather than on the current page keeps
+        // paging from falling back once it reaches the oldest message.
+        if (!hasStoredMessages(conversationId)) {
+            int[] directParticipants = findDirectParticipants(conversationId, userId);
+            if (directParticipants != null) {
+                return loadLegacyDirectHistory(
+                        conversationId, directParticipants[0], directParticipants[1], beforeMessageId, limit);
+            }
         }
 
         String sql = """
@@ -185,6 +194,19 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
             }
         } catch (SQLException exception) {
             throw new IllegalStateException("failed to initialize legacy messenger conversations", exception);
+        }
+    }
+
+    private boolean hasStoredMessages(long conversationId) {
+        String sql = "SELECT 1 FROM messenger_messages WHERE conversation_id = ? LIMIT 1";
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, conversationId);
+            try (ResultSet result = statement.executeQuery()) {
+                return result.next();
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("failed to inspect stored messenger history", exception);
         }
     }
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,6 +2,8 @@
 
 This directory provides the disposable Polaris side of the renderer end-to-end tests. It recreates an isolated schema, imports the Polaris base database, seeds synthetic test data, then starts Polaris on dedicated loopback ports. Normal Polaris startup applies any migrations newer than the base database.
 
+Polaris overlays the `emulator_settings` table on top of `config.ini` once the database connects, so any key present in that table wins. `seed.sql` therefore seeds the listener and session keys the harness depends on — `ws.enabled`, `ws.host`, `ws.port`, `ws.whitelist`, `crypto.ws.enabled`, `enc.enabled`, `client.release.allowed` and `session.reconnect.grace.seconds` — before Polaris starts. The base database ships the legacy aliases `ws.nitro.host` and `ws.nitro.port`, which startup copies into `ws.host`/`ws.port` when those keys are absent; seeding them first keeps the WebSocket listener and the `/__e2e` probe on `E2E_GAME_PORT` instead of the stock `0.0.0.0:2096`. Only `db.*`, `game.*`, `rcon.*` and `e2e.enabled` are genuinely controlled by `config.ini.template`.
+
 The scripts never require production credentials or production data. `prepare-database` only accepts a loopback database host and a database name beginning with `polaris_e2e_`. It deletes and recreates that database on every run.
 
 ## Prerequisites
@@ -32,7 +34,7 @@ The runtime and database scripts share these variables:
 | `E2E_SSO_TICKET` | `e2e-inventory-ticket` | Ticket assigned to fixture user `900001` |
 | `E2E_USER_ID` | `900001` | Fixture user used by probes and tests |
 | `E2E_ROOM_ID` | `900002` | Fixture room |
-| `E2E_GAME_PORT` | `31999` | WebSocket listener and HTTP probe |
+| `E2E_GAME_PORT` | `31999` | WebSocket listener and HTTP probe; required by `prepare-database` too, which seeds it as `ws.port` |
 | `E2E_RAW_PORT` | `31998` | Raw game listener |
 | `E2E_RCON_PORT` | `32000` | RCON listener |
 | `E2E_WS_URL` | `ws://127.0.0.1:31999` | Renderer WebSocket URL |

--- a/e2e/config.ini.template
+++ b/e2e/config.ini.template
@@ -16,6 +16,11 @@ game.host=127.0.0.1
 game.port=${E2E_RAW_PORT}
 rcon.host=127.0.0.1
 rcon.port=${E2E_RCON_PORT}
+# The emulator_settings overlay is applied after the database connects and wins
+# over this file, so ws.*, enc.enabled, crypto.ws.enabled, client.release.allowed
+# and session.reconnect.grace.seconds are really set by e2e/seed.sql. They are
+# repeated here so a run against a database without those rows still works —
+# keep both copies in sync.
 ws.enabled=true
 ws.host=127.0.0.1
 ws.port=${E2E_GAME_PORT}

--- a/e2e/prepare-database.ps1
+++ b/e2e/prepare-database.ps1
@@ -2,7 +2,8 @@ param(
     [string] $Mysql = $env:E2E_MYSQL,
     [string] $Database = $env:E2E_DB_NAME,
     [string] $Ticket = $env:E2E_SSO_TICKET,
-    [string] $SecondTicket = $env:E2E_SECOND_SSO_TICKET
+    [string] $SecondTicket = $env:E2E_SECOND_SSO_TICKET,
+    [string] $GamePort = $env:E2E_GAME_PORT
 )
 
 $ErrorActionPreference = 'Stop'
@@ -11,11 +12,13 @@ if ([string]::IsNullOrWhiteSpace($Mysql)) { throw 'E2E_MYSQL is required' }
 if ([string]::IsNullOrWhiteSpace($Database)) { throw 'E2E_DB_NAME is required' }
 if ([string]::IsNullOrWhiteSpace($Ticket)) { throw 'E2E_SSO_TICKET is required' }
 if ([string]::IsNullOrWhiteSpace($SecondTicket)) { throw 'E2E_SECOND_SSO_TICKET is required' }
+if ([string]::IsNullOrWhiteSpace($GamePort)) { throw 'E2E_GAME_PORT is required' }
 if (-not (Test-Path -LiteralPath $Mysql)) { throw "MySQL client not found: $Mysql" }
 if ($env:E2E_DB_HOST -notin @('127.0.0.1', 'localhost', '::1')) { throw 'E2E_DB_HOST must use a loopback host' }
 if ($Database -notmatch '^polaris_e2e_[A-Za-z0-9_]+$') { throw 'E2E_DB_NAME must start with polaris_e2e_' }
 if ($Ticket -notmatch '^[A-Za-z0-9._-]+$') { throw 'E2E_SSO_TICKET contains unsupported characters' }
 if ($SecondTicket -notmatch '^[A-Za-z0-9._-]+$') { throw 'E2E_SECOND_SSO_TICKET contains unsupported characters' }
+if ($GamePort -notmatch '^[0-9]+$' -or [int] $GamePort -lt 1 -or [int] $GamePort -gt 65535) { throw 'E2E_GAME_PORT must be a TCP port number' }
 
 $repo = Split-Path -Parent $PSScriptRoot
 $baseDatabase = Join-Path $repo 'Emulator\src\main\resources\db\migration\V20260518000000__base_database.sql'
@@ -30,6 +33,6 @@ if ($LASTEXITCODE -ne 0) { throw "Database reset failed with exit code $LASTEXIT
 & $Mysql "--host=$($env:E2E_DB_HOST)" "--port=$($env:E2E_DB_PORT)" "--user=$($env:E2E_DB_USER)" "--database=$Database" --default-character-set=utf8mb4 --execute "source $($baseDatabase.Replace('\', '/'))"
 if ($LASTEXITCODE -ne 0) { throw "Database import failed with exit code $LASTEXITCODE" }
 
-$seedContent = "SET @e2e_sso_ticket='$Ticket';`nSET @e2e_second_sso_ticket='$SecondTicket';`n" + [System.IO.File]::ReadAllText($seed)
+$seedContent = "SET @e2e_sso_ticket='$Ticket';`nSET @e2e_second_sso_ticket='$SecondTicket';`nSET @e2e_ws_port='$GamePort';`n" + [System.IO.File]::ReadAllText($seed)
 $seedContent | & $Mysql "--host=$($env:E2E_DB_HOST)" "--port=$($env:E2E_DB_PORT)" "--user=$($env:E2E_DB_USER)" "--database=$Database"
 if ($LASTEXITCODE -ne 0) { throw "E2E seed failed with exit code $LASTEXITCODE" }

--- a/e2e/prepare-database.sh
+++ b/e2e/prepare-database.sh
@@ -7,11 +7,13 @@ set -euo pipefail
 : "${E2E_DB_USER:?E2E_DB_USER is required}"
 : "${E2E_SSO_TICKET:?E2E_SSO_TICKET is required}"
 : "${E2E_SECOND_SSO_TICKET:?E2E_SECOND_SSO_TICKET is required}"
+: "${E2E_GAME_PORT:?E2E_GAME_PORT is required}"
 
 [[ "$E2E_DB_HOST" == '127.0.0.1' || "$E2E_DB_HOST" == 'localhost' || "$E2E_DB_HOST" == '::1' ]] || { echo 'E2E_DB_HOST must use a loopback host' >&2; exit 2; }
 [[ "$E2E_DB_NAME" =~ ^polaris_e2e_[A-Za-z0-9_]+$ ]] || { echo 'E2E_DB_NAME must start with polaris_e2e_' >&2; exit 2; }
 [[ "$E2E_SSO_TICKET" =~ ^[A-Za-z0-9._-]+$ ]] || { echo 'invalid E2E_SSO_TICKET' >&2; exit 2; }
 [[ "$E2E_SECOND_SSO_TICKET" =~ ^[A-Za-z0-9._-]+$ ]] || { echo 'invalid E2E_SECOND_SSO_TICKET' >&2; exit 2; }
+[[ "$E2E_GAME_PORT" =~ ^[0-9]+$ && "$E2E_GAME_PORT" -ge 1 && "$E2E_GAME_PORT" -le 65535 ]] || { echo 'E2E_GAME_PORT must be a TCP port number' >&2; exit 2; }
 
 repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 base_database="$repo/Emulator/src/main/resources/db/migration/V20260518000000__base_database.sql"
@@ -26,6 +28,7 @@ mysql "${mysql_args[@]}" \
 {
   printf "SET @e2e_sso_ticket='%s';\n" "$E2E_SSO_TICKET"
   printf "SET @e2e_second_sso_ticket='%s';\n" "$E2E_SECOND_SSO_TICKET"
+  printf "SET @e2e_ws_port='%s';\n" "$E2E_GAME_PORT"
   cat "$repo/e2e/seed.sql"
 } |
   mysql "${mysql_args[@]}" "--database=$E2E_DB_NAME"

--- a/e2e/seed.sql
+++ b/e2e/seed.sql
@@ -35,3 +35,25 @@ INSERT INTO items (
     900004, 900001, 0, 18, '', 0, 0, 0.000000, 0,
     '', '', '0:0', 0
 );
+
+-- The `emulator_settings` overlay is applied after the database connects and
+-- overwrites config.ini, so every key below is decided here rather than in
+-- config.ini.template. The base database ships the legacy aliases
+-- ws.nitro.host='0.0.0.0' and ws.nitro.port='2096', which normal startup copies
+-- into ws.host/ws.port; without these rows the WebSocket listener and the
+-- /__e2e probe bind 0.0.0.0:2096 instead of the port the harness advertises and
+-- readiness never succeeds. Seeding the canonical keys first also makes that
+-- copy a no-op, because it only fills in absent keys.
+-- Keep these values in sync with e2e/config.ini.template.
+INSERT INTO emulator_settings (`key`, `value`) VALUES
+    ('ws.enabled', 'true'),
+    ('ws.host', '127.0.0.1'),
+    ('ws.port', @e2e_ws_port),
+    -- 'error' is the sentinel the upgrade handler uses for a request with no
+    -- Origin header, which is what the Node test client sends.
+    ('ws.whitelist', 'localhost,127.0.0.1,error'),
+    ('crypto.ws.enabled', '0'),
+    ('enc.enabled', '0'),
+    ('client.release.allowed', 'NITRO-3-6-0'),
+    ('session.reconnect.grace.seconds', '30')
+ON DUPLICATE KEY UPDATE `value` = VALUES(`value`);


### PR DESCRIPTION
Every renderer end-to-end job (messenger, login-reconnect, inventory) has been red since 17 July. There are two independent causes, both here rather than in the renderer.

## Readiness never succeeded

`emulator_settings` is overlaid on top of `config.ini` after the database connects, so any key in that table wins. Since 721f48ac the base database's legacy `ws.nitro.host` / `ws.nitro.port` aliases are copied into `ws.host` / `ws.port`, which means a fresh `polaris_e2e_*` database always ends up with `0.0.0.0:2096`. The WebSocket listener and the `/__e2e` probe bound that instead of `E2E_GAME_PORT`, so `start-emulator.sh` polled 31999 for 90 seconds and exited with `Polaris readiness deadline exceeded` before a single scenario ran.

The timing lines up: all three workflows last passed 2026-07-17 at 16:19Z, and 721f48ac landed at 21:19Z the same day.

The same overlay was also quietly discarding three other values the template declares — `session.reconnect.grace.seconds` (30 became 5, which the login-reconnect scenario depends on), `enc.enabled` and `ws.whitelist`.

`seed.sql` now writes those keys before Polaris starts. That also makes the alias copy a no-op, because it only fills in keys that are absent. `prepare-database` requires `E2E_GAME_PORT` and validates it as a port number. `config.ini.template` keeps its copies for a run against a database without those rows, with a comment explaining which file actually decides.

## Direct message history returned the wrong table

`loadHistory` sent every direct conversation to `loadLegacyDirectHistory`, which reads `chatlogs_private`. Everything this emulator stores goes to `messenger_messages`, so each message sent after a conversation was adopted vanished from history, and the rows that were returned carried no metadata.

The legacy read is now a fallback used only for conversations with no stored messages. Adopted chatlog history stays visible, which was the point of f1b97dc6, without hiding anything sent since. The check is made per conversation rather than per page so paging does not fall back once it reaches the oldest stored message.

One known limit: a conversation holding both legacy and modern rows shows only the modern ones. Merging the two would need the ids namespaced, since the tables have independent sequences and the client uses ids for paging and read cursors.

## Verification

Run against MariaDB 11.4 with the three renderer scenarios from `Nitro_Render_V3` at Dev (c67308b):

```
messenger        exit=0   Tests 1 passed (1)
loginReconnect   exit=0   Tests 1 passed (1)
inventory        exit=0   Tests 1 passed (1)
```

`mvn -f Emulator/pom.xml test` is green and `spotless:check` passes. The formatter touched the rest of `JdbcMessengerHistoryRepository.java` because `ratchetFrom` is `HEAD^` and the file had pre-existing drift.

Renderer PR duckietm/Nitro_Render_V3#144 fixes the invalid `E2E_DB_NAME` that stopped messenger and login-reconnect even earlier, at the prepare-database step. Both changes are needed; this one has to land first, since the workflows clone this repository's `dev`.