### PR TITLE
fix(wired): disable malformed-wired quarantine behind a hardcoded flag

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomItemManager.java
@@ -27,6 +27,24 @@ import org.slf4j.LoggerFactory;
 public class RoomItemManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(RoomItemManager.class);
 
+    /**
+     * Whether wired furniture whose {@code wired_data} fails to parse is pulled out of the
+     * executable indexes and the tick service.
+     *
+     * <p>Deliberately hardcoded rather than configurable — this is a temporary switch, not a
+     * supported setting.
+     *
+     * <p>{@code false} (current) restores the pre-modernization outcome: a parse failure is
+     * logged and the furniture stays registered, running on the defaults its constructor set.
+     * Operators saw degraded settings, never dead furniture.
+     *
+     * <p>{@code true} quarantines the item. It stays visible in the room but is removed from the
+     * trigger/effect/condition indexes and unregistered from the tick service, so it is inert with
+     * no in-game signal. Safer for the emulator, but it silently breaks working hotels — a repeater
+     * quarantined this way never fires again.
+     */
+    static final boolean QUARANTINE_MALFORMED_WIRED = false;
+
     private final Room room;
     private final RoomItemIndex index;
     private final RoomItemMovementService movement;
@@ -100,15 +118,7 @@ public class RoomItemManager {
                             wired.loadWiredData(set, this.room);
                         }
                     } catch (Exception exception) {
-                        if (item instanceof InteractionWired) {
-                            this.registry.quarantineWired(item);
-                        }
-                        LOGGER.error(
-                                "Quarantined malformed wired item room={} item={} type={} cause={}",
-                                this.room.getId(),
-                                itemId,
-                                item == null ? "unknown" : item.getClass().getSimpleName(),
-                                exception.getClass().getSimpleName());
+                        handleMalformedWiredData(item, itemId, exception);
                     }
                 }
             }
@@ -117,6 +127,37 @@ public class RoomItemManager {
         } catch (Exception e) {
             LOGGER.error("Caught exception", e);
         }
+    }
+
+    /**
+     * Decides what happens to a wired item whose stored data could not be parsed.
+     *
+     * <p>Package-visible so the behaviour can be asserted without a database.
+     *
+     * @see #QUARANTINE_MALFORMED_WIRED
+     */
+    void handleMalformedWiredData(HabboItem item, int itemId, Exception exception) {
+        String type = item == null ? "unknown" : item.getClass().getSimpleName();
+
+        if (QUARANTINE_MALFORMED_WIRED && item instanceof InteractionWired) {
+            this.registry.quarantineWired(item);
+            LOGGER.error(
+                    "Quarantined malformed wired item room={} item={} type={} cause={}",
+                    this.room.getId(),
+                    itemId,
+                    type,
+                    exception.getClass().getSimpleName());
+            return;
+        }
+
+        // Left registered on purpose: the item keeps running on its constructor defaults, which is
+        // how the emulator behaved before quarantining was introduced.
+        LOGGER.error(
+                "Malformed wired item kept active on defaults (quarantine disabled) room={} item={} type={} cause={}",
+                this.room.getId(),
+                itemId,
+                type,
+                exception.getClass().getSimpleName());
     }
 
     // ==================== ITEM RETRIEVAL ====================

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemManagerWiredLoadIsolationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemManagerWiredLoadIsolationTest.java
@@ -20,7 +20,11 @@ import org.mockito.ArgumentCaptor;
 class RoomItemManagerWiredLoadIsolationTest {
 
     @Test
-    void malformedWiredRowIsQuarantinedWithoutBlockingLaterItems() throws Exception {
+    void malformedWiredRowStaysActiveWithoutBlockingLaterItems() throws Exception {
+        assertFalse(
+                RoomItemManager.QUARANTINE_MALFORMED_WIRED,
+                "This test characterises the quarantine-disabled path; flip it back or update the test.");
+
         Room room = new Room(41, 7);
         room.replaceSpecialTypes(new RoomSpecialTypes());
         RoomItemManager manager = room.getItemManager();
@@ -51,10 +55,12 @@ class RoomItemManagerWiredLoadIsolationTest {
                 "The production loader must continue excluding never-configured blank rows");
         verify(malformed).loadWiredData(rows, room);
         verify(healthy).loadWiredData(rows, room);
-        assertFalse(room.getRoomSpecialTypes()
-                .getTriggers(WiredTriggerType.SAY_SOMETHING)
-                .contains(malformed));
-        assertSame(malformed, manager.getRoomItems().get(1001), "quarantine must not delete hotel furniture");
+        assertTrue(
+                room.getRoomSpecialTypes()
+                        .getTriggers(WiredTriggerType.SAY_SOMETHING)
+                        .contains(malformed),
+                "With quarantine disabled the furni must stay in the executable index and keep running on defaults");
+        assertSame(malformed, manager.getRoomItems().get(1001), "loading must not delete hotel furniture");
     }
 
     private static InteractionWiredTrigger trigger(int id, WiredTriggerType type) {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemRegistryBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemRegistryBehaviorTest.java
@@ -1,7 +1,9 @@
 package com.eu.habbo.habbohotel.rooms;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -38,6 +40,31 @@ class RoomItemRegistryBehaviorTest {
             verify(specialTypes).removeCondition(condition);
             verify(specialTypes).removeExtra(extra);
             wiredManager.verify(() -> WiredManager.invalidateRoom(room), org.mockito.Mockito.times(4));
+        }
+    }
+
+    @Test
+    void malformedWiredStaysRegisteredWhileQuarantineIsDisabled() {
+        assertFalse(
+                RoomItemManager.QUARANTINE_MALFORMED_WIRED,
+                "This test characterises the quarantine-disabled path; flip it back or update the test.");
+
+        Room room = mock(Room.class);
+        RoomSpecialTypes specialTypes = mock(RoomSpecialTypes.class);
+        when(room.getRoomSpecialTypes()).thenReturn(specialTypes);
+
+        RoomItemManager manager = new RoomItemManager(room);
+        InteractionWiredTrigger trigger = mock(InteractionWiredTrigger.class);
+
+        try (MockedStatic<WiredManager> wiredManager = mockStatic(WiredManager.class)) {
+            manager.handleMalformedWiredData(trigger, 1001, new NumberFormatException("legacy value"));
+
+            // Pre-modernization behaviour: the furni keeps running on its constructor defaults,
+            // so it must not leave the executable indexes or the tick service.
+            verify(specialTypes, never()).removeTrigger(trigger);
+            // quarantineWired() always ends with invalidateRoom(), so its absence proves
+            // the item was never pulled from the indexes or the tick service.
+            wiredManager.verify(() -> WiredManager.invalidateRoom(room), never());
         }
     }
 


### PR DESCRIPTION
## Problem

When a wired item's `wired_data` fails to parse, `RoomItemManager.loadWiredData` quarantines it: the item is removed from the trigger/effect/condition indexes and unregistered from the tick service. The furniture stays visible in the room but is completely inert, and nothing signals this in-game — only an ERROR line in `logging/errors/runtime.txt`.

For a repeater that means it never fires again. For an effect it means the loop still ticks but does nothing, which is indistinguishable from "the loop is broken".

This is a behaviour change against older builds. Previously only `SQLException` was caught per row; a parse failure was logged and the item stayed registered, running on the defaults set by its constructor. Hotels saw furni with degraded settings, never dead furni.

The exposure grew when the wired payload guards were added, since more stored values can now throw — in particular legacy, non-JSON `wired_data` written before those guards existed. `WiredTriggerRepeaterShort.loadWiredData` calls `Integer.parseInt` unguarded, so a legacy value there throws `NumberFormatException` and the short repeater is pulled out of the tick service permanently.

## Change

Adds `RoomItemManager.QUARANTINE_MALFORMED_WIRED`, hardcoded to `false`.

- `false` (this PR): log the failure and leave the item registered, matching the older behaviour.
- `true`: current behaviour, quarantine the item.

The quarantine code and `RoomItemRegistry.quarantineWired` are untouched, so re-enabling is a one-line change. The flag is deliberately a constant rather than a config key — it is a temporary switch while wired parity is investigated, not a supported setting.

The failure branch moved into a package-visible `handleMalformedWiredData` so the decision can be asserted without a database.

## Not changed

Per-item isolation is preserved. A row that fails to parse still does not prevent later rows from loading — that part of the current loader is an improvement over the old code, where a `RuntimeException` aborted the whole room's wired load and left every remaining item on defaults.

## Tests

- `RoomItemManagerWiredLoadIsolationTest` updated: still asserts blank rows stay excluded, later items keep loading, and furniture is never deleted; now asserts the malformed item stays in the executable index.
- `RoomItemRegistryBehaviorTest` gains coverage that the load path does not quarantine while the flag is off. The existing test covering `quarantineWired` mechanics is unchanged.
- Both tests assert the flag's value first, so flipping it fails loudly with a message instead of failing obscurely.

Verified by flipping the flag to `true` and confirming the new tests fail, then back to `false`. Full unit suite: 1230 passing, 0 failures.
