### PR TITLE
fix(wired): restore refactor behavior parity

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveDuckets.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveDuckets.java
@@ -97,7 +97,7 @@ public class WiredEffectGiveDuckets extends InteractionWiredEffect {
         for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
             Habbo habbo = room.getHabbo(unit);
             if (habbo == null) continue;
-            habbo.givePoints(0, this.amount);
+            habbo.givePixels(this.amount);
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemPersistence.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemPersistence.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.habbohotel.rooms;
 
 import com.eu.habbo.habbohotel.items.interactions.InteractionGuildGate;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWired;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -13,7 +14,7 @@ final class RoomItemPersistence {
     private static final String DELETE_ITEM_SQL = "DELETE FROM items WHERE id = ?";
     private static final String UPDATE_ITEM_SQL = "UPDATE items SET user_id = ?, room_id = ?, wall_pos = ?, "
             + "x = ?, y = ?, z = ?, rot = ?, extra_data = ?, "
-            + "limited_data = ? WHERE id = ?";
+            + "limited_data = ?, wired_data = CASE WHEN ? = 1 THEN ? ELSE wired_data END WHERE id = ?";
 
     private final RoomDependencies.ConnectionProvider database;
 
@@ -74,7 +75,9 @@ final class RoomItemPersistence {
                 statement.setInt(7, item.getRotation());
                 statement.setString(8, item instanceof InteractionGuildGate ? "" : item.getDatabaseExtraData());
                 statement.setString(9, item.getLimitedStack() + ":" + item.getLimitedSells());
-                statement.setInt(10, item.getId());
+                statement.setInt(10, item instanceof InteractionWired ? 1 : 0);
+                statement.setString(11, wiredData(item));
+                statement.setInt(12, item.getId());
                 statement.addBatch();
             }
 
@@ -89,5 +92,14 @@ final class RoomItemPersistence {
     private static double persistedHeight(double height) {
         double bounded = Math.max(-9999, Math.min(9999, height));
         return Math.round(bounded * Math.pow(10, 6)) / Math.pow(10, 6);
+    }
+
+    private static String wiredData(HabboItem item) {
+        if (!(item instanceof InteractionWired wired) || item.getRoomId() == 0) {
+            return "";
+        }
+
+        String data = wired.getWiredData();
+        return data == null ? "" : data;
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/WiredInteractionProtocolContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/WiredInteractionProtocolContractTest.java
@@ -19,8 +19,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.ToIntFunction;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -40,10 +38,6 @@ class WiredInteractionProtocolContractTest {
     private static final String REGENERATE_PROPERTY = "polaris.wired.protocol.regenerate";
     private static final Path CONTRACT =
             Path.of("src", "test", "resources", "wired-compatibility", "interaction-protocol-v1.txt");
-    private static final Path ITEM_MANAGER =
-            Path.of("src", "main", "java", "com", "eu", "habbo", "habbohotel", "items", "ItemManager.java");
-    private static final Pattern INTERACTION = Pattern.compile(
-            "new\\s+ItemInteraction\\(\\s*\"([^\"]+)\"\\s*,\\s*([A-Za-z0-9_$.]+)\\.class\\s*\\)", Pattern.MULTILINE);
 
     private static final List<String> INCOMING_HEADERS = List.of(
             "WiredTriggerSaveDataEvent",
@@ -101,8 +95,8 @@ class WiredInteractionProtocolContractTest {
         TestItemManager manager = new TestItemManager();
         manager.loadDefaults();
 
-        List<String> expectedNames = registrations().stream()
-                .map(InteractionRegistration::key)
+        List<String> expectedNames = WiredInteractionRegistryFixture.registrations().stream()
+                .map(WiredInteractionRegistryFixture.Registration::key)
                 .distinct()
                 .sorted()
                 .toList();
@@ -120,11 +114,12 @@ class WiredInteractionProtocolContractTest {
         lines.add("# Every interaction key has one canonical source registration.");
         lines.add("");
 
-        List<InteractionRegistration> registrations = registrations();
+        List<WiredInteractionRegistryFixture.Registration> registrations =
+                WiredInteractionRegistryFixture.registrations();
         for (int index = 0; index < registrations.size(); index++) {
-            InteractionRegistration registration = registrations.get(index);
+            WiredInteractionRegistryFixture.Registration registration = registrations.get(index);
             lines.add("INTERACTION " + String.format("%03d", index) + " " + registration.key() + "="
-                    + registration.type());
+                    + registration.sourceType());
         }
 
         lines.add("");
@@ -166,29 +161,14 @@ class WiredInteractionProtocolContractTest {
 
     private static Map<String, List<String>> duplicateRegistrations() throws Exception {
         Map<String, List<String>> byKey = new LinkedHashMap<>();
-        for (InteractionRegistration registration : registrations()) {
+        for (WiredInteractionRegistryFixture.Registration registration :
+                WiredInteractionRegistryFixture.registrations()) {
             byKey.computeIfAbsent(registration.key(), ignored -> new ArrayList<>())
-                    .add(registration.type());
+                    .add(registration.sourceType());
         }
         byKey.entrySet().removeIf(entry -> entry.getValue().size() < 2);
         return byKey;
     }
-
-    private static List<InteractionRegistration> registrations() throws Exception {
-        String source = Files.readString(ITEM_MANAGER, StandardCharsets.UTF_8);
-        Matcher matcher = INTERACTION.matcher(source);
-        List<InteractionRegistration> registrations = new ArrayList<>();
-        while (matcher.find()) {
-            String key = matcher.group(1);
-            if (key.startsWith("wf_")) {
-                registrations.add(new InteractionRegistration(key, matcher.group(2)));
-            }
-        }
-        assertTrue(!registrations.isEmpty(), "No wired interactions found in " + ITEM_MANAGER);
-        return registrations;
-    }
-
-    private record InteractionRegistration(String key, String type) {}
 
     private static final class TestItemManager extends ItemManager {
         private void loadDefaults() {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/WiredInteractionRegistryFixture.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/WiredInteractionRegistryFixture.java
@@ -1,0 +1,103 @@
+package com.eu.habbo.habbohotel.items;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.habbohotel.items.interactions.InteractionWired;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Shared discovery and construction for registered WIRED compatibility tests. */
+public final class WiredInteractionRegistryFixture {
+    private static final Path ITEM_MANAGER =
+            Path.of("src", "main", "java", "com", "eu", "habbo", "habbohotel", "items", "ItemManager.java");
+    private static final Pattern IMPORT = Pattern.compile("import\\s+([A-Za-z0-9_$.]+);", Pattern.MULTILINE);
+    private static final Pattern INTERACTION = Pattern.compile(
+            "new\\s+ItemInteraction\\(\\s*\"(wf_[^\"]+)\"\\s*,\\s*([A-Za-z0-9_$.]+)\\.class\\s*\\)", Pattern.MULTILINE);
+
+    private WiredInteractionRegistryFixture() {}
+
+    public static List<Registration> registrations() throws Exception {
+        return registrations(source());
+    }
+
+    public static Set<Class<? extends InteractionWired>> wiredTypes() throws Exception {
+        String source = source();
+        Map<String, String> imports = imports(source);
+        Set<Class<? extends InteractionWired>> result = new LinkedHashSet<>();
+        for (Registration registration : registrations(source)) {
+            Class<?> type = resolveType(imports, registration.sourceType());
+            if (InteractionWired.class.isAssignableFrom(type)) {
+                result.add(type.asSubclass(InteractionWired.class));
+            }
+        }
+        return result;
+    }
+
+    public static InteractionWired instantiate(Class<? extends InteractionWired> type) throws Exception {
+        Constructor<? extends InteractionWired> constructor =
+                type.getConstructor(int.class, int.class, Item.class, String.class, int.class, int.class);
+        Item baseItem = mock(Item.class);
+        when(baseItem.getSpriteId()).thenReturn(123);
+        when(baseItem.getName()).thenReturn("wired_fixture");
+        return constructor.newInstance(4242, 7, baseItem, "0", 0, 0);
+    }
+
+    public static Throwable rootCause(Throwable failure) {
+        Throwable result = failure;
+        if (result instanceof InvocationTargetException invocation && invocation.getCause() != null) {
+            result = invocation.getCause();
+        }
+        while (result.getCause() != null && result.getCause() != result) {
+            result = result.getCause();
+        }
+        return result;
+    }
+
+    private static String source() throws Exception {
+        return Files.readString(ITEM_MANAGER, StandardCharsets.UTF_8);
+    }
+
+    private static List<Registration> registrations(String source) {
+        Matcher matcher = INTERACTION.matcher(source);
+        List<Registration> registrations = new ArrayList<>();
+        while (matcher.find()) {
+            registrations.add(new Registration(matcher.group(1), matcher.group(2)));
+        }
+        return registrations;
+    }
+
+    private static Map<String, String> imports(String source) {
+        Map<String, String> imports = new LinkedHashMap<>();
+        Matcher matcher = IMPORT.matcher(source);
+        while (matcher.find()) {
+            String name = matcher.group(1);
+            imports.put(name.substring(name.lastIndexOf('.') + 1), name);
+        }
+        return imports;
+    }
+
+    private static Class<?> resolveType(Map<String, String> imports, String sourceName) throws ClassNotFoundException {
+        int nestedSeparator = sourceName.indexOf('.');
+        String outerName = nestedSeparator < 0 ? sourceName : sourceName.substring(0, nestedSeparator);
+        String fullyQualifiedOuter = imports.get(outerName);
+        if (fullyQualifiedOuter == null) {
+            throw new ClassNotFoundException("No import found for registered type " + sourceName);
+        }
+        String nestedName = nestedSeparator < 0 ? "" : "$" + sourceName.substring(nestedSeparator + 1);
+        return Class.forName(fullyQualifiedOuter + nestedName);
+    }
+
+    public record Registration(String key, String sourceType) {}
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredPersistenceCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredPersistenceCompatibilityTest.java
@@ -6,11 +6,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.WiredInteractionRegistryFixture;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWired;
 import com.eu.habbo.habbohotel.rooms.Room;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,8 +17,6 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,11 +42,6 @@ class WiredPersistenceCompatibilityTest {
     private static final String REGENERATE_PROPERTY = "polaris.wired.persistence.regenerate";
     private static final Path CONTRACT =
             Path.of("src", "test", "resources", "wired-compatibility", "persistence-matrix-v1.txt");
-    private static final Path ITEM_MANAGER =
-            Path.of("src", "main", "java", "com", "eu", "habbo", "habbohotel", "items", "ItemManager.java");
-    private static final Pattern IMPORT = Pattern.compile("import\\s+([A-Za-z0-9_$.]+);", Pattern.MULTILINE);
-    private static final Pattern INTERACTION = Pattern.compile(
-            "new\\s+ItemInteraction\\(\\s*\"(wf_[^\"]+)\"\\s*,\\s*([A-Za-z0-9_$.]+)\\.class\\s*\\)", Pattern.MULTILINE);
     private static final Pattern FAILURE_ROW = Pattern.compile("^CASE (\\S+) ERROR (\\S+)$");
 
     private static final Map<String, String> PAYLOADS = Map.of(
@@ -81,7 +72,7 @@ class WiredPersistenceCompatibilityTest {
 
     @Test
     void matrixCoversEveryRegisteredInteractionWiredClass() throws Exception {
-        Set<Class<? extends InteractionWired>> types = wiredTypes();
+        Set<Class<? extends InteractionWired>> types = WiredInteractionRegistryFixture.wiredTypes();
         assertEquals(235, types.size(), "Review every added or removed registered wired persistence type");
     }
 
@@ -126,7 +117,7 @@ class WiredPersistenceCompatibilityTest {
         lines.add("# OUT is Base64 UTF-8. ERROR records current load/serialize failure behavior.");
         lines.add("");
 
-        for (Class<? extends InteractionWired> type : wiredTypes().stream()
+        for (Class<? extends InteractionWired> type : WiredInteractionRegistryFixture.wiredTypes().stream()
                 .sorted(Comparator.comparing(Class::getName))
                 .toList()) {
             lines.add("TYPE " + type.getName());
@@ -152,7 +143,7 @@ class WiredPersistenceCompatibilityTest {
 
     private static String outcome(Class<? extends InteractionWired> type, String payload) {
         try {
-            InteractionWired item = instantiate(type);
+            InteractionWired item = WiredInteractionRegistryFixture.instantiate(type);
             ResultSet resultSet = resultSet(payload);
             Room room = mock(Room.class, Answers.RETURNS_DEEP_STUBS);
             item.loadWiredData(resultSet, room);
@@ -161,18 +152,9 @@ class WiredPersistenceCompatibilityTest {
                     .encodeToString((serialized == null ? "<null>" : serialized).getBytes(StandardCharsets.UTF_8));
             return encoded.isEmpty() ? "OUT" : "OUT " + encoded;
         } catch (Throwable failure) {
-            Throwable root = rootCause(failure);
+            Throwable root = WiredInteractionRegistryFixture.rootCause(failure);
             return "ERROR " + root.getClass().getName();
         }
-    }
-
-    private static InteractionWired instantiate(Class<? extends InteractionWired> type) throws Exception {
-        Constructor<? extends InteractionWired> constructor =
-                type.getConstructor(int.class, int.class, Item.class, String.class, int.class, int.class);
-        Item baseItem = mock(Item.class);
-        when(baseItem.getSpriteId()).thenReturn(123);
-        when(baseItem.getName()).thenReturn("wired_fixture");
-        return constructor.newInstance(4242, 7, baseItem, "0", 0, 0);
     }
 
     private static ResultSet resultSet(String payload) throws Exception {
@@ -182,52 +164,5 @@ class WiredPersistenceCompatibilityTest {
             return "wired_data".equals(column) ? payload : "";
         });
         return resultSet;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Set<Class<? extends InteractionWired>> wiredTypes() throws Exception {
-        String source = Files.readString(ITEM_MANAGER, StandardCharsets.UTF_8);
-        Map<String, String> imports = imports(source);
-        Matcher matcher = INTERACTION.matcher(source);
-        Set<Class<? extends InteractionWired>> result = new LinkedHashSet<>();
-        while (matcher.find()) {
-            Class<?> type = resolveType(imports, matcher.group(2));
-            if (InteractionWired.class.isAssignableFrom(type)) {
-                result.add((Class<? extends InteractionWired>) type);
-            }
-        }
-        return result;
-    }
-
-    private static Map<String, String> imports(String source) {
-        Map<String, String> imports = new LinkedHashMap<>();
-        Matcher matcher = IMPORT.matcher(source);
-        while (matcher.find()) {
-            String name = matcher.group(1);
-            imports.put(name.substring(name.lastIndexOf('.') + 1), name);
-        }
-        return imports;
-    }
-
-    private static Class<?> resolveType(Map<String, String> imports, String sourceName) throws ClassNotFoundException {
-        int nestedSeparator = sourceName.indexOf('.');
-        String outerName = nestedSeparator < 0 ? sourceName : sourceName.substring(0, nestedSeparator);
-        String fullyQualifiedOuter = imports.get(outerName);
-        if (fullyQualifiedOuter == null) {
-            throw new ClassNotFoundException("No import found for registered type " + sourceName);
-        }
-        String nestedName = nestedSeparator < 0 ? "" : "$" + sourceName.substring(nestedSeparator + 1);
-        return Class.forName(fullyQualifiedOuter + nestedName);
-    }
-
-    private static Throwable rootCause(Throwable failure) {
-        Throwable result = failure;
-        if (result instanceof InvocationTargetException invocation && invocation.getCause() != null) {
-            result = invocation.getCause();
-        }
-        while (result.getCause() != null && result.getCause() != result) {
-            result = result.getCause();
-        }
-        return result;
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredRegisteredExecutionCompatibilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredRegisteredExecutionCompatibilityTest.java
@@ -3,9 +3,8 @@ package com.eu.habbo.habbohotel.items.interactions.wired;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.WiredInteractionRegistryFixture;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWired;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
@@ -16,20 +15,12 @@ import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredEvent;
 import com.eu.habbo.habbohotel.wired.core.WiredServices;
 import com.eu.habbo.habbohotel.wired.core.WiredState;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
@@ -52,11 +43,6 @@ class WiredRegisteredExecutionCompatibilityTest {
     private static final String REGENERATE_PROPERTY = "polaris.wired.execution.regenerate";
     private static final Path CONTRACT =
             Path.of("src", "test", "resources", "wired-compatibility", "registered-execution-v1.txt");
-    private static final Path ITEM_MANAGER =
-            Path.of("src", "main", "java", "com", "eu", "habbo", "habbohotel", "items", "ItemManager.java");
-    private static final Pattern IMPORT = Pattern.compile("import\\s+([A-Za-z0-9_$.]+);", Pattern.MULTILINE);
-    private static final Pattern INTERACTION = Pattern.compile(
-            "new\\s+ItemInteraction\\(\\s*\"(wf_[^\"]+)\"\\s*,\\s*([A-Za-z0-9_$.]+)\\.class\\s*\\)", Pattern.MULTILINE);
 
     @Test
     void everyRegisteredWiredExecutionProbeStaysStable() throws Exception {
@@ -79,7 +65,10 @@ class WiredRegisteredExecutionCompatibilityTest {
 
     @Test
     void executionMatrixCoversEveryRegisteredWiredClass() throws Exception {
-        assertEquals(235, wiredTypes().size(), "Review every added or removed registered wired execution type");
+        assertEquals(
+                235,
+                WiredInteractionRegistryFixture.wiredTypes().size(),
+                "Review every added or removed registered wired execution type");
     }
 
     @Test
@@ -100,7 +89,7 @@ class WiredRegisteredExecutionCompatibilityTest {
         lines.add("# ERROR records current failure behavior; it is not approval of that behavior.");
         lines.add("");
 
-        for (Class<? extends InteractionWired> type : wiredTypes().stream()
+        for (Class<? extends InteractionWired> type : WiredInteractionRegistryFixture.wiredTypes().stream()
                 .sorted(Comparator.comparing(Class::getName))
                 .toList()) {
             lines.add(outcome(type));
@@ -110,7 +99,7 @@ class WiredRegisteredExecutionCompatibilityTest {
 
     private static String outcome(Class<? extends InteractionWired> type) {
         try {
-            InteractionWired item = instantiate(type);
+            InteractionWired item = WiredInteractionRegistryFixture.instantiate(type);
             Room room = mock(Room.class, Answers.RETURNS_DEEP_STUBS);
 
             if (item instanceof InteractionWiredTrigger trigger) {
@@ -184,63 +173,8 @@ class WiredRegisteredExecutionCompatibilityTest {
     }
 
     private static String error(Throwable failure) {
-        return "ERROR:" + rootCause(failure).getClass().getName();
-    }
-
-    private static InteractionWired instantiate(Class<? extends InteractionWired> type) throws Exception {
-        Constructor<? extends InteractionWired> constructor =
-                type.getConstructor(int.class, int.class, Item.class, String.class, int.class, int.class);
-        Item baseItem = mock(Item.class);
-        when(baseItem.getSpriteId()).thenReturn(123);
-        when(baseItem.getName()).thenReturn("wired_fixture");
-        return constructor.newInstance(4242, 7, baseItem, "0", 0, 0);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Set<Class<? extends InteractionWired>> wiredTypes() throws Exception {
-        String source = Files.readString(ITEM_MANAGER, StandardCharsets.UTF_8);
-        Map<String, String> imports = imports(source);
-        Matcher matcher = INTERACTION.matcher(source);
-        Set<Class<? extends InteractionWired>> result = new LinkedHashSet<>();
-        while (matcher.find()) {
-            Class<?> type = resolveType(imports, matcher.group(2));
-            if (InteractionWired.class.isAssignableFrom(type)) {
-                result.add((Class<? extends InteractionWired>) type);
-            }
-        }
-        return result;
-    }
-
-    private static Map<String, String> imports(String source) {
-        Map<String, String> imports = new LinkedHashMap<>();
-        Matcher matcher = IMPORT.matcher(source);
-        while (matcher.find()) {
-            String name = matcher.group(1);
-            imports.put(name.substring(name.lastIndexOf('.') + 1), name);
-        }
-        return imports;
-    }
-
-    private static Class<?> resolveType(Map<String, String> imports, String sourceName) throws ClassNotFoundException {
-        int nestedSeparator = sourceName.indexOf('.');
-        String outerName = nestedSeparator < 0 ? sourceName : sourceName.substring(0, nestedSeparator);
-        String fullyQualifiedOuter = imports.get(outerName);
-        if (fullyQualifiedOuter == null) {
-            throw new ClassNotFoundException("No import found for registered type " + sourceName);
-        }
-        String nestedName = nestedSeparator < 0 ? "" : "$" + sourceName.substring(nestedSeparator + 1);
-        return Class.forName(fullyQualifiedOuter + nestedName);
-    }
-
-    private static Throwable rootCause(Throwable failure) {
-        Throwable result = failure;
-        if (result instanceof InvocationTargetException invocation && invocation.getCause() != null) {
-            result = invocation.getCause();
-        }
-        while (result.getCause() != null && result.getCause() != result) {
-            result = result.getCause();
-        }
-        return result;
+        return "ERROR:"
+                + WiredInteractionRegistryFixture.rootCause(failure).getClass().getName();
     }
 
     @FunctionalInterface

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveDucketsTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveDucketsTest.java
@@ -1,0 +1,44 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredEvent;
+import com.eu.habbo.habbohotel.wired.core.WiredServices;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.habbohotel.wired.core.WiredState;
+import org.junit.jupiter.api.Test;
+
+class WiredEffectGiveDucketsTest {
+
+    @Test
+    void usesThePixelGrantPath() {
+        Room room = mock(Room.class);
+        RoomUnit actor = mock(RoomUnit.class);
+        Habbo habbo = mock(Habbo.class);
+        when(room.getHabbo(actor)).thenReturn(habbo);
+
+        WiredEffectGiveDuckets effect = new WiredEffectGiveDuckets(42, 7, mock(Item.class), "0", 0, 0);
+        WiredSettings settings = new WiredSettings(new int[] {WiredSourceUtil.SOURCE_TRIGGER}, "25", new int[0], 0);
+        WiredContext context = new WiredContext(
+                WiredEvent.builder(WiredEvent.Type.CUSTOM, room).actor(actor).build(),
+                null,
+                mock(WiredServices.class),
+                new WiredState(100));
+
+        assertTrue(effect.saveData(settings, null));
+        effect.execute(context);
+
+        verify(habbo).givePixels(25);
+        verify(habbo, never()).givePoints(0, 25);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemPersistenceBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemPersistenceBehaviorTest.java
@@ -2,9 +2,14 @@ package com.eu.habbo.habbohotel.rooms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveDuckets;
 import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -61,20 +66,22 @@ class RoomItemPersistenceBehaviorTest {
         assertEquals(
                 "UPDATE items SET user_id = ?, room_id = ?, wall_pos = ?, "
                         + "x = ?, y = ?, z = ?, rot = ?, extra_data = ?, "
-                        + "limited_data = ? WHERE id = ?",
+                        + "limited_data = ?, wired_data = CASE WHEN ? = 1 THEN ? ELSE wired_data END WHERE id = ?",
                 update.sql());
         assertEquals(
-                Map.of(
-                        1, 7,
-                        2, 41,
-                        3, ":w=1,2 l=3,4",
-                        4, 5,
-                        5, 6,
-                        6, 7.125D,
-                        7, 3,
-                        8, "updated",
-                        9, "11:2",
-                        10, 1001),
+                Map.ofEntries(
+                        Map.entry(1, 7),
+                        Map.entry(2, 41),
+                        Map.entry(3, ":w=1,2 l=3,4"),
+                        Map.entry(4, 5),
+                        Map.entry(5, 6),
+                        Map.entry(6, 7.125D),
+                        Map.entry(7, 3),
+                        Map.entry(8, "updated"),
+                        Map.entry(9, "11:2"),
+                        Map.entry(10, 0),
+                        Map.entry(11, ""),
+                        Map.entry(12, 1001)),
                 update.parameters());
         RoomJdbcTestSupport.SqlCall delete = dataSource.calls().stream()
                 .filter(call -> call.sql().startsWith("DELETE FROM items"))
@@ -88,6 +95,31 @@ class RoomItemPersistenceBehaviorTest {
         assertFalse(deleted.needsDelete());
         assertFalse(clean.needsUpdate());
         assertFalse(clean.needsDelete());
+    }
+
+    @Test
+    void pendingWiredItemSaveIncludesItsWiredData() throws Exception {
+        RoomJdbcTestSupport.RecordingDataSource dataSource = new RoomJdbcTestSupport.RecordingDataSource();
+        RoomItemManager manager = new RoomItemManager(new Room(41, 7));
+        WiredEffectGiveDuckets wired = new WiredEffectGiveDuckets(1001, 7, mock(Item.class), "0", 0, 0);
+        wired.setRoomId(41);
+        assertTrue(wired.saveData(
+                new WiredSettings(new int[] {WiredSourceUtil.SOURCE_TRIGGER}, "25", new int[0], 0), null));
+        wired.needsUpdate(true);
+        items(manager).put(wired.getId(), wired);
+
+        try (RoomJdbcTestSupport.InstalledDatabase ignored = RoomJdbcTestSupport.install(dataSource)) {
+            manager.saveAllPendingItems();
+        }
+
+        RoomJdbcTestSupport.SqlCall update = dataSource.calls().stream()
+                .filter(call -> call.sql().startsWith("UPDATE items"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(1, update.parameters().get(10));
+        assertEquals(wired.getWiredData(), update.parameters().get(11));
+        assertEquals(wired.getId(), update.parameters().get(12));
+        assertFalse(wired.needsUpdate());
     }
 
     private static TestItem item(int id, String extraData) {


### PR DESCRIPTION
Restores two behaviors lost during the WIRED and room-persistence refactors.

- Give Duckets uses the dedicated pixel grant path again, preserving its economy-ledger reason.
- Batched room-item saves now persist `wired_data` for wired furniture before clearing its dirty state. Non-wired rows retain their existing `wired_data` value.

The room batching refactor had replaced polymorphic `item.run()` calls with one direct item update. That update saved standard furniture fields but omitted the WIRED payload, so internal WIRED changes could disappear after a room save/reload. The fix keeps the optimized single batch while conditionally updating `wired_data` for wired items.

Compatibility:
- [x] Public API, live collections, packet layouts, plugin behavior, and serialized WIRED format remain compatible.
- [x] Non-wired room-item persistence retains existing column data.
- [x] No schema migration is required.
