### PR TITLE
fix(rooms): stop the pirate easter egg bypassing chat guards

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatManager.java
@@ -267,15 +267,6 @@ public class RoomChatManager {
         }
         habbo.getHabboStats().lastChat = millis;
 
-        // Easter egg
-        if (roomChatMessage != null
-                && Emulator.getConfig().getBoolean("easter_eggs.enabled")
-                && roomChatMessage.getMessage().equalsIgnoreCase("i am a pirate")) {
-            habbo.getHabboStats().chatCounter.addAndGet(1);
-            Emulator.getThreading().run(new YouAreAPirate(habbo, this.room));
-            return;
-        }
-
         // Handle idle event
         UserIdleEvent event = new UserIdleEvent(habbo, UserIdleEvent.IdleReason.TALKED, false);
         Emulator.getPluginManager().fireEvent(event);
@@ -347,6 +338,19 @@ public class RoomChatManager {
                     }
                 }
             }
+        }
+
+        // Easter egg. Must stay below the mute and flood guards above: it consumes the
+        // message and returns, so anything placed before it is trivially bypassed by
+        // repeating the trigger. One song per Habbo at a time, otherwise a single client
+        // can stack unbounded singing tasks on the scheduler.
+        if (Emulator.getConfig().getBoolean("easter_eggs.enabled")
+                && roomChatMessage.getMessage().equalsIgnoreCase("i am a pirate")) {
+            if (habbo.getHabboStats().singingPirate.compareAndSet(false, true)) {
+                Emulator.getThreading().run(new YouAreAPirate(habbo, this.room));
+            }
+
+            return;
         }
 
         String wiredSayMessage = roomChatMessage.getMessage();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,6 +83,7 @@ public class HabboStats implements Runnable {
     public boolean perkTrade;
     public long roomEnterTimestamp;
     public AtomicInteger chatCounter = new AtomicInteger(0);
+    public final AtomicBoolean singingPirate = new AtomicBoolean(false);
     public long lastChat;
     public long lastUsersSearched;
     public boolean nux;

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/YouAreAPirate.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/YouAreAPirate.java
@@ -8,67 +8,67 @@ import com.eu.habbo.habbohotel.rooms.RoomChatType;
 import com.eu.habbo.habbohotel.users.Habbo;
 
 public class YouAreAPirate implements Runnable {
-    public static String[] iamapirate = new String[]{
-            "Do what you want, 'cause a pirate is free,",
-            "You are a pirate!",
-            "",
-            "Yar har, fiddle di dee,",
-            "Being a pirate is all right with me,",
-            "Do what you want 'cause a pirate is free, ",
-            "You are a pirate!",
-            "Yo Ho, ahoy and avast,",
-            "Being a pirate is really badass!",
-            "Hang the black flag at the end of the mast!",
-            "You are a pirate!",
-            "",
-            "You are a pirate! - Yay!",
-            "",
-            "We've got us a map, (a map! )",
-            "To lead us to a hidden box,",
-            "That's all locked up with locks! (with locks! )",
-            "And buried deep away!",
-            "",
-            "We'll dig up the box, (the box! )",
-            "We know it's full of precious booty! ",
-            "Burst open the locks!",
-            "And then we'll say hooray! ",
-            "",
-            "Yar har, fiddle di dee,",
-            "Being a pirate is all right with me!",
-            "Do what you want 'cause a pirate is free, ",
-            "",
-            "You are a pirate!",
-            "Yo Ho, ahoy and avast,",
-            "Being a Pirate is really badass!",
-            "Hang the black flag",
-            "At the end of the mast!",
-            "You are a pirate!",
-            "",
-            "Hahaha!",
-            "",
-            "",
-            "We're sailing away (set sail! ), ",
-            "Adventure awaits on every shore!",
-            "We set sail and explore (ya-har! )",
-            "And run and jump all day (Yay! )",
-            "We float on our boat (the boat! )",
-            "Until it's time to drop the anchor, ",
-            "Then hang up our coats (aye-aye! )",
-            "Until we sail again!",
-            "",
-            "Yar har, fiddle di dee,",
-            "Being a pirate is all right with me!",
-            "Do what you want 'cause a pirate is free, ",
-            "You are a pirate!",
-            "",
-            "Yar har, wind at your back, lads,",
-            "Wherever you go!",
-            "",
-            "",
-            "Blue sky above and blue ocean below,",
-            "You are a pirate!",
-            "",
-            "You are a pirate!"
+    public static String[] iamapirate = new String[] {
+        "Do what you want, 'cause a pirate is free,",
+        "You are a pirate!",
+        "",
+        "Yar har, fiddle di dee,",
+        "Being a pirate is all right with me,",
+        "Do what you want 'cause a pirate is free, ",
+        "You are a pirate!",
+        "Yo Ho, ahoy and avast,",
+        "Being a pirate is really badass!",
+        "Hang the black flag at the end of the mast!",
+        "You are a pirate!",
+        "",
+        "You are a pirate! - Yay!",
+        "",
+        "We've got us a map, (a map! )",
+        "To lead us to a hidden box,",
+        "That's all locked up with locks! (with locks! )",
+        "And buried deep away!",
+        "",
+        "We'll dig up the box, (the box! )",
+        "We know it's full of precious booty! ",
+        "Burst open the locks!",
+        "And then we'll say hooray! ",
+        "",
+        "Yar har, fiddle di dee,",
+        "Being a pirate is all right with me!",
+        "Do what you want 'cause a pirate is free, ",
+        "",
+        "You are a pirate!",
+        "Yo Ho, ahoy and avast,",
+        "Being a Pirate is really badass!",
+        "Hang the black flag",
+        "At the end of the mast!",
+        "You are a pirate!",
+        "",
+        "Hahaha!",
+        "",
+        "",
+        "We're sailing away (set sail! ), ",
+        "Adventure awaits on every shore!",
+        "We set sail and explore (ya-har! )",
+        "And run and jump all day (Yay! )",
+        "We float on our boat (the boat! )",
+        "Until it's time to drop the anchor, ",
+        "Then hang up our coats (aye-aye! )",
+        "Until we sail again!",
+        "",
+        "Yar har, fiddle di dee,",
+        "Being a pirate is all right with me!",
+        "Do what you want 'cause a pirate is free, ",
+        "You are a pirate!",
+        "",
+        "Yar har, wind at your back, lads,",
+        "Wherever you go!",
+        "",
+        "",
+        "Blue sky above and blue ocean below,",
+        "You are a pirate!",
+        "",
+        "You are a pirate!"
     };
 
     public final Habbo habbo;
@@ -86,18 +86,39 @@ public class YouAreAPirate implements Runnable {
 
     @Override
     public void run() {
-        if (this.room == this.habbo.getHabboInfo().getCurrentRoom()) {
-            if (!iamapirate[this.index].isEmpty()) {
-                this.room.talk(this.habbo, new RoomChatMessage(iamapirate[this.index], this.habbo, RoomChatMessageBubbles.PIRATE), RoomChatType.SHOUT);
-            }
-            this.index++;
-
-            if (this.index == iamapirate.length) {
-                this.room.giveEffect(this.habbo, this.oldEffect, -1);
-                return;
-            }
-
-            Emulator.getThreading().run(this, iamapirate[this.index - 1].length() * 100L);
+        if (this.room != this.habbo.getHabboInfo().getCurrentRoom()) {
+            this.finish(false);
+            return;
         }
+
+        // A mute landing mid-song (moderator or flood) has to stop the singing too,
+        // otherwise the song keeps shouting on behalf of a muted user.
+        if (!this.habbo.getHabboStats().allowTalk()) {
+            this.finish(true);
+            return;
+        }
+
+        if (!iamapirate[this.index].isEmpty()) {
+            this.room.talk(
+                    this.habbo,
+                    new RoomChatMessage(iamapirate[this.index], this.habbo, RoomChatMessageBubbles.PIRATE),
+                    RoomChatType.SHOUT);
+        }
+        this.index++;
+
+        if (this.index == iamapirate.length) {
+            this.finish(true);
+            return;
+        }
+
+        Emulator.getThreading().run(this, iamapirate[this.index - 1].length() * 100L);
+    }
+
+    private void finish(boolean stillInRoom) {
+        if (stillInRoom) {
+            this.room.giveEffect(this.habbo, this.oldEffect, -1);
+        }
+
+        this.habbo.getHabboStats().singingPirate.set(false);
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/PirateEasterEggGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/PirateEasterEggGuardTest.java
@@ -1,0 +1,121 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The "i am a pirate" easter egg consumes the chat message and returns early, so every guard it is
+ * placed above is bypassable by simply repeating the trigger. These are structural ratchets:
+ * {@link RoomChatManager#talk} needs a live {@link com.eu.habbo.Emulator} to exercise directly, so
+ * the ordering and the one-song-per-Habbo gate are asserted against the source instead.
+ */
+class PirateEasterEggGuardTest {
+
+    private static final Path CHAT_MANAGER =
+            Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/RoomChatManager.java");
+    private static final Path PIRATE_RUNNABLE =
+            Path.of("src/main/java/com/eu/habbo/threading/runnables/YouAreAPirate.java");
+
+    @Test
+    void easterEggIsEvaluatedAfterTheMuteAndFloodGuards() throws Exception {
+        MethodDeclaration talk = talkMethod();
+        String body = talk.getBody().orElseThrow().toString();
+
+        int muteWhisper = body.indexOf("MutedWhisperComposer");
+        int floodMute = body.indexOf("floodMuteHabbo");
+        int easterEgg = body.indexOf("i am a pirate");
+
+        assertTrue(muteWhisper >= 0, "expected the room mute guard to still exist in talk()");
+        assertTrue(floodMute >= 0, "expected the flood protection guard to still exist in talk()");
+        assertTrue(easterEgg >= 0, "expected the pirate easter egg to still exist in talk()");
+
+        assertTrue(
+                easterEgg > muteWhisper,
+                "the pirate easter egg must be evaluated after the room mute guard, otherwise a"
+                        + " room-muted Habbo can keep triggering it");
+        assertTrue(
+                easterEgg > floodMute,
+                "the pirate easter egg must be evaluated after flood protection, otherwise the"
+                        + " trigger is unrated and can be spammed without ever being flood muted");
+    }
+
+    @Test
+    void onlyOneSongCanBeScheduledPerHabbo() throws Exception {
+        MethodDeclaration talk = talkMethod();
+
+        Optional<MethodCallExpr> gate = talk.findAll(MethodCallExpr.class).stream()
+                .filter(call -> call.getNameAsString().equals("compareAndSet"))
+                .filter(call -> call.getScope()
+                        .map(scope -> scope.toString().endsWith("singingPirate"))
+                        .orElse(false))
+                .findFirst();
+
+        assertTrue(
+                gate.isPresent(),
+                "talk() must gate YouAreAPirate behind singingPirate.compareAndSet(false, true);"
+                        + " without it one client can stack unbounded singing tasks");
+    }
+
+    @Test
+    void songReleasesTheGateOnEveryExitPath() throws Exception {
+        CompilationUnit unit = StaticJavaParser.parse(Files.readString(PIRATE_RUNNABLE));
+        MethodDeclaration run = unit.findAll(MethodDeclaration.class).stream()
+                .filter(method -> method.getNameAsString().equals("run"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("YouAreAPirate.run() not found"));
+        String body = run.getBody().orElseThrow().toString();
+
+        List<String> exits = List.of(
+                "getCurrentRoom", // singer left the room
+                "allowTalk", // singer was muted mid-song
+                "iamapirate.length"); // song finished
+
+        for (String exit : exits) {
+            assertTrue(body.contains(exit), "YouAreAPirate.run() must still handle the '" + exit + "' exit path");
+        }
+
+        long releases = unit.findAll(MethodCallExpr.class).stream()
+                .filter(call -> call.getNameAsString().equals("set"))
+                .filter(call -> call.getScope()
+                        .map(scope -> scope.toString().endsWith("singingPirate"))
+                        .orElse(false))
+                .filter(call -> call.getArguments().size() == 1
+                        && call.getArgument(0).toString().equals("false"))
+                .count();
+
+        assertTrue(
+                releases >= 1,
+                "YouAreAPirate must release singingPirate when the song ends, otherwise the Habbo"
+                        + " can never trigger the easter egg again for the rest of the session");
+    }
+
+    @Test
+    void easterEggStaysBehindItsConfigSwitch() throws Exception {
+        MethodDeclaration talk = talkMethod();
+
+        boolean gated = talk.findAll(StringLiteralExpr.class).stream()
+                .anyMatch(literal -> literal.getValue().equals("easter_eggs.enabled"));
+
+        assertTrue(gated, "the pirate easter egg must stay behind easter_eggs.enabled");
+    }
+
+    private static MethodDeclaration talkMethod() throws Exception {
+        CompilationUnit unit = StaticJavaParser.parse(Files.readString(CHAT_MANAGER));
+
+        return unit.findAll(MethodDeclaration.class).stream()
+                .filter(method -> method.getNameAsString().equals("talk"))
+                .filter(method -> method.getParameters().size() == 4)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("RoomChatManager.talk(4 args) not found"));
+    }
+}


### PR DESCRIPTION
## The problem

The `i am a pirate` easter egg was evaluated at the very top of `RoomChatManager#talk`, above every chat guard, and it consumed the message with an early `return`:

```java
// Easter egg
if (roomChatMessage != null
        && Emulator.getConfig().getBoolean("easter_eggs.enabled")
        && roomChatMessage.getMessage().equalsIgnoreCase("i am a pirate")) {
    habbo.getHabboStats().chatCounter.addAndGet(1);
    Emulator.getThreading().run(new YouAreAPirate(habbo, this.room));
    return;
}
```

Everything below it was therefore bypassable by repeating the trigger:

- **Mute bypass.** Mute areas, room mute and per-user room mute all sit further down the method. Hotel-wide mute was still enforced (`allowTalk()`), but the room-level ones were not.
- **No flood accounting.** The branch bumps `chatCounter` and returns *before* the threshold is evaluated, so no amount of triggering could ever flood-mute the sender. With `room.chat.delay` defaulting to `false`, the only remaining limit was the packet decoder.
- **Unbounded task fan-out.** Nothing tracked whether a Habbo was already singing. Each trigger constructed a new `YouAreAPirate`, and each of those schedules 68 self-rescheduling tasks shouting to every user in the room for roughly three minutes. A single client could stack these indefinitely — one cheap packet, a lot of server work.

`easter_eggs.enabled` ships as `1`, so this is the default configuration.

