### PR TITLE
🆙 Small performance fix Catalog Studio

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
+++ b/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
@@ -27,6 +27,8 @@ import com.eu.habbo.threading.ThreadPooling;
 import com.eu.habbo.util.imager.badges.BadgeImager;
 import java.io.File;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -164,13 +166,22 @@ final class PolarisBootstrap {
         GameServer gameServer = new GameServer(
                 configuration.getValue("game.host", "127.0.0.1"), configuration.getInt("game.port", 30000));
         runtime.installGameServer(gameServer);
+        ExecutorService catalogReloadExecutor = Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "CatalogReload");
+            thread.setDaemon(true);
+            return thread;
+        });
         CatalogStudioRuntime.install(
                 runtime.database().getDataSource(),
                 runtime.gameEnvironment().getItemManager(),
-                (published, nextDraftId) -> {
-                    runtime.gameEnvironment().getCatalogManager().initialize();
-                    gameServer.getGameClientManager().sendBroadcastResponse(new CatalogUpdatedComposer());
-                });
+                (published, nextDraftId) -> catalogReloadExecutor.submit(() -> {
+                    try {
+                        runtime.gameEnvironment().getCatalogManager().initialize();
+                        gameServer.getGameClientManager().sendBroadcastResponse(new CatalogUpdatedComposer());
+                    } catch (Exception exception) {
+                        LOGGER.error("Catalog reload after publish failed", exception);
+                    }
+                }));
         boolean stressEnabled = configuration.getBoolean("stress.enabled", false);
         StressRunRegistry.install(new StressRunManager(
                 runtime.gameEnvironment().getRoomManager(),

--- a/Emulator/src/test/resources/architecture/frozen-violations.tsv
+++ b/Emulator/src/test/resources/architecture/frozen-violations.tsv
@@ -912,7 +912,7 @@ U|com/eu/habbo/habbohotel/rooms/RoomItemPlacementService.java|CALL|getThreading|
 U|com/eu/habbo/habbohotel/rooms/RoomLayout.java|CALL|getConfig|4
 U|com/eu/habbo/habbohotel/rooms/RoomLayout.java|CALL|isNumeric|1
 U|com/eu/habbo/habbohotel/rooms/RoomManager.java|CALL|getConfig|1
-U|com/eu/habbo/habbohotel/rooms/RoomManager.java|CALL|getDatabase|14
+U|com/eu/habbo/habbohotel/rooms/RoomManager.java|CALL|getDatabase|15
 U|com/eu/habbo/habbohotel/rooms/RoomManager.java|CALL|getGameEnvironment|14
 U|com/eu/habbo/habbohotel/rooms/RoomManager.java|CALL|getGameServer|1
 U|com/eu/habbo/habbohotel/rooms/RoomManager.java|CALL|getIntUnixTimestamp|6


### PR DESCRIPTION
In PolarisBootstrap.java, the post-publish hook no longer blocks the admin's save on the full catalog reload

Effect: the publish transaction still commits synchronously (so the data is safely saved before the "published" response goes back), but the heavy initialize() full reload now runs on a background thread. The admin's save returns immediately; the live catalog goes hot a moment later, and the existing CatalogUpdatedComposer broadcast fires once the reload actually completes so open catalog windows refresh at the right time.