### PR TITLE
docs: credit bop for the easter egg exploit and Nitro memory leak reports

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/AboutCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/AboutCommand.java
@@ -85,7 +85,8 @@ public class AboutCommand extends Command {
                 .append("- Krews Team\r")
                 .append("- DuckieTM, simoleo89, Medievalshell, Lorenzo, Remco, Dennis (DennisObject)\r")
                 .append("- Dippy (Improved wired architecture base)\r")
-                .append("- Seth / iSetht (Opacity & Gravity wireds)\r\n")
+                .append("- Seth / iSetht (Opacity & Gravity wireds)\r")
+                .append("- bop (Easter egg exploit & Nitro Memory Leaks)\r\n")
                 .append("Report issues at: ")
                 .append(REPORT_ISSUES_URL);
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ How it works, what it covers and how to configure it is documented in
 - **Dippy** — Improved wired architecture base
 - **Seth / iSetht** — Opacity & Gravity wireds
 - **Puffin** — the MyBoBBa catalogue assets, **xlRaiko** — the clothing pack
+- **bop** — Easter egg exploit & Nitro Memory Leaks
 
 ## Community
 


### PR DESCRIPTION
Credits bop for reporting the `i am a pirate` easter egg exploit (fixed in #531) and the Nitro renderer memory leaks (fixed in duckietm/Nitro_Render_V3#146).

Two surfaces, kept in sync:
- `README.md` Credits section
- `AboutCommand` — the in-game `:about` credits list

`:about` renders as:
```
- Seth / iSetht (Opacity & Gravity wireds)
- bop (Easter egg exploit & Nitro Memory Leaks)
```